### PR TITLE
[Tiri] Restored tail calls for typed self-recursion

### DIFF
--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -198,6 +198,7 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
    }
 
    IrEmitter child_emitter(child_ctx);
+   child_emitter.current_callable = Payload.callable;
    for (auto i = BCReg(0); i < param_count; ++i) {
       const FunctionParameter &param = Payload.parameters[i.raw()];
       if (param.name.is_blank or param.name.symbol IS nullptr) continue;

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1108,6 +1108,19 @@ static bool fixed_return_contract_is_proved(
    return true;
 }
 
+// A direct call to the same immutable function can forward its result contract to the terminal activation.  The
+// terminal return performs the identical type validation and fixed-arity adjustment once, so intermediate recursive
+// activations do not need to regain control solely to repeat those operations.
+
+static bool tail_call_forwards_current_contract(
+   const ParserContext &Context, StaticCallableHandle CurrentCallable, const ExprNode &Expression)
+{
+   if (not CurrentCallable or Expression.kind != AstNodeKind::CallExpr) return false;
+   const auto &call = std::get<CallExprPayload>(Expression.data);
+   if (call.callable != CurrentCallable) return false;
+   return Context.descriptors().callable(CurrentCallable).immutable;
+}
+
 ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Payload)
 {
    BCIns ins;
@@ -1129,6 +1142,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
       this->func_state.return_contract_explicit and not this->func_state.return_contract_variadic;
    bool return_contract_elided = has_return_contract and
       fixed_return_contract_is_proved(this->ctx, this->func_state, Payload);
+   bool return_contract_forwarded = false;
    BCREG cleanup_temp_regs = return_cleanup_temp_regs(&this->func_state);
    BCREG multres_slot = BCREG(this->func_state.varmap.size() + cleanup_temp_regs);
    if (cleanup_temp_regs > 0) return_allocator.reserve(BCReg(cleanup_temp_regs + 1));
@@ -1150,10 +1164,19 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
          BCOp call_op = bc_op(*ip);
          bool has_post_call_control_flow = last.u.s.info + 1 != this->func_state.pc;
          bool has_user_cleanup = cleanup_temp_regs > 0;
-         bool tail_call_eligible = not truncate_return_results and this->func_state.try_depth IS 0 and
-            not has_return_contract and not has_post_call_control_flow and not has_user_cleanup and
-            (call_op IS BC_CALL or call_op IS BC_CALLM);
-         if (truncate_return_results) {
+         bool forwards_current_contract = tail_call_forwards_current_contract(
+            this->ctx, this->current_callable, *Payload.values.back());
+         bool tail_call_eligible = this->func_state.try_depth IS 0 and not has_post_call_control_flow and
+            not has_user_cleanup and (call_op IS BC_CALL or call_op IS BC_CALLM) and
+            (forwards_current_contract or (not truncate_return_results and not has_return_contract));
+         if (tail_call_eligible) {
+            return_contract_forwarded = forwards_current_contract;
+            lj_assertX(last.u.s.info + 1 IS this->func_state.pc,
+               "tail call is not the final expression instruction");
+            this->func_state.pc--;
+            ins = BCINS_AD(bc_op(*ip) - BC_CALL + BC_CALLT, bc_a(*ip), bc_c(*ip));
+         }
+         else if (truncate_return_results) {
             BCREG result_count = this->func_state.return_declared_count;
             setbc_b(ip, result_count + 1);
             ins = result_count > 0 ?
@@ -1190,12 +1213,6 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
             // The callee must execute before user-visible cleanup.  Preserve all results and MULTRES across handlers.
             setbc_b(ip, 0);
             ins = BCINS_AD(BC_RETM, return_base, last.u.s.aux - return_base);
-         }
-         else if (tail_call_eligible) {
-            lj_assertX(last.u.s.info + 1 IS this->func_state.pc,
-               "tail call is not the final expression instruction");
-            this->func_state.pc--;
-            ins = BCINS_AD(bc_op(*ip) - BC_CALL + BC_CALLT, bc_a(*ip), bc_c(*ip));
          }
          else {
             setbc_b(ip, 0);
@@ -1266,7 +1283,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
    if (this->func_state.flags & PROTO_CHILD) bcemit_AJ(&this->func_state, BC_UCLO, 0, 0);
    if (preserve_multres) bcemit_AD(&this->func_state, BC_MRRESTORE, multres_slot, 0);
 
-   if (has_return_contract and not return_contract_elided and bc_op(ins) != BC_RET0) {
+   if (has_return_contract and not return_contract_elided and not return_contract_forwarded and
+       bc_op(ins) != BC_RET0) {
       std::array<RuntimeContract, MAX_RETURN_TYPES> contracts;
       for (uint8_t i = 0; i < this->func_state.return_contract_count; ++i) {
          contracts[i] = RuntimeContract{

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1250,7 +1250,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
       }
    }
 
-   if (truncate_return_results and this->func_state.return_declared_count IS 0) {
+   if (truncate_return_results and this->func_state.return_declared_count IS 0 and
+       not return_contract_forwarded) {
       ins = BCINS_AD(BC_RET0, 0, 1);
    }
    else if (truncate_return_results and bc_op(ins) IS BC_RET) {

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
@@ -158,6 +158,7 @@ private:
    OperatorEmitter   operator_emitter;
    LocalBindingTable binding_table;
    ConstantEvaluator constant_evaluator;
+   StaticCallableHandle current_callable = 0;
 
    ParserResult<IrEmitUnit> emit_block(const BlockStmt& block, FuncScopeFlag flags = FuncScopeFlag::None);
    ParserResult<IrEmitUnit> emit_block_with_bindings(const BlockStmt& block, FuncScopeFlag flags, std::span<const BlockBinding> bindings);

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -4227,6 +4227,34 @@ static bool test_tail_call_eligibility(kt::Log &Log)
       return false;
    }
 
+   constexpr std::string_view recursive_contract_source =
+      "local function recurse(Count:num, Value:any):num\n"
+      "   if Count is 0 then return Value end\n"
+      "   return recurse(Count - 1, Value)\n"
+      "end\n"
+      "return recurse\n";
+   auto recursive_contract = compile_snapshot(L, recursive_contract_source, true, error);
+   if (not recursive_contract or count_opcode_tree(*recursive_contract, BC_CALLT) != 1 or
+       count_opcode_tree(*recursive_contract, BC_CALL) != 0 or
+       count_opcode_tree(*recursive_contract, BC_CONTRACT) != 2) {
+      Log.error("a direct self-tail call did not forward its fixed return contract: %s", error.c_str());
+      return false;
+   }
+
+   constexpr std::string_view mutable_recursive_source =
+      "local function recurse(Count:num):num\n"
+      "   if Count is 0 then return 0 end\n"
+      "   return recurse(Count - 1)\n"
+      "end\n"
+      "recurse = function(Value:num):num return Value end\n"
+      "return recurse\n";
+   auto mutable_recursive = compile_snapshot(L, mutable_recursive_source, true, error);
+   if (not mutable_recursive or count_opcode_tree(*mutable_recursive, BC_CALLT) != 0 or
+       count_opcode_tree(*mutable_recursive, BC_CALL) IS 0) {
+      Log.error("a mutable recursive target was incorrectly treated as the current function: %s", error.c_str());
+      return false;
+   }
+
    constexpr std::string_view cleanup_source =
       "local function source():<num, str> return 7, 'cleanup' end\n"
       "local function cleaned()\n"

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -4241,6 +4241,19 @@ static bool test_tail_call_eligibility(kt::Log &Log)
       return false;
    }
 
+   constexpr std::string_view recursive_void_source =
+      "local function recurse(Count:num):<>\n"
+      "   if Count is 0 then return end\n"
+      "   return recurse(Count - 1)\n"
+      "end\n"
+      "return recurse\n";
+   auto recursive_void = compile_snapshot(L, recursive_void_source, true, error);
+   if (not recursive_void or count_opcode_tree(*recursive_void, BC_CALLT) != 1 or
+       count_opcode_tree(*recursive_void, BC_CALL) != 0) {
+      Log.error("an explicit-void self-tail call was overwritten by result truncation: %s", error.c_str());
+      return false;
+   }
+
    constexpr std::string_view mutable_recursive_source =
       "local function recurse(Count:num):num\n"
       "   if Count is 0 then return 0 end\n"

--- a/src/tiri/tests/test_return_types.tiri
+++ b/src/tiri/tests/test_return_types.tiri
@@ -340,6 +340,42 @@ end
    assert(fib(10) is 55, "recursive fibonacci with type should work")
 end
 
+@Test function TypedTailRecursionDoesNotGrowTheStack()
+   function count_down(Count: num, Accumulator: num):num
+      if Count is 0 then return Accumulator end
+      return count_down(Count - 1, Accumulator + 1)
+   end
+
+   assert(count_down(100000, 0) is 100000,
+      "a typed self-tail call should complete without exhausting the stack")
+end
+
+@Test function TypedTailRecursionPreservesTheReturnContract()
+   function typed_tail(Count: num, Value:any):num
+      if Count is 0 then return Value end
+      return typed_tail(Count - 1, Value)
+   end
+
+   try
+      typed_tail(1000, 'wrong')
+   except ex
+      assert(ex.message, "the terminal activation should report the invalid result")
+   success
+      error("a forwarded recursive return contract should still reject an invalid result")
+   end
+end
+
+@Test function TypedTailRecursionPreservesFixedArity()
+   function fixed_tail(Count: num):num
+      if Count is 0 then return 1, 2 end
+      return fixed_tail(Count - 1)
+   end
+
+   local first, truncated = fixed_tail(1000)
+   assert(first is 1, "the declared recursive result should be preserved")
+   assert(truncated is nil, "the terminal activation should truncate undeclared recursive results")
+end
+
 @Test function RecursiveFunctionWithoutTypeError()
    try
       exec([[

--- a/src/tiri/tests/test_return_types.tiri
+++ b/src/tiri/tests/test_return_types.tiri
@@ -376,6 +376,18 @@ end
    assert(truncated is nil, "the terminal activation should truncate undeclared recursive results")
 end
 
+@Test function ExplicitVoidTailRecursionExecutesEveryCall()
+   local visits = 0
+   function void_tail(Count: num):<>
+      visits++
+      if Count is 0 then return end
+      return void_tail(Count - 1)
+   end
+
+   void_tail(100000)
+   assert(visits is 100001, "an explicit-void self-tail call should execute every recursive activation")
+end
+
 @Test function RecursiveFunctionWithoutTypeError()
    try
       exec([[


### PR DESCRIPTION
* Forward identical return contracts and fixed arity to terminal recursive activations
* Added bytecode and runtime coverage for deep recursion, contract enforcement, truncation and mutable targets