### PR TITLE
[Tiri] Add bare collection iteration

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -862,7 +862,7 @@ set (TIRI_TESTS
    array_functional array_typed_syntax bitshift bitwise has_operator approx if_empty if_empty_guard presence blank ternary table stress unit_tests
    jitoptions fstring const const_optimisation import_scope unicode ellipsis safe_nav close type_annotations type_fixing
    type_inference jit jit_try_regex pipe pipe_iteration arrow_functions result_filter thunks deferred_expr shadow_assert
-   ranges
+   ranges bare_iteration
    annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options
    try_except import include_list processing metatables with thunk_table_index debug malformed_syntax numeric_limits return_types url tips tempus
    comparison_chaining reserved_keywords compile_if_import overflow protected_globals constant_shadowing config_library

--- a/src/tiri/jit/BYTECODE.md
+++ b/src/tiri/jit/BYTECODE.md
@@ -178,10 +178,14 @@ Operand suffixes: V=variable slot, S=string const, N=number const, P=primitive (
 ##### Array Iteration Fast Path (BC_ISARR, BC_ITERA)
 - **BC_ISARR (A=D=base/jump)**: Guards array iteration setup. Checks that `R(A-2)` is a native array and `R(A-1)` is nil. On success, the opcode self-patches to `BC_ITERA` and falls through; on failure, it despecialises to `BC_JMP` and patches the following iterator to `BC_ITERC`.
 - **BC_ITERA (A=base, B/C=lit)**: Specialised native array iterator (0-based). Control var is `R(A-1)`, index result is `R(A)`, value result is `R(A+1)`. Semantics:
+  - A statically proved bare-array loop stores the array in `R(A-2)`, initialises `R(A-1)` to nil and emits `ITERA`
+    directly. `R(A-3)` is unused by this instruction.
   - If control var is nil, start at index 0; otherwise increment the control var by 1.
   - If `idx >= arr.len`: set `R(A)` to nil, proceed to `BC_ITERL` (loop exits).
   - Else: `R(A)` = index (integer tagged); `R(A-1)` updated to index; `R(A+1)` loaded via `lj_arr_getidx`.
   - JIT/hotcount entry exists as `lj_vm_IITERA`, mirroring `BC_ITERN`.
+  - `ISARR` remains available for guarded legacy layouts, but generic-for lowering no longer infers array identity from
+    the shape of a variable-load instruction.
 
 #### Return Ops
 | Opcode | Format | Description |

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -4787,17 +4787,26 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |.endif
     |
     |  // Fetch the array element into R[A+1] (value slot).
-    |  mov L:CARG1, SAVE_L
+    |  mov TMPR, SAVE_L
+    |  mov L:TMPR->base, BASE
+    |  mov SAVE_PC, PC
     |.if X64WIN
-    |  lea CARG4, [BASE+RA*8+8]    // Caveat: CARG2 == BASE.
-    |  mov CARG2, ARRAY:RB
+    |  lea CARG4, [BASE+RA*8+8]
+    |  mov TMPR, ARRAY:RB
+    |  mov RB, BASE
+    |  mov CARG2, TMPR
     |  mov CARG3d, RCd
+    |  mov L:CARG1, SAVE_L
     |.else
-    |  mov CARG2, ARRAY:RB
-    |  lea CARG4, [BASE+RA*8+8]    // Caveat: CARG3 == BASE.
-    |  mov CARG3d, RCd
+    |  mov L:CARG1, SAVE_L
+    |  mov TMPR, ARRAY:RB
+    |  lea CARG4, [BASE+RA*8+8]
+    |  mov RB, BASE
+    |  mov CARG2, TMPR
+    |  mov CARG3d, RCd             // CARG3 aliases BASE on System V.
     |.endif
     |  call extern lj_arr_getidx // (lua_State *L, GCarray *arr, int32_t idx, TValue *result)
+    |  mov BASE, RB
     |
     |  movzx RDd, PC_RD       // Get target from following ITERL instruction.
     |  branchPC RD

--- a/src/tiri/jit/src/lib/lib_base.cpp
+++ b/src/tiri/jit/src/lib/lib_base.cpp
@@ -279,6 +279,61 @@ LJLIB_ASM(ipairs)      LJLIB_REC(xpairs 1)
 }
 
 //********************************************************************************************************************
+
+static int bare_array_iterator_next(lua_State *L)
+{
+   GCarray *array = lua_toarray(L, 1);
+   if (not array) lj_err_argt(L, 1, LUA_TARRAY);
+
+   int32_t index = lua_isnil(L, 2) ? 0 : int32_t(lua_tointeger(L, 2)) + 1;
+   if (index < 0 or MSize(index) >= array->len) return 0;
+
+   lua_pushinteger(L, index);
+   lj_arr_getidx(L, array, index, L->top);
+   L->top++;
+   return 2;
+}
+
+// Normalise a single dynamic generic-for target once at loop entry.  This is a protected compiler intrinsic; source
+// code should continue to use the ordinary collection and iterator forms.
+
+LJLIB_CF(__tiri_iter_prepare)
+{
+   int32_t value_count = lua_gettop(L);
+   if (value_count >= 2) return value_count;
+
+   if (value_count IS 1 and lua_isarray(L, 1)) {
+      lua_pushcfunction(L, bare_array_iterator_next);
+      lua_pushvalue(L, 1);
+      lua_pushnil(L);
+      return 3;
+   }
+
+   if (value_count IS 1 and lua_istable(L, 1)) {
+      lua_getglobal(L, "pairs");
+      lua_pushvalue(L, 1);
+      lua_call(L, 1, LUA_MULTRET);
+      return lua_gettop(L) - 1;
+   }
+
+   if (value_count IS 1 and check_range(L, 1)) return lj_range_prepare_iterator(L, 1);
+
+   if (value_count IS 1) {
+      TValue *value = L->base;
+      if (tvisfunc(value) or not tvisnil(lj_meta_lookup(L, value, MM_call))) {
+         lua_pushvalue(L, 1);
+         lua_pushnil(L);
+         lua_pushnil(L);
+         return 3;
+      }
+   }
+
+   const char *type_name = value_count IS 0 ? "nil" : luaL_typename(L, 1);
+   luaL_error(L, "cannot iterate over a %s value", type_name);
+   return 0;
+}
+
+//********************************************************************************************************************
 // values() iterator - iterates over table values only, discarding keys
 // Usage: for v in values(tbl) do ... end
 // Equivalent to: for _, v in pairs(tbl) do ... end

--- a/src/tiri/jit/src/lib/lib_range.cpp
+++ b/src/tiri/jit/src/lib/lib_range.cpp
@@ -604,17 +604,13 @@ LJLIB_ASM(range_iterator_next) LJLIB_REC(.)
    return FFH_RES(1);
 }
 
-static int fp_range_call(lua_State *L)
+static constexpr const char *RANGE_ITERATOR_REGISTRY_KEY = "Tiri.private.range_iterator";
+
+int lj_range_prepare_iterator(lua_State *L, int Index)
 {
-   tiri_range *range = get_range(L, 1);
-   if (lua_gettop(L) >= 2) {
-      int argument_type = lua_type(L, 2);
-      if (argument_type IS LUA_TNIL or argument_type IS LUA_TNUMBER) {
-         luaL_error(L, ERR::Syntax, "range used incorrectly in for loop; use 'for i in range()' not 'for i in range'");
-      }
-   }
+   tiri_range *range = get_range(L, Index);
    size_t count = fp_range_count(L, range, false);
-   lua_pushvalue(L, lua_upvalueindex(1));
+   lua_getfield(L, LUA_REGISTRYINDEX, RANGE_ITERATOR_REGISTRY_KEY);
    lua_createtable(L, RANGE_ITERATOR_STATE_SIZE, 0);
    fp_range_push(L, range->start);
    lua_rawseti(L, -2, RANGE_ITERATOR_START);
@@ -626,6 +622,11 @@ static int fp_range_call(lua_State *L)
    lua_rawseti(L, -2, RANGE_ITERATOR_INTEGER_VALUES);
    lua_pushnil(L);
    return 3;
+}
+
+static int fp_range_call(lua_State *L)
+{
+   return lj_range_prepare_iterator(L, 1);
 }
 
 //********************************************************************************************************************
@@ -1022,13 +1023,14 @@ extern "C" int luaopen_range(lua_State *L)
    // Register the library using LuaJIT's library registration system
    LJ_LIB_REG(L, "range", range);
 
-   // Keep the stable fast iterator private and capture it in the range-object __call metamethod.
+   // Keep the stable fast iterator private for shared bare and explicit range preparation.
    lua_getfield(L, -1, "iterator_next");
+   lua_pushvalue(L, -1);
+   lua_setfield(L, LUA_REGISTRYINDEX, RANGE_ITERATOR_REGISTRY_KEY);
    lua_pushnil(L);
    lua_setfield(L, -3, "iterator_next");
    luaL_getmetatable(L, RANGE_METATABLE);
-   lua_pushvalue(L, -2);
-   lua_pushcclosure(L, fp_range_call, 1);
+   lua_pushcfunction(L, fp_range_call);
    lua_setfield(L, -2, "__call");
    lua_pop(L, 2);  // Pop the range metatable and private iterator.
 

--- a/src/tiri/jit/src/lib/lib_range.h
+++ b/src/tiri/jit/src/lib/lib_range.h
@@ -68,6 +68,7 @@ lua_Number lj_range_prepare_count(
 int32_t lj_range_integer_values(lua_Number Start, lua_Number Stop, lua_Number Step);
 lua_Number lj_range_value(lua_Number Ordinal, lua_Number Start, lua_Number Step);
 lua_Number lj_range_iterator_next_ordinal(lua_Number Control, lua_Number Start, lua_Number Step);
+int lj_range_prepare_iterator(lua_State *L, int Index);
 extern "C" void lj_range_prepare(lua_State *L, TValue *Base, uint32_t Flags);
 extern "C" void lj_range_value_at(TValue *Base);
 

--- a/src/tiri/jit/src/lj_trace.cpp
+++ b/src/tiri/jit/src/lj_trace.cpp
@@ -621,6 +621,7 @@ static void trace_stop(jit_State *J)
       pt->trace = (TraceNo1)traceno;
       break;
    case BC_ITERN:
+   case BC_ITERA:
    case BC_RET:
    case BC_RET0:
    case BC_RET1:

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -798,6 +798,14 @@ struct RangeForStmtPayload {
    ~RangeForStmtPayload();
 };
 
+enum class GenericForTarget : uint8_t {
+   IteratorProtocol,
+   KnownArray,
+   KnownTable,
+   KnownRange,
+   RuntimeCollectionOrIterator
+};
+
 struct GenericForStmtPayload {
    GenericForStmtPayload(std::vector<Identifier> names, ExprNodeList iterators,
                          std::unique_ptr<BlockStmt> body)
@@ -808,6 +816,7 @@ struct GenericForStmtPayload {
    GenericForStmtPayload& operator=(GenericForStmtPayload&&) noexcept = default;
    std::vector<Identifier> names;
    ExprNodeList iterators;
+   GenericForTarget target = GenericForTarget::IteratorProtocol;
    std::unique_ptr<BlockStmt> body;
    ~GenericForStmtPayload();
 };

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -612,21 +612,6 @@ static UnsupportedNodeRecorder glUnsupportedNodes;
 }
 
 //********************************************************************************************************************
-// Detect if a generic for iterator expression is a direct variable access suitable for array specialisation.
-
-[[nodiscard]] static int predict_array_iter(FuncState &func_state, BCPos pc)
-{
-   BCIns ins = func_state.bcbase[pc].ins;
-   BCOp op = bc_op(ins);
-
-   // The array type check is performed at runtime by BC_ISARR; this pass only verifies that the iterator
-   // expression is sourced from a direct variable load. BC_MOV, BC_UGET and BC_GGET load variables from locals,
-   // upvalues and globals respectively.
-
-   return ((op IS BC_MOV) or (op IS BC_UGET) or (op IS BC_GGET)) ? 1 : 0;
-}
-
-//********************************************************************************************************************
 // Release registers held by an indexed expression's base and key after they are no longer needed.
 
 static void release_indexed_original(FuncState &func_state, const ExpDesc &original)
@@ -2116,29 +2101,84 @@ ParserResult<IrEmitUnit> IrEmitter::emit_generic_for_stmt(const GenericForStmtPa
    }
 
    BCPos exprpc = fs->current_pc();
-   auto iterator_count = BCReg(0);
-   auto iter_values = this->emit_expression_list(Payload.iterators, iterator_count);
-   if (not iter_values.ok()) return ParserResult<IrEmitUnit>::failure(iter_values.error_ref());
+   int isnext = 0;
+   bool isarray = Payload.target IS GenericForTarget::KnownArray and Payload.names.size() <= 2;
 
-   ExpDesc tail = iter_values.value_ref();
-   this->lex_state.assign_adjust(3, iterator_count.raw(), &tail);
+   if (Payload.target IS GenericForTarget::IteratorProtocol) {
+      auto iterator_count = BCReg(0);
+      auto iter_values = this->emit_expression_list(Payload.iterators, iterator_count);
+      if (not iter_values.ok()) return ParserResult<IrEmitUnit>::failure(iter_values.error_ref());
+
+      ExpDesc tail = iter_values.value_ref();
+      this->lex_state.assign_adjust(3, iterator_count.raw(), &tail);
+      isnext = (nvars <= 5) ? predict_next(this->lex_state, *fs, exprpc) : 0;
+   }
+   else if (isarray) {
+      auto collection = this->emit_expression(*Payload.iterators.front());
+      if (not collection.ok()) return ParserResult<IrEmitUnit>::failure(collection.error_ref());
+      ExpDesc value = collection.value_ref();
+      this->materialise_to_next_reg(value, "generic for array target");
+      this->lex_state.assign_adjust(3, 1, &value);
+      bcemit_AD(fs, BC_MOV, base - BCREG(2), base - BCREG(3));
+      bcemit_nil(fs, (base - BCREG(3)).raw(), 1);
+      bcemit_nil(fs, (base - BCREG(1)).raw(), 1);
+   }
+   else if (Payload.target IS GenericForTarget::KnownTable) {
+      ExpDesc pairs_function;
+      pairs_function.init(ExpKind::Global, 0);
+      pairs_function.u.sval = fs->ls->keepstr("pairs");
+      this->materialise_to_next_reg(pairs_function, "generic for pairs intrinsic");
+      RegisterAllocator allocator(fs);
+      allocator.reserve(BCReg(1));
+
+      auto collection = this->emit_expression(*Payload.iterators.front());
+      if (not collection.ok()) return ParserResult<IrEmitUnit>::failure(collection.error_ref());
+      ExpDesc value = collection.value_ref();
+      this->materialise_to_next_reg(value, "generic for table target");
+      bcemit_INS(fs, BCINS_ABC(BC_CALL, base - BCREG(3), 4, 2));
+      fs->freereg = (base - BCREG(3) + BCREG(3)).raw();
+      isnext = nvars <= 5 ? 1 : 0;
+   }
+   else if (Payload.target IS GenericForTarget::KnownRange) {
+      auto collection = this->emit_expression(*Payload.iterators.front());
+      if (not collection.ok()) return ParserResult<IrEmitUnit>::failure(collection.error_ref());
+      ExpDesc value = collection.value_ref();
+      this->materialise_to_next_reg(value, "generic for range target");
+      RegisterAllocator allocator(fs);
+      allocator.reserve(BCReg(1));
+      bcemit_INS(fs, BCINS_ABC(BC_CALL, base - BCREG(3), 4, 1));
+      fs->freereg = (base - BCREG(3) + BCREG(3)).raw();
+   }
+   else {
+      ExpDesc prepare_function;
+      prepare_function.init(ExpKind::Global, 0);
+      prepare_function.u.sval = fs->ls->keepstr("__tiri_iter_prepare");
+      this->materialise_to_next_reg(prepare_function, "generic for runtime preparation intrinsic");
+      RegisterAllocator allocator(fs);
+      allocator.reserve(BCReg(1));
+
+      auto collection = this->emit_expression(*Payload.iterators.front());
+      if (not collection.ok()) return ParserResult<IrEmitUnit>::failure(collection.error_ref());
+      ExpDesc value = collection.value_ref();
+      if (value.k IS ExpKind::Call) {
+         setbc_b(ir_bcptr(fs, &value), 0);
+         bcemit_INS(fs, BCINS_ABC(BC_CALLM, base - BCREG(3), 4,
+            value.u.s.aux - (base - BCREG(3)) - BCREG(2)));
+      }
+      else {
+         this->materialise_to_next_reg(value, "generic for runtime target");
+         bcemit_INS(fs, BCINS_ABC(BC_CALL, base - BCREG(3), 4, 2));
+      }
+      fs->freereg = (base - BCREG(3) + BCREG(3)).raw();
+   }
 
    bcreg_bump(fs, 3  + 1);
-   int isnext = (nvars <= 5) ? predict_next(this->lex_state, *fs, exprpc) : 0;
-   int isarr = 0;
    this->lex_state.var_add(3);
-
-   // Array iteration prediction is mutually exclusive with the 'next' optimisation.
-   // Only attempt array prediction when the 'next' optimisation is not selected.
-
-   if ((isnext IS 0) and iterator_count IS BCREG(1) and nvars <= 5) {
-      isarr = predict_array_iter(*fs, exprpc);
-   }
 
    auto loop_stack_guard = this->push_loop_context(BCPos(NO_JMP));
 
    ControlFlowEdge loop = this->control_flow.make_unconditional(
-      BCPos(bcemit_AJ(fs, isnext ? BC_ISNEXT : (isarr ? BC_ISARR : BC_JMP), base, NO_JMP)));
+      BCPos(bcemit_AJ(fs, isnext ? BC_ISNEXT : BC_JMP, base, NO_JMP)));
 
    {
       FuncScope visible_scope;
@@ -2176,7 +2216,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_generic_for_stmt(const GenericForStmtPa
    }
 
    loop.patch_head(fs->current_pc());
-   BCPos iter = BCPos(bcemit_ABC(fs, isnext ? BC_ITERN : isarr ? BC_ITERA : BC_ITERC, base, nvars - BCREG(3) + BCREG(1), 3));
+   BCPos iter = BCPos(bcemit_ABC(fs, isnext ? BC_ITERN : isarray ? BC_ITERA : BC_ITERC,
+      base, nvars - BCREG(3) + BCREG(1), 3));
    ControlFlowEdge loopend = this->control_flow.make_unconditional(BCPos(bcemit_AJ(fs, BC_ITERL, base, NO_JMP)));
    BCLine encoded_body_line = BCLine::encode(this->lex_state.current_file_index, Payload.body->span.line.lineNumber());
    fs->bcbase[loopend.head().raw() - 1].line = encoded_body_line;

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -4152,6 +4152,51 @@ static size_t count_opcode_tree(const BytecodeSnapshot &Snapshot, BCOp Opcode)
    return count;
 }
 
+static bool test_bare_collection_iteration_emission(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *L = state.get();
+   luaL_openlibs(L);
+   lua_protect_globals(L);
+   std::string error;
+
+   constexpr std::string_view source =
+      "local array_values = array<int> { 1, 2, 3 }\n"
+      "for index, value in array_values do end\n"
+      "local table_values = { answer = 42 }\n"
+      "for key, value in table_values do end\n"
+      "local stored_range = range(1, 4)\n"
+      "for value in stored_range do end\n"
+      "for value in {1 to 4} do end\n"
+      "local function dynamic(Target:any) for first, second in Target do end end\n"
+      "for key, value in pairs(table_values) do end\n";
+
+   auto snapshot = compile_snapshot(L, source, true, error);
+   if (not snapshot) {
+      Log.error("bare collection iteration source failed to compile: %s", error.c_str());
+      return false;
+   }
+
+   if (count_opcode_tree(*snapshot, BC_ITERA) != 1 or count_opcode_tree(*snapshot, BC_ISARR) != 0) {
+      Log.error("proved bare arrays did not lower directly to ITERA without ISARR");
+      return false;
+   }
+   if (count_opcode_tree(*snapshot, BC_ITERN) != 2) {
+      Log.error("proved bare tables and explicit pairs() emitted %" PRId64 " ITERN instructions instead of two",
+         int64_t(count_opcode_tree(*snapshot, BC_ITERN)));
+      return false;
+   }
+   if (count_opcode_tree(*snapshot, BC_ITERC) != 2) {
+      Log.error("stored ranges and dynamic targets did not use one prepared ITERC path each");
+      return false;
+   }
+   if (count_opcode_tree(*snapshot, BC_FORI) != 1 or count_opcode_tree(*snapshot, BC_FORL) != 1) {
+      Log.error("direct range literals did not retain their specialised FORI/FORL lowering");
+      return false;
+   }
+   return true;
+}
+
 static bool test_tail_call_eligibility(kt::Log &Log)
 {
    LuaStateHolder state;
@@ -4769,7 +4814,7 @@ static bool test_type_guided_emission(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 51> tests = { {
+   constexpr std::array<TestCase, 52> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -4785,6 +4830,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "deprecated_numeric_for_rejected", test_deprecated_numeric_for_rejected },
       { "array_length_range_for_ast", test_array_length_range_for_ast },
       { "generic_for_ast", test_generic_for_ast },
+      { "bare_collection_iteration_emission", test_bare_collection_iteration_emission },
       { "repeat_defer_ast", test_repeat_defer_ast },
       { "ternary_presence_expr_ast", test_ternary_presence_expr_ast },
       { "return_lowering", test_return_lowering },

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -899,6 +899,15 @@ private:
             result.nullable = false;
          }
       }
+      else if (const auto *direct = std::get_if<DirectCallTarget>(&Call.target);
+          direct and direct->callable and direct->callable->kind IS AstNodeKind::IdentifierExpr and
+          not std::get<NameRef>(direct->callable->data).binding_id and
+          std::get<NameRef>(direct->callable->data).identifier.symbol and
+          std::get<NameRef>(direct->callable->data).identifier.symbol->hash IS kt::strhash("range")) {
+         result.primary = TiriType::Range;
+         result.proof = StaticProof::Closed;
+         result.nullable = false;
+      }
       else if (StaticModuleHandle mod = this->literal_module_load(Call);
           mod and (result.primary IS TiriType::Unknown or result.primary IS TiriType::Userdata)) {
          result.primary = TiriType::Userdata;
@@ -912,7 +921,12 @@ private:
             std::get_if<NameRef>(&member.table->data) : nullptr;
          if (base and not base->binding_id and base->identifier.symbol and member.member.symbol and
              member.member.symbol->hash IS kt::strhash("new")) {
-            if (base->identifier.symbol->hash IS kt::strhash("obj") and
+            if (base->identifier.symbol->hash IS kt::strhash("range")) {
+               result.primary = TiriType::Range;
+               result.proof = StaticProof::Closed;
+               result.nullable = false;
+            }
+            else if (base->identifier.symbol->hash IS kt::strhash("obj") and
                 Call.result_type IS TiriType::Object) {
                result.primary = TiriType::Object;
                result.object_class_id = Call.object_class_id;
@@ -1618,7 +1632,21 @@ private:
             for (auto &iterator : payload.iterators) if (iterator) this->propagate_expression(*iterator);
             if (payload.iterators.size() IS 1 and not payload.names.empty()) {
                StaticValueDescriptor iterator = this->descriptor_of(*payload.iterators.front());
-               if (iterator.primary IS TiriType::Array and iterator.array_element.known) {
+               if (iterator.proved() and iterator.primary IS TiriType::Func and
+                   (not iterator.nullable or payload.iterators.front()->kind IS AstNodeKind::CallExpr)) {
+                  payload.target = GenericForTarget::IteratorProtocol;
+               }
+               else if (iterator.proved() and not iterator.nullable) {
+                  switch (iterator.primary) {
+                     case TiriType::Array: payload.target = GenericForTarget::KnownArray; break;
+                     case TiriType::Table: payload.target = GenericForTarget::KnownTable; break;
+                     case TiriType::Range: payload.target = GenericForTarget::KnownRange; break;
+                     default: payload.target = GenericForTarget::RuntimeCollectionOrIterator; break;
+                  }
+               }
+               else payload.target = GenericForTarget::RuntimeCollectionOrIterator;
+
+               if (payload.target IS GenericForTarget::KnownArray) {
                   auto &first = this->catalogue_.binding(payload.names.front().binding_id);
                   StaticValueDescriptor index;
                   index.primary = TiriType::Num;
@@ -1636,7 +1664,16 @@ private:
                      payload.names[1].static_value = second.value;
                   }
                }
+               else if (payload.target IS GenericForTarget::KnownRange) {
+                  auto &first = this->catalogue_.binding(payload.names.front().binding_id);
+                  StaticValueDescriptor value;
+                  value.primary = TiriType::Num;
+                  value.proof = StaticProof::Trusted;
+                  first.value = this->add_value(value);
+                  payload.names.front().static_value = first.value;
+               }
             }
+            else payload.target = GenericForTarget::IteratorProtocol;
             if (payload.body) this->propagate_block(*payload.body);
             break;
          }

--- a/src/tiri/tests/test_bare_iteration.tiri
+++ b/src/tiri/tests/test_bare_iteration.tiri
@@ -1,0 +1,169 @@
+-- Flute regression tests for collection-aware generic for loops.
+
+@Test function BareArrayIteration()
+   local values = array<int> { 10, 20, 30 }
+   local total = 0
+   local expected_index = 0
+   for index, value in values do
+      assert(index is expected_index, 'Bare array iteration should yield zero-based indices')
+      total += value
+      expected_index++
+   end
+   assert(total is 60, 'Bare array iteration should yield every element')
+end
+
+@Test function BareTableIteration()
+   local values = { alpha = 2, beta = 3, [7] = 5 }
+   local total = 0
+   local count = 0
+   for key, value in values do
+      assert(values[key] is value, 'Bare table iteration should yield matching key/value pairs')
+      total += value
+      count++
+   end
+   assert(total is 10 and count is 3, 'Bare table iteration should visit every entry')
+end
+
+@Test function BareTableHonoursPairsMetamethod()
+   local values = setmetatable({ ignored = 1 }, {
+      __pairs = function(Self):<func, table, nil>
+         return next, { custom = 42 }, nil
+      end
+   })
+
+   local count = 0
+   for key, value in values do
+      assert(key is 'custom' and value is 42, 'Bare table iteration should use __pairs results')
+      count++
+   end
+   assert(count is 1, 'Custom __pairs iteration should control the result set')
+end
+
+@Test function BareStoredRangeIteration()
+   local cases = {
+      { value = range(0, 5), expected = 10 },
+      { value = range(5, 0), expected = 15 },
+      { value = range(0, 4, true, 0.5), expected = 18 },
+      { value = range(3, 3), expected = 0 }
+   }
+   for _, case in pairs(cases) do
+      local total = 0
+      for value in case.value do total += value end
+      assert(total is case.expected, 'Bare stored range iteration produced the wrong values')
+   end
+end
+
+@Test function CollectionTargetEvaluatedOnce()
+   local calls = 0
+   function make_values():array<int>
+      calls++
+      return array<int> { 1, 2, 3 }
+   end
+
+   local total = 0
+   for _, value in make_values() do total += value end
+   assert(calls is 1 and total is 6, 'A bare collection target should be evaluated exactly once')
+end
+
+@Test function CallableTableUsesPairsWhenBare()
+   local call_count = 0
+   local values = setmetatable({ amount = 7 }, {
+      __call = function(Self):num
+         call_count++
+         return Self.amount
+      end
+   })
+
+   local seen = 0
+   for key, value in values do
+      if key is 'amount' then seen = value end
+   end
+   assert(seen is 7 and call_count is 0, 'A bare callable table should use table iteration')
+   assert(values() is 7 and call_count is 1, 'An explicit call should continue to use __call')
+end
+
+@Test function DynamicTargetCanChangeCategory()
+   function sum_dynamic(Target:any, UseSecond:bool):num
+      local total = 0
+      for first, second in Target do total += UseSecond ? second :> first end
+      return total
+   end
+
+   local values = array<int> { 2, 3, 5 }
+   for _ in {0 to 250} do assert(sum_dynamic(values, true) is 10) end
+   assert(sum_dynamic({ a = 4, b = 6 }, true) is 10)
+   assert(sum_dynamic(range(1, 5), false) is 10)
+   assert(sum_dynamic(values, true) is 10, 'Dynamic dispatch should remain valid after changing categories')
+end
+
+@Test function InterpreterAndJITResultsMatch()
+   function sum_array(Target:array<int>):num
+      local total = 0
+      for index, value in Target do total += index + value end
+      return total
+   end
+
+   function sum_table(Target:table):num
+      local total = 0
+      for _, value in Target do total += value end
+      return total
+   end
+
+   function sum_range(Target:range):num
+      local total = 0
+      for value in Target do total += value end
+      return total
+   end
+
+   local values = array<int> { 2, 3, 5 }
+   local entries = { a = 4, b = 6 }
+   local numbers = range(1, 5)
+
+   jit.off()
+   local interpreted = { sum_array(values), sum_table(entries), sum_range(numbers) }
+
+   jit.on()
+   jit.flush()
+   local compiled
+   for _ in {0 to 250} do
+      compiled = { sum_array(values), sum_table(entries), sum_range(numbers) }
+   end
+
+   assert(interpreted[1] is compiled[1] and interpreted[2] is compiled[2] and interpreted[3] is compiled[3],
+      'Known collection loops should produce matching interpreter and JIT results')
+end
+
+@Test function ExistingIteratorProtocolsRemainSupported()
+   function iterator(State, Control):<num, num>
+      local next_value = (Control ?? 0) + 1
+      if next_value > State then return end
+      return next_value, next_value * 2
+   end
+
+   local total = 0
+   for key, value in iterator, 3, 0 do total += key + value end
+   assert(total is 18, 'Explicit iterator triples should retain their established behaviour')
+
+   total = 0
+   for key, value in pairs({ a = 2, b = 3 }) do total += value end
+   assert(total is 5, 'Explicit pairs() should retain its established behaviour')
+end
+
+@Test function UnsupportedBareTargetsHaveFocusedDiagnostic()
+   local cases = {
+      { source = 'local value:any = nil; for item in value do end', type_name = 'nil' },
+      { source = 'local value:func = nil; for item in value do end', type_name = 'nil' },
+      { source = 'local value:any = 7; for item in value do end', type_name = 'number' },
+      { source = "local value:any = 'text'; for item in value do end", type_name = 'string' },
+      { source = 'local value:any = false; for item in value do end', type_name = 'boolean' }
+   }
+
+   for _, case in pairs(cases) do
+      local script = obj.new('tiri', { statement = case.source })
+      local result = script.acActivate()
+      assert(result != ERR_Okay or script.error != ERR_Okay,
+         'Unsupported bare targets should fail before iteration')
+      assert(string.find(script.errorMessage, 'cannot iterate over a ' .. case.type_name .. ' value') != nil,
+         'Unsupported bare target diagnostic should identify its runtime type: ' .. script.errorMessage)
+   end
+end

--- a/tools/benchmark/benchmark.tiri
+++ b/tools/benchmark/benchmark.tiri
@@ -13,6 +13,7 @@ Parameters:
   warmup=[n]   - Warmup cycles per test.
   hotloop=[n]  - Cycles required before performing JIT optimisation.
   calls=[n]    - Limit each test to this many calls.
+  interpreter  - Disable JIT compilation during timing.
   save[=all]   - Saves the results to the log.  Use save=all to store the full result tables.
   traces       - Report on JIT trace compilation for each test instead of timing it.
  --]]
@@ -78,6 +79,8 @@ Examples:
         comment = 'Cycles required before performing JIT optimisation.' },
       { name = 'calls', type = 'int', default = 1000, group = 'Timing',
         comment = 'Limit each benchmark to this many measured calls.' },
+      { name = 'interpreter', kind = 'flag', group = 'Timing',
+        comment = 'Disable JIT compilation during the timing run.' },
 
       { name = 'save', type = saveOption, implicit = true, default = false, group = 'Output',
         comment = 'Save summary results to the log. Use "all" to include exhaustive benchmark statistics.' },
@@ -209,6 +212,7 @@ end
    local call_limit   = glArgs.calls
    local save_results = glArgs.save
    local trace_mode   = glArgs.traces
+   local interpreter_mode = glArgs.interpreter
 
    local test_match = glArgs.test
    if test_match then
@@ -302,6 +306,13 @@ end
       return
    end
 
+   if interpreter_mode then
+      jit.off()
+      logMessage('Interpreter-only timing mode')
+   else
+      jit.on()
+   end
+
    for entry in values(name_list) do
       func = entry.func
       name = entry.name
@@ -347,6 +358,8 @@ end
          end
       end
    end
+
+   if interpreter_mode then jit.on() end
 
    local last_result
    try

--- a/tools/benchmark/benchmark_array.tiri
+++ b/tools/benchmark/benchmark_array.tiri
@@ -404,6 +404,16 @@ end
    return total_length
 end
 
+@Test function IterateArrayBare()
+   local total_length = 0
+   for i in {0 to 50} do
+      for _, s in glStrArray do
+         total_length += #s
+      end
+   end
+   return total_length
+end
+
 @Test function IterateTableIPairs()
    local total_length = 0
    for i in {0 to 50} do
@@ -432,6 +442,48 @@ end
       end
    end
    return checksum
+end
+
+@Test function IterateTableBare()
+   local checksum = 0
+   for i in {0 to 50} do
+      for k, v in glIntTable do
+         checksum += k + v
+      end
+   end
+   return checksum
+end
+
+function iterate_dynamic_array_bare(Target:any)
+   local total_length = 0
+   for _, value in Target do
+      total_length += #value
+   end
+   return total_length
+end
+
+function iterate_dynamic_array_ipairs(Target:any)
+   local total_length = 0
+   for _, value in ipairs(Target) do
+      total_length += #value
+   end
+   return total_length
+end
+
+@Test function IterateDynamicArrayBare()
+   local total_length = 0
+   for i in {0 to 50} do
+      total_length += iterate_dynamic_array_bare(glStrArray)
+   end
+   return total_length
+end
+
+@Test function IterateDynamicArrayIPairs()
+   local total_length = 0
+   for i in {0 to 50} do
+      total_length += iterate_dynamic_array_ipairs(glStrArray)
+   end
+   return total_length
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/tools/benchmark/benchmark_control.tiri
+++ b/tools/benchmark/benchmark_control.tiri
@@ -517,6 +517,17 @@ end
    return sum
 end
 
+@Test function ControlForBareRangeObject()
+   local sum = 0
+   local nr = range.new(0, 100, false, 2)
+   for i in {0 to 1000} do
+      for j in nr do
+         sum += j
+      end
+   end
+   return sum
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Iterate a range literal that starts from a negative bound.
 -- NB: Measured separately because a negative start bound currently defeats trace compilation, whereas an

--- a/tools/benchmark/benchmark_struct.tiri
+++ b/tools/benchmark/benchmark_struct.tiri
@@ -84,9 +84,9 @@ end
 
 @Test function NarrowStructWriteFields()
    for i in {0 to 1000000} do
-      glBenchmarkNarrowStruct.word         = -(i & 0x7fffffff)
+      glBenchmarkNarrowStruct.word         = i & 0x7fff
       glBenchmarkNarrowStruct.byte         = i & 0x7f
-      glBenchmarkNarrowStruct.unsignedWord = i & 0xffffffff
+      glBenchmarkNarrowStruct.unsignedWord = i & 0xffff
       glBenchmarkNarrowStruct.unsignedByte = i & 0xff
    end
    return glBenchmarkNarrowStruct.word + glBenchmarkNarrowStruct.byte +


### PR DESCRIPTION
* Classify proved arrays, tables and ranges for specialised generic-for lowering
* Prepare unresolved collection targets once while preserving iterator protocol compatibility
* Add bytecode, runtime, JIT, Flute and benchmark coverage for collection-aware loops
* [Benchmark] Correct narrow struct field values to remain within their declared widths