### PR TITLE
[Tiri] Added element-specific array type contracts

### DIFF
--- a/apps/tests/test_find.tiri
+++ b/apps/tests/test_find.tiri
@@ -2,7 +2,7 @@
 
 glTask = mSys.CurrentTask()
 
-function resolveFirstPath(Candidates:array):str
+function resolveFirstPath(Candidates:array<string>):str
    for candidate in values(Candidates) do
       err, resolved = mSys.ResolvePath(candidate, RSF_APPROXIMATE)
       if err is ERR_Okay then return resolved end
@@ -35,7 +35,7 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function runFind(Parameters:array):table
+function runFind(Parameters:array<string>):table
    local output = ''
    local errors = ''
    local task_params = array<string> { quoteTaskParam(glFindPath:replace('\\', '/')) }
@@ -51,10 +51,10 @@ function runFind(Parameters:array):table
       args = task_params:concat(' '),
       flags = TSF_WAIT|TSF_SHELL,
       timeout = 10,
-      outputCallback = function(Task:obj, Buffer:array)
+      outputCallback = function(Task:obj, Buffer:array<byte>)
          output ..= Buffer:getString()
       end,
-      errorCallback = function(Task:obj, Buffer:array)
+      errorCallback = function(Task:obj, Buffer:array<byte>)
          errors ..= Buffer:getString()
       end
    })

--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -10,7 +10,7 @@ glUploadFile <const> = 'temp:tuku-test-upload.txt'
 
 glTask = mSys.CurrentTask()
 
-function resolveFirstPath(Candidates:array):str
+function resolveFirstPath(Candidates:array<string>):str
    for candidate in values(Candidates) do
       err, resolved = mSys.ResolvePath(candidate, RSF_APPROXIMATE)
       if err is ERR_Okay then return resolved end
@@ -278,7 +278,7 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function runTuku(Parameters:array):table
+function runTuku(Parameters:array<string>):table
    local output = ''
    local errors = ''
    local task_params = array<string> { quoteTaskParam(glTukuPath:replace('\\', '/')) }
@@ -294,10 +294,10 @@ function runTuku(Parameters:array):table
       args = task_params:concat(' '),
       flags = TSF_WAIT|TSF_SHELL, -- The SHELL option keeps the DOS window from opening.
       timeout = 10,
-      outputCallback = function(Task:obj, Buffer:array)
+      outputCallback = function(Task:obj, Buffer:array<byte>)
          output ..= Buffer:getString()
       end,
-      errorCallback = function(Task:obj, Buffer:array)
+      errorCallback = function(Task:obj, Buffer:array<byte>)
          errors ..= Buffer:getString()
       end
    })

--- a/apps/tuku.tiri
+++ b/apps/tuku.tiri
@@ -103,7 +103,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Converts an array of name=value form arguments into application/x-www-form-urlencoded request content.
 
-function encodeFormBody(Form:array):str
+function encodeFormBody(Form:array<string>):str
    params = array<table>
 
    for field in values(Form) do
@@ -132,7 +132,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Converts an array of name=value or name=@file arguments into multipart/form-data request content.
 
-function buildMultipartBody(Fields:array):<str, str>
+function buildMultipartBody(Fields:array<string>):<str, str>
    boundary = '----TukuBoundary' .. tostring(math.floor(mSys.PreciseTime())) .. string.format('%08x', math.random(0, 0x7FFFFFFF))
    crlf <const> = '\r\n'
    body = ''
@@ -429,7 +429,7 @@ function makeRequestConfig(Args:table):table
 
    if Args._captureBody then
       Args._bodyBuffer = ''
-      request.incoming = function(HTTP:obj, Buffer:array)
+      request.incoming = function(HTTP:obj, Buffer:array<byte>)
          Args._bodyBuffer ..= Buffer:getString()
       end
    elseif output_file != nil then
@@ -438,12 +438,12 @@ function makeRequestConfig(Args:table):table
       -- Redirect probes only need status and headers.
    elseif Args['include'] and not Args.status then
       Args._bodyBuffer = ''
-      request.incoming = function(HTTP:obj, Buffer:array)
+      request.incoming = function(HTTP:obj, Buffer:array<byte>)
          Args._bodyBuffer ..= Buffer:getString()
       end
    elseif not Args.status then
       -- Streams response body chunks to standard output when the body is not redirected or suppressed.
-      request.incoming = function(HTTP:obj, Buffer:array)
+      request.incoming = function(HTTP:obj, Buffer:array<byte>)
          io.write(Buffer:getString())
       end
    end
@@ -554,7 +554,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Returns available response header names, falling back to the phase 3 common keys on older HTTP builds.
 
-function readResponseHeaderNames(HTTP:obj):array
+function readResponseHeaderNames(HTTP:obj):array<string>
    names = array<string>
    seen = {}
 
@@ -627,7 +627,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Removes sensitive headers (Authorization, Cookie) from a custom header array.
 
-function filterSensitiveHeaders(Headers:array):array
+function filterSensitiveHeaders(Headers:array<string>):array<string>
    result = array<string>
    for header in values(Headers) do
       name = tostring(header)

--- a/examples/gradients.tiri
+++ b/examples/gradients.tiri
@@ -66,7 +66,7 @@ end
 -- The mesh is rebuilt from fresh struct values each time rather than read-modify-written, which keeps the nested
 -- FRGB colours marshalling cleanly back into the gradient.
 
-function gouraudVertex(X:num, Y:num, Col:array):any
+function gouraudVertex(X:num, Y:num, Col:array<double>):any
    v = struct.new('GouraudVertex')
    v.x = X
    v.y = Y

--- a/scripts/benchmark.tiri
+++ b/scripts/benchmark.tiri
@@ -25,7 +25,7 @@ end
 
 -- Generate a text report from benchmark statistics
 
-bmark.textReport = function(Results:table):array
+bmark.textReport = function(Results:table):array<string>
    assert(Results, "Results are required")
    local msg = array<string>
    msg:push('=== BENCHMARK RESULTS ===')
@@ -312,7 +312,7 @@ end
 -- Calculate 95% confidence interval for an array of values.
 -- Returns table with lower, upper bounds and margin of error.
 
-bmark.confidenceInterval = function(Values:array, Confidence:num):table
+bmark.confidenceInterval = function(Values:array<any>, Confidence:num):table
    Confidence ??= 0.95
 
    local n = #Values
@@ -366,7 +366,7 @@ end
 -- are considered outliers.  Default multiplier k is 1.5 (standard), use 3.0 for extreme outliers only.  Returns
 -- table with filtered values and outlier information.
 
-bmark.removeOutliers = function(Values:array, Multiplier:num):table
+bmark.removeOutliers = function(Values:array<double>, Multiplier:num):table
    Multiplier ??= 1.5
 
    local n = #Values
@@ -445,7 +445,7 @@ end
 -- Generate a histogram from an array of values.
 -- Returns table with bins, counts, and distribution information.
 
-bmark.histogram = function(Values:array, BinCount:num):table
+bmark.histogram = function(Values:array<double>, BinCount:num):table
    BinCount ??= 10
 
    local n = #Values
@@ -531,7 +531,7 @@ end
 
 -- Generate an ASCII histogram representation for console output.
 
-bmark.histogramText = function(Histogram:table, Width:num):array
+bmark.histogramText = function(Histogram:table, Width:num):array<string>
    Width ??= 40
 
    local msg = array<string>
@@ -718,7 +718,7 @@ end
 
 -- Generate a text report from a comparison result
 
-bmark.comparisonReport = function(Comparison:table):array
+bmark.comparisonReport = function(Comparison:table):array<string>
    local msg = array<string>
 
    local function formatChange(Change:num, Improved:boolean):string

--- a/scripts/gui/fileview.tiri
+++ b/scripts/gui/fileview.tiri
@@ -215,7 +215,7 @@ function updateFileAttributes(Item:table, Info)
    end
 end
 
-function defineViewColumns(Path:str):array
+function defineViewColumns(Path:str):array<table>
    if not Path then
       return array<table> {
          { attrib='name',      title='Name',       width=16, showIcons=true },
@@ -242,7 +242,7 @@ end
 
 -- Return allowed file extensions as a string list, which is cached.
 
-function getFilters(self):array
+function getFilters(self):array<string>
    if self._filters then return self._filters end
    self._filters = array<string>
    if self.filterList then
@@ -870,7 +870,7 @@ gui.fileview = function(Options)
    -- Execute a command with a given Mode.  All files listed in the Items argument will be passed to the object as
    -- a mass execution operation.
 
-   function openFiles(Items:array, Mode:str)
+   function openFiles(Items:array<table>, Mode:str)
       Items ?! return
       self.path ?! return
 

--- a/scripts/gui/libview.tiri
+++ b/scripts/gui/libview.tiri
@@ -476,7 +476,7 @@ gui.initView = function(Options:table, BuildUI, NewItems)
 
    -- Return a table of all selected items
 
-   vw.selectedItems = function():array
+   vw.selectedItems = function():array<table>
       list = array<table> { }
       for item in values(vw.items) do
          if item._selected then

--- a/scripts/net/url.tiri
+++ b/scripts/net/url.tiri
@@ -182,7 +182,7 @@ end
 @input Query string without a leading question mark
 @result Array of decoded key-value tables
 ]])
-url.parseQueryList = function(Query:str):array
+url.parseQueryList = function(Query:str):array<table>
    params = array<table>
    Query ?! return params
 

--- a/scripts/options.tiri
+++ b/scripts/options.tiri
@@ -78,7 +78,7 @@ rx_css_colour <const> = regex.new(
 ----------------------------------------------------------------------------------------------------------------------
 -- Build the canonical name and alias list for a parameter definition.
 
-function normalise_names(Definition:table):array
+function normalise_names(Definition:table):array<string>
    names = array<string>
    seen = {}
 
@@ -221,7 +221,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Convert an existing array or table into an array of strings.
 
-function string_array(Value:any):array
+function string_array(Value:any):array<string>
    result = array<string>
 
    for item in values(Value) do
@@ -234,7 +234,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Convert a comma-separated string into an array of trimmed strings.
 
-function convert_csv(Value:any, Param:table):array
+function convert_csv(Value:any, Param:table):array<string>
    if type(Value) is 'array' or type(Value) is 'table' then
       return string_array(Value)
    end
@@ -254,7 +254,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Convert a raw value into an array of strings.
 
-function convert_array(Value:any, Param:table):array
+function convert_array(Value:any, Param:table):array<string>
    if type(Value) is 'array' or type(Value) is 'table' then
       return string_array(Value)
    end
@@ -549,7 +549,7 @@ function add_result_value(Result:table, ArgNames:table, Presence:table, Param:ta
    IsExplicit:bool):table
 
    if Param.multiple then
-      local param_values:array = Result[Param.name]
+      local param_values:array<any> = Result[Param.name]
       if param_values is nil then
          param_values = array<any>
          Result[Param.name] = param_values
@@ -721,7 +721,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Remove launcher options and the script path from ordered task parameters.
 
-function get_script_arguments(Parameters:array):array
+function get_script_arguments(Parameters:array<string>):array<string>
    result = array<string>
    index = 0
    script_seen = false
@@ -755,7 +755,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Read ordered arguments from the active task, or return nil if they are unavailable.
 
-function get_task_parameters(Options:table):array
+function get_task_parameters(Options:table):array<string>
    if Options and Options.taskParameters != nil then
       assert(type(Options.taskParameters) is 'array', 'Options.taskParameters must be an array.')
       return Options.taskParameters
@@ -774,7 +774,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Parse ordered command-line tokens, preserving the order of named and positional input.
 
-function parse_ordered_input(Parser:table, Result:table, ArgNames:table, Presence:table, Input:array)
+function parse_ordered_input(Parser:table, Result:table, ArgNames:table, Presence:table, Input:array<string>)
    -- Parse one ordered command-line token and apply it to the result table.
 
    function parse_ordered_token(Parser:table, Result:table, ArgNames:table, Presence:table, Token:str, PosIndex:num):num
@@ -932,7 +932,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Join prepared text lines into one help string.
 
-function append_help_line(Output:array, Line:str)
+function append_help_line(Output:array<string>, Line:str)
    if Line:trim() is '' then
       if #Output > 0 and Output[#Output - 1] != '' then
          Output:push('')
@@ -944,7 +944,7 @@ function append_help_line(Output:array, Line:str)
    Output:push(Line:rtrim())
 end
 
-function line_list(Lines:array):str
+function line_list(Lines:array<string>):str
    output = array<string>
 
    for line in values(Lines) do
@@ -1070,7 +1070,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Append parser metadata fields to help output.
 
-function append_metadata(Lines:array, Parser:table)
+function append_metadata(Lines:array<string>, Parser:table)
    if Parser.epilog then
       Lines:push('')
       Lines:push(Parser.epilog)
@@ -1524,7 +1524,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Normalise a relationship field to an array of canonical parameter names.
 
-function relationship_names(Parser:table, Param:table, Field:str, Value:any):array
+function relationship_names(Parser:table, Param:table, Field:str, Value:any):array<string>
    names = array<string>
 
    if type(Value) is 'string' then
@@ -1869,7 +1869,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Parse a non-command parser context from explicit ordered input.
 
-function parse_context_ordered_input(Parser:table, Input:array):table
+function parse_context_ordered_input(Parser:table, Input:array<string>):table
    input_result = {}
    input_arg_names = {}
    input_presence = {}
@@ -1929,7 +1929,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Parse ordered input for a parser that defines subcommands.
 
-function parse_command_ordered_input(Parser:table, Input:array):table
+function parse_command_ordered_input(Parser:table, Input:array<string>):table
    global_input = array<string>
    command_input = array<string>
    command = nil

--- a/scripts/tempus.tiri
+++ b/scripts/tempus.tiri
@@ -662,7 +662,7 @@ end
 
 function convert_time_zone_info(Info:table):table
    local transitions = array<table> {}
-   local source_transitions:array = Info.transitions
+   local source_transitions:array<table> = Info.transitions
    if source_transitions is nil then source_transitions = array<table> {} end
 
    for _, transition in ipairs(source_transitions) do

--- a/src/backstage/CMakeLists.txt
+++ b/src/backstage/CMakeLists.txt
@@ -12,24 +12,26 @@ set_module_defaults (${MOD} "Bk")
 
 target_sources (${MOD} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/${MOD}.cpp")
 
-if (NOT (ORIGO_CMD STREQUAL "ORIGO_CMD-NOTFOUND"))
-   set (BACKSTAGE_ROUTES_STAMP "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/backstage_routes.stamp")
-   set (BACKSTAGE_ROUTES_TABLE "${CMAKE_CURRENT_SOURCE_DIR}/routes.cpp")
+if (BUILD_DEFS)
+   if (NOT (ORIGO_CMD STREQUAL "ORIGO_CMD-NOTFOUND"))
+      set (BACKSTAGE_ROUTES_STAMP "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/backstage_routes.stamp")
+      set (BACKSTAGE_ROUTES_TABLE "${CMAKE_CURRENT_SOURCE_DIR}/routes.cpp")
 
-   add_custom_command (OUTPUT "${BACKSTAGE_ROUTES_STAMP}"
-      BYPRODUCTS "${BACKSTAGE_ROUTES_TABLE}"
-      COMMAND ${ORIGO_CMD} "${CMAKE_CURRENT_SOURCE_DIR}/interface.tiri" "--log-warning"
-      COMMAND ${CMAKE_COMMAND} -E touch "${BACKSTAGE_ROUTES_STAMP}"
-      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-      DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/interface.tiri"
-      COMMENT "Generating Backstage route table and missing route stubs"
-      VERBATIM)
+      add_custom_command (OUTPUT "${BACKSTAGE_ROUTES_STAMP}"
+         BYPRODUCTS "${BACKSTAGE_ROUTES_TABLE}"
+         COMMAND ${ORIGO_CMD} "${CMAKE_CURRENT_SOURCE_DIR}/interface.tiri" "--log-warning"
+         COMMAND ${CMAKE_COMMAND} -E touch "${BACKSTAGE_ROUTES_STAMP}"
+         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/interface.tiri"
+         COMMENT "Generating Backstage route table and missing route stubs"
+         VERBATIM)
 
-   add_custom_target (backstage_routes
-      DEPENDS "${BACKSTAGE_ROUTES_STAMP}"
-      SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/interface.tiri")
+      add_custom_target (backstage_routes
+         DEPENDS "${BACKSTAGE_ROUTES_STAMP}"
+         SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/interface.tiri")
 
-   add_dependencies (${MOD} backstage_routes)
+      add_dependencies (${MOD} backstage_routes)
+   endif ()
 endif ()
 
 flute_test (backstage_ping "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_backstage.tiri")

--- a/src/backstage/interface.tiri
+++ b/src/backstage/interface.tiri
@@ -441,7 +441,7 @@ function bool_literal(Value:any):str
    return Value ? 'true' :> 'false'
 end
 
-function sorted_field_names(Fields:table):array
+function sorted_field_names(Fields:table):array<string>
    names = array<string> { }
    if not Fields then return names end
 
@@ -453,7 +453,7 @@ function sorted_field_names(Fields:table):array
    return names
 end
 
-function route_param_array(Name:str, Names:array, Fields:table):str
+function route_param_array(Name:str, Names:array<string>, Fields:table):str
    out = f"static constexpr std::array<BackstageParam, {#Names}> {Name} = {{"
 
    if #Names > 0 then

--- a/src/backstage/tests/test_backstage.tiri
+++ b/src/backstage/tests/test_backstage.tiri
@@ -114,7 +114,7 @@ function websocket_frame(Payload:str, Opcode:num):str
    return frame
 end
 
-function websocket_exchange(Frames:array, ExpectedTokens:array):str
+function websocket_exchange(Frames:array<string>, ExpectedTokens:array<string>):str
    response = ''
    frames_sent = false
 

--- a/src/regex/tests/test_quantifiers.tiri
+++ b/src/regex/tests/test_quantifiers.tiri
@@ -5,7 +5,7 @@
    local lazy = regex.new("<.+?>")
    local text = "<em>bold</em>"
 
-   local match:array = greedy.search(text)
+   local match:array<array> = greedy.search(text)
    assert(match[0][0] is "<em>bold</em>", "Greedy quantifier should consume closing tag, got " .. tostring(match[0][0]))
 
    match = lazy.search(text)

--- a/src/svg/tests/test_svg.tiri
+++ b/src/svg/tests/test_svg.tiri
@@ -67,7 +67,7 @@ end
 -- an 8x8 discrete cosine transform.  Bitmap.data is an external byte-array view over the pixel buffer, so this avoids
 -- the overhead of calling a pixel reader for every source pixel.
 
-function pHash(Bitmap:obj):array
+function pHash(Bitmap:obj):array<byte>
    local sample_size <const> = 32
    local dct_size <const> = 8
    local pixels = Bitmap.data
@@ -148,7 +148,7 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-function pHashString(Hash:array):str
+function pHashString(Hash:array<byte>):str
    local result = ''
    for i in {0 to #Hash} do result ..= string.format('%d,', Hash[i]) end
    return result
@@ -156,7 +156,7 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-function pHashDistance(Left:array, Right:array):num
+function pHashDistance(Left:array<byte>, Right:array<byte>):num
    assert(#Left is #Right, 'Perceptual hashes must have the same length')
    local set_bits <const> = array<byte> { 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4 }
    local distance = 0
@@ -171,7 +171,7 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-function pHashTestSVG(Path:str, ExpectedHash:array, MaxDistance:num, Stable:bool)
+function pHashTestSVG(Path:str, ExpectedHash:array<byte>, MaxDistance:num, Stable:bool)
    local bmp = renderSVGToBitmap(glSVGFolder .. Path, Stable)
    local hash = pHash(bmp)
    local distance = pHashDistance(hash, ExpectedHash)

--- a/src/tiri/jit/src/bytecode/lj_bcread.cpp
+++ b/src/tiri/jit/src/bytecode/lj_bcread.cpp
@@ -352,13 +352,15 @@ static bool bcread_signature_uleb(const uint8_t *&Cursor, const uint8_t *End, ui
 }
 
 static void bcread_signature_entry(LexState *State, const uint8_t *&Cursor, const uint8_t *End,
-   ProtoTypeEntry &Entry)
+   ProtoTypeEntry &Entry, uint8_t Version)
 {
    if (End - Cursor < 2) bcread_error(State, ErrMsg::BCBAD);
    uint8_t type = *Cursor++;
    uint8_t flags = *Cursor++;
    uint32_t constraint = 0;
    if (not bcread_signature_uleb(Cursor, End, constraint)) bcread_error(State, ErrMsg::BCBAD);
+   uint32_t reserved = 0;
+   if (Version >= 2 and not bcread_signature_uleb(Cursor, End, reserved)) bcread_error(State, ErrMsg::BCBAD);
 
    constexpr uint8_t known_flags = PROTO_TYPE_NULLABLE | PROTO_TYPE_REQUIRED | PROTO_TYPE_ORIGIN_MASK |
       PROTO_TYPE_STRENGTH_MASK;
@@ -372,14 +374,22 @@ static void bcread_signature_entry(LexState *State, const uint8_t *&Cursor, cons
    }
 
    TiriType entry_type = TiriType(type);
-   if (constraint and entry_type != TiriType::Struct and entry_type != TiriType::Object) {
+   if (constraint and entry_type != TiriType::Struct and entry_type != TiriType::Object and
+       entry_type != TiriType::Array) {
       bcread_error(State, ErrMsg::BCBAD);
    }
+   if (entry_type IS TiriType::Array) {
+      if (Version < 2 or not reserved or reserved > uint32_t(AET::MAX)) bcread_error(State, ErrMsg::BCBAD);
+      AET member = AET(reserved - 1);
+      if ((member IS AET::STRUCT) != (constraint != 0)) bcread_error(State, ErrMsg::BCBAD);
+   }
+   else if (reserved) bcread_error(State, ErrMsg::BCBAD);
 
    Entry = ProtoTypeEntry{
       .constraint = constraint,
       .type = entry_type,
-      .flags = flags
+      .flags = flags,
+      .reserved = uint16_t(reserved)
    };
 }
 
@@ -393,7 +403,9 @@ static void bcread_signature(LexState *State, MSize Size, MSize NumParams, BCRea
    bcread_need(State, Size);
    const uint8_t *cursor = bcread_mem(State, Size);
    const uint8_t *end = cursor + Size;
-   if (end - cursor < 2 or *cursor++ != PROTO_SIGNATURE_VERSION) bcread_error(State, ErrMsg::BCBAD);
+   if (end - cursor < 2) bcread_error(State, ErrMsg::BCBAD);
+   uint8_t version = *cursor++;
+   if (version != 1 and version != PROTO_SIGNATURE_VERSION) bcread_error(State, ErrMsg::BCBAD);
 
    uint8_t flags = *cursor++;
    constexpr uint8_t known_flags = proto_signature_flag(ProtoSignatureFlag::ParameterVariadic) |
@@ -430,10 +442,10 @@ static void bcread_signature(LexState *State, MSize Size, MSize NumParams, BCRea
    Result.result_count = uint8_t(result_count);
    Result.result_entry_count = uint8_t(result_entry_count);
    for (uint32_t i = 0; i < parameter_count; ++i) {
-      bcread_signature_entry(State, cursor, end, Result.parameters[i]);
+      bcread_signature_entry(State, cursor, end, Result.parameters[i], version);
    }
    for (uint32_t i = 0; i < result_entry_count; ++i) {
-      bcread_signature_entry(State, cursor, end, Result.results[i]);
+      bcread_signature_entry(State, cursor, end, Result.results[i], version);
       if (not explicit_results and not dynamic_results and
           (proto_type_origin(Result.results[i]) != ProtoTypeOrigin::Inferred or
            proto_type_strength(Result.results[i]) != ProtoTypeStrength::Trusted)) {

--- a/src/tiri/jit/src/bytecode/lj_bcwrite.cpp
+++ b/src/tiri/jit/src/bytecode/lj_bcwrite.cpp
@@ -252,7 +252,7 @@ static MSize bcwrite_signature_size(const GCproto *Proto)
    auto entries = proto_parameter_types(Proto);
    MSize entry_count = MSize(signature->parameter_count) + signature->result_entry_count;
    for (MSize i = 0; i < entry_count; ++i) {
-      size += 2 + bcwrite_uleb128_size(entries[i].constraint);
+      size += 2 + bcwrite_uleb128_size(entries[i].constraint) + bcwrite_uleb128_size(entries[i].reserved);
    }
    return size;
 }
@@ -274,6 +274,7 @@ static char * bcwrite_signature(char *Buffer, const GCproto *Proto)
       *Buffer++ = uint8_t(entries[i].type);
       *Buffer++ = entries[i].flags;
       Buffer = lj_strfmt_wuleb128(Buffer, entries[i].constraint);
+      Buffer = lj_strfmt_wuleb128(Buffer, entries[i].reserved);
    }
    return Buffer;
 }

--- a/src/tiri/jit/src/debug/dump_bytecode.cpp
+++ b/src/tiri/jit/src/debug/dump_bytecode.cpp
@@ -323,6 +323,13 @@ static std::string signature_type_name(lua_State *L, const ProtoTypeEntry &Entry
       if (auto class_name = ResolveClassID(CLASSID(Entry.constraint))) return std::format("obj<{}>", class_name);
       return std::format("obj<#{:08x}>", Entry.constraint);
    }
+   if (Entry.type IS TiriType::Array and Entry.reserved) {
+      ArrayElementDescriptor element;
+      element.storage = proto_array_member(Entry);
+      element.known = true;
+      if (element.storage IS AET::STRUCT and Entry.constraint) element.struct_def = find_struct(L, Entry.constraint);
+      return std::format("array<{}>", array_element_name(element));
+   }
    return name;
 }
 

--- a/src/tiri/jit/src/lj_ir.h
+++ b/src/tiri/jit/src/lj_ir.h
@@ -220,7 +220,8 @@ typedef enum {
   _(STRUCT_DATA, offsetof(GCstruct, data)) \
   _(STRUCT_DEF, offsetof(GCstruct, def)) \
   _(TAB_GCONTRACTS, offsetof(GCtab, global_type_contracts)) \
-  _(OBJ_CLASSPTR, offsetof(GCobject, classptr))
+  _(OBJ_CLASSPTR, offsetof(GCobject, classptr)) \
+  _(ARRAY_STRUCTDEF, offsetof(GCarray, structdef))
 
 typedef enum {
 #define FLENUM(name, ofs)   IRFL_##name,

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -467,6 +467,34 @@ static RecordedContract rec_contract_guard_userdata(jit_State *J, TRef ValueRef,
    return rec_contract_guard_range(J, ValueRef, Value, false);
 }
 
+static RecordedContract rec_contract_guard_array(
+   jit_State *J, TRef ValueRef, cTValue *Value, const RuntimeContractEntry &Entry)
+{
+   if (not tvisarray(Value)) return RecordedContract::Mismatch;
+   if (Entry.array_element_type IS AET::ANY) return RecordedContract::Basic;
+
+   GCarray *array = arrayV(Value);
+   AET observed_element_type = array->elemtype;
+   if (Entry.array_element_type IS AET::STR_GC) {
+      if (observed_element_type != AET::STR_GC and observed_element_type != AET::CSTR and
+          observed_element_type != AET::STR_CPP) return RecordedContract::Mismatch;
+   }
+   else if (observed_element_type != Entry.array_element_type) return RecordedContract::Mismatch;
+
+   IRBuilder ir(J);
+   TRef element_type_ref = ir.fload(ValueRef, IRFL_ARRAY_ELEMTYPE, IRT_U8);
+   ir.guard_eq_int(element_type_ref, ir.kint(int32_t(observed_element_type)));
+
+   if (Entry.array_element_type IS AET::STRUCT) {
+      struct_record *definition = find_struct(J->L, Entry.constraint_name);
+      if (not definition or array->structdef != definition) return RecordedContract::Mismatch;
+      TRef definition_ref = ir.fload(ValueRef, IRFL_ARRAY_STRUCTDEF, IRT_PTR);
+      ir.guard_eq(definition_ref, ir.kkptr(definition), IRT_PTR);
+   }
+
+   return RecordedContract::Basic;
+}
+
 static RecordedContract rec_contract_record(jit_State *J, BCREG Base, GCstr *Encoded)
 {
    RuntimeContractDescriptor descriptor;
@@ -517,7 +545,7 @@ static RecordedContract rec_contract_record(jit_State *J, BCREG Base, GCstr *Enc
             if (not tvistab(value)) result = RecordedContract::Mismatch;
             break;
          case TiriType::Array:
-            if (not tvisarray(value)) result = RecordedContract::Mismatch;
+            result = rec_contract_guard_array(J, value_ref, value, *entry);
             break;
          case TiriType::Object:
             result = rec_contract_guard_object(J, value_ref, value, entry->object_class_id);
@@ -526,7 +554,7 @@ static RecordedContract rec_contract_record(jit_State *J, BCREG Base, GCstr *Enc
             result = rec_contract_guard_callable(J, value_ref, value);
             break;
          case TiriType::Struct:
-            result = rec_contract_guard_struct(J, value_ref, value, entry->struct_name);
+            result = rec_contract_guard_struct(J, value_ref, value, entry->constraint_name);
             break;
          case TiriType::Range:
             if (not tvisudata(value)) result = RecordedContract::Mismatch;

--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -153,7 +153,8 @@ private:
    }
 
    ParserResult<ParameterListResult> parse_parameter_list(bool);
-   ParserResult<Token> parse_type_annotation(TiriType &Type, struct_record *&StructDef);
+   ParserResult<Token> parse_type_annotation(
+      TiriType &Type, struct_record *&StructDef, ArrayElementDescriptor &ArrayElement);
    ParserResult<std::vector<TableField>> parse_table_fields(bool *);
    ParserResult<ExprNodeList> parse_call_arguments(bool *);
 

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -653,6 +653,8 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
 
          Token start = this->ctx.tokens().current();
          GCstr *type_str = start.payload().as_string();
+         std::string_view element_name(strdata(type_str), type_str->len);
+         if (element_name.starts_with("array<")) type_str = this->ctx.lex().keepstr("array");
          int64_t specified_size = this->ctx.lex().array_typed_size;
          this->ctx.tokens().advance();
 

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -93,11 +93,35 @@ ParserResult<ExprNodeList> AstBuilder::parse_expression_list()
 //********************************************************************************************************************
 // Parses comma-separated lists of identifiers with optional attributes (e.g., <close>).
 
-ParserResult<Token> AstBuilder::parse_type_annotation(TiriType &Type, struct_record *&StructDef)
+ParserResult<Token> AstBuilder::parse_type_annotation(
+   TiriType &Type, struct_record *&StructDef, ArrayElementDescriptor &ArrayElement)
 {
    Token type_token = this->ctx.tokens().current();
    auto kind = type_token.kind();
    std::string_view type_view;
+
+   if (kind IS TokenKind::ArrayTyped) {
+      this->ctx.tokens().advance();
+      if (this->ctx.lex().array_typed_size != -1) {
+         return this->fail<Token>(ParserErrorCode::UnexpectedToken, type_token,
+            "Array type annotations cannot declare a size");
+      }
+      GCstr *element_symbol = type_token.payload().as_string();
+      std::string_view element_name(strdata(element_symbol), element_symbol->len);
+      if (element_name.starts_with("array<")) {
+         return this->fail<Token>(ParserErrorCode::UnexpectedToken, type_token,
+            "Nested array specialisation is not supported; use array<array>");
+      }
+      auto element = describe_array_element(element_name, &this->ctx.lua());
+      if (not element or element->storage IS AET::PTR or
+          (element->storage IS AET::STRUCT and not element->struct_def)) {
+         return this->fail<Token>(ParserErrorCode::UnknownTypeName, type_token,
+            std::format("Unknown array element type '{}'", element_name));
+      }
+      Type = TiriType::Array;
+      ArrayElement = *element;
+      return ParserResult<Token>::success(type_token);
+   }
 
    if (kind IS TokenKind::StructTyped) {
       // struct<Name> lexes as a single token carrying the referenced struct name
@@ -131,6 +155,50 @@ ParserResult<Token> AstBuilder::parse_type_annotation(TiriType &Type, struct_rec
          std::format("Unknown type name '{}'; expected a valid type name", type_view));
    }
 
+   if (Type IS TiriType::Array) {
+      if (this->ctx.check(TokenKind::Less)) {
+         this->ctx.tokens().advance();
+         Token element_token = this->ctx.tokens().current();
+         std::string element_storage;
+         if (element_token.kind() IS TokenKind::StructTyped) {
+            GCstr *name = element_token.payload().as_string();
+            element_storage = std::format("struct<{}>", std::string_view(strdata(name), name->len));
+            this->ctx.tokens().advance();
+         }
+         else if (element_token.kind() IS TokenKind::ArrayTyped) {
+            return this->fail<Token>(ParserErrorCode::UnexpectedToken, element_token,
+               "Nested array specialisation is not supported; use array<array>");
+         }
+         else if (element_token.kind() IS TokenKind::Identifier) {
+            GCstr *name = element_token.identifier();
+            element_storage.assign(strdata(name), name->len);
+            this->ctx.tokens().advance();
+         }
+         else {
+            return this->fail<Token>(ParserErrorCode::ExpectedTypeName, element_token,
+               "Expected an array element type");
+         }
+
+         if (this->ctx.check(TokenKind::Comma)) {
+            return this->fail<Token>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
+               "Array type annotations cannot declare a size");
+         }
+         auto close = this->ctx.consume(TokenKind::Greater, ParserErrorCode::ExpectedToken);
+         if (not close.ok()) return ParserResult<Token>::failure(close.error_ref());
+
+         auto element = describe_array_element(element_storage, &this->ctx.lua());
+         if (not element or element->storage IS AET::PTR or
+             (element->storage IS AET::STRUCT and not element->struct_def)) {
+            return this->fail<Token>(ParserErrorCode::UnknownTypeName, element_token,
+               std::format("Unknown array element type '{}'", element_storage));
+         }
+         ArrayElement = *element;
+         return ParserResult<Token>::success(type_token);
+      }
+      return this->fail<Token>(ParserErrorCode::ExpectedTypeName, type_token,
+         "Array annotations require an element type; use array<any> for a wildcard array contract");
+   }
+
    if (Type IS TiriType::Struct and this->ctx.check(TokenKind::Less)) {
       this->ctx.tokens().advance();
       auto name_token = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
@@ -162,7 +230,8 @@ ParserResult<std::vector<Identifier>> AstBuilder::parse_name_list()
       // Parse optional type annotation (:type)
       if (this->ctx.check(TokenKind::Colon)) {
          this->ctx.tokens().advance();
-         auto parsed = this->parse_type_annotation(identifier.type, identifier.struct_def);
+         auto parsed = this->parse_type_annotation(
+            identifier.type, identifier.struct_def, identifier.array_element);
          if (not parsed.ok()) return ParserResult<Identifier>::failure(parsed.error_ref());
       }
 
@@ -225,7 +294,8 @@ ParserResult<std::vector<Identifier>> AstBuilder::parse_name_list()
       // Parse optional type annotation (:type) after attribute (supports `name <const>:type` syntax)
       if (identifier.type IS TiriType::Unknown and this->ctx.check(TokenKind::Colon)) {
          this->ctx.tokens().advance();
-         auto parsed = this->parse_type_annotation(identifier.type, identifier.struct_def);
+         auto parsed = this->parse_type_annotation(
+            identifier.type, identifier.struct_def, identifier.array_element);
          if (not parsed.ok()) return ParserResult<Identifier>::failure(parsed.error_ref());
       }
 
@@ -270,7 +340,7 @@ ParserResult<AstBuilder::ParameterListResult> AstBuilder::parse_parameter_list(b
 
          if (this->ctx.check(TokenKind::Colon)) {
             this->ctx.tokens().advance();
-            auto parsed = this->parse_type_annotation(param.type, param.struct_def);
+            auto parsed = this->parse_type_annotation(param.type, param.struct_def, param.array_element);
             if (not parsed.ok()) return ParserResult<ParameterListResult>::failure(parsed.error_ref());
             param.type_is_explicit = true;
          }
@@ -575,10 +645,12 @@ ParserResult<FunctionReturnTypes> AstBuilder::parse_return_type_annotation()
 
          TiriType parsed = TiriType::Unknown;
          struct_record *struct_def = nullptr;
-         auto type_token = this->parse_type_annotation(parsed, struct_def);
+         ArrayElementDescriptor array_element;
+         auto type_token = this->parse_type_annotation(parsed, struct_def, array_element);
          if (not type_token.ok()) return ParserResult<FunctionReturnTypes>::failure(type_token.error_ref());
          result.types[result.count] = parsed;
-         result.struct_defs[result.count++] = struct_def;
+         result.struct_defs[result.count] = struct_def;
+         result.array_elements[result.count++] = array_element;
 
       } while (this->ctx.match(TokenKind::Comma).ok());
 
@@ -588,7 +660,8 @@ ParserResult<FunctionReturnTypes> AstBuilder::parse_return_type_annotation()
       else return this->fail<FunctionReturnTypes>(ParserErrorCode::ExpectedToken, current, "expected '>' to close return type list");
    }
    else {
-      auto type_token = this->parse_type_annotation(result.types[0], result.struct_defs[0]);
+      auto type_token = this->parse_type_annotation(
+         result.types[0], result.struct_defs[0], result.array_elements[0]);
       if (not type_token.ok()) return ParserResult<FunctionReturnTypes>::failure(type_token.error_ref());
       result.count = 1;
    }

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -62,6 +62,7 @@ struct FunctionReturnTypes {
    std::array<TiriType, MAX_RETURN_TYPES> types{};  // Return types (Unknown = unused slot)
    std::array<CLASSID, MAX_RETURN_TYPES> object_class_ids{}; // Inferred object-class constraints
    std::array<struct_record *, MAX_RETURN_TYPES> struct_defs{}; // Resolved layouts for struct<Name> results
+   std::array<ArrayElementDescriptor, MAX_RETURN_TYPES> array_elements{};
    std::array<StaticValueHandle, MAX_RETURN_TYPES> descriptors{};
    uint8_t count = 0;           // Number of stored result types (0 = none)
    bool is_variadic = false;    // True if declaration ends with ... (last type repeats)
@@ -218,11 +219,13 @@ struct Identifier {
    bool is_future_reserved = false;  // True when parsed from a keyword reserved for future syntax
    TiriType type = TiriType::Unknown;  // Explicit type annotation (Unknown = no annotation)
    struct_record *struct_def = nullptr; // Resolved layout for struct<Name> annotations
+   ArrayElementDescriptor array_element{}; // Member identity for array<Element> annotations
    mutable StaticBindingID binding_id = 0;
    mutable StaticValueHandle static_value = 0;
    mutable TiriType global_contract_type = TiriType::Unknown;
    mutable CLASSID global_contract_object_class_id = CLASSID::NIL;
    mutable struct_record *global_contract_struct_def = nullptr;
+   mutable ArrayElementDescriptor global_contract_array_element{};
    mutable GlobalContractPolicy global_contract_policy = GlobalContractPolicy::Advisory;
 
    // Default constructor
@@ -294,6 +297,7 @@ struct FunctionParameter {
    Identifier name;
    TiriType type = TiriType::Any;
    struct_record *struct_def = nullptr;
+   ArrayElementDescriptor array_element{};
    bool type_is_explicit = false;
    bool is_self = false;
 };

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -150,6 +150,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_global()
       declaration.global_contract_type = TiriType::Func;
       declaration.global_contract_object_class_id = CLASSID::NIL;
       declaration.global_contract_struct_def = nullptr;
+      declaration.global_contract_array_element = {};
       declaration.global_contract_policy = GlobalContractPolicy::Enforced;
       name.segments.push_back(std::move(declaration));
       name.is_explicit_global = true;  // Mark as explicitly global

--- a/src/tiri/jit/src/parser/func_state.h
+++ b/src/tiri/jit/src/parser/func_state.h
@@ -70,6 +70,7 @@ struct FuncState {
       return arr;
    }();
    std::array<struct_record *, MAX_RETURN_TYPES> return_struct_defs{};
+   std::array<ArrayElementDescriptor, MAX_RETURN_TYPES> return_array_elements{};
    uint8_t return_declared_count = 0;
    uint8_t return_contract_count = 0;
    bool return_contract_variadic = false;

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -154,12 +154,19 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
          }
       }
 
+      ArrayElementDescriptor parameter_array = param.array_element;
+      if (not param.type_is_explicit and param.name.static_value) {
+         parameter_array = this->ctx.descriptors().value(param.name.static_value).array_element;
+      }
       uint32_t constraint = (parameter_struct and parameter_type IS TiriType::Struct) ?
          struct_key(parameter_struct->Name) : 0;
+      if (parameter_type IS TiriType::Array and parameter_array.storage IS AET::STRUCT and
+          parameter_array.struct_def) constraint = struct_key(parameter_array.struct_def->Name);
       child_state.signature_parameters.push_back(ProtoTypeEntry{
          .constraint = constraint,
          .type = parameter_type,
-         .flags = proto_type_flags(true, false, origin, strength)
+         .flags = proto_type_flags(true, false, origin, strength),
+         .reserved = parameter_type IS TiriType::Array ? proto_array_member(parameter_array.storage) : uint16_t(0)
       });
    }
 
@@ -171,12 +178,14 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
       if (param.type != TiriType::Unknown and param.type != TiriType::Any) {
          param_info.fixed_type = param.type;
          param_info.struct_def = param.struct_def;
+         param_info.array_element = param.array_element;
       }
       else if (param.name.static_value) {
          const auto &descriptor = this->ctx.descriptors().value(param.name.static_value);
          if (descriptor.primary != TiriType::Unknown and descriptor.primary != TiriType::Any) {
             param_info.fixed_type = descriptor.primary;
             param_info.struct_def = descriptor.struct_def;
+            param_info.array_element = descriptor.array_element;
          }
       }
       param_info.binding_id = param.name.binding_id;
@@ -207,6 +216,7 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
       RuntimeContract contract{
          .type = param.type,
          .struct_def = param.struct_def,
+         .array_element = param.array_element,
          .label = param.name.is_blank ? nullptr : param.name.symbol,
          .boundary = ContractBoundary::Parameter,
          .position = uint8_t(i.raw() + 1),
@@ -240,14 +250,21 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
       for (size_t i = 0; i < Payload.return_types.count and i < child_state.return_types.size(); ++i) {
          child_state.return_types[i] = Payload.return_types.types[i];
          child_state.return_struct_defs[i] = Payload.return_types.struct_defs[i];
+         child_state.return_array_elements[i] = Payload.return_types.array_elements[i];
          auto type = Payload.return_types.types[i];
          auto struct_def = Payload.return_types.struct_defs[i];
+         auto array_element = Payload.return_types.array_elements[i];
+         uint32_t constraint = (struct_def and type IS TiriType::Struct) ? struct_key(struct_def->Name) : 0;
+         if (type IS TiriType::Array and array_element.storage IS AET::STRUCT and array_element.struct_def) {
+            constraint = struct_key(array_element.struct_def->Name);
+         }
          child_state.signature_results[i] = ProtoTypeEntry{
-            .constraint = (struct_def and type IS TiriType::Struct) ? struct_key(struct_def->Name) : 0,
+            .constraint = constraint,
             .type = type,
             .flags = proto_type_flags(true, false, ProtoTypeOrigin::Declared,
                (type IS TiriType::Any or type IS TiriType::Unknown) ?
-                  ProtoTypeStrength::Advisory : ProtoTypeStrength::Checked)
+                  ProtoTypeStrength::Advisory : ProtoTypeStrength::Checked),
+            .reserved = type IS TiriType::Array ? proto_array_member(array_element.storage) : uint16_t(0)
          };
       }
    }
@@ -259,13 +276,18 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
       for (size_t i = 0; i < Payload.return_types.count and i < child_state.signature_results.size(); ++i) {
          auto type = Payload.return_types.types[i];
          auto struct_def = Payload.return_types.struct_defs[i];
+         auto array_element = Payload.return_types.array_elements[i];
          uint32_t constraint = 0;
          if (struct_def and type IS TiriType::Struct) constraint = struct_key(struct_def->Name);
          else if (type IS TiriType::Object) constraint = uint32_t(Payload.return_types.object_class_ids[i]);
+         else if (type IS TiriType::Array and array_element.storage IS AET::STRUCT and array_element.struct_def) {
+            constraint = struct_key(array_element.struct_def->Name);
+         }
          child_state.signature_results[i] = ProtoTypeEntry{
             .constraint = constraint,
             .type = type,
-            .flags = proto_type_flags(true, false, ProtoTypeOrigin::Inferred, ProtoTypeStrength::Trusted)
+            .flags = proto_type_flags(true, false, ProtoTypeOrigin::Inferred, ProtoTypeStrength::Trusted),
+            .reserved = type IS TiriType::Array ? proto_array_member(array_element.storage) : uint16_t(0)
          };
       }
    }

--- a/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
@@ -14,6 +14,7 @@
       .type = Identifier.global_contract_type,
       .object_class_id = Identifier.global_contract_object_class_id,
       .struct_def = Identifier.global_contract_struct_def,
+      .array_element = Identifier.global_contract_array_element,
       .label = Identifier.symbol,
       .boundary = ContractBoundary::Global,
       .position = 1,

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -741,6 +741,9 @@ void IrEmitter::apply_inferred_local_type(BCReg Slot, const ExprNode& Value)
    info->fixed_type = inferred.type;
    info->object_class_id = (inferred.type IS TiriType::Object) ? inferred.object_class_id : CLASSID::NIL;
    info->struct_def = inferred.struct_def;
+   if (Value.static_value) {
+      info->array_element = this->ctx.descriptors().value(Value.static_value).array_element;
+   }
    info->static_value = Value.static_value;
    info->static_results = Value.static_results;
 }
@@ -760,6 +763,7 @@ bool IrEmitter::apply_analysed_local_type(BCReg Slot, StaticBindingID Binding)
    info->fixed_type = value.primary;
    info->object_class_id = value.object_class_id;
    info->struct_def = value.struct_def;
+   info->array_element = value.array_element;
    this->assert_analysed_local_type(Slot, Binding);
    return true;
 }
@@ -776,6 +780,8 @@ void IrEmitter::assert_analysed_local_type(BCReg Slot, StaticBindingID Binding) 
    lj_assertX(info.fixed_type IS value.primary, "analysed and emitted binding types diverged");
    lj_assertX(info.object_class_id IS value.object_class_id, "analysed and emitted binding object classes diverged");
    lj_assertX(info.struct_def IS value.struct_def, "analysed and emitted binding structures diverged");
+   lj_assertX(info.array_element IS value.array_element,
+      "analysed and emitted binding array member types diverged");
 }
 
 BCReg IrEmitter::finalise_pending_local_assignment(PreparedAssignment& Target)
@@ -1104,6 +1110,7 @@ static bool fixed_return_contract_is_proved(
       RuntimeContract contract{
          .type = State.return_types[i],
          .struct_def = State.return_struct_defs[i],
+         .array_element = State.return_array_elements[i],
          .boundary = ContractBoundary::Result,
          .position = uint8_t(i + 1),
          .nullable = true,
@@ -1280,6 +1287,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
          contracts[i] = RuntimeContract{
             .type = this->func_state.return_types[i],
             .struct_def = this->func_state.return_struct_defs[i],
+            .array_element = this->func_state.return_array_elements[i],
             .label = nullptr,
             .boundary = ContractBoundary::Result,
             .position = uint8_t(i + 1),
@@ -1383,6 +1391,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
          .type = identifier.type,
          .object_class_id = variable.object_class_id,
          .struct_def = variable.struct_def ? variable.struct_def : identifier.struct_def,
+         .array_element = identifier.array_element.known ? identifier.array_element : variable.array_element,
          .label = is_blank_symbol(identifier) ? nullptr : identifier.symbol,
          .boundary = ContractBoundary::Local,
          .position = uint8_t(base.raw() + i.raw() + 1)
@@ -1444,6 +1453,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
          // Explicit type annotation takes precedence
          info->fixed_type = identifier.type;
          info->struct_def = identifier.struct_def;
+         info->array_element = identifier.array_element;
       }
       else if (this->apply_analysed_local_type(base + i, identifier.binding_id)) {
          // The analyser owns sticky fixation.  Its per-binding result covers deferred and secondary values.
@@ -2149,6 +2159,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_generic_for_stmt(const GenericForStmtPa
             variable.fixed_type = descriptor.primary;
             variable.object_class_id = descriptor.object_class_id;
             variable.struct_def = descriptor.struct_def;
+            variable.array_element = descriptor.array_element;
          }
          if (identifier.symbol and not identifier.is_blank) {
             BlockBinding binding;

--- a/src/tiri/jit/src/parser/lexer.cpp
+++ b/src/tiri/jit/src/parser/lexer.cpp
@@ -1086,14 +1086,13 @@ static LexToken lex_array_typed(LexState *State, TValue *tv)
 
    lex_skip_inline_ws(State);
 
-   // Handle nested array type: array< array<inner_type> >
-   // When the inner type is itself array<...>, skip the inner type specification.
-   // The type name "array" maps to AET::ARRAY at runtime; inner element types are
-   // determined when individual inner arrays are created.
+   // Preserve a nested array spelling so annotation parsing can reject unsupported recursive specialisation.
+   // Constructor parsing deliberately reduces it to the existing immediate array member identity.
 
    if (type_str == "array" and State->c IS '<') {
       int depth = 1;
       lex_next(State);  // Consume inner '<'
+      std::string inner;
       while (depth > 0) {
          if (State->c IS '<') depth++;
          else if (State->c IS '>') depth--;
@@ -1101,9 +1100,13 @@ static LexToken lex_array_typed(LexState *State, TValue *tv)
             lj_lex_error(State, TK_eof, ErrMsg::XTOKEN, State->token2str('>'));
             break;
          }
-         if (depth > 0) lex_next(State);
+         if (depth > 0) {
+            inner.push_back(char(State->c));
+            lex_next(State);
+         }
       }
       if (State->c IS '>') lex_next(State);  // Move past the inner closing '>'
+      nested_type = std::format("array<{}>", inner);
       lex_skip_inline_ws(State);
    }
    else if (type_str IS "struct" and State->c IS '<') {

--- a/src/tiri/jit/src/parser/lexer.h
+++ b/src/tiri/jit/src/parser/lexer.h
@@ -165,6 +165,7 @@ public:
       TiriType primary = TiriType::Unknown;
       CLASSID  object_class_id = CLASSID::NIL;
       struct_record *struct_def = nullptr;
+      ArrayElementDescriptor array_element{};
       GlobalContractPolicy contract_policy = GlobalContractPolicy::Advisory;
    };
    ankerl::unordered_dense::map<GCstr*, GlobalTypeHint> global_type_hints;

--- a/src/tiri/jit/src/parser/lexer_types.h
+++ b/src/tiri/jit/src/parser/lexer_types.h
@@ -208,6 +208,7 @@ typedef struct VarInfo {
    TiriType fixed_type;  // Type once established (Unknown = not yet fixed)
    CLASSID object_class_id = CLASSID::NIL;  // CLASSID for Object types (0 = unknown class)
    struct_record *struct_def = nullptr; // Resolved layout for struct values and callable definitions
+   ArrayElementDescriptor array_element{}; // Member identity for fixed array bindings
    BCLine line = 0;    // Line number where the variable was declared (for diagnostics)
    BCLine column = 0;  // Column number where the variable was declared (for diagnostics)
 } VarInfo;

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -597,6 +597,14 @@ static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeCo
       if (contract.struct_def) struct_name = contract.struct_def->Name;
       contract_append_text(fs, descriptor, struct_name, "runtime contract structure name");
 
+      if (contract.type IS TiriType::Array) {
+         lj_assertX(contract.array_element.known, "array runtime contracts require a member identity");
+         descriptor.push_back(char(uint8_t(contract.array_element.storage)));
+         std::string_view array_struct_name;
+         if (contract.array_element.struct_def) array_struct_name = contract.array_element.struct_def->Name;
+         contract_append_text(fs, descriptor, array_struct_name, "runtime array contract structure name");
+      }
+
       std::string_view label;
       if (contract.label and contract.label != NAME_BLANK) {
          label = std::string_view(strdata(contract.label), contract.label->len);
@@ -725,6 +733,7 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS,
          .type = vinfo->fixed_type,
          .object_class_id = vinfo->object_class_id,
          .struct_def = vinfo->struct_def,
+         .array_element = vinfo->array_element,
          .label = strref(vinfo->name),
          .boundary = ContractBoundary::Local,
          .position = uint8_t(vinfo->slot + 1)
@@ -743,6 +752,7 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS,
          .type = vinfo->fixed_type,
          .object_class_id = vinfo->object_class_id,
          .struct_def = vinfo->struct_def,
+         .array_element = vinfo->array_element,
          .label = strref(vinfo->name),
          .boundary = ContractBoundary::Upvalue,
          .position = uint8_t(LHS->u.s.info + 1)
@@ -769,6 +779,7 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS,
             .type = found->second.primary,
             .object_class_id = found->second.object_class_id,
             .struct_def = found->second.struct_def,
+            .array_element = found->second.array_element,
             .label = LHS->u.sval,
             .boundary = ContractBoundary::Global,
             .position = 1,

--- a/src/tiri/jit/src/parser/parse_types.h
+++ b/src/tiri/jit/src/parser/parse_types.h
@@ -89,6 +89,7 @@ struct RuntimeContract {
    TiriType type = TiriType::Unknown;
    CLASSID object_class_id = CLASSID::NIL;
    struct_record *struct_def = nullptr;
+   ArrayElementDescriptor array_element{};
    GCstr *label = nullptr;
    ContractBoundary boundary = ContractBoundary::Local;
    uint8_t position = 0;

--- a/src/tiri/jit/src/parser/parser_symbols.cpp
+++ b/src/tiri/jit/src/parser/parser_symbols.cpp
@@ -358,6 +358,14 @@ static std::string expression_name_to_string(const ExprNode &Expression)
    return {};
 }
 
+static std::string annotation_type_to_string(
+   TiriType Type, struct_record *StructDef, const ArrayElementDescriptor &ArrayElement)
+{
+   if (Type IS TiriType::Struct and StructDef) return std::format("struct<{}>", StructDef->Name);
+   if (Type IS TiriType::Array) return std::format("array<{}>", array_element_name(ArrayElement));
+   return type_to_string(Type);
+}
+
 static std::string build_signature(const std::string &Name, const FunctionExprPayload &Function)
 {
    std::string signature = Name + "(";
@@ -372,7 +380,7 @@ static std::string build_signature(const std::string &Name, const FunctionExprPa
       signature += identifier_to_string(param.name);
       if (param.type != TiriType::Any and param.type != TiriType::Unknown) {
          signature += ": ";
-         signature += type_to_string(param.type);
+         signature += annotation_type_to_string(param.type, param.struct_def, param.array_element);
       }
    }
 
@@ -385,13 +393,15 @@ static std::string build_signature(const std::string &Name, const FunctionExprPa
 
    if (Function.return_types.count IS 1) {
       signature += ":";
-      signature += type_to_string(Function.return_types.types[0]);
+      signature += annotation_type_to_string(Function.return_types.types[0], Function.return_types.struct_defs[0],
+         Function.return_types.array_elements[0]);
    }
    else if (Function.return_types.count > 1) {
       signature += ":<";
       for (uint8_t i = 0; i < Function.return_types.count; ++i) {
          if (i > 0) signature += ", ";
-         signature += type_to_string(Function.return_types.types[i]);
+         signature += annotation_type_to_string(Function.return_types.types[i], Function.return_types.struct_defs[i],
+            Function.return_types.array_elements[i]);
       }
       if (Function.return_types.is_variadic) signature += ", ...";
       signature += ">";
@@ -432,7 +442,7 @@ static void add_params(ParserSymbolMetadata &Symbol, const FunctionExprPayload &
 
       ParserDocParamMetadata meta;
       meta.name = identifier_to_string(param.name);
-      meta.type = type_to_string(param.type);
+      meta.type = annotation_type_to_string(param.type, param.struct_def, param.array_element);
 
       bool found = false;
       if (Doc) meta.doc = find_param_doc(*Doc, meta.name, param_index, found);
@@ -597,7 +607,8 @@ static void add_results(ParserSymbolMetadata &Symbol, const FunctionExprPayload 
          meta.inferred = inferred_type;
       }
       else if (i < result_count) {
-         meta.type = type_to_string(Function.return_types.types[i]);
+         meta.type = annotation_type_to_string(Function.return_types.types[i], Function.return_types.struct_defs[i],
+            Function.return_types.array_elements[i]);
          meta.inferred = i >= explicit_count;
       }
 

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1289,7 +1289,7 @@ static bool test_signature_metadata_roundtrip(kt::Log &Log)
       "   Value: int\n"
       "end\n"
       "local function outer(Value:num, Flexible:any, Untyped, Item:struct<SignatureLayout>, Generic:struct, "
-      "Object:obj, ...):func\n"
+      "Object:obj, Numbers:array<int>, Records:array<struct<SignatureLayout>>, ...):func\n"
       "   local function inner(Text:str):<str, num, ...>\n"
       "      return Text, Value, Value\n"
       "   end\n"
@@ -1312,7 +1312,7 @@ static bool test_signature_metadata_roundtrip(kt::Log &Log)
 
    const ProtoSignature *outer_signature = proto_signature(outer);
    const ProtoSignature *inner_signature = proto_signature(inner);
-   if (not outer_signature or outer_signature->parameter_count != 6 or outer_signature->result_count != 1 or
+   if (not outer_signature or outer_signature->parameter_count != 8 or outer_signature->result_count != 1 or
        not (outer_signature->flags & proto_signature_flag(ProtoSignatureFlag::ExplicitResults)) or
        not (outer_signature->flags & proto_signature_flag(ProtoSignatureFlag::ParameterVariadic))) {
       Log.error("outer prototype signature header is incomplete");
@@ -1327,7 +1327,11 @@ static bool test_signature_metadata_roundtrip(kt::Log &Log)
        proto_type_origin(outer_params[1]) != ProtoTypeOrigin::Declared or
        proto_type_origin(outer_params[2]) != ProtoTypeOrigin::Unspecified or
        outer_params[3].constraint != struct_key("SignatureLayout") or outer_params[4].type != TiriType::Struct or
-       outer_params[4].constraint != 0 or outer_params[5].type != TiriType::Object or outer_params[5].constraint != 0) {
+       outer_params[4].constraint != 0 or outer_params[5].type != TiriType::Object or outer_params[5].constraint != 0 or
+       outer_params[6].type != TiriType::Array or proto_array_member(outer_params[6]) != AET::INT32 or
+       outer_params[6].constraint != 0 or outer_params[7].type != TiriType::Array or
+       proto_array_member(outer_params[7]) != AET::STRUCT or
+       outer_params[7].constraint != struct_key("SignatureLayout")) {
       Log.error("outer prototype parameter entries lost type, provenance, strength or constraint data");
       return false;
    }
@@ -1871,9 +1875,11 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
    lua_State *L = state.get();
    constexpr std::string_view source =
       "extern obj\n"
+      "extern array\n"
       "function dynamic(Value:any):any return Value end\n"
       "local value = obj.new('time')\n"
-      "value = dynamic(value)\n";
+      "value = dynamic(value)\n"
+      "local numbers:array<int> = dynamic(array<int> {})\n";
    if (lua_load(L, source, "contract-roundtrip")) {
       Log.error("failed to compile contract source: %s", lua_tostring(L, -1));
       return false;
@@ -1920,9 +1926,27 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
       return false;
    };
    bool class_survived = has_time_contract(has_time_contract, restored_proto);
+   auto has_int_array_contract = [L](auto &Self, GCproto *Proto) -> bool {
+      for (uint32_t i = 1; i < Proto->sizebc; ++i) {
+         BCIns instruction = proto_bc(Proto)[i];
+         if (bc_op(instruction) != BC_CONTRACT) continue;
+         GCstr *encoded = gco_to_string(proto_kgc(Proto, ~(ptrdiff_t)bc_d(instruction)));
+         RuntimeContractDescriptor descriptor;
+         if (decode_runtime_contract(encoded, descriptor) and descriptor.contract_count > 0 and
+             descriptor.entries[0].type IS TiriType::Array and
+             descriptor.entries[0].array_element_type IS AET::INT32) return true;
+      }
+      GCRef *constant = mref<GCRef>(Proto->k) - 1;
+      for (uint32_t i = 0; i < Proto->sizekgc; ++i, --constant) {
+         GCobj *child = gcref(*constant);
+         if (child->gch.gct IS ~LJ_TPROTO and Self(Self, gco_to_proto(child))) return true;
+      }
+      return false;
+   };
+   bool array_survived = has_int_array_contract(has_int_array_contract, restored_proto);
    lua_pop(L, 1);
-   if (not class_survived) {
-      Log.error("reloaded bytecode lost the multi-byte object class constraint in BC_CONTRACT");
+   if (not class_survived or not array_survived) {
+      Log.error("reloaded bytecode lost an object or array member constraint in BC_CONTRACT");
       return false;
    }
    return true;
@@ -1941,7 +1965,8 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
       } while (Value);
    };
    auto build_descriptor = [&append_uleb](TiriType Type, CLASSID ObjectClassId,
-      std::string_view StructName, std::string_view Label, uint8_t EntryFlags) {
+      std::string_view StructName, std::string_view Label, uint8_t EntryFlags,
+      AET ArrayElementType = AET::MAX, std::string_view ArrayStructName = {}) {
       std::string result{
          char(uint8_t(ContractBoundary::Global)),
          char(0),
@@ -1954,6 +1979,11 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
       append_uleb(result, uint32_t(ObjectClassId));
       result.push_back(char(uint8_t(StructName.size())));
       result.append(StructName);
+      if (Type IS TiriType::Array) {
+         result.push_back(char(uint8_t(ArrayElementType)));
+         result.push_back(char(uint8_t(ArrayStructName.size())));
+         result.append(ArrayStructName);
+      }
       result.push_back(char(uint8_t(Label.size())));
       result.append(Label);
       return result;
@@ -1971,7 +2001,7 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
        decoded.entries[0].type != TiriType::Struct or decoded.entries[0].position != 1 or
        decoded.entries[0].object_class_id != CLASSID::NIL or
        not contract_entry_is_const(decoded.entries[0]) or
-       decoded.entries[0].struct_name != "Point" or decoded.entries[0].label != "Value") {
+       decoded.entries[0].constraint_name != "Point" or decoded.entries[0].label != "Value") {
       Log.error("valid runtime contract descriptor did not round-trip through the shared decoder");
       return false;
    }
@@ -1989,7 +2019,7 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
    if (not decode_runtime_contract(object_descriptor, object_decoded) or
        object_decoded.entries[0].type != TiriType::Object or
        object_decoded.entries[0].object_class_id != CLASSID::TIME or
-       not object_decoded.entries[0].struct_name.empty()) {
+       not object_decoded.entries[0].constraint_name.empty()) {
       Log.error("object class constraint did not round-trip through the shared decoder");
       return false;
    }
@@ -2000,6 +2030,35 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
    if (not decode_runtime_contract(broad_descriptor, object_decoded) or
        object_decoded.entries[0].object_class_id != CLASSID::NIL) {
       Log.error("broad object contract gained a class constraint while decoding");
+      return false;
+   }
+
+   std::string array_encoded = build_descriptor(
+      TiriType::Array, CLASSID::NIL, {}, "Values", const_flags, AET::INT32);
+   RuntimeContractDescriptor array_decoded;
+   GCstr *array_descriptor = lj_str_new(lua, array_encoded.data(), array_encoded.size());
+   if (not decode_runtime_contract(array_descriptor, array_decoded) or
+       array_decoded.entries[0].array_element_type != AET::INT32 or
+       not array_decoded.entries[0].constraint_name.empty()) {
+      Log.error("array member constraint did not round-trip through the shared decoder");
+      return false;
+   }
+
+   std::string struct_array_encoded = build_descriptor(
+      TiriType::Array, CLASSID::NIL, {}, "Points", const_flags, AET::STRUCT, "Point");
+   GCstr *struct_array_descriptor = lj_str_new(lua, struct_array_encoded.data(), struct_array_encoded.size());
+   if (not decode_runtime_contract(struct_array_descriptor, array_decoded) or
+       array_decoded.entries[0].array_element_type != AET::STRUCT or
+       array_decoded.entries[0].constraint_name != "Point") {
+      Log.error("named-structure array constraint did not round-trip through the shared decoder");
+      return false;
+   }
+
+   std::string legacy_broad_array = build_descriptor(
+      TiriType::Num, CLASSID::NIL, {}, "Values", const_flags);
+   legacy_broad_array[4] = char(uint8_t(TiriType::Array));
+   if (not rejected(legacy_broad_array)) {
+      Log.error("legacy broad-array contract unexpectedly satisfied the member-aware decoder");
       return false;
    }
 
@@ -2171,17 +2230,21 @@ static bool test_runtime_contract_batching(kt::Log &Log)
 
    GCproto *fragmented = compile_child(
       "struct FragmentedRecord Value: int end\n"
-      "return function(A:num, B:any, C:struct<FragmentedRecord>) return A end\n",
+      "return function(A:num, B:any, C:struct<FragmentedRecord>, "
+      "D:array<struct<FragmentedRecord>>) return A end\n",
       "fragmented-parameter-contracts");
    auto fragmented_contracts = read_contracts(fragmented, ContractBoundary::Parameter);
    const RuntimeContractCache *fragmented_cache = fragmented ? proto_contract_cache(fragmented) : nullptr;
    if (not fragmented or decode_failed or fragmented_contracts.size() != 2 or
        fragmented_contracts[0].base != 0 or fragmented_contracts[0].descriptor.contract_count != 1 or
        fragmented_contracts[0].descriptor.entries[0].position != 1 or fragmented_contracts[1].base != 2 or
-       fragmented_contracts[1].descriptor.contract_count != 1 or
+       fragmented_contracts[1].descriptor.contract_count != 2 or
        fragmented_contracts[1].descriptor.entries[0].position != 3 or
-       fragmented_contracts[1].descriptor.entries[0].struct_name != "FragmentedRecord" or
-       not fragmented_cache or fragmented_cache->record_count != 2 or fragmented_cache->entry_count != 2) {
+       fragmented_contracts[1].descriptor.entries[0].constraint_name != "FragmentedRecord" or
+       fragmented_contracts[1].descriptor.entries[1].position != 4 or
+       fragmented_contracts[1].descriptor.entries[1].array_element_type != AET::STRUCT or
+       fragmented_contracts[1].descriptor.entries[1].constraint_name != "FragmentedRecord" or
+       not fragmented_cache or fragmented_cache->record_count != 2 or fragmented_cache->entry_count != 3) {
       Log.error("an unchecked parameter gap did not split dense contract runs");
       return false;
    }
@@ -2191,10 +2254,12 @@ static bool test_runtime_contract_batching(kt::Log &Log)
    const CachedRuntimeContractRecord *fragmented_records = runtime_contract_cache_records(fragmented_cache);
    const CachedRuntimeContractEntry *fragmented_entries = runtime_contract_cache_entries(fragmented_cache);
    if (fragmented_records[0].contract_count != 1 or fragmented_records[0].entry_index != 0 or
-       fragmented_records[1].contract_count != 1 or fragmented_records[1].entry_index != 1 or
+       fragmented_records[1].contract_count != 2 or fragmented_records[1].entry_index != 1 or
        fragmented_records[0].bytecode_position >= fragmented_records[1].bytecode_position or
        fragmented_entries[0].type != TiriType::Num or fragmented_entries[0].position != 1 or
-       fragmented_entries[1].type != TiriType::Struct or fragmented_entries[1].position != 3) {
+       fragmented_entries[1].type != TiriType::Struct or fragmented_entries[1].position != 3 or
+       fragmented_entries[2].type != TiriType::Array or fragmented_entries[2].array_element_type != AET::STRUCT or
+       fragmented_entries[2].position != 4) {
       Log.error("single-entry runtime contract cache records have an invalid layout");
       return false;
    }
@@ -2207,9 +2272,11 @@ static bool test_runtime_contract_batching(kt::Log &Log)
       const char *text = strdata(fragmented_descriptor) + Offset;
       return std::string_view(text, uint8_t(text[-1]));
    };
-   if (cached_text(fragmented_entries[1].struct_offset) != "FragmentedRecord" or
-       cached_text(fragmented_entries[1].label_offset) != "C") {
-      Log.error("single-entry runtime contract cache lost rooted structure or label text");
+   if (cached_text(fragmented_entries[1].constraint_offset) != "FragmentedRecord" or
+       cached_text(fragmented_entries[2].constraint_offset) != "FragmentedRecord" or
+       cached_text(fragmented_entries[1].label_offset) != "C" or
+       cached_text(fragmented_entries[2].label_offset) != "D") {
+      Log.error("runtime contract cache lost rooted structure, array member or label text");
       return false;
    }
    lua_pop(lua, 1);
@@ -3428,6 +3495,32 @@ static bool test_static_descriptor_model(kt::Log &Log)
       return false;
    }
 
+   StaticValueDescriptor int_array{
+      .primary = TiriType::Array,
+      .array_element = { AET::INT32, TiriType::Num, CLASSID::NIL, nullptr, true },
+      .proof = StaticProof::Closed
+   };
+   RuntimeContract int_array_contract{
+      .type = TiriType::Array,
+      .array_element = { AET::INT32, TiriType::Num, CLASSID::NIL, nullptr, true }
+   };
+   if (not static_value_satisfies_contract(int_array, int_array_contract)) {
+      Log.error("an exact array member descriptor did not satisfy its matching contract");
+      return false;
+   }
+   StaticValueDescriptor string_array = int_array;
+   string_array.array_element = { AET::STR_GC, TiriType::Str, CLASSID::NIL, nullptr, true };
+   if (static_value_satisfies_contract(string_array, int_array_contract)) {
+      Log.error("a mismatched array member descriptor satisfied an exact contract");
+      return false;
+   }
+   StaticValueDescriptor joined_arrays = join_static_descriptors(int_array, string_array);
+   if (joined_arrays.primary != TiriType::Any or joined_arrays.array_element.known or
+       joined_arrays.proof != StaticProof::Advisory) {
+      Log.error("a conflicting array descriptor join did not retain an unresolved member identity");
+      return false;
+   }
+
    struct ArrayMapping {
       std::string_view name;
       AET storage;
@@ -4333,13 +4426,13 @@ static bool test_safe_index_bytecode_selection(kt::Log &Log)
    };
 
    constexpr std::string_view native_literal =
-      "local function read(Values:array):any\n"
+      "local function read(Values:array<any>):any\n"
       "   return Values?[0]\n"
       "end\n";
    if (not expect_access(native_literal, BC_ASGETB, BC_TGETB, "native-array literal-key")) passed = false;
 
    constexpr std::string_view native_variable =
-      "local function read(Values:array, Index:num):any\n"
+      "local function read(Values:array<any>, Index:num):any\n"
       "   return Values?[Index]\n"
       "end\n";
    if (not expect_access(native_variable, BC_ASGETV, BC_TGETV, "native-array variable-key")) passed = false;
@@ -4390,7 +4483,7 @@ static bool test_type_guided_emission(kt::Log &Log)
    std::string error;
    constexpr std::string_view source =
       "extern array\n"
-      "local function read(Values:array):num\n"
+      "local function read(Values:array<int>):num\n"
       "   return Values[0]\n"
       "end\n"
       "local alias = read\n"
@@ -4473,7 +4566,7 @@ static bool test_type_guided_emission(kt::Log &Log)
       "extern array\n"
       "extern obj\n"
       "struct GuidedLayout Value: int end\n"
-      "local function update_array(Values:array):num\n"
+      "local function update_array(Values:array<int>):num\n"
       "   Values[0] = Values[0] + 1\n"
       "   return Values?[0]\n"
       "end\n"

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -448,6 +448,9 @@ private:
          value.object_class_id = Function.return_types.object_class_ids[i];
          value.struct_def = Function.return_types.struct_defs[i] ?
             Function.return_types.struct_defs[i] : value.struct_def;
+         if (Function.return_types.array_elements[i].known) {
+            value.array_element = Function.return_types.array_elements[i];
+         }
          value.nullable = true;
          if (Function.return_types.is_explicit and value.primary != TiriType::Any and
              value.primary != TiriType::Unknown) {
@@ -819,11 +822,12 @@ private:
    }
 
    [[nodiscard]] StaticValueDescriptor declared_descriptor(
-      TiriType Type, struct_record *StructDef, StaticProof Proof) const
+      TiriType Type, struct_record *StructDef, const ArrayElementDescriptor &ArrayElement, StaticProof Proof) const
    {
       StaticValueDescriptor result;
       result.primary = Type;
       result.struct_def = StructDef;
+      result.array_element = ArrayElement;
       result.proof = Proof;
       result.nullable = true;
       return result;
@@ -1312,7 +1316,8 @@ private:
       StaticValueDescriptor value;
 
       if (Name.type != TiriType::Unknown and Name.type != TiriType::Any) {
-         value = this->declared_descriptor(Name.type, Name.struct_def, StaticProof::Checked);
+         value = this->declared_descriptor(
+            Name.type, Name.struct_def, Name.array_element, StaticProof::Checked);
       }
       else if (binding.function) {
          value.primary = TiriType::Func;
@@ -1387,7 +1392,7 @@ private:
             value = ContextParameters[i];
          }
          else {
-            value = this->declared_descriptor(parameter.type, parameter.struct_def,
+            value = this->declared_descriptor(parameter.type, parameter.struct_def, parameter.array_element,
                parameter.type IS TiriType::Any ? StaticProof::Advisory : StaticProof::Checked);
          }
          auto &binding = this->catalogue_.binding(parameter.name.binding_id);
@@ -1412,6 +1417,9 @@ private:
                value.object_class_id = Function.return_types.object_class_ids[i];
                value.struct_def = Function.return_types.struct_defs[i] ?
                   Function.return_types.struct_defs[i] : value.struct_def;
+               if (Function.return_types.array_elements[i].known) {
+                  value.array_element = Function.return_types.array_elements[i];
+               }
                value.nullable = true;
                value.proof = Function.return_types.is_explicit ?
                   (value.primary IS TiriType::Any ? StaticProof::Advisory : StaticProof::Checked) :
@@ -1586,7 +1594,8 @@ private:
                if (name.type IS TiriType::Any or not name.symbol) continue;
                StaticValueDescriptor value;
                if (name.type != TiriType::Unknown) {
-                  value = this->declared_descriptor(name.type, name.struct_def, StaticProof::Checked);
+                  value = this->declared_descriptor(
+                     name.type, name.struct_def, name.array_element, StaticProof::Checked);
                }
                else if (not payload.values.empty()) {
                   size_t source = std::min(i, payload.values.size() - 1);

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -3,6 +3,8 @@
 #include "static_type_descriptor.h"
 
 #include <algorithm>
+#include <format>
+#include <string>
 
 #include <kotuku/main.h>
 #include <kotuku/objects.h>
@@ -23,6 +25,83 @@ bool StaticValueDescriptor::proved() const noexcept
 {
    return this->proof IS StaticProof::Closed or this->proof IS StaticProof::Checked or
       this->proof IS StaticProof::Trusted;
+}
+
+[[nodiscard]] static AET public_array_storage(AET Storage) noexcept
+{
+   if (Storage IS AET::CSTR or Storage IS AET::STR_CPP) return AET::STR_GC;
+   return Storage;
+}
+
+bool array_element_matches(
+   const ArrayElementDescriptor &Expected, const ArrayElementDescriptor &Actual) noexcept
+{
+   if (not Expected.known or Expected.storage IS AET::ANY) return Actual.known;
+   if (not Actual.known or public_array_storage(Expected.storage) != public_array_storage(Actual.storage)) return false;
+   if (Expected.storage IS AET::STRUCT and Expected.struct_def) return Expected.struct_def IS Actual.struct_def;
+   return true;
+}
+
+ArrayElementDescriptor describe_array_element(const GCarray *Array) noexcept
+{
+   if (not Array) return {};
+   ArrayElementDescriptor result;
+   result.storage = public_array_storage(Array->elemtype);
+   result.logical_type = TiriType::Any;
+   result.struct_def = Array->elemtype IS AET::STRUCT ? Array->structdef : nullptr;
+   result.known = true;
+   switch (result.storage) {
+      case AET::BYTE:
+      case AET::INT16:
+      case AET::INT32:
+      case AET::INT64:
+      case AET::FLOAT:
+      case AET::DOUBLE: result.logical_type = TiriType::Num; break;
+      case AET::STR_GC: result.logical_type = TiriType::Str; break;
+      case AET::TABLE:  result.logical_type = TiriType::Table; break;
+      case AET::ARRAY:  result.logical_type = TiriType::Array; break;
+      case AET::OBJECT: result.logical_type = TiriType::Object; break;
+      case AET::STRUCT: result.logical_type = TiriType::Struct; break;
+      case AET::PTR:
+      case AET::ANY:    break;
+      case AET::CSTR:
+      case AET::STR_CPP:
+      case AET::MAX: break;
+   }
+   return result;
+}
+
+bool array_element_matches(const ArrayElementDescriptor &Expected, const GCarray *Actual) noexcept
+{
+   return array_element_matches(Expected, describe_array_element(Actual));
+}
+
+std::string array_element_name(const ArrayElementDescriptor &Element)
+{
+   if (not Element.known) return "array";
+   std::string_view name = "any";
+   switch (public_array_storage(Element.storage)) {
+      case AET::BYTE:   name = "byte"; break;
+      case AET::INT16:  name = "int16"; break;
+      case AET::INT32:  name = "int"; break;
+      case AET::INT64:  name = "int64"; break;
+      case AET::FLOAT:  name = "float"; break;
+      case AET::DOUBLE: name = "double"; break;
+      case AET::STR_GC: name = "string"; break;
+      case AET::TABLE:  name = "table"; break;
+      case AET::ARRAY:  name = "array"; break;
+      case AET::OBJECT: name = "object"; break;
+      case AET::PTR:    name = "pointer"; break;
+      case AET::ANY:    name = "any"; break;
+      case AET::STRUCT:
+         if (Element.struct_def) return std::format("struct<{}>", Element.struct_def->Name);
+         name = "struct";
+         break;
+      case AET::CSTR:
+      case AET::STR_CPP:
+      case AET::MAX: break;
+   }
+   return std::string(name);
 }
 
 StaticValueDescriptor StaticResultSet::value_at(size_t Position) const
@@ -162,7 +241,17 @@ StaticValueDescriptor join_static_descriptors(
    if (Left.object_class_id != Right.object_class_id) result.object_class_id = CLASSID::NIL;
    if (Left.struct_def != Right.struct_def) result.struct_def = nullptr;
    if (Left.module != Right.module) result.module = nullptr;
-   if (not (Left.array_element IS Right.array_element)) result.array_element = {};
+   if (Left.primary IS TiriType::Array and not (Left.array_element IS Right.array_element)) {
+      if (Left.array_element.known and Right.array_element.known and
+          (Left.array_element.storage IS AET::ANY or Right.array_element.storage IS AET::ANY)) {
+         result.array_element = { AET::ANY, TiriType::Any, CLASSID::NIL, nullptr, true };
+      }
+      else {
+         result.primary = TiriType::Any;
+         result.array_element = {};
+         result.proof = StaticProof::Advisory;
+      }
+   }
    return result;
 }
 
@@ -213,6 +302,8 @@ bool static_value_satisfies_contract(
             Value.object_class_id IS Contract.object_class_id;
       case TiriType::Struct:
          return not Contract.struct_def or Value.struct_def IS Contract.struct_def;
+      case TiriType::Array:
+         return array_element_matches(Contract.array_element, Value.array_element);
       default:
          return true;
    }

--- a/src/tiri/jit/src/parser/static_type_descriptor.h
+++ b/src/tiri/jit/src/parser/static_type_descriptor.h
@@ -43,6 +43,12 @@ struct ArrayElementDescriptor {
    [[nodiscard]] bool operator==(const ArrayElementDescriptor &) const = default;
 };
 
+[[nodiscard]] bool array_element_matches(
+   const ArrayElementDescriptor &Expected, const ArrayElementDescriptor &Actual) noexcept;
+[[nodiscard]] bool array_element_matches(const ArrayElementDescriptor &Expected, const GCarray *Actual) noexcept;
+[[nodiscard]] ArrayElementDescriptor describe_array_element(const GCarray *) noexcept;
+[[nodiscard]] std::string array_element_name(const ArrayElementDescriptor &);
+
 struct StaticValueDescriptor {
    TiriType primary = TiriType::Unknown;
    CLASSID object_class_id = CLASSID::NIL;

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -149,6 +149,10 @@
          return std::format("parameter {} has struct type '{}', expected '{}'",
             i + 1, actual_name, expected_name);
       }
+      if (not (expected.array_element IS actual.array_element)) {
+         return std::format("parameter {} has array type 'array<{}>', expected 'array<{}>'", i + 1,
+            array_element_name(actual.array_element), array_element_name(expected.array_element));
+      }
    }
 
    const FunctionReturnTypes &expected_results = Expected.return_types;
@@ -184,6 +188,11 @@
             actual_results.struct_defs[i]->Name : "struct";
          return std::format("return {} has struct type '{}', expected '{}'",
             i + 1, actual_name, expected_name);
+      }
+      if (not (expected_results.array_elements[i] IS actual_results.array_elements[i])) {
+         return std::format("return {} has array type 'array<{}>', expected 'array<{}>'", i + 1,
+            array_element_name(actual_results.array_elements[i]),
+            array_element_name(expected_results.array_elements[i]));
       }
    }
 
@@ -261,7 +270,7 @@ private:
 
    // Argument type checking for function calls
    void check_arguments(const FunctionExprPayload &, const CallExprPayload &);
-   void check_argument_type(const ExprNode &, TiriType, size_t);
+   void check_argument_type(const ExprNode &, const FunctionParameter &, size_t);
 
    // Type inference - determines types from expressions and context
    [[nodiscard]] InferredType infer_expression_type(const ExprNode &);
@@ -279,7 +288,7 @@ private:
 
    // Type fixation - locks variable type after first concrete assignment
    void fix_local_type(GCstr *, StaticBindingID, TiriType, CLASSID ObjectClassId = CLASSID::NIL,
-      struct_record *StructDef = nullptr);
+      struct_record *StructDef = nullptr, ArrayElementDescriptor ArrayElement = {});
    void publish_binding_type(StaticBindingID, const InferredType &);
 
    // Usage tracking - marks variables as used for unused variable detection
@@ -384,7 +393,7 @@ private:
    [[nodiscard]] bool is_global_const(GCstr *Name) const;
    [[nodiscard]] bool is_implicit_global(GCstr *Name) const;
    void fix_global_type(GCstr *Name, TiriType Type, CLASSID ObjectClassId = CLASSID::NIL,
-      struct_record *StructDef = nullptr);
+      struct_record *StructDef = nullptr, ArrayElementDescriptor ArrayElement = {});
    void mark_dynamic_ingress(GCstr *Name, bool IsGlobal);
    void degrade_global_type(GCstr *Name);
    void invalidate_global_flow_policy(GCstr *Name, SourceSpan Location);
@@ -710,6 +719,7 @@ void TypeAnalyser::leave_function()
                published.types[i] = position.concrete.primary;
                published.object_class_ids[i] = position.concrete.object_class_id;
                published.struct_defs[i] = position.concrete.struct_def;
+               published.array_elements[i] = position.concrete.array_element;
             }
          }
       }
@@ -1598,6 +1608,18 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
                   value_type.struct_def->Name, existing->struct_def->Name);
                this->record_diagnostic(std::move(diag));
             }
+            else if (existing->primary IS TiriType::Array and value_type.primary IS TiriType::Array and
+                value_type.array_element.known and
+                not array_element_matches(existing->array_element, value_type.array_element)) {
+               TypeDiagnostic diag;
+               diag.location = target.span;
+               diag.expected = TiriType::Array;
+               diag.actual = TiriType::Array;
+               diag.code = ParserErrorCode::TypeMismatchAssignment;
+               diag.message = std::format("array member mismatch: expected array<{}>, got array<{}>",
+                  array_element_name(existing->array_element), array_element_name(value_type.array_element));
+               this->record_diagnostic(std::move(diag));
+            }
          }
          else {
             // Unfixed variable: first non-nil assignment fixes the type
@@ -1608,11 +1630,12 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
             }
             else if ((existing->primary != TiriType::Any) and (value_type.primary != TiriType::Nil)) {
                if (is_global) {
-                  this->fix_global_type(name, value_type.primary, value_type.object_class_id, value_type.struct_def);
+                  this->fix_global_type(name, value_type.primary, value_type.object_class_id, value_type.struct_def,
+                     value_type.array_element);
                }
                else {
                   this->fix_local_type(name, name_ref->binding_id, value_type.primary,
-                     value_type.object_class_id, value_type.struct_def);
+                     value_type.object_class_id, value_type.struct_def, value_type.array_element);
                }
             }
          }
@@ -1656,6 +1679,7 @@ void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
          // We have an explicit value at this position
          const ExprNode& value_expr = *Payload.values[value_index];
          value_type = this->infer_expression_type(value_expr);
+         value_type = this->refine_static_expression_type(value_expr, value_type);
          have_value_type = true;
          initialiser = &value_expr;
 
@@ -1683,6 +1707,7 @@ void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
       if (name.type != TiriType::Unknown) {
          inferred.primary = name.type;
          inferred.struct_def = name.struct_def;
+         inferred.array_element = name.array_element;
          // 'any' type is not fixed - it accepts any value
          inferred.is_fixed = (name.type != TiriType::Any);
 
@@ -1714,6 +1739,18 @@ void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
                diag.code = ParserErrorCode::TypeMismatchAssignment;
                diag.message = std::format("struct layout mismatch: cannot assign '{}' to '{}'",
                   value_type.struct_def->Name, name.struct_def->Name);
+               this->record_diagnostic(std::move(diag));
+            }
+            else if (name.type IS TiriType::Array and value_type.primary IS TiriType::Array and
+                value_type.array_element.known and
+                not array_element_matches(name.array_element, value_type.array_element)) {
+               TypeDiagnostic diag;
+               diag.location = initialiser ? initialiser->span : name.span;
+               diag.expected = TiriType::Array;
+               diag.actual = TiriType::Array;
+               diag.code = ParserErrorCode::TypeMismatchAssignment;
+               diag.message = std::format("array member mismatch: expected array<{}>, got array<{}>",
+                  array_element_name(name.array_element), array_element_name(value_type.array_element));
                this->record_diagnostic(std::move(diag));
             }
          }
@@ -1868,6 +1905,7 @@ void TypeAnalyser::discover_global_decl_policy(const GlobalDeclStmtPayload &Payl
       if (value_index < Payload.values.size()) {
          const ExprNode &value_expr = *Payload.values[value_index];
          value_type = this->infer_expression_type(value_expr);
+         value_type = this->refine_static_expression_type(value_expr, value_type);
          have_value_type = true;
 
          if (value_index IS Payload.values.size() - 1 and
@@ -1891,6 +1929,7 @@ void TypeAnalyser::discover_global_decl_policy(const GlobalDeclStmtPayload &Payl
       if (name.type != TiriType::Unknown) {
          inferred.primary = name.type;
          inferred.struct_def = name.struct_def;
+         inferred.array_element = name.array_element;
          inferred.is_fixed = (name.type != TiriType::Any);
       }
       else if (have_value_type) {
@@ -1917,11 +1956,13 @@ void TypeAnalyser::discover_global_decl_policy(const GlobalDeclStmtPayload &Payl
       name.global_contract_object_class_id = inferred.primary IS TiriType::Object ?
          inferred.object_class_id : CLASSID::NIL;
       name.global_contract_struct_def = inferred.struct_def;
+      name.global_contract_array_element = inferred.array_element;
       name.global_contract_policy = contract_policy;
       if (name.has_const and not inferred.is_fixed) {
          name.global_contract_type = TiriType::Any;
          name.global_contract_object_class_id = CLASSID::NIL;
          name.global_contract_struct_def = nullptr;
+         name.global_contract_array_element = {};
          name.global_contract_policy = GlobalContractPolicy::Enforced;
       }
       if (PublishStaticPolicy) this->declare_global(name.symbol, inferred, name.span, name.has_const, contract_policy);
@@ -2353,7 +2394,7 @@ void TypeAnalyser::check_arguments(const FunctionExprPayload &Function, const Ca
    size_t param_index = 0;
    for (const auto &param : Function.parameters) {
       if (param_index >= Call.arguments.size()) break;
-      this->check_argument_type(*Call.arguments[param_index], param.type, param_index);
+      this->check_argument_type(*Call.arguments[param_index], param, param_index);
       param_index += 1;
    }
 }
@@ -2361,19 +2402,27 @@ void TypeAnalyser::check_arguments(const FunctionExprPayload &Function, const Ca
 //********************************************************************************************************************
 // Check a single argument against its expected type, reporting diagnostics for mismatches.
 
-void TypeAnalyser::check_argument_type(const ExprNode& Argument, TiriType Expected, size_t Index)
+void TypeAnalyser::check_argument_type(
+   const ExprNode& Argument, const FunctionParameter &Parameter, size_t Index)
 {
+   TiriType Expected = Parameter.type;
    if (Expected IS TiriType::Any) return;
 
    InferredType actual = this->infer_expression_type(Argument);
 
-   if (not actual.matches(Expected)) {
+   bool member_matches = Expected != TiriType::Array or actual.primary != TiriType::Array or
+      not actual.array_element.known or array_element_matches(Parameter.array_element, actual.array_element);
+   if (not actual.matches(Expected) or not member_matches) {
       TypeDiagnostic diag;
       diag.location = Argument.span;
       diag.expected = Expected;
       diag.actual = actual.primary;
       diag.code = ParserErrorCode::TypeMismatchArgument;
-      diag.message = std::format("type mismatch: argument {} expects '{}', got '{}'",
+      if (Expected IS TiriType::Array and actual.primary IS TiriType::Array) {
+         diag.message = std::format("type mismatch: argument {} expects array<{}>, got array<{}>", Index + 1,
+            array_element_name(Parameter.array_element), array_element_name(actual.array_element));
+      }
+      else diag.message = std::format("type mismatch: argument {} expects '{}', got '{}'",
          Index + 1, type_name(Expected), type_name(actual.primary));
       this->record_diagnostic(std::move(diag));
    }
@@ -2449,6 +2498,7 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                result.primary = target->return_types.types[0];
                result.object_class_id = target->return_types.object_class_ids[0];
                result.struct_def = target->return_types.struct_defs[0];
+               result.array_element = target->return_types.array_elements[0];
                payload->struct_def = result.struct_def;
                return result;
             }
@@ -2460,6 +2510,9 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                   result.object_class_id = payload->object_class_id;
                }
                result.struct_def = payload->struct_def;
+               if (result.primary IS TiriType::Array and Expr.static_value) {
+                  result.array_element = this->ctx_.descriptors().value(Expr.static_value).array_element;
+               }
                if ((result.primary IS TiriType::Struct or result.primary IS TiriType::Func) and
                    not result.struct_def and not payload->arguments.empty()) {
                   const auto *literal = std::get_if<LiteralValue>(&payload->arguments[0]->data);
@@ -2478,6 +2531,7 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                   result.is_nullable = descriptor.nullable;
                   result.object_class_id = descriptor.object_class_id;
                   result.struct_def = descriptor.struct_def;
+                  result.array_element = descriptor.array_element;
                   return result;
                }
             }
@@ -2493,6 +2547,7 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                result.is_nullable = descriptor.nullable;
                result.object_class_id = descriptor.object_class_id;
                result.struct_def = descriptor.struct_def;
+               result.array_element = descriptor.array_element;
                return result;
             }
          }
@@ -2742,20 +2797,27 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
 
 InferredType TypeAnalyser::refine_static_expression_type(const ExprNode &Expr, InferredType Type) const
 {
-   if ((Type.primary != TiriType::Any and Type.primary != TiriType::Unknown) or not Expr.static_value) return Type;
+   if (not Expr.static_value) return Type;
+
+   const StaticValueDescriptor &descriptor = this->ctx_.descriptors().value(Expr.static_value);
+   if (Type.primary IS TiriType::Array and descriptor.primary IS TiriType::Array) {
+      Type.array_element = descriptor.array_element;
+      return Type;
+   }
+   if (Type.primary != TiriType::Any and Type.primary != TiriType::Unknown) return Type;
 
    if (Expr.kind IS AstNodeKind::IdentifierExpr) {
       const auto &reference = std::get<NameRef>(Expr.data);
       if (reference.binding_id and this->explicit_variant_bindings_.contains(reference.binding_id)) return Type;
    }
 
-   const StaticValueDescriptor &descriptor = this->ctx_.descriptors().value(Expr.static_value);
    if (descriptor.primary IS TiriType::Unknown or descriptor.primary IS TiriType::Any) return Type;
 
    Type.primary = descriptor.primary;
    Type.is_nullable = descriptor.nullable;
    Type.object_class_id = descriptor.object_class_id;
    Type.struct_def = descriptor.struct_def;
+   Type.array_element = descriptor.array_element;
    Type.is_fixed = true;
    return Type;
 }
@@ -2796,6 +2858,7 @@ bool TypeAnalyser::is_explicit_variant_expression(const ExprNode &Expr, size_t P
       result.is_nullable = descriptor.nullable;
       result.object_class_id = descriptor.object_class_id;
       result.struct_def = descriptor.struct_def;
+      result.array_element = descriptor.array_element;
       return result;
    }
 
@@ -2823,6 +2886,7 @@ bool TypeAnalyser::is_explicit_variant_expression(const ExprNode &Expr, size_t P
       result.primary = type;
       result.object_class_id = target->return_types.object_class_ids[type_position];
       result.struct_def = target->return_types.struct_defs[type_position];
+      result.array_element = target->return_types.array_elements[type_position];
    }
 
    return result;
@@ -2933,20 +2997,22 @@ void TypeAnalyser::publish_binding_type(StaticBindingID Binding, const InferredT
    value.primary = Type.primary;
    value.object_class_id = Type.object_class_id;
    value.struct_def = Type.struct_def;
+   value.array_element = Type.array_element;
    value.nullable = Type.is_nullable;
    value.proof = StaticProof::Advisory;
    this->ctx_.descriptors().binding(Binding).analysed_value = this->ctx_.descriptors().add_value(value);
 }
 
 void TypeAnalyser::fix_local_type(GCstr *Name, StaticBindingID Binding, TiriType Type,
-   CLASSID ObjectClassId, struct_record *StructDef)
+   CLASSID ObjectClassId, struct_record *StructDef, ArrayElementDescriptor ArrayElement)
 {
    for (auto it = this->scope_stack_.rbegin(); it != this->scope_stack_.rend(); ++it) {
       auto existing = it->lookup_local_type(Name);
       if (existing) {
-         it->fix_local_type(Name, Type, ObjectClassId, StructDef);
+         it->fix_local_type(Name, Type, ObjectClassId, StructDef, ArrayElement);
          InferredType fixed(Type, false, false, true, ObjectClassId);
          fixed.struct_def = StructDef;
+         fixed.array_element = ArrayElement;
          this->publish_binding_type(Binding, fixed);
          this->trace_fix(this->ctx_.lex().linenumber, Name, Type);
          return;
@@ -3116,7 +3182,8 @@ void TypeAnalyser::invalidate_global_flow_policy(GCstr *Name, SourceSpan Locatio
    this->trace_decl(this->ctx_.lex().linenumber, Name, TiriType::Any, true);
 }
 
-void TypeAnalyser::fix_global_type(GCstr *Name, TiriType Type, CLASSID ObjectClassId, struct_record *StructDef)
+void TypeAnalyser::fix_global_type(GCstr *Name, TiriType Type, CLASSID ObjectClassId, struct_record *StructDef,
+   ArrayElementDescriptor ArrayElement)
 {
    if (not Name) return;
    if (auto it = this->global_types_.find(Name); it != this->global_types_.end()) {
@@ -3124,6 +3191,7 @@ void TypeAnalyser::fix_global_type(GCstr *Name, TiriType Type, CLASSID ObjectCla
       it->second.type.is_fixed = true;
       it->second.type.object_class_id = ObjectClassId;
       it->second.type.struct_def = StructDef;
+      it->second.type.array_element = ArrayElement;
       if (not it->second.implicit) it->second.contract_policy = GlobalContractPolicy::Enforced;
       this->trace_fix(this->ctx_.lex().linenumber, Name, Type);
    }
@@ -3198,7 +3266,10 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
 
          const bool struct_matches = expected != TiriType::Struct or not ctx->expected_returns.struct_defs[i] or
             actual.struct_def IS ctx->expected_returns.struct_defs[i];
-         if (actual.primary != expected or not struct_matches) {
+         const bool array_matches = expected != TiriType::Array or actual.primary != TiriType::Array or
+            not actual.array_element.known or
+            array_element_matches(ctx->expected_returns.array_elements[i], actual.array_element);
+         if (actual.primary != expected or not struct_matches or not array_matches) {
             TypeDiagnostic diag;
             diag.location = expression.span;
             diag.expected = expected;
@@ -3257,7 +3328,9 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
             actual.object_class_id IS position.concrete.object_class_id;
          const bool struct_matches = position.concrete.primary != TiriType::Struct or
             not position.concrete.struct_def or actual.struct_def IS position.concrete.struct_def;
-         if (type_matches and class_matches and struct_matches) continue;
+         const bool array_matches = position.concrete.primary != TiriType::Array or
+            array_element_matches(position.concrete.array_element, actual.array_element);
+         if (type_matches and class_matches and struct_matches and array_matches) continue;
 
          TypeDiagnostic diag;
          diag.location = expression.span;
@@ -3583,20 +3656,21 @@ void TypeAnalyser::publish_global_type_hints(LexState &Lex) const
    for (const auto &[name, info] : this->global_types_) {
       if (info.contract_policy IS GlobalContractPolicy::Variant) {
          Lex.global_type_hints[name] = {
-            TiriType::Any, CLASSID::NIL, nullptr, GlobalContractPolicy::Variant
+            TiriType::Any, CLASSID::NIL, nullptr, {}, GlobalContractPolicy::Variant
          };
          continue;
       }
       if (info.is_const and not info.type.is_fixed) {
          Lex.global_type_hints[name] = {
-            TiriType::Any, CLASSID::NIL, nullptr, GlobalContractPolicy::Enforced
+            TiriType::Any, CLASSID::NIL, nullptr, {}, GlobalContractPolicy::Enforced
          };
          continue;
       }
       if (not info.type.is_fixed) continue;
       if (info.contract_policy IS GlobalContractPolicy::Enforced) {
          Lex.global_type_hints[name] = {
-            info.type.primary, info.type.object_class_id, info.type.struct_def, GlobalContractPolicy::Enforced
+            info.type.primary, info.type.object_class_id, info.type.struct_def, info.type.array_element,
+            GlobalContractPolicy::Enforced
          };
          continue;
       }
@@ -3605,7 +3679,8 @@ void TypeAnalyser::publish_global_type_hints(LexState &Lex) const
          case TiriType::Object:
          case TiriType::Array:
             Lex.global_type_hints[name] = {
-               info.type.primary, info.type.object_class_id, info.type.struct_def, GlobalContractPolicy::Advisory
+               info.type.primary, info.type.object_class_id, info.type.struct_def, info.type.array_element,
+               GlobalContractPolicy::Advisory
             };
             break;
          default:

--- a/src/tiri/jit/src/parser/type_checker.cpp
+++ b/src/tiri/jit/src/parser/type_checker.cpp
@@ -64,7 +64,8 @@ const FunctionExprPayload* TypeCheckScope::lookup_function(GCstr *Name) const
    return nullptr;
 }
 
-void TypeCheckScope::fix_local_type(GCstr *Name, TiriType Type, CLASSID ObjectClassId, struct_record *StructDef)
+void TypeCheckScope::fix_local_type(GCstr *Name, TiriType Type, CLASSID ObjectClassId, struct_record *StructDef,
+   ArrayElementDescriptor ArrayElement)
 {
    for (auto it = this->variables_.rbegin(); it != this->variables_.rend(); ++it) {
       if (it->name IS Name and not it->is_parameter) {
@@ -72,6 +73,7 @@ void TypeCheckScope::fix_local_type(GCstr *Name, TiriType Type, CLASSID ObjectCl
          it->type.is_fixed = true;
          it->type.object_class_id = ObjectClassId;
          it->type.struct_def = StructDef;
+         it->type.array_element = ArrayElement;
          return;
       }
    }

--- a/src/tiri/jit/src/parser/type_checker.h
+++ b/src/tiri/jit/src/parser/type_checker.h
@@ -15,6 +15,7 @@ struct InferredType {
    bool requires_destination_type = false; // Dynamic ingress cannot be replaced by a concrete type without annotation
    CLASSID object_class_id = CLASSID::NIL;  // CLASSID for Object types
    struct_record *struct_def = nullptr; // Resolved layout for Struct types and definition callables
+   ArrayElementDescriptor array_element{};
 
    InferredType() = default;
    explicit InferredType(TiriType Primary, bool IsConstant = false, bool IsNullable = false, bool IsFixed = false,
@@ -96,7 +97,7 @@ public:
    void declare_local(GCstr *, const InferredType &, SourceSpan Location = {}, bool IsConst = false);
    void declare_function(GCstr *, const FunctionExprPayload *, SourceSpan Location = {});
    void fix_local_type(GCstr *, TiriType Type, CLASSID ObjectClassId = CLASSID::NIL,
-      struct_record *StructDef = nullptr);
+      struct_record *StructDef = nullptr, ArrayElementDescriptor ArrayElement = {});
    void mark_dynamic_ingress(GCstr *);
 
    // Mark a variable as used (called when variable is referenced)

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -204,9 +204,11 @@ static uint64_t array_unsigned_integer(lua_Number Value, unsigned Bits)
 
 static LJ_AINLINE void array_store_int32(void *Element, cTValue *Value)
 {
-   uint32_t bits;
-   auto result = array_prepare_int32(Value, &bits);
-   lj_assertX(result IS ArrayElementResult::OK, "invalid prepared int32 array value");
+   uint32_t bits = 0;
+   if (array_prepare_int32(Value, &bits) != ArrayElementResult::OK) {
+      lj_assertX(false, "invalid prepared int32 array value");
+      return;
+   }
    std::memcpy(Element, &bits, sizeof(bits));
 }
 

--- a/src/tiri/jit/src/runtime/lj_contract.h
+++ b/src/tiri/jit/src/runtime/lj_contract.h
@@ -45,10 +45,11 @@ enum class ContractEntryFlag : uint8_t {
 
 struct RuntimeContractEntry {
    TiriType type = TiriType::Unknown;
+   AET array_element_type = AET::MAX;
    uint8_t flags = 0;
    uint8_t position = 0;
    CLASSID object_class_id = CLASSID::NIL;
-   std::string_view struct_name;
+   std::string_view constraint_name; // Named structure, or the structure member of array<struct<Name>>.
    std::string_view label;
 };
 
@@ -84,10 +85,11 @@ struct RuntimeContractDescriptor {
 struct CachedRuntimeContractEntry {
    union {
       uint32_t object_class_id;
-      uint16_t struct_offset;
+      uint16_t constraint_offset; // Structure or array-member structure name, selected by type.
    };
    uint16_t label_offset;
    TiriType type;
+   AET array_element_type;
    uint8_t flags;
    uint8_t position;
 };
@@ -123,6 +125,7 @@ struct GlobalContractCache {
    uint32_t reserved;
 };
 
+static_assert(sizeof(RuntimeContractEntry) IS 40, "runtime contract entries must remain compact");
 static_assert(sizeof(CachedRuntimeContractEntry) IS 12, "cached runtime contract entries must remain compact");
 static_assert(sizeof(CachedRuntimeContractRecord) IS 12, "cached runtime contract records must remain compact");
 static_assert(sizeof(RuntimeContractCache) IS 8, "runtime contract cache header must remain compact");
@@ -295,6 +298,8 @@ private:
       auto &entry = Result.entries[i];
       uint8_t type;
       uint32_t object_class_id = 0;
+      std::string_view struct_name;
+      std::string_view array_struct_name;
       uint8_t allowed_entry_flags = contract_flag(ContractEntryFlag::Nullable) |
          contract_flag(ContractEntryFlag::Required) | contract_flag(ContractEntryFlag::Const) |
          contract_flag(ContractEntryFlag::Initialising) | contract_flag(ContractEntryFlag::GlobalHint);
@@ -303,11 +308,22 @@ private:
           (entry.flags & ~allowed_entry_flags) != 0 or
           not reader.read_byte(entry.position) or entry.position IS 0 or
           not reader.read_uleb32(object_class_id) or
-          not reader.read_text(entry.struct_name) or not reader.read_text(entry.label)) {
+          not reader.read_text(struct_name)) {
          return fail(RuntimeContractDecodeError::Entry);
       }
       entry.type = TiriType(type);
-      entry.object_class_id = CLASSID(object_class_id);
+      entry.array_element_type = AET::MAX;
+      entry.object_class_id = CLASSID::NIL;
+      entry.constraint_name = {};
+      if (entry.type IS TiriType::Array) {
+         uint8_t array_element_type;
+         if (not reader.read_byte(array_element_type) or array_element_type >= uint8_t(AET::MAX) or
+             not reader.read_text(array_struct_name)) {
+            return fail(RuntimeContractDecodeError::Entry);
+         }
+         entry.array_element_type = AET(array_element_type);
+      }
+      if (not reader.read_text(entry.label)) return fail(RuntimeContractDecodeError::Entry);
       bool is_const = contract_entry_is_const(entry);
       bool is_initialising = contract_entry_is_initialising(entry);
       bool is_global_hint = contract_entry_is_global_hint(entry);
@@ -319,12 +335,21 @@ private:
               is_initialising))) {
          return fail(RuntimeContractDecodeError::Entry);
       }
-      if (not entry.struct_name.empty() and entry.type != TiriType::Struct) {
+      if (not struct_name.empty() and entry.type != TiriType::Struct) {
          return fail(RuntimeContractDecodeError::Entry);
       }
-      if (entry.object_class_id != CLASSID::NIL and entry.type != TiriType::Object) {
+      if (object_class_id != uint32_t(CLASSID::NIL) and entry.type != TiriType::Object) {
          return fail(RuntimeContractDecodeError::Entry);
       }
+      if (entry.type IS TiriType::Array) {
+         if (entry.array_element_type IS AET::STRUCT) {
+            if (array_struct_name.empty()) return fail(RuntimeContractDecodeError::Entry);
+         }
+         else if (not array_struct_name.empty()) return fail(RuntimeContractDecodeError::Entry);
+      }
+      if (entry.type IS TiriType::Object) entry.object_class_id = CLASSID(object_class_id);
+      else if (entry.type IS TiriType::Struct) entry.constraint_name = struct_name;
+      else if (entry.type IS TiriType::Array) entry.constraint_name = array_struct_name;
    }
 
    if (not reader.at_end()) return fail(RuntimeContractDecodeError::Descriptor);

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -646,7 +646,8 @@ void lj_meta_istype(lua_State *L, BCREG ra, BCREG tp)
 //
 //   boundary, descriptor_flags, static_value_count, contract_count,
 //   repeated { type, entry_flags, position, object_class_id_uleb32,
-//              struct_name_length, struct_name_bytes, label_length, label_bytes }
+//              struct_name_length, struct_name_bytes, optional array member and structure name,
+//              label_length, label_bytes }
 
 namespace {
 
@@ -674,6 +675,20 @@ namespace {
    return not contract_is_range(L, Value);
 }
 
+[[nodiscard]] static bool contract_array_element_matches(
+   lua_State *L, const GCarray *Array, const RuntimeContractEntry &Entry)
+{
+   if (Entry.array_element_type IS AET::ANY) return true;
+   AET actual = Array->elemtype;
+   AET expected = Entry.array_element_type;
+   bool string_match = expected IS AET::STR_GC and
+      (actual IS AET::STR_GC or actual IS AET::CSTR or actual IS AET::STR_CPP);
+   if (not string_match and actual != expected) return false;
+   if (expected != AET::STRUCT) return true;
+   struct_record *definition = find_struct(L, Entry.constraint_name);
+   return definition and Array->structdef IS definition;
+}
+
 [[nodiscard]] static bool contract_matches(lua_State *L, cTValue *Value, const RuntimeContractEntry &Entry)
 {
    bool nullable = (Entry.flags & contract_flag(ContractEntryFlag::Nullable)) != 0;
@@ -688,12 +703,13 @@ namespace {
       case TiriType::Num:     return tvisnumber(Value);
       case TiriType::Str:     return tvisstr(Value);
       case TiriType::Table:   return tvistab(Value);
-      case TiriType::Array:   return tvisarray(Value);
+      case TiriType::Array:
+         return tvisarray(Value) and contract_array_element_matches(L, arrayV(Value), Entry);
       case TiriType::Func:    return contract_is_callable(L, Value);
       case TiriType::Struct: {
          if (not tvisstruct(Value)) return false;
-         if (Entry.struct_name.empty()) return true;
-         struct_record *definition = find_struct(L, Entry.struct_name);
+         if (Entry.constraint_name.empty()) return true;
+         struct_record *definition = find_struct(L, Entry.constraint_name);
          return definition and structV(Value)->def IS definition;
       }
       case TiriType::Object: {
@@ -730,8 +746,39 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
       return;
    }
 
-   if (Entry.type IS TiriType::Struct and not Entry.struct_name.empty()) {
-      std::snprintf(Buffer, Size, "struct<%.*s>", int(Entry.struct_name.size()), Entry.struct_name.data());
+   if (Entry.type IS TiriType::Struct and not Entry.constraint_name.empty()) {
+      std::snprintf(Buffer, Size, "struct<%.*s>", int(Entry.constraint_name.size()), Entry.constraint_name.data());
+      return;
+   }
+
+   if (Entry.type IS TiriType::Array) {
+      const char *member = "any";
+      switch (Entry.array_element_type) {
+         case AET::BYTE:   member = "byte"; break;
+         case AET::INT16:  member = "int16"; break;
+         case AET::INT32:  member = "int"; break;
+         case AET::INT64:  member = "int64"; break;
+         case AET::FLOAT:  member = "float"; break;
+         case AET::DOUBLE: member = "double"; break;
+         case AET::CSTR:
+         case AET::STR_CPP:
+         case AET::STR_GC: member = "string"; break;
+         case AET::TABLE:  member = "table"; break;
+         case AET::ARRAY:  member = "array"; break;
+         case AET::PTR:    member = "pointer"; break;
+         case AET::ANY:    member = "any"; break;
+         case AET::OBJECT: member = "object"; break;
+         case AET::STRUCT:
+            if (not Entry.constraint_name.empty()) {
+               std::snprintf(Buffer, Size, "array<struct<%.*s>>", int(Entry.constraint_name.size()),
+                  Entry.constraint_name.data());
+               return;
+            }
+            member = "struct";
+            break;
+         case AET::MAX: break;
+      }
+      std::snprintf(Buffer, Size, "array<%s>", member);
       return;
    }
 
@@ -769,6 +816,15 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
    else if (tvisstruct(Value) and structV(Value)->def) {
       const auto &name = structV(Value)->def->Name;
       std::snprintf(actual, sizeof(actual), "struct<%.*s>", int(name.size()), name.data());
+   }
+   else if (tvisarray(Value)) {
+      RuntimeContractEntry actual_entry;
+      actual_entry.type = TiriType::Array;
+      actual_entry.array_element_type = arrayV(Value)->elemtype;
+      if (arrayV(Value)->elemtype IS AET::STRUCT and arrayV(Value)->structdef) {
+         actual_entry.constraint_name = arrayV(Value)->structdef->Name;
+      }
+      contract_type_name(actual, sizeof(actual), actual_entry);
    }
    else if (contract_is_range(L, Value)) std::snprintf(actual, sizeof(actual), "range");
    else std::snprintf(actual, sizeof(actual), "%s", lj_typename(Value));
@@ -853,11 +909,13 @@ static void apply_cached_contract(lua_State *L, TValue *Base, uint32_t DynamicCo
       const CachedRuntimeContractEntry &cached = Entries[entry_index];
       RuntimeContractEntry entry{
          .type = cached.type,
+         .array_element_type = cached.type IS TiriType::Array ? cached.array_element_type : AET::MAX,
          .flags = cached.flags,
          .position = cached.position,
          .object_class_id = cached.type IS TiriType::Object ? CLASSID(cached.object_class_id) : CLASSID::NIL,
-         .struct_name = cached.type IS TiriType::Struct ?
-            cached_contract_text(Descriptor, cached.struct_offset) : std::string_view{},
+         .constraint_name = (cached.type IS TiriType::Struct or
+            (cached.type IS TiriType::Array and cached.array_element_type IS AET::STRUCT)) ?
+            cached_contract_text(Descriptor, cached.constraint_offset) : std::string_view{},
          .label = cached_contract_text(Descriptor, cached.label_offset)
       };
       if (entry.type IS TiriType::Any or entry.type IS TiriType::Unknown) continue;
@@ -948,12 +1006,14 @@ void lj_contract_build_cache(lua_State *L, GCproto *Prototype)
          const RuntimeContractEntry &source = descriptor.entries[j];
          CachedRuntimeContractEntry &target = entries[entry_index++];
          if (source.type IS TiriType::Object) target.object_class_id = uint32_t(source.object_class_id);
-         else if (source.type IS TiriType::Struct) {
-            target.struct_offset = cached_contract_text_offset(encoded, source.struct_name);
+         else if (source.type IS TiriType::Struct or
+                  (source.type IS TiriType::Array and source.array_element_type IS AET::STRUCT)) {
+            target.constraint_offset = cached_contract_text_offset(encoded, source.constraint_name);
          }
          else target.object_class_id = 0;
          target.label_offset = cached_contract_text_offset(encoded, source.label);
          target.type = source.type;
+         target.array_element_type = source.array_element_type;
          target.flags = source.flags;
          target.position = source.position;
       }
@@ -1107,12 +1167,15 @@ static void env_check_contract(lua_State *L, GCtab *Environment, GCstr *Name, cT
          "decoded global contract cache does not match persisted policy");
       cached_entry = RuntimeContractEntry{
          .type = cached->entry.type,
+         .array_element_type = cached->entry.type IS TiriType::Array ?
+            cached->entry.array_element_type : AET::MAX,
          .flags = cached->entry.flags,
          .position = cached->entry.position,
          .object_class_id = cached->entry.type IS TiriType::Object ?
             CLASSID(cached->entry.object_class_id) : CLASSID::NIL,
-         .struct_name = cached->entry.type IS TiriType::Struct ?
-            cached_contract_text(cached->descriptor, cached->entry.struct_offset) : std::string_view{},
+         .constraint_name = (cached->entry.type IS TiriType::Struct or
+            (cached->entry.type IS TiriType::Array and cached->entry.array_element_type IS AET::STRUCT)) ?
+            cached_contract_text(cached->descriptor, cached->entry.constraint_offset) : std::string_view{},
          .label = cached_contract_text(cached->descriptor, cached->entry.label_offset)
       };
       entry = &cached_entry;

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -623,7 +623,7 @@ inline constexpr int LJ_MAX_TRY_DEPTH = 32;
 // Function signature metadata.  Entries contain only state-portable identifiers: struct constraints use struct_key()
 // and object constraints use CLASSID.  Parameter entries are stored first, followed by result entries.
 
-inline constexpr uint8_t PROTO_SIGNATURE_VERSION = 1;
+inline constexpr uint8_t PROTO_SIGNATURE_VERSION = 2;
 
 enum class ProtoTypeOrigin : uint8_t {
    Unspecified = 0,
@@ -1016,6 +1016,16 @@ enum class AET : uint8_t {
    MAX,
    VULNERABLE = PTR
 };
+
+[[nodiscard]] constexpr inline uint16_t proto_array_member(AET Type) noexcept
+{
+   return uint16_t(Type) + 1;
+}
+
+[[nodiscard]] constexpr inline AET proto_array_member(const ProtoTypeEntry &Entry) noexcept
+{
+   return Entry.reserved ? AET(Entry.reserved - 1) : AET::MAX;
+}
 
 // Array flags
 inline constexpr uint8_t ARRAY_READONLY  = 0x01;  // Cannot modify elements

--- a/src/tiri/jit/src/runtime/lj_tab.cpp
+++ b/src/tiri/jit/src/runtime/lj_tab.cpp
@@ -689,11 +689,12 @@ void lj_tab_set_global_contract(lua_State *L, GCtab *Environment, const GCstr *N
       const RuntimeContractEntry &source = decoded.entries[0];
       replacement.descriptor = Descriptor;
       if (source.type IS TiriType::Object) replacement.entry.object_class_id = uint32_t(source.object_class_id);
-      else if (source.type IS TiriType::Struct) {
-         ptrdiff_t offset = source.struct_name.data() - strdata(Descriptor);
+      else if (source.type IS TiriType::Struct or
+               (source.type IS TiriType::Array and source.array_element_type IS AET::STRUCT)) {
+         ptrdiff_t offset = source.constraint_name.data() - strdata(Descriptor);
          lj_assertX(offset > 0 and uint64_t(offset) <= UINT16_MAX,
-            "global contract structure offset is out of range");
-         replacement.entry.struct_offset = uint16_t(offset);
+            "global contract constraint offset is out of range");
+         replacement.entry.constraint_offset = uint16_t(offset);
       }
       replacement.entry.label_offset = 0;
       if (not source.label.empty()) {
@@ -703,6 +704,7 @@ void lj_tab_set_global_contract(lua_State *L, GCtab *Environment, const GCstr *N
          replacement.entry.label_offset = uint16_t(offset);
       }
       replacement.entry.type = source.type;
+      replacement.entry.array_element_type = source.array_element_type;
       replacement.entry.flags = source.flags;
       replacement.entry.position = source.position;
    }

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -958,7 +958,7 @@ static bool test_lib_array_new(kt::Log &Log)
 
    // Test array.new via Lua
    const char* code = R"(
-      local arr:array = array.new(100, "int")
+      local arr:array<int> = array.new(100, "int")
       return arr != nil and #arr is 100 and array.type(arr) is "int"
    )";
 
@@ -987,7 +987,7 @@ static bool test_lib_array_index(kt::Log &Log)
 
    // Test array indexing via library metamethods
    const char* code = R"(
-      local arr:array = array.new(10, "int")
+      local arr:array<int> = array.new(10, "int")
       arr[0] = 100
       arr[5] = 500
       arr[9] = 900
@@ -1019,7 +1019,7 @@ static bool test_lib_array_table(kt::Log &Log)
 
    // Test array.table conversion
    const char* code = R"(
-      local arr:array = array.new(5, "int")
+      local arr:array<int> = array.new(5, "int")
       arr[0] = 10
       arr[1] = 20
       arr[2] = 30
@@ -1054,8 +1054,8 @@ static bool test_lib_array_copy(kt::Log &Log)
 
    // Test array.copy
    const char* code = R"(
-      local src:array = array.new(5, "int")
-      local dst:array = array.new(5, "int")
+      local src:array<int> = array.new(5, "int")
+      local dst:array<int> = array.new(5, "int")
       src[0] = 100
       src[1] = 200
       src[2] = 300
@@ -1090,7 +1090,7 @@ static bool test_lib_array_string(kt::Log &Log)
 
    // Test array.getString and setString
    const char* code = R"(
-      local arr:array = array.new(10, "char")
+      local arr:array<byte> = array.new(10, "char")
       array.setString(arr, "hello")
       local s:str = array.getString(arr, 0, 5)
       return s is "hello"
@@ -1121,7 +1121,7 @@ static bool test_lib_array_fill(kt::Log &Log)
 
    // Test array.fill
    const char* code = R"(
-      local arr:array = array.new(10, "int")
+      local arr:array<int> = array.new(10, "int")
       array.fill(arr, 42)
       local ok = true
       for i in {0 into 9} do
@@ -1155,7 +1155,7 @@ static bool test_lib_array_len_operator(kt::Log &Log)
 
    // Test # operator via __len metamethod
    const char* code = R"(
-      local arr:array = array.new(42, "double")
+      local arr:array<double> = array.new(42, "double")
       return #arr is 42
    )";
 
@@ -1184,7 +1184,7 @@ static bool test_lib_array_double_type(kt::Log &Log)
 
    // Test double array type
    const char* code = R"(
-      local arr:array = array.new(5, "double")
+      local arr:array<double> = array.new(5, "double")
       arr[0] = 3.14159
       arr[2] = -2.71828
       arr[4] = 1.41421

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -3,6 +3,39 @@
 @BeforeEach(hotpath=200)
 function enforce_hotpath() end
 
+struct ArrayBindingPoint
+   Value: int
+end
+
+@Test function ArrayBindingPublicMemberKinds()
+   function identity_byte(Value:array<char>):array<byte> return Value end
+   function identity_int16(Value:array<int16>):array<int16> return Value end
+   function identity_int(Value:array<int>):array<int> return Value end
+   function identity_int64(Value:array<int64>):array<int64> return Value end
+   function identity_float(Value:array<float>):array<float> return Value end
+   function identity_double(Value:array<double>):array<double> return Value end
+   function identity_string(Value:array<string>):array<string> return Value end
+   function identity_table(Value:array<table>):array<table> return Value end
+   function identity_array(Value:array<array>):array<array> return Value end
+   function identity_object(Value:array<object>):array<object> return Value end
+   function identity_any(Value:array<any>):array<any> return Value end
+   function identity_struct(Value:array<struct<ArrayBindingPoint>>):array<struct<ArrayBindingPoint>> return Value end
+
+   assert(identity_byte(array<byte> {}) != nil, 'char and byte should share one binding identity')
+   assert(identity_int16(array<int16> {}) != nil, 'int16 binding identity should be accepted')
+   assert(identity_int(array<int> {}) != nil, 'int binding identity should be accepted')
+   assert(identity_int64(array<int64> {}) != nil, 'int64 binding identity should be accepted')
+   assert(identity_float(array<float> {}) != nil, 'float binding identity should be accepted')
+   assert(identity_double(array<double> {}) != nil, 'double binding identity should be accepted')
+   assert(identity_string(array<string> {}) != nil, 'string binding identity should be accepted')
+   assert(identity_table(array<table> {}) != nil, 'table binding identity should be accepted')
+   assert(identity_array(array<array> {}) != nil, 'immediate nested-array identity should be accepted')
+   assert(identity_object(array<object> {}) != nil, 'object binding identity should be accepted')
+   assert(identity_any(array<any> {}) != nil, 'any member identity should be accepted')
+   assert(identity_struct(array<struct<ArrayBindingPoint>> {}) != nil,
+      'named-structure binding identity should be accepted')
+end
+
 @Test function IntegerArrayConcat()
    int_array = array<int, 5>
    int_array[0] = 10

--- a/src/tiri/tests/test_array_typed_syntax.tiri
+++ b/src/tiri/tests/test_array_typed_syntax.tiri
@@ -369,7 +369,7 @@ end
 
 @Test function ArrayTypedReassignment()
    -- Reassigning array variable
-   arr = array<int> { 1, 2, 3 }
+   local arr:array<any> = array<int> { 1, 2, 3 }
    assert(#arr is 3, "Initial array should have 3 elements")
 
    arr = array<double> { 1.5, 2.5 }
@@ -379,7 +379,7 @@ end
 
 @Test function ArrayTypedAsReturnValue()
    -- Function returning typed array
-   function makeNumbers(n):array
+   function makeNumbers(n):array<any>
       result = array<int, n>
       for i in {0 to n} do
          result[i] = i + 1

--- a/src/tiri/tests/test_global_types.tiri
+++ b/src/tiri/tests/test_global_types.tiri
@@ -420,6 +420,31 @@ end
    assert(glGTCrossAlias is 'replaced', 'A rejected cross-chunk store must preserve the previous value')
 end
 
+@Test function CrossChunkArrayMemberPolicy()
+   global glGTMemberArray:array<int> = array<int> { 7 }
+   local writer = exec([[
+return function(Value:any)
+   local environment = _G
+   environment.glGTMemberArray = Value
+end
+]])
+
+   writer(array<int> { 9 })
+   assert(glGTMemberArray[0] is 9, 'A matching member identity should cross an environment alias')
+   try
+      writer(array<string> { 'wrong' })
+      error('A different array member identity should be rejected')
+   except e
+      assert(e.message:find('expected array<int>') != nil and e.message:find('got array<string>') != nil,
+         'The global member diagnostic should include both array identities: ' .. e.message)
+   end
+   assert(glGTMemberArray[0] is 9, 'A rejected cross-chunk array store should preserve the previous value')
+
+   exec([[global glGTWildcardArray:array<any> = array<int> { 1 }]])
+   exec([[global glGTWildcardArray:array<any> = array<string> { 'open' }]])
+   assert(glGTWildcardArray[0] is 'open', 'array<any> should remain an explicit global member wildcard')
+end
+
 @Test function DeclarationGovernsRawsetSeededName()
    rawset(_G, 'glGTSeeded', 'seed')
    global glGTSeeded = 'declared'

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -54,6 +54,14 @@ struct JITRangeTraceFields
    UnsignedByte: uint8
 end
 
+struct JITArrayContractAlpha
+   Value: int
+end
+
+struct JITArrayContractBeta
+   Value: int
+end
+
 @BeforeAll
 function SetupJitTests()
    jit.on()
@@ -74,7 +82,7 @@ end
 function numberPresent(Value:num):bool return Value?? end
 function stringPresent(Value:str):bool return Value?? end
 function booleanPresent(Value:bool):bool return Value?? end
-function arrayPresent(Value:array):bool return Value?? end
+function arrayPresent(Value:array<any>):bool return Value?? end
 function tablePresent(Value:table):bool return Value?? end
 function anyPresent(Value:any):bool return Value?? end
 ]] })
@@ -170,15 +178,15 @@ end
 
 @Test function ArrayParameterAndLengthRangeBytecode()
    local script = obj.new('tiri', { statement=[[
-global glBytecodeValues:array = array<int> { 1, 2, 3 }
+global glBytecodeValues:array<any> = array<int> { 1, 2, 3 }
 
-function increment(Array:array)
+function increment(Array:array<any>)
    for index in {0 to #Array} do
       Array[index] += 1
    end
 end
 
-function incrementInTry(Array:array)
+function incrementInTry(Array:array<any>)
    try
       for index in {0 to #Array} do
          Array[index] += 1
@@ -337,7 +345,7 @@ function canonical_array_try_workload(Count):str
    return values:concat(',', '%d')
 end
 
-global glCanonicalArrayRangeValues:array = array<int> { 1, 2, 3, 4, 5, 6, 7, 8 }
+global glCanonicalArrayRangeValues:array<any> = array<int> { 1, 2, 3, 4, 5, 6, 7, 8 }
 
 function canonical_global_array_workload(Count)
    local total = 0
@@ -365,7 +373,7 @@ function find_array_bounds_trace(MaxTraceNo)
    return nil, nil, 0
 end
 
-function resize_during_array_loop(Array:array, Shrink:bool)
+function resize_during_array_loop(Array:array<any>, Shrink:bool)
    local alias = Array
    for index in {0 to #Array} do
       if Shrink and index is 16 then alias:resize(8) end
@@ -373,7 +381,7 @@ function resize_during_array_loop(Array:array, Shrink:bool)
    end
 end
 
-function clear_during_array_loop(Array:array, Clear:bool)
+function clear_during_array_loop(Array:array<any>, Clear:bool)
    local alias = Array
    for index in {0 to #Array} do
       if Clear and index is 16 then alias:clear() end
@@ -381,14 +389,14 @@ function clear_during_array_loop(Array:array, Clear:bool)
    end
 end
 
-function reassign_during_array_loop(Array:array, Reassign:bool)
+function reassign_during_array_loop(Array:array<any>, Reassign:bool)
    for index in {0 to #Array} do
       if Reassign and index is 16 then Array = array<int, 8> end
       Array[index] += 1
    end
 end
 
-function push_during_array_loop(Array:array):<num, num, num>
+function push_during_array_loop(Array:array<any>):<num, num, num>
    local original_length = #Array
    for index in {0 to #Array} do
       if index is 0 then Array:push(99) end
@@ -2628,6 +2636,88 @@ end
    assert(result is 5, f"Expected traced complex struct result 5, got {result}")
    assert(value.name is "trace", "Expected traced string assignment to retain its value")
    assert(count_jit_traces(30) > 0, "Expected complex struct field types to remain traceable")
+end
+
+@Test(hotpath=50) function JITArrayBindingMemberContract()
+   function checked_member(Value:array<int>):num
+      return Value[0]
+   end
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   local ints = array<int> { 4 }
+   for _ in {1 into 100} do
+      assert(checked_member(ints) is 4, 'The hot matching array contract should pass')
+   end
+
+   local failed = false
+   try
+      checked_member(array<string> { 'wrong' })
+   except e
+      failed = true
+      assert(e.message:find('expected array<int>') != nil and e.message:find('got array<string>') != nil,
+         'A hot member mismatch should report both array identities: ' .. e.message)
+   end
+   assert(failed, 'Changing only the array member type at a hot contract site should raise')
+end
+
+@Test(hotpath=50) function JITStringArrayBindingMemberContract()
+   function checked_string_member(Value:array<string>):str
+      return Value[0]
+   end
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   local strings = array<string> { 'kept' }
+   for _ in {1 into 100} do
+      assert(checked_string_member(strings) is 'kept', 'The hot string-array contract should pass')
+   end
+   assert(count_jit_traces(30) > 0, 'A string-array member contract should remain traceable')
+
+   local failed = false
+   try
+      checked_string_member(array<int> { 7 })
+   except e
+      failed = true
+      assert(e.message:find('expected array<string>') != nil and e.message:find('got array<int>') != nil,
+         'A hot string member mismatch should report both array identities: ' .. e.message)
+   end
+   assert(failed, 'A hot string-array contract should reject a numeric member type')
+end
+
+@Test(hotpath=50) function JITStructArrayBindingMemberContract()
+   function checked_struct_member(Value:array<struct<JITArrayContractAlpha>>):num
+      return Value[0].Value
+   end
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   local matching = array<struct<JITArrayContractAlpha>> {
+      struct<JITArrayContractAlpha> { Value=9 }
+   }
+   for _ in {1 into 100} do
+      assert(checked_struct_member(matching) is 9, 'The hot structure-array contract should pass')
+   end
+   assert(count_jit_traces(30) > 0, 'A structure-array member contract should remain traceable')
+
+   local failed = false
+   try
+      checked_struct_member(array<struct<JITArrayContractBeta>> {
+         struct<JITArrayContractBeta> { Value=4 }
+      })
+   except e
+      failed = true
+      assert(e.message:find('expected array<struct<JITArrayContractAlpha>>') != nil and
+         e.message:find('got array<struct<JITArrayContractBeta>>') != nil,
+         'A hot structure member mismatch should report both layouts: ' .. e.message)
+   end
+   assert(failed, 'A hot structure-array contract should reject a different layout')
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_type_annotations.tiri
+++ b/src/tiri/tests/test_type_annotations.tiri
@@ -76,10 +76,36 @@ end
    end
 end
 
+@Test function ArrayMemberAnnotations()
+   function accept_ints(Values:array<int>):array<int>
+      return Values
+   end
+
+   local values:array<int> = array<int> { 3, 5 }
+   global glAnnotatedWords:array<string> = array<string> { 'one' }
+   assert(accept_ints(values)[1] is 5, 'Concrete array annotations should work in parameters, locals and results')
+   assert(glAnnotatedWords[0] is 'one', 'Concrete array annotations should work for globals')
+
+   function assert_rejected(Source:str, Message:str)
+      try
+         exec(Source)
+         error('Expected array annotation syntax to be rejected')
+      except e
+         assert(e.message:find(Message) != nil, 'Unexpected array annotation diagnostic: ' .. e.message)
+      end
+   end
+
+   assert_rejected('function invalid(Value:array) end', 'element type')
+   assert_rejected('function invalid(Value:array<missing>) end', 'Unknown array element type')
+   assert_rejected('function invalid(Value:array<pointer>) end', 'Unknown array element type')
+   assert_rejected('function invalid(Value:array<array<string>>) end', 'Nested array specialisation')
+   assert_rejected('function invalid(Value:array<int, 4>) end', 'cannot declare a size')
+end
+
 @Test function MistypedArrayArgumentRaisesCleanly()
    -- Annotated parameters emit specialised bytecode, so passing a mismatched value must raise a
    -- catchable error rather than crash or silently operate on the wrong type.
-   function increment(Values:array)
+   function increment(Values:array<any>)
       for index in {0 to #Values} do
          Values[index] += 1
       end

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -81,6 +81,43 @@ function expect_userdata_diagnostic(Callback:func, Actual:str)
    assert(failed, 'Expected a userdata diagnostic contract failure')
 end
 
+function expect_array_contract_failure(Callback:func, Expected:str, Actual:str)
+   local failed = false
+   try
+      Callback()
+   except e
+      failed = true
+      assert(e.message:find('expected array<' .. Expected .. '>') != nil,
+         'The message should identify the expected array member: ' .. e.message)
+      assert(e.message:find('got array<' .. Actual .. '>') != nil,
+         'The message should identify the actual array member: ' .. e.message)
+   end
+   assert(failed, 'Expected an array member contract failure')
+end
+
+@Test function ArrayBindingMemberContracts()
+   function accept_ints(Value:array<int>):array<int> return Value end
+   function checked_ints(Value:any):array<int> return dynamic_value(Value) end
+
+   local ints = array<int> { 1 }
+   local words = array<string> { 'text' }
+   assert(accept_ints(dynamic_value(ints)) is ints, 'A matching dynamic array should satisfy the member contract')
+   expect_array_contract_failure(function() accept_ints(dynamic_value(words)) end, 'int', 'string')
+   expect_array_contract_failure(function() checked_ints(words) end, 'int', 'string')
+
+   local inferred = array<int> { 2 }
+   expect_array_contract_failure(function() inferred = dynamic_value(words) end, 'int', 'string')
+   assert(inferred[0] is 2, 'A rejected inferred-array store should preserve the previous value')
+   inferred = nil
+   inferred = dynamic_value(ints)
+   assert(inferred[0] is 1, 'Nil should not clear an inferred array member contract')
+
+   local wildcard:array<any> = ints
+   wildcard = dynamic_value(words)
+   assert(wildcard[0] is 'text', 'array<any> should accept every native-array member identity')
+   expect_contract_failure(function() wildcard = dynamic_value({}) end, 'local')
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- Parameter matrix and exact, non-coercing predicates.
 
@@ -90,7 +127,7 @@ end
    function accept_num(Value:num) return Value end
    function accept_str(Value:str) return Value end
    function accept_table(Value:table) return Value end
-   function accept_array(Value:array) return Value end
+   function accept_array(Value:array<any>) return Value end
    function accept_func(Value:func) return Value end
    function accept_struct(Value:struct) return Value end
    function accept_obj(Value:obj) return Value end
@@ -212,7 +249,7 @@ end
 end
 
 @Test function GuardPrecedesSpecialisedMutation()
-   function increment(Values:array)
+   function increment(Values:array<any>)
       Values[0] += 1
    end
 
@@ -260,7 +297,7 @@ end
    function checked_num(Value:any):num return dynamic_value(Value) end
    function checked_str(Value:any):str return dynamic_value(Value) end
    function checked_table(Value:any):table return dynamic_value(Value) end
-   function checked_array(Value:any):array return dynamic_value(Value) end
+   function checked_array(Value:any):array<any> return dynamic_value(Value) end
    function checked_func(Value:any):func return dynamic_value(Value) end
    function checked_struct(Value:any):struct return dynamic_value(Value) end
    function checked_alpha(Value:any):struct<ContractAlpha> return dynamic_value(Value) end
@@ -752,7 +789,7 @@ end
    expect_contract_failure(function() exec("glContractNumber = 'wrong'") end, 'global')
    assert(glContractNumber is 3, 'A rejected store from a separately compiled chunk must preserve the global value')
 
-   global glContractArray:array = array<int> { 4, 8 }
+   global glContractArray:array<any> = array<int> { 4, 8 }
    function read_contract_array():num
       return glContractArray[1]
    end
@@ -1185,7 +1222,7 @@ end
 
 @Test function ContractDisassemblyOrder()
    local script = obj.new('tiri', { statement = [[
-function first(Values:array):any
+function first(Values:array<any>):any
    return Values[0]
 end
 ]] })

--- a/src/tiri/tests/test_type_guided_emission.tiri
+++ b/src/tiri/tests/test_type_guided_emission.tiri
@@ -27,7 +27,7 @@ function make_point_pair():<str, struct<EmissionPoint>>
    return 'point', struct<EmissionPoint> { Value=37 }
 end
 
-function make_number_array():array
+function make_number_array():array<any>
    return array<int> { 5, 10, 15 }
 end
 
@@ -143,11 +143,11 @@ end
 end
 
 @Test function ArrayDescriptorInvalidation()
-   local values = array<int> { 1 }
+   local values:array<any> = array<int> { 1 }
    values = array<string> { 'changed' }
    assert(values[0] is 'changed', 'Conflicting array reassignment must not retain a stale numeric descriptor')
 
-   local branch_values = array<int> { 2 }
+   local branch_values:array<any> = array<int> { 2 }
    if true then branch_values = array<table> { { value=23 } } end
    assert(branch_values[0].value is 23, 'A conflicting branch assignment must degrade the element descriptor')
 end

--- a/tools/idl/include/doc.tiri
+++ b/tools/idl/include/doc.tiri
@@ -276,7 +276,7 @@ setAction('Query', {
 setAction('Read', {
    comment   = 'Reads raw data information from objects.',
    prototype = 'ERR acRead(*Object, std::span<int8_t> Buffer, INT *Result)',
-   tiriPrototype = 'err, Result:num = Object.acRead(Buffer:array)',
+   tiriPrototype = 'err, Result:num = Object.acRead(Buffer:array<any>)',
    params    = {
       { name='Buffer', type='std::span<int8_t>', comment='A mutable buffer that will receive the data.' },
       { name='Result', type='INT', comment='The Read action will write this parameter with the total number of bytes read into the Buffer.' }

--- a/tools/idl/include/parser.tiri
+++ b/tools/idl/include/parser.tiri
@@ -69,7 +69,7 @@ global glOfficialTags = {
 ----------------------------------------------------------------------------------------------------------------------
 -- Parse and validate comma or newline-separated documentation tags for the supplied context.
 
-function parseTags(Tags:str, Context:str):array
+function parseTags(Tags:str, Context:str):array<string>
    result = array<string>
    Tags ?! return result
 
@@ -91,7 +91,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Apply automatic documentation tags to a tag list based on a field definition.
 
-global function addTag(Tags:array, Tag:str):array
+global function addTag(Tags:array<string>, Tag:str):array<string>
    Tags ?= array<string>
 
    for existing_tag in values(Tags) do
@@ -105,7 +105,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Apply automatic documentation tags to a tag list based on a field definition.
 
-global function getTagsFromField(Field:table, Tags:array):array
+global function getTagsFromField(Field:table, Tags:array<string>):array<string>
    Field ?! return Tags
    Tags ?= array<string>
 
@@ -122,7 +122,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Apply automatic documentation tags for every field or parameter in a collection.
 
-global function getTagsFromCollection(Tags:array, Fields:any):array
+global function getTagsFromCollection(Tags:array<string>, Fields:any):array<string>
    Tags ?= array<string>
    Fields ?! return Tags
 

--- a/tools/tiri_lsp/include/lsp_cache.tiri
+++ b/tools/tiri_lsp/include/lsp_cache.tiri
@@ -118,7 +118,7 @@ function extractChildAttr(Content:str, TagName:str, AttrName:str):str
    return content
 end
 
-function extractSources(Content:str):array
+function extractSources(Content:str):array<table>
    sources = array<table>
    sourceMatch = extractXMLElement(Content, 'source', 0)
    sourceMatch ?! return sources
@@ -140,7 +140,7 @@ function extractSources(Content:str):array
    return sources
 end
 
-function extractInputParams(Content:str):array
+function extractInputParams(Content:str):array<table>
    params = array<table>
    inputMatch = extractXMLElement(Content, 'input', 0)
    inputMatch ?! return params

--- a/tools/tiri_lsp/include/lsp_definition.tiri
+++ b/tools/tiri_lsp/include/lsp_definition.tiri
@@ -181,7 +181,7 @@ function makeXmlLocation(Entry:table, ByteStart:num, ByteEnd:num):table
    return makeOffsetLocation(glDocCache.sdkPath .. Entry.file, ByteStart or Entry.byteStart or 0, ByteEnd or Entry.byteEnd or 0)
 end
 
-function pushLocation(Locations:array, Location:table)
+function pushLocation(Locations:array<table>, Location:table)
    if Location then Locations:push(Location) end
 end
 
@@ -268,7 +268,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Current Document Symbols
 
-function addSymbol(Symbols:array, Name:str, Kind:str, Line:num, StartChar:num, EndChar:num)
+function addSymbol(Symbols:array<table>, Name:str, Kind:str, Line:num, StartChar:num, EndChar:num)
    if not Name or Name is '' then return end
    Symbols:push({
       name = Name,
@@ -283,7 +283,7 @@ function addSymbol(Symbols:array, Name:str, Kind:str, Line:num, StartChar:num, E
    })
 end
 
-function addFunctionParameters(Symbols:array, Params:str, LineText:str, Line:num, SearchFrom:num)
+function addFunctionParameters(Symbols:array<table>, Params:str, LineText:str, Line:num, SearchFrom:num)
    Params ?! return
    scan_from = SearchFrom or 0
 
@@ -319,7 +319,7 @@ end
 
 -- Add 'StructName.FieldName' symbols for the struct fields present in LineCode.
 
-function addStructFieldSymbols(Symbols:array, StructName:str, LineCode:str, LineText:str, Line:num, SearchFrom:num)
+function addStructFieldSymbols(Symbols:array<table>, StructName:str, LineCode:str, LineText:str, Line:num, SearchFrom:num)
    scan_from = SearchFrom or 0
 
    for segment in values(LineCode:split(',')) do
@@ -336,7 +336,7 @@ function addStructFieldSymbols(Symbols:array, StructName:str, LineCode:str, Line
    end
 end
 
-global function extractDefinitionSymbols(Doc:table):array
+global function extractDefinitionSymbols(Doc:table):array<table>
    symbols = array<table>
    total_lines = getTotalLines(Doc)
    in_block_comment = false
@@ -472,7 +472,7 @@ function symbolNameMatches(SymbolName:str, TokenInfo:table):bool
    return false
 end
 
-function resolveDocumentSymbolDefinition(Doc:table, TokenInfo:table, Position:table):array
+function resolveDocumentSymbolDefinition(Doc:table, TokenInfo:table, Position:table):array<table>
    TokenInfo ?! return nil
 
    symbols = extractDefinitionSymbols(Doc)
@@ -557,7 +557,7 @@ function resolveScriptImport(Doc:table, Name:str):table
    return nil
 end
 
-function resolveLoaderDefinition(Doc:table, Position:table):array
+function resolveLoaderDefinition(Doc:table, Position:table):array<table>
    string_info = getLoaderStringAtPosition(Doc, Position)
    string_info ?! return nil
 
@@ -606,7 +606,7 @@ function buildDefinitionTypeMap(Doc:table):table
    return type_map
 end
 
-function addSourceFallback(Locations:array, ApiEntry:table)
+function addSourceFallback(Locations:array<table>, ApiEntry:table)
    if not ApiEntry or not ApiEntry.sources or not ApiEntry.module then return end
 
    module_folder = ApiEntry.module:lower()
@@ -622,7 +622,7 @@ function addSourceFallback(Locations:array, ApiEntry:table)
    end
 end
 
-function resolveClassDefinition(ClassName:str):array
+function resolveClassDefinition(ClassName:str):array<table>
    class_name = normaliseClassName(ClassName)
    class_name ?! return nil
 
@@ -633,7 +633,7 @@ function resolveClassDefinition(ClassName:str):array
    return #locations > 0 and locations or nil
 end
 
-function resolveApiMemberDefinition(Doc:table, TokenInfo:table):array
+function resolveApiMemberDefinition(Doc:table, TokenInfo:table):array<table>
    if not TokenInfo or not TokenInfo.object or not glDocCache then return nil end
 
    token = TokenInfo.text
@@ -707,7 +707,7 @@ function resolveApiMemberDefinition(Doc:table, TokenInfo:table):array
    return nil
 end
 
-function resolveApiDefinition(Doc:table, Position:table, TokenInfo:table):array
+function resolveApiDefinition(Doc:table, Position:table, TokenInfo:table):array<table>
    obj_new_string = getObjNewStringAtPosition(Doc, Position)
    if obj_new_string then
       class_locations = resolveClassDefinition(obj_new_string.text)
@@ -730,7 +730,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Public Resolver
 
-global function resolveDefinition(Doc:table, Position:table):array
+global function resolveDefinition(Doc:table, Position:table):array<table>
    Doc ?! return nil
    Position ?! return nil
 

--- a/tools/tiri_lsp/include/lsp_parsing.tiri
+++ b/tools/tiri_lsp/include/lsp_parsing.tiri
@@ -34,7 +34,7 @@ MULTIBYTE_OPERATORS = {
 -- Tokenize a Tiri source file and return semantic tokens
 -- Returns array of tokens: { line, startChar, length, tokenType, tokenModifiers }
 
-global function tokenizeTiri(Source:str):array
+global function tokenizeTiri(Source:str):array<table>
    tokens = array<table>
    line = 0
    col = 0
@@ -845,7 +845,7 @@ end
 -- Extract folding ranges from Tiri source
 -- Returns array of FoldingRange objects for code folding
 
-global function extractFoldingRanges(Doc:table):array
+global function extractFoldingRanges(Doc:table):array<table>
    ranges = array<table>
    total_lines = getTotalLines(Doc)
    block_stack = array<table>  -- Stack of { line, kind } for nested blocks
@@ -973,7 +973,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Encode tokens into LSP semantic tokens format (delta-encoded integers)
 
-global function encodeSemanticTokens(Tokens:array):array
+global function encodeSemanticTokens(Tokens:array<table>):array<int>
    data = array<int>
    prev_line = 0
    prev_char = 0
@@ -999,7 +999,7 @@ end
 -- Compute semantic token edits between old and new data arrays
 -- Returns array of SemanticTokensEdit: { start, deleteCount, data? }
 
-global function computeTokenEdits(OldData:array, NewData:array):array
+global function computeTokenEdits(OldData:array<int>, NewData:array<int>):array<table>
    old_len = #OldData
    new_len = #NewData
 

--- a/tools/tiri_lsp/include/lsp_signature.tiri
+++ b/tools/tiri_lsp/include/lsp_signature.tiri
@@ -107,7 +107,7 @@ end
 
 -- Add a call frame to the parser stack for an opening parenthesis.
 
-function signaturePushFrame(Stack:array, Content:str, Pos:num)
+function signaturePushFrame(Stack:array<table>, Content:str, Pos:num)
    call = signatureReadCallName(Content, Pos)
    Stack:push({
       name = call?.name,
@@ -233,7 +233,7 @@ end
 
 -- Convert internal parameter records to LSP ParameterInformation records.
 
-function signatureBuildParameterInfo(Params:any):array
+function signatureBuildParameterInfo(Params:any):array<table>
    result = array<table>
    for param in values(Params or array<table>) do
       label = param.label or signatureParamLabel(param)
@@ -267,7 +267,7 @@ end
 
 -- Split a prototype parameter string while ignoring commas inside nested expressions.
 
-function signatureSplitParams(ParamText:str):array
+function signatureSplitParams(ParamText:str):array<table>
    params = array<table>
    current = ''
    paren_depth = 0
@@ -301,7 +301,7 @@ end
 
 -- Extract raw parameter labels from the first parenthesised parameter list in a prototype.
 
-function signatureParamsFromPrototype(Prototype:str):array
+function signatureParamsFromPrototype(Prototype:str):array<table>
    Prototype ?! return array<table>
    open_pos = Prototype:find('(', 0, true)
    close_pos = Prototype:find(')', open_pos or 0, true)
@@ -490,7 +490,7 @@ end
 
 -- Extract API parameters from a generated XML prototype.
 
-function signatureXmlParamsFromPrototype(Prototype:str):array
+function signatureXmlParamsFromPrototype(Prototype:str):array<table>
    params = array<table>
    for param in values(signatureParamsFromPrototype(Prototype)) do
       params:push(signatureParamFromPrototypeLabel(param.label))
@@ -500,7 +500,7 @@ end
 
 -- Extract Tiri parameters from a generated Tiri prototype.
 
-function signatureTiriParamsFromPrototype(Prototype:str):array
+function signatureTiriParamsFromPrototype(Prototype:str):array<table>
    params = array<table>
    for param in values(signatureParamsFromPrototype(Prototype)) do
       params:push(signatureParamFromTiriLabel(param.label))
@@ -528,7 +528,7 @@ end
 
 -- Copy parameter documentation from generated API metadata onto parsed prototype parameters.
 
-function signatureCopyParamDocs(Params:array, SourceParams:any):array
+function signatureCopyParamDocs(Params:array<table>, SourceParams:any):array<table>
    if not SourceParams then return Params end
 
    for param in values(Params or array<table>) do
@@ -556,7 +556,7 @@ end
 
 -- Build visible API parameters, optionally hiding the generated receiver argument.
 
-function signatureXmlParams(MethodDoc:table, HideReceiver:bool):array
+function signatureXmlParams(MethodDoc:table, HideReceiver:bool):array<table>
    source_params = MethodDoc.params
    if not source_params or #source_params is 0 then
       source_params = signatureXmlParamsFromPrototype(MethodDoc.prototype)
@@ -580,7 +580,7 @@ end
 
 -- Build the display label for a signature sourced from XML API metadata.
 
-function signatureXmlLabel(DisplayName:str, Params:array):str
+function signatureXmlLabel(DisplayName:str, Params:array<table>):str
    labels = array<string>
    for param in values(Params or array<table>) do
       labels:push(signatureParamLabel(param))

--- a/tools/tiri_lsp/include/lsp_symbols.tiri
+++ b/tools/tiri_lsp/include/lsp_symbols.tiri
@@ -60,14 +60,14 @@ function symbolCountChar(LineCode:str, Char:str):num
    return count
 end
 
-function symbolCurrentParent(Stack:array):table
+function symbolCurrentParent(Stack:array<table>):table
    for i in {#Stack - 1 into 0 by -1} do
       if Stack[i].symbol then return Stack[i].symbol end
    end
    return nil
 end
 
-function symbolAddChild(Roots:array, Stack:array, Symbol:table)
+function symbolAddChild(Roots:array<table>, Stack:array<table>, Symbol:table)
    parent = symbolCurrentParent(Stack)
    if parent then
       parent.children:push(Symbol)
@@ -90,7 +90,7 @@ function symbolMakeRange(LineNo:num, StartChar:num, EndChar:num):table
    }
 end
 
-function symbolAnnotationLabels(Annotations:array):array
+function symbolAnnotationLabels(Annotations:array<table>):array<string>
    labels = array<string>
    for anno in values(Annotations or array<table>) do
       labels:push('@' .. anno.name)
@@ -98,14 +98,14 @@ function symbolAnnotationLabels(Annotations:array):array
    return labels
 end
 
-function symbolHasAnnotation(Annotations:array, Name:str):bool
+function symbolHasAnnotation(Annotations:array<table>, Name:str):bool
    for anno in values(Annotations or array<table>) do
       if anno.name is Name then return true end
    end
    return false
 end
 
-function symbolBuildDetail(Base:str, Annotations:array):str
+function symbolBuildDetail(Base:str, Annotations:array<table>):str
    parts = array<string>
    if Base and Base != '' then parts:push(Base) end
    for label in values(symbolAnnotationLabels(Annotations)) do
@@ -115,7 +115,7 @@ function symbolBuildDetail(Base:str, Annotations:array):str
    return parts:concat(' ')
 end
 
-function symbolMergeAnnotations(Left:array, Right:array):array
+function symbolMergeAnnotations(Left:array<table>, Right:array<table>):array<table>
    merged = array<table>
    for anno in values(Left or array<table>) do merged:push(anno) end
    for anno in values(Right or array<table>) do merged:push(anno) end
@@ -169,7 +169,7 @@ function symbolReadAnnotationArgs(Text:str, Pos:num):<str,num>
    return Text:sub(start_pos + 1), Pos
 end
 
-function symbolParseAnnotationPrefix(LineText:str):<array,num>
+function symbolParseAnnotationPrefix(LineText:str):<array<table>,num>
    annotations = array<table>
    pos = 0
 
@@ -208,7 +208,7 @@ function symbolParseAnnotationPrefix(LineText:str):<array,num>
    return annotations, pos
 end
 
-function symbolMakeDocumentSymbol(Name:str, Kind:num, LineNo:num, LineText:str, NameStart:num, Detail:str, Annotations:array):table
+function symbolMakeDocumentSymbol(Name:str, Kind:num, LineNo:num, LineText:str, NameStart:num, Detail:str, Annotations:array<table>):table
    name_start = NameStart or 0
    symbol = {
       name = Name,
@@ -229,7 +229,7 @@ function symbolMakeDocumentSymbol(Name:str, Kind:num, LineNo:num, LineText:str, 
    return symbol
 end
 
-function symbolDetectFunction(LineCode:str, LineText:str, LineNo:num, Annotations:array):table
+function symbolDetectFunction(LineCode:str, LineText:str, LineNo:num, Annotations:array<table>):table
    start_pos, stop_pos, cap = rx_symbol_named_function.findFirst(LineCode)
    if start_pos then
       scope = nil
@@ -343,7 +343,7 @@ function symbolAddStructFields(Symbol:table, LineCode:str, LineText:str, LineNo:
    end
 end
 
-function symbolPushBlockFrames(Stack:array, LineCode:str, FunctionFrame:table)
+function symbolPushBlockFrames(Stack:array<table>, LineCode:str, FunctionFrame:table)
    function_count = symbolCountBlockKeyword(LineCode, 'function') + symbolCountBlockKeyword(LineCode, 'thunk')
    if FunctionFrame and function_count > 0 then function_count -= 1 end
 
@@ -380,7 +380,7 @@ function symbolPushBlockFrames(Stack:array, LineCode:str, FunctionFrame:table)
    end
 end
 
-function symbolCloseBlockFrames(Stack:array, LineCode:str, LineNo:num, LineText:str)
+function symbolCloseBlockFrames(Stack:array<table>, LineCode:str, LineNo:num, LineText:str)
    close_count = symbolCountBlockKeyword(LineCode, 'end') + symbolCountBlockKeyword(LineCode, 'until')
    for i in {1 to close_count+1} do
       if #Stack > 0 then
@@ -394,7 +394,7 @@ function symbolIsBraceFrame(Frame:table):bool
    return Frame.kind is 'table'
 end
 
-function symbolFindTopTableFrame(Stack:array):table
+function symbolFindTopTableFrame(Stack:array<table>):table
    for i in {#Stack - 1 into 0 by -1} do
       frame = Stack[i]
       if symbolIsBraceFrame(frame) then
@@ -404,7 +404,7 @@ function symbolFindTopTableFrame(Stack:array):table
    return nil
 end
 
-function symbolCloseTables(Stack:array, LineCode:str, LineNo:num, LineText:str)
+function symbolCloseTables(Stack:array<table>, LineCode:str, LineNo:num, LineText:str)
    table_frame = symbolFindTopTableFrame(Stack)
    if not table_frame then return end
 
@@ -437,7 +437,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Extract document symbols from Tiri source.
 
-global function extractDocumentSymbols(Doc:table):array
+global function extractDocumentSymbols(Doc:table):array<table>
    symbols = array<table>
    total_lines = getTotalLines(Doc)
    stack = array<table>

--- a/tools/tiri_lsp/tests/test_definition.tiri
+++ b/tools/tiri_lsp/tests/test_definition.tiri
@@ -22,13 +22,13 @@ function makeDoc(Content:str):table
    }
 end
 
-function assertLocationLine(Locations:array, Line:num, Message:str)
+function assertLocationLine(Locations:array<table>, Line:num, Message:str)
    assert(Locations and #Locations > 0, Message .. ': expected at least one location.')
    assert(Locations[0].range.start.line is Line,
       f'{Message}: expected line {Line}, got {Locations[0].range.start.line}')
 end
 
-function assertUriContains(Locations:array, Needle:str, Message:str)
+function assertUriContains(Locations:array<table>, Needle:str, Message:str)
    assert(Locations and #Locations > 0, Message .. ': expected at least one location.')
    uri = Locations[0].uri:replace('\\', '/'):lower()
    assert(uri:find(Needle:lower(), 0, true), f'{Message}: expected URI to contain {Needle}, got {Locations[0].uri}')

--- a/tools/tiri_lsp/tests/test_document_symbols.tiri
+++ b/tools/tiri_lsp/tests/test_document_symbols.tiri
@@ -21,7 +21,7 @@ function makeDoc(Content:str):table
    }
 end
 
-function findSymbol(Symbols:array, Name:str):table
+function findSymbol(Symbols:array<table>, Name:str):table
    for symbol in values(Symbols) do
       if symbol.name is Name then return symbol end
    end

--- a/tools/tiri_lsp/tests/test_folding.tiri
+++ b/tools/tiri_lsp/tests/test_folding.tiri
@@ -21,7 +21,7 @@ function makeDoc(Content:str):table
    }
 end
 
-function findRange(Ranges:array, StartLine:num, EndLine:num):table
+function findRange(Ranges:array<table>, StartLine:num, EndLine:num):table
    for range in values(Ranges) do
       if range.startLine is StartLine and range.endLine is EndLine then return range end
    end

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -24,7 +24,7 @@ function makeDoc(Content:str):table
    }
 end
 
-function findToken(Tokens:array, Line:num, Char:num, Text:str):table
+function findToken(Tokens:array<table>, Line:num, Char:num, Text:str):table
    for token in values(Tokens) do
       if token.line is Line and token.char is Char and token.length is #Text then
          return token
@@ -32,12 +32,12 @@ function findToken(Tokens:array, Line:num, Char:num, Text:str):table
    end
 end
 
-function assertOperatorToken(Tokens:array, Line:num, Char:num, Text:str, Message:str)
+function assertOperatorToken(Tokens:array<table>, Line:num, Char:num, Text:str, Message:str)
    token = findToken(Tokens, Line, Char, Text)
    assert(token and token.type is 1, Message)
 end
 
-function assertNoToken(Tokens:array, Line:num, Char:num, Text:str, Message:str)
+function assertNoToken(Tokens:array<table>, Line:num, Char:num, Text:str, Message:str)
    token = findToken(Tokens, Line, Char, Text)
    assert(not token, Message)
 end


### PR DESCRIPTION
* Added array<T> descriptors across parsing, static analysis, bytecode persistence, globals and runtime validation
* Added JIT guards for array storage and named structure identities without disabling hot traces
* Migrated wildcard array annotations to array<any> across scripts, tools and tests
* Hardened validated int32 array stores against failed preparation