### PR TITLE
[Tiri] Restored typed array literal performance

### DIFF
--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -313,12 +313,7 @@ LJLIB_CF(array_of)
    else arr = lj_array_new(L, uint32_t(num_values), elem_type);
    setarrayV(L, L->top++, arr);
 
-   for (int i = 0; i < num_values; i++) {
-      lj_array_check_element(L, arr, L->base + i + 1);
-   }
-   for (int i = 0; i < num_values; i++) {
-      lj_array_store_validated(L, arr, MSize(i), L->base + i + 1);
-   }
+   lj_array_store_new_values(L, arr, L->base + 1, MSize(num_values));
 
    return 1;
 }

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -313,6 +313,43 @@ void lj_array_store_checked(lua_State *L, GCarray *Array, MSize Index, cTValue *
 }
 
 //********************************************************************************************************************
+
+template<typename T>
+static bool array_store_integer_sequence(GCarray *Array, cTValue *Values, MSize Count)
+{
+   for (MSize index = 0; index < Count; index++) {
+      if (not tvisint(Values + index)) return false;
+      Array->get<T>()[index] = T(intV(Values + index));
+   }
+   return true;
+}
+
+//********************************************************************************************************************
+
+// Populate a new, unexposed array.  If the integer fast path encounters another value type, the checked fallback
+// validates the complete sequence before overwriting any values already stored by the fast path.
+
+void lj_array_store_new_values(lua_State *L, GCarray *Array, cTValue *Values, MSize Count)
+{
+   if (glArrayConversion[size_t(Array->elemtype)].primitive) {
+      bool stored = false;
+      switch (Array->elemtype) {
+         case AET::BYTE:   stored = array_store_integer_sequence<uint8_t>(Array, Values, Count); break;
+         case AET::INT16:  stored = array_store_integer_sequence<int16_t>(Array, Values, Count); break;
+         case AET::INT32:  stored = array_store_integer_sequence<int32_t>(Array, Values, Count); break;
+         case AET::INT64:  stored = array_store_integer_sequence<int64_t>(Array, Values, Count); break;
+         case AET::FLOAT:  stored = array_store_integer_sequence<float>(Array, Values, Count); break;
+         case AET::DOUBLE: stored = array_store_integer_sequence<double>(Array, Values, Count); break;
+         default: break;
+      }
+      if (stored) return;
+   }
+
+   for (MSize index = 0; index < Count; index++) lj_array_check_element(L, Array, Values + index);
+   for (MSize index = 0; index < Count; index++) array_store_validated(L, Array, index, Values + index);
+}
+
+//********************************************************************************************************************
 // Append a single value to an array.  Called from JIT traces when recording array.push(), mirroring the semantics
 // of array.push() for one value.  Byte arrays accept strings, appending their bytes verbatim.
 

--- a/src/tiri/jit/src/runtime/lj_array.h
+++ b/src/tiri/jit/src/runtime/lj_array.h
@@ -25,6 +25,7 @@ enum class ArrayElementResult : uint8_t {
 extern void lj_array_check_element(lua_State *, GCarray *, cTValue *);
 extern void lj_array_store_validated(lua_State *, GCarray *, MSize Index, cTValue *);
 extern void lj_array_store_checked(lua_State *, GCarray *, MSize Index, cTValue *);
+extern void lj_array_store_new_values(lua_State *, GCarray *, cTValue *Values, MSize Count);
 
 //********************************************************************************************************************
 


### PR DESCRIPTION
* Added a single-pass fast path for constructing primitive arrays from integer values
* Preserved complete element validation for mixed and invalid constructor inputs