### PR TITLE
[Tiri] Changed math.random upper-bound overload to zero-based indexing

### DIFF
--- a/src/tiri/jit/src/lib/lib_math.cpp
+++ b/src/tiri/jit/src/lib/lib_math.cpp
@@ -200,7 +200,7 @@ LJLIB_CF(math_random)      LJLIB_REC(.)
       double r1 = lj_lib_checknum(L, 1);
 #endif
       if (n == 1) {
-         d = lj_vm_floor(d * r1) + 1.0;  //  d is an int in range [1, r1]
+         d = lj_vm_floor(d * r1);  //  d is an int in range [0, r1)
       }
       else {
 #if LJ_DUALNUM

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -1233,10 +1233,9 @@ static void recff_math_random(jit_State* J, RecordFFData* rd)
          tr = emitir(IRTN(IR_FPMATH), tr, IRFPM_FLOOR);
          tr = emitir(IRTN(IR_ADD), tr, tr1);
       }
-      else {  // d = floor(d*r1) + 1.0
+      else {  // d = floor(d*r1)
          tr = emitir(IRTN(IR_MUL), tr, tr1);
          tr = emitir(IRTN(IR_FPMATH), tr, IRFPM_FLOOR);
-         tr = emitir(IRTN(IR_ADD), tr, one);
       }
    }
    J->base[0] = tr;

--- a/src/tiri/tests/test_math.tiri
+++ b/src/tiri/tests/test_math.tiri
@@ -23,6 +23,17 @@
    assert(math.round(1234.5, -2) is 1200, 'math.round(1234.5, -2) should be 1200')
 end
 
+@Test function RandomUsesZeroBasedUpperBound()
+   for _ in {0 to 100} do
+      assert(math.random(1) is 0, 'math.random(1) should return the only value in the range [0, 1)')
+   end
+
+   assert(math.random(7, 7) is 7, 'math.random(Min, Max) should retain its explicit inclusive bounds')
+
+   local fraction = math.random()
+   assert(fraction >= 0 and fraction < 1, 'math.random() should return a value in the range [0, 1)')
+end
+
 @Test function Clamp()
    assert(math.clamp(-5, 0, 10) is 0, 'math.clamp() should clamp values below the lower bound')
    assert(math.clamp(5, 0, 10) is 5, 'math.clamp() should leave values inside the range unchanged')


### PR DESCRIPTION
* Returned values in [0, N) from interpreted and JIT-compiled math.random(N) calls
* Added regression coverage for zero-based, fractional and explicit-bound behaviour