### PR TITLE
[Tiri] The length operator now returns nil for tables addressed with a string key

### DIFF
--- a/src/tiri/jit/src/debug/lj_errmsg.h
+++ b/src/tiri/jit/src/debug/lj_errmsg.h
@@ -33,6 +33,7 @@ ERRDEF(BADKEY,   "String key not recognised")
 ERRDEF(OPARITH,  "Perform arithmetic on")
 ERRDEF(OPCAT,    "Concatenate")
 ERRDEF(OPLEN,    "Get length of")
+ERRDEF(LENMM,    "__len metamethod must return a number")
 
 // Type checks.
 ERRDEF(BADSELF,  "Calling " LUA_QS " on bad self (%s)")

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -864,6 +864,14 @@ static void build_subroutines(BuildCtx *ctx)
   |->cont_nop:
   |  ins_next
   |
+  |->cont_len:                         // RA = resultptr
+  |  str BASE, L->base
+  |  mov CARG2, RA
+  |  mov CARG1, L
+  |  str PC, SAVE_PC
+  |  bl extern lj_meta_len_result      // (lua_State *L, TValue *Result)
+  |  ldr BASE, L->base
+  |  mov RA, CRET1
   |->cont_ra:				// RA = resultptr
   |  ldr INS, [PC, #-8]		// Load full 64-bit BCIns
   |   ldr TMP0, [RA]

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -2769,6 +2769,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  cbnz TAB:CARG2, >9
     |3:
     |->BC_LEN_Z:
+    |  // An ordinary table that has ever been addressed with a string key has no sequence length.
+    |  ldrb TMP1w, TAB:CARG1->flags
+    |  tbnz TMP1w, #TAB_STRING_KEYED_BIT, >8
     |  bl extern lj_tab_len		// (GCtab *t)
     |  // Returns uint32_t (but less than 2^31).
     |  b <1
@@ -2778,6 +2781,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  bne ->vmeta_len
     |  ldr CARG1w, ARRAY:CARG1->len
     |  b <1
+    |
+    |8:  // String-keyed table: the length operator yields nil.
+    |  str TISNIL, [BASE, RA, lsl #3]
+    |  ins_next
     |
     |9:
     |  ldrb TMP1w, TAB:CARG2->nomm
@@ -3349,6 +3356,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  cmp TMP1, TISNIL			// Previous value is nil?
     |  beq >4
     |2:
+    |  // The raw store commits here, so classify the receiving table (lj_tab_newkey() covers the new-key path
+    |  // below).  A store diverted to __newindex never reaches this point.
+    |  ldrb CARG4w, TAB:CARG2->flags
+    |  orr CARG4w, CARG4w, #TAB_STRING_KEYED
+    |  strb CARG4w, TAB:CARG2->flags
     |   str TMP0, NODE:CARG3->val
     |    tbnz TMP2w, #2, >7		// isblack(table)
     |3:

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -1255,6 +1255,14 @@ static void build_subroutines(BuildCtx *ctx)
   |->cont_nop:
   |  ins_next
   |
+  |->cont_len:				// RA = resultptr
+  |  stp BASE, L->base
+  |  mr CARG2, RA
+  |  mr CARG1, L
+  |  stw PC, SAVE_PC
+  |  bl extern lj_meta_len_result	// (lua_State *L, TValue *Result)
+  |  lp BASE, L->base
+  |  mr RA, CRET1
   |->cont_ra:				// RA = resultptr
   |  ld INS, -8(PC)
   |.if FPU

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -4044,6 +4044,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  bne >9
     |3:
     |->BC_LEN_Z:
+    |  // An ordinary table that has ever been addressed with a string key has no sequence length.
+    |  lbz TMP0, TAB:CARG1->flags
+    |  andix. TMP0, TMP0, TAB_STRING_KEYED
+    |  bne >8
     |  bl extern lj_tab_len		// (GCtab *t)
     |  // Returns uint32_t (but less than 2^31).
     |  b <1
@@ -4051,6 +4055,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  checkarray TMP0; bne ->vmeta_len
     |  lwz CRET1, ARRAY:CARG1->len
     |  b <1
+    |8:  // String-keyed table: the length operator yields nil.
+    |  ins_next1
+    |  stwx TISNIL, BASE, RA
+    |  ins_next2
     |9:
     |  lbz TMP0, TAB:TMP2->nomm
     |  andix. TMP0, TMP0, 1<<MM_len
@@ -4983,6 +4991,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |   cmpw TMP0, STR:RC; bne >5
     |    checknil CARG2; beq >4		// Key found, but nil value?
     |2:
+    |  // The raw store commits here, so classify the receiving table (lj_tab_newkey() covers the new-key path
+    |  // below).  A store diverted to __newindex never reaches this point.
+    |  lbz CARG1, TAB:RB->flags
+    |  ori CARG1, CARG1, TAB_STRING_KEYED
+    |  stb CARG1, TAB:RB->flags
     |  andix. TMP0, TMP3, LJ_GC_BLACK	// isblack(table)
     |.if FPU
     |    stfd f14, NODE:TMP2->val

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -3441,6 +3441,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  jnz >9
     |3:
     |->BC_LEN_Z:
+    |  // An ordinary table that has ever been addressed with a string key has no sequence length.
+    |  test byte TAB:CARG1->flags, TAB_STRING_KEYED
+    |  jnz >8
     |  mov RB, BASE        // Save BASE.
     |  call extern lj_tab_len    // (GCtab *t)
     |  // Length of table returned in eax (RD).
@@ -3462,6 +3465,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  cvtsi2sd xmm0, dword ARRAY:RD->len
     |  jmp <1
     |.endif
+    |8:  // String-keyed table: the length operator yields nil.
+    |  movzx RAd, PC_RA
+    |  mov aword [BASE+RA*8], LJ_TNIL
+    |  ins_next
     |9:  // Check for __len.
     |  test byte TAB:RB->nomm, 1<<MM_len
     |  jnz <3
@@ -4073,7 +4080,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |2:
     |  test byte TAB:RB->marked, LJ_GC_BLACK // isblack(table)
     |  jnz >7
-    |3:  // Set node value.
+    |3:  // Set node value.  The raw store commits here, so classify the receiving table (lj_tab_newkey() covers the
+    |    // new-key path below).  A store diverted to __newindex never reaches this point.
+    |  or byte TAB:RB->flags, TAB_STRING_KEYED
     |  mov ITYPE, [BASE+RA*8]
     |  mov [TMPR], ITYPE
     |  ins_next

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -830,6 +830,15 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov BASE, L:RB->base
   |  test RC, RC
   |  jz >3
+  |  jmp ->cont_ra
+  |->cont_len:          // BASE = base, RC = result
+  |  mov L:RB, SAVE_L
+  |  mov L:RB->base, BASE
+  |  mov CARG2, RC
+  |  mov L:CARG1, L:RB
+  |  mov SAVE_PC, PC
+  |  call extern lj_meta_len_result  // (lua_State *L, TValue *Result)
+  |  mov BASE, L:RB->base
   |->cont_ra:           // BASE = base, RC = result
   |  movzx RAd, PC_RA
   |  mov RB, [RC]

--- a/src/tiri/jit/src/lj_ir.h
+++ b/src/tiri/jit/src/lj_ir.h
@@ -221,7 +221,8 @@ typedef enum {
   _(STRUCT_DEF, offsetof(GCstruct, def)) \
   _(TAB_GCONTRACTS, offsetof(GCtab, global_type_contracts)) \
   _(OBJ_CLASSPTR, offsetof(GCobject, classptr)) \
-  _(ARRAY_STRUCTDEF, offsetof(GCarray, structdef))
+  _(ARRAY_STRUCTDEF, offsetof(GCarray, structdef)) \
+  _(TAB_FLAGS, offsetof(GCtab, flags))
 
 typedef enum {
 #define FLENUM(name, ofs)   IRFL_##name,

--- a/src/tiri/jit/src/lj_opt_mem.cpp
+++ b/src/tiri/jit/src/lj_opt_mem.cpp
@@ -614,10 +614,17 @@ TRef lj_opt_fwd_fload(jit_State* J)
    }
 
    // No conflicting store: const-fold field loads from allocations.
-   if (fid == IRFL_TAB_META) {
+   if (fid IS IRFL_TAB_META or fid IS IRFL_TAB_GCONTRACTS) {
       IRIns* ir = IR(oref);
-      if (ir->o == IR_TNEW or ir->o == IR_TDUP)
+      if (ir->o IS IR_TNEW or ir->o IS IR_TDUP)
          return lj_ir_knull(J, IRT_TAB);
+   }
+   else if (fid IS IRFL_TAB_FLAGS) {
+      IRIns* ir = IR(oref);
+      if (ir->o IS IR_TNEW)
+         return lj_ir_kint(J, 0);
+      else if (ir->o IS IR_TDUP)
+         return lj_ir_kint(J, ir_ktab(IR(ir->op1))->flags);
    }
 
 cselim:

--- a/src/tiri/jit/src/lj_opt_mem.cpp
+++ b/src/tiri/jit/src/lj_opt_mem.cpp
@@ -565,8 +565,9 @@ static AliasRet aa_fref(jit_State* J, IRIns* refa, IRIns* refb)
       return ALIAS_NO;  //  Different fields.
    if (refa->op1 == refb->op1)
       return ALIAS_MUST;  //  Same field, same object.
-   else if (refa->op2 >= IRFL_TAB_META and refa->op2 <= IRFL_TAB_NOMM)
+   else if ((refa->op2 >= IRFL_TAB_META and refa->op2 <= IRFL_TAB_NOMM) or refa->op2 IS IRFL_TAB_FLAGS)
       return aa_table(J, refa->op1, refb->op1);  //  Disambiguate tables.
+      // IRFLDEF is append-only, so IRFL_TAB_FLAGS sits outside the contiguous table-field range above.
    else
       return ALIAS_MAY;  //  Same field, possibly different object.
 }

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1642,6 +1642,16 @@ static TRef rec_mm_len(jit_State *J, TRef tr, TValue* tv)
    else {
       if (tref_istab(tr)) {
          IRBuilder ir(J);
+         // A table that has ever been addressed with a string key has no sequence length.  The classification is
+         // one-way, so guarding the observed state is sufficient: the first string-keyed store side-exits the trace
+         // and the recompilation specialises to nil.
+         TRef flags = ir.fload(tr, IRFL_TAB_FLAGS, IRT_U8);
+         TRef classified = ir.emit_int(IR_BAND, flags, ir.kint(TAB_STRING_KEYED));
+         if (tabV(tv)->flags & TAB_STRING_KEYED) {
+            ir.guard_ne_int(classified, ir.kint(0));
+            return TREF_NIL;
+         }
+         ir.guard_eq_int(classified, ir.kint(0));
          return ir.emit_int(IR_ALEN, tr, TREF_NIL); //equiv to: rc = emitir(IRTI(IR_ALEN), rc, TREF_NIL);
       }
       else if (tref_isarray(tr)) {
@@ -2152,6 +2162,15 @@ handlemm:
          TRef fref = ir.emit(IRT(IR_FREF, IRT_PGC), ix->tab, IRFL_TAB_NOMM);
          ir.emit(IRT(IR_FSTORE, IRT_U8), fref, ir.kint(0));
       }
+
+      // Publish the permanent string-key classification so that a concurrently recorded '#' guard observes it.
+
+      if (tref_isstr(ix->key) and tref_istab(ix->tab)) {
+         TRef fref = ir.emit(IRT(IR_FREF, IRT_PGC), ix->tab, IRFL_TAB_FLAGS);
+         TRef flags = ir.fload(ix->tab, IRFL_TAB_FLAGS, IRT_U8);
+         ir.emit(IRT(IR_FSTORE, IRT_U8), fref, ir.emit_int(IR_BOR, flags, ir.kint(TAB_STRING_KEYED)));
+      }
+
       J->needsnap = 1;
       return 0;
    }

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1465,10 +1465,12 @@ void lj_record_ret(jit_State *J, BCREG rbase, ptrdiff_t gotresults)
       if (FRC::dec_depth_by(J, 2) < 0) lj_trace_err(J, LJ_TRERR_NYIRETL);
       fm.pop_delta_frame(cbase);
       slots.set_maxslot(cbase - FRC::CONT_FRAME_SIZE);
-      if (cont IS lj_cont_ra) {
+      if (cont IS lj_cont_ra or cont IS lj_cont_len) {
          // Copy result to destination slot.
          BCREG dst = bc_a(*(frame_contpc(frame) - 1));
-         slots[dst] = gotresults ? slots[cbase + rbase] : TREF_NIL;
+         TRef result = gotresults ? slots[cbase + rbase] : TREF_NIL;
+         if (cont IS lj_cont_len and not tref_isnumber(result)) lj_trace_err(J, LJ_TRERR_BADTYPE);
+         slots[dst] = result;
          slots.ensure_slot(dst);
       }
       else if (cont IS lj_cont_nop) {
@@ -1630,7 +1632,7 @@ static TRef rec_mm_len(jit_State *J, TRef tr, TValue* tv)
    ix.tab = tr;
    copyTV(J->L, &ix.tabv, tv);
    if (lj_record_mm_lookup(J, &ix, MM_len)) {
-      BCREG func = rec_mm_prep(J, lj_cont_ra);
+      BCREG func = rec_mm_prep(J, lj_cont_len);
       TRef* base = J->base + func;
       TValue* basev = J->L->base + func;
       base[0] = ix.mobj; copyTV(J->L, basev + 0, &ix.mobjv);

--- a/src/tiri/jit/src/lj_snap.cpp
+++ b/src/tiri/jit/src/lj_snap.cpp
@@ -798,12 +798,17 @@ static void snap_unsink(jit_State *J, GCtrace *T, ExitState *ex, SnapNo snapno, 
             TValue tmp, * val;
             lj_assertJ(irs->o IS IR_ASTORE or irs->o IS IR_HSTORE or irs->o IS IR_FSTORE, "sunk store with bad op %d", irs->o);
             if (irk->o IS IR_FREF) {
-               lj_assertJ(irk->op2 IS IRFL_TAB_META, "sunk store with bad field %d", irk->op2);
                snap_restoreval(J, T, ex, snapno, rfilt, irs->op2, &tmp);
-               // NOBARRIER: The table is new (marked white).
-               GCtab* metatable = tabV(&tmp);
-               setgcref(t->metatable, obj2gco(metatable));
-               lj_gc_checkfinaliser(J->L, obj2gco(t), metatable);
+               if (irk->op2 IS IRFL_TAB_META) {
+                  // NOBARRIER: The table is new (marked white).
+                  GCtab* metatable = tabV(&tmp);
+                  setgcref(t->metatable, obj2gco(metatable));
+                  lj_gc_checkfinaliser(J->L, obj2gco(t), metatable);
+               }
+               else if (irk->op2 IS IRFL_TAB_FLAGS) {
+                  t->flags = uint8_t(numberVint(&tmp));
+               }
+               else lj_assertJ(false, "sunk store with bad field %d", irk->op2);
             }
             else {
                irk = &T->ir[irk->op2];

--- a/src/tiri/jit/src/parser/ir_emitter/operator_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/operator_emitter.cpp
@@ -565,7 +565,7 @@ static void bcemit_unop(FuncState* fs, BCOp op, ExpDesc* e)
    expr_free(fs, e);
    e->u.s.info = bcemit_AD(fs, op, 0, e->u.s.info);
    e->k = ExpKind::Relocable;
-   // BC_UNM (negate) and BC_LEN (length) always return number
+   // BC_UNM and successful BC_LEN operations always return a number.  Ordinary associative tables may produce nil.
    e->result_type = TiriType::Num;
 }
 

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -3463,6 +3463,22 @@ static bool test_static_descriptor_model(kt::Log &Log)
       return false;
    }
 
+   StaticValueDescriptor table_value{
+      .primary = TiriType::Table,
+      .proof = StaticProof::Closed
+   };
+   StaticValueDescriptor table_length = describe_length_result(table_value);
+   StaticValueDescriptor string_value{
+      .primary = TiriType::Str,
+      .proof = StaticProof::Closed
+   };
+   StaticValueDescriptor string_length = describe_length_result(string_value);
+   if (table_length.primary != TiriType::Num or not table_length.nullable or
+       string_length.primary != TiriType::Num or string_length.nullable) {
+      Log.error("length descriptors did not retain numeric type with operand-specific nullability");
+      return false;
+   }
+
    StaticValueDescriptor nil_value{
       .primary = TiriType::Nil,
       .proof = StaticProof::Closed,

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -1269,7 +1269,10 @@ private:
          }
          case AstNodeKind::UnaryExpr: {
             auto &payload = std::get<UnaryExprPayload>(Expression.data);
-            if (payload.op IS AstUnaryOperator::Negate and payload.operand) {
+            if (payload.op IS AstUnaryOperator::Length and payload.operand) {
+               value = describe_length_result(this->descriptor_of(*payload.operand));
+            }
+            else if (payload.op IS AstUnaryOperator::Negate and payload.operand) {
                value = describe_unary_numeric_result(this->descriptor_of(*payload.operand));
             }
             else {

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -286,6 +286,16 @@ StaticValueDescriptor describe_unary_numeric_result(const StaticValueDescriptor 
    return result;
 }
 
+StaticValueDescriptor describe_length_result(const StaticValueDescriptor &Operand)
+{
+   StaticValueDescriptor result;
+   result.primary = TiriType::Num;
+   result.proof = StaticProof::Advisory;
+   result.nullable = Operand.primary IS TiriType::Table or Operand.primary IS TiriType::Any or
+      Operand.primary IS TiriType::Unknown;
+   return result;
+}
+
 bool static_value_satisfies_contract(
    const StaticValueDescriptor &Value, const RuntimeContract &Contract)
 {

--- a/src/tiri/jit/src/parser/static_type_descriptor.h
+++ b/src/tiri/jit/src/parser/static_type_descriptor.h
@@ -135,6 +135,7 @@ private:
 [[nodiscard]] StaticValueDescriptor describe_arithmetic_result(
    const StaticValueDescriptor &, const StaticValueDescriptor &);
 [[nodiscard]] StaticValueDescriptor describe_unary_numeric_result(const StaticValueDescriptor &);
+[[nodiscard]] StaticValueDescriptor describe_length_result(const StaticValueDescriptor &);
 [[nodiscard]] bool static_value_satisfies_contract(
    const StaticValueDescriptor &, const RuntimeContract &);
 [[nodiscard]] StaticResultSet map_static_result_filter(

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -2767,6 +2767,11 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                   return result;
                case AstUnaryOperator::Length:
                   result.primary = TiriType::Num;
+                  if (payload->operand) {
+                     InferredType operand_type = this->infer_expression_type(*payload->operand);
+                     result.is_nullable = operand_type.primary IS TiriType::Table or
+                        operand_type.primary IS TiriType::Any or operand_type.primary IS TiriType::Unknown;
+                  }
                   return result;
             }
          }

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -451,6 +451,14 @@ TValue * lj_meta_cat(lua_State *L, TValue *top, int left)
 //********************************************************************************************************************
 // Helper for LEN. __len metamethod.
 
+TValue * lj_meta_len_result(lua_State *L, TValue *Result)
+{
+   if (not tvisnumber(Result)) lj_err_msg(L, ErrMsg::LENMM);
+   return Result;
+}
+
+//********************************************************************************************************************
+
 TValue * lj_meta_len(lua_State *L, cTValue *o)
 {
    cTValue *mo = lj_meta_lookup(L, o, MM_len);
@@ -460,7 +468,7 @@ TValue * lj_meta_len(lua_State *L, cTValue *o)
       else lj_err_optype(L, o, ErrMsg::OPLEN);
       return nullptr;
    }
-   return mmcall(L, lj_cont_ra, mo, o, o);
+   return mmcall(L, lj_cont_len, mo, o, o);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_meta.h
+++ b/src/tiri/jit/src/runtime/lj_meta.h
@@ -27,6 +27,7 @@ extern "C" [[nodiscard]] TValue* lj_meta_tset(lua_State* L, cTValue* o, cTValue*
 extern "C" [[nodiscard]] TValue* lj_meta_arith(lua_State* L, TValue* ra, cTValue* rb, cTValue* rc, BCREG op);
 extern "C" [[nodiscard]] TValue* lj_meta_cat(lua_State* L, TValue* top, int left);
 extern "C" [[nodiscard]] TValue* lj_meta_len(lua_State* L, cTValue* o);
+extern "C" [[nodiscard]] TValue* lj_meta_len_result(lua_State* L, TValue* Result);
 extern "C" [[nodiscard]] TValue* lj_meta_equal(lua_State* L, GCobj* o1, GCobj* o2, int ne);
 extern "C" [[nodiscard]] TValue* lj_meta_equal_cd(lua_State* L, BCIns ins);
 extern "C" [[nodiscard]] TValue* lj_meta_equal_thunk(lua_State* L, BCIns ins);

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -967,10 +967,17 @@ typedef struct Node {
 
 static_assert(offsetof(Node, val) == 0);
 
+// GCtab::flags bits.  These record permanent facts about a table's usage history and are never cleared.
+
+inline constexpr uint32_t TAB_STRING_KEYED_BIT = 0;  // Bit index, for backends that test single bits.
+inline constexpr uint8_t  TAB_STRING_KEYED = (uint8_t)(1u << TAB_STRING_KEYED_BIT); // Ever addressed by a string key.
+
 typedef struct GCtab {
    GCHeader;
    uint8_t  nomm;      // Negative cache for fast metamethods.
    int8_t   colo;      // Array colocation.
+   uint8_t  flags;     // [12] Permanent table classification bits (TAB_*).  Never cleared once set.
+   uint8_t  _pad0[3];  // [13] Padding to align the array field.
    MRef     array;     // [16] Array part.
    GCRef    gclist;    // [24] GC list for marking (must match GCudata.gclist)
    GCRef    metatable; // [32] Must be at same offset in GCudata.
@@ -981,6 +988,21 @@ typedef struct GCtab {
    GCRef    global_type_contracts; // Runtime contracts for globals stored in this environment table.
    MRef     global_contract_cache; // Environment-owned decoded derivative of global_type_contracts.
 } GCtab;
+
+// The generated VM and the JIT backends encode these offsets directly, so any layout drift must fail the build
+// rather than silently corrupt table access.
+
+static_assert(offsetof(GCtab, nomm) == 10);
+static_assert(offsetof(GCtab, colo) == 11);
+static_assert(offsetof(GCtab, flags) == 12);
+static_assert(offsetof(GCtab, array) == 16);
+static_assert(offsetof(GCtab, gclist) == 24);
+static_assert(offsetof(GCtab, metatable) == 32);
+static_assert(offsetof(GCtab, node) == 40);
+static_assert(offsetof(GCtab, asize) == 48);
+static_assert(offsetof(GCtab, hmask) == 52);
+static_assert(sizeof(GCtab) == 80);
+static_assert((sizeof(GCtab) & 7) == 0);
 
 [[nodiscard]] constexpr inline size_t sizetabcolo(MSize n) noexcept { return n * sizeof(TValue) + sizeof(GCtab); }
 

--- a/src/tiri/jit/src/runtime/lj_tab.cpp
+++ b/src/tiri/jit/src/runtime/lj_tab.cpp
@@ -89,6 +89,7 @@ static GCtab * newtab(lua_State *L, uint32_t asize, uint32_t hbits)
       t->gct = ~LJ_TTAB;
       t->nomm = (uint8_t)~0;
       t->colo = (int8_t)asize;
+      t->flags = 0;
       setmref(t->array, (TValue*)((char*)t + sizeof(GCtab)));
       setgcrefnull(t->metatable);
       setgcrefnull(t->global_type_contracts);
@@ -105,6 +106,7 @@ static GCtab * newtab(lua_State *L, uint32_t asize, uint32_t hbits)
       t->gct = ~LJ_TTAB;
       t->nomm = (uint8_t)~0;
       t->colo = 0;
+      t->flags = 0;
       setmref(t->array, nullptr);
       setgcrefnull(t->metatable);
       setgcrefnull(t->global_type_contracts);
@@ -173,6 +175,7 @@ GCtab * lj_tab_dup(lua_State *L, const GCtab *kt)
    t = newtab(L, kt->asize, kt->hmask > 0 ? lj_fls(kt->hmask) + 1 : 0);
    lj_assertL(kt->asize == t->asize and kt->hmask == t->hmask, "mismatched size of table and template");
    t->nomm = 0;  //  Keys with metamethod names may be present.
+   t->flags = kt->flags;  //  Classification is inherited by duplicates of a template table.
 
    asize = kt->asize;
    if (asize > 0) {
@@ -458,6 +461,9 @@ genlookup:
 TValue * lj_tab_newkey(lua_State *L, GCtab *t, cTValue *key)
 {
    Node *n = hashkey(t, key);
+   // Catch store routes that reach the hash part without passing through lj_tab_setstr(), such as the interpreter's
+   // inline BC_TSETS chain-miss path.
+   if (tvisstr(key)) t->flags |= TAB_STRING_KEYED;
    if (not tvisnil(&n->val) or t->hmask == 0) {
       Node* nodebase = noderef(t->node);
       Node* collide, * freenode = getfreetop(t, nodebase);
@@ -552,6 +558,7 @@ TValue* lj_tab_setstr(lua_State* L, GCtab* t, const GCstr* key)
 {
    TValue k;
    Node* n = hashstr(t, key);
+   t->flags |= TAB_STRING_KEYED;  //  Permanently classify the table as associative.
    do {
       if (tvisstr(&n->key) and strV(&n->key) == key) return &n->val;
    } while ((n = nextnode(n)));

--- a/src/tiri/jit/src/runtime/lj_vm.h
+++ b/src/tiri/jit/src/runtime/lj_vm.h
@@ -114,6 +114,7 @@ LJ_ASMF double lj_vm_pow(double, double);
 // Continuations for metamethods.
 LJ_ASMF void lj_cont_cat(void);  //  Continue with concatenation.
 LJ_ASMF void lj_cont_ra(void);  //  Store result in RA from instruction.
+LJ_ASMF void lj_cont_len(void);  //  Validate and store a __len result.
 LJ_ASMF void lj_cont_nop(void);  //  Do nothing, just continue execution.
 LJ_ASMF void lj_cont_condt(void);  //  Branch if result is true.
 LJ_ASMF void lj_cont_condf(void);  //  Branch if result is false.

--- a/src/tiri/jit/src/runtime/unit_test_indexing.cpp
+++ b/src/tiri/jit/src/runtime/unit_test_indexing.cpp
@@ -556,11 +556,177 @@ static bool test_table_string_hash_keys_unchanged(kt::Log& Log)
    return true;
 }
 
+// The permanent string-key classification underpins the Tiri '#' operator returning nil for associative tables.
+
+static bool test_table_flags_initialise_clear(kt::Log& Log)
+{
+   LuaStateHolder Holder;
+   lua_State* L = Holder.get();
+   if (not L) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   // Both the colocated and separately allocated array paths must start unclassified.
+
+   GCtab* colocated = lj_tab_new(L, 4, 0);
+   GCtab* separated = lj_tab_new(L, 0, 3);
+   if (colocated->flags != 0) {
+      Log.error("colocated table did not initialise flags to zero");
+      return false;
+   }
+   if (separated->flags != 0) {
+      Log.error("separately allocated table did not initialise flags to zero");
+      return false;
+   }
+
+   return true;
+}
+
+static bool test_table_numeric_keys_do_not_classify(kt::Log& Log)
+{
+   LuaStateHolder Holder;
+   lua_State* L = Holder.get();
+   if (not L) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   GCtab* table = lj_tab_new(L, 4, 3);
+   TValue value;
+   setnumV(&value, 1.0);
+
+   copyTV(L, lj_tab_setint(L, table, 0), &value);   // Array part.
+   copyTV(L, lj_tab_setint(L, table, 5000), &value); // Hash part.
+
+   TValue bool_key;
+   setboolV(&bool_key, 1);
+   copyTV(L, lj_tab_set(L, table, &bool_key), &value);
+
+   if (table->flags & TAB_STRING_KEYED) {
+      Log.error("non-string keys incorrectly classified the table as string-keyed");
+      return false;
+   }
+
+   return true;
+}
+
+static bool test_table_string_key_classifies(kt::Log& Log)
+{
+   LuaStateHolder Holder;
+   lua_State* L = Holder.get();
+   if (not L) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   GCtab* table = lj_tab_new(L, 0, 3);
+   GCstr* key = lj_str_newlit(L, "name");
+   TValue value;
+   setnumV(&value, 7.0);
+   copyTV(L, lj_tab_setstr(L, table, key), &value);
+
+   if (not (table->flags & TAB_STRING_KEYED)) {
+      Log.error("string key did not classify the table");
+      return false;
+   }
+
+   // Storing nil through a string key must classify too, and removing the value must not clear the flag.
+
+   TValue nil_value;
+   setnilV(&nil_value);
+   copyTV(L, lj_tab_setstr(L, table, key), &nil_value);
+   if (not (table->flags & TAB_STRING_KEYED)) {
+      Log.error("removing the string value cleared the classification");
+      return false;
+   }
+
+   GCtab* nil_only = lj_tab_new(L, 0, 3);
+   GCstr* missing = lj_str_newlit(L, "missing");
+   copyTV(L, lj_tab_setstr(L, nil_only, missing), &nil_value);
+   if (not (nil_only->flags & TAB_STRING_KEYED)) {
+      Log.error("assigning nil through a string key did not classify the table");
+      return false;
+   }
+
+   return true;
+}
+
+static bool test_table_classification_survives_mutation(kt::Log& Log)
+{
+   LuaStateHolder Holder;
+   lua_State* L = Holder.get();
+   if (not L) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   GCtab* table = lj_tab_new(L, 2, 1);
+   GCstr* key = lj_str_newlit(L, "field");
+   TValue value;
+   setnumV(&value, 3.0);
+   copyTV(L, lj_tab_setstr(L, table, key), &value);
+
+   lj_tab_clear(table);
+   if (not (table->flags & TAB_STRING_KEYED)) {
+      Log.error("lj_tab_clear() cleared the classification");
+      return false;
+   }
+
+   lj_tab_resize(L, table, 32, 4);
+   if (not (table->flags & TAB_STRING_KEYED)) {
+      Log.error("lj_tab_resize() cleared the classification");
+      return false;
+   }
+
+   GCtab* copy = lj_tab_dup(L, table);
+   if (not (copy->flags & TAB_STRING_KEYED)) {
+      Log.error("lj_tab_dup() did not copy the classification");
+      return false;
+   }
+
+   // A duplicate of an unclassified table must remain unclassified.
+
+   GCtab* pure = lj_tab_new(L, 4, 0);
+   GCtab* pure_copy = lj_tab_dup(L, pure);
+   if (pure_copy->flags & TAB_STRING_KEYED) {
+      Log.error("lj_tab_dup() invented a classification for a pure table");
+      return false;
+   }
+
+   return true;
+}
+
+static bool test_table_layout_offsets_stable(kt::Log& Log)
+{
+   // The generated VM encodes these offsets directly.  static_assert() in lj_obj.h guards the build; this test
+   // guards the installed binary that the Flute suites exercise.
+
+   if (not (offsetof(GCtab, flags) IS 12)) {
+      Log.error("GCtab::flags is no longer at offset 12");
+      return false;
+   }
+   if (not (offsetof(GCtab, array) IS 16) or not (offsetof(GCtab, metatable) IS 32)) {
+      Log.error("GCtab array/metatable offsets have shifted");
+      return false;
+   }
+   if (not (offsetof(GCtab, asize) IS 48) or not (offsetof(GCtab, hmask) IS 52)) {
+      Log.error("GCtab asize/hmask offsets have shifted");
+      return false;
+   }
+   if (not (sizeof(GCtab) IS 80)) {
+      Log.error("sizeof(GCtab) has changed");
+      return false;
+   }
+
+   return true;
+}
+
 }  // namespace
 
 extern void indexing_unit_tests(int& Passed, int& Total)
 {
-   constexpr std::array<TestCase, 16> Tests = { {
+   constexpr std::array<TestCase, 21> Tests = { {
       { "array_first_element_access", test_array_first_element_access },
       { "table_length_operator", test_table_length_operator },
       { "ipairs_starting_index", test_ipairs_starting_index },
@@ -576,7 +742,12 @@ extern void indexing_unit_tests(int& Passed, int& Total)
       { "table_hash_mixer_matches_expected", test_table_hash_mixer_matches_expected },
       { "table_numeric_hash_keys_roundtrip", test_table_numeric_hash_keys_roundtrip },
       { "table_gc_hash_keys_roundtrip", test_table_gc_hash_keys_roundtrip },
-      { "table_string_hash_keys_unchanged", test_table_string_hash_keys_unchanged }
+      { "table_string_hash_keys_unchanged", test_table_string_hash_keys_unchanged },
+      { "table_flags_initialise_clear", test_table_flags_initialise_clear },
+      { "table_numeric_keys_do_not_classify", test_table_numeric_keys_do_not_classify },
+      { "table_string_key_classifies", test_table_string_key_classifies },
+      { "table_classification_survives_mutation", test_table_classification_survives_mutation },
+      { "table_layout_offsets_stable", test_table_layout_offsets_stable }
    } };
 
    if (NewObject(CLASSID::TIRI, &glTestScript) != ERR::Okay) return;

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -2915,6 +2915,33 @@ end
    jit.opt.start()
 end
 
+function string_keyed_side_exit(ExitAt, UseTemplate):any
+   for i in {0 to 100} do
+      local temporary = UseTemplate ? { 1 } :> {}
+      temporary.key = i
+      if i is ExitAt then return temporary end
+   end
+   return nil
+end
+
+@Test function StringKeyedSunkTablesRestoreFlagsOnSideExit()
+   jit.flush()
+   jit.opt.start('hotloop=2', 'hotexit=1', 'minstitch=0')
+
+   assert(string_keyed_side_exit(-1, false) is nil, 'TNEW workload should record without taking the side exit')
+   local tnew_result = string_keyed_side_exit(50, false)
+   assert(tnew_result.key is 50, 'A restored TNEW should retain its string-keyed value')
+   assert(#tnew_result is nil, 'A restored TNEW should retain its string-key classification')
+
+   jit.flush()
+   assert(string_keyed_side_exit(-1, true) is nil, 'TDUP workload should record without taking the side exit')
+   local tdup_result = string_keyed_side_exit(50, true)
+   assert(tdup_result.key is 50, 'A restored TDUP should retain its string-keyed value')
+   assert(#tdup_result is nil, 'A restored TDUP should retain its string-key classification')
+
+   jit.opt.start()
+end
+
 function traced_metamethod_length(Value, Count):num
    local total = 0
    for i in {1 into Count} do

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -10,6 +10,8 @@ local ir_max <const> = 51  -- IRDEF order; traceIR exposes the opcode as traceIR
 local ir_fpmath <const> = 52  -- IRDEF order; floating-point rounding and related operations.
 local ir_xload <const> = 70  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
 local ir_xstore <const> = 78  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
+local ir_tnew <const> = 81  -- IRDEF order; fresh table allocation.
+local ir_tdup <const> = 82  -- IRDEF order; template table allocation.
 local ir_conv <const> = 91  -- IRDEF order; numeric and integer conversions.
 local ir_bufput <const> = 86
 local ir_bufstr <const> = 87
@@ -17,6 +19,7 @@ local ir_calln <const> = 95  -- IRDEF order; traceIR exposes the opcode as trace
 local ir_calla <const> = 96
 local ir_calll <const> = 97
 local ir_calls <const> = 98
+local rid_sink <const> = 254  -- lj_target.h register marker, exposed in the low byte of traceIR().prev.
 
 struct JITValidatedStructFields
    Flag: bool
@@ -2845,6 +2848,71 @@ end
       t[key] = i
    end
    assert(#t is nil, f"A hot computed string-key store should classify the table, got {tostring(#t)}")
+end
+
+function string_keyed_tnew_value(Value):any
+   local temporary = {}
+   temporary.key = Value
+   return temporary.key
+end
+
+function string_keyed_tdup_value(Value):any
+   local temporary = { 1 }
+   temporary.key = Value
+   return temporary.key
+end
+
+function string_keyed_tnew_workload(Value)
+   local total = 0
+   for i in {0 to 100} do
+      total += string_keyed_tnew_value(Value + i)
+   end
+   return total
+end
+
+function string_keyed_tdup_workload(Value)
+   local total = 0
+   for i in {0 to 100} do
+      total += string_keyed_tdup_value(Value + i)
+   end
+   return total
+end
+
+@Test function StringKeyedStoresPreserveAllocationSinking()
+   jit.flush()
+   jit.opt.start('hotloop=2', 'hotexit=1', 'minstitch=0')
+
+   assert(string_keyed_tnew_workload(3) is 5250, 'TNEW workload should retain its result on trace')
+   assert(string_keyed_tdup_workload(3) is 5250, 'TDUP workload should retain its result on trace')
+
+   jit.off()
+   local allocation_counts = { [ir_tnew] = 0, [ir_tdup] = 0 }
+   local sunk_counts = { [ir_tnew] = 0, [ir_tdup] = 0 }
+
+   for trace_no in {1 into 100} do
+      local info = jit.util.traceInfo(trace_no)
+      if info is nil then continue end
+
+      for instruction in {1 into info.nins} do
+         local _, ir_ot, _, _, ir_prev = jit.util.traceIR(trace_no, instruction)
+         if ir_ot is nil then continue end
+
+         local opcode = ir_ot >> 8
+         if opcode is ir_tnew or opcode is ir_tdup then
+            allocation_counts[opcode]++
+            if (ir_prev & 255) is rid_sink then sunk_counts[opcode]++ end
+         end
+      end
+   end
+
+   assert(allocation_counts[ir_tnew] > 0 and sunk_counts[ir_tnew] is allocation_counts[ir_tnew],
+      f'Every temporary TNEW receiving a string-keyed store should be sunk: {sunk_counts[ir_tnew]}/' ..
+      f'{allocation_counts[ir_tnew]}')
+   assert(allocation_counts[ir_tdup] > 0 and sunk_counts[ir_tdup] is allocation_counts[ir_tdup],
+      f'Every temporary TDUP receiving a string-keyed store should be sunk: {sunk_counts[ir_tdup]}/' ..
+      f'{allocation_counts[ir_tdup]}')
+   jit.on()
+   jit.opt.start()
 end
 
 @Test(hotpath=100) function ClearInHotCodeKeepsClassification()

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -2915,6 +2915,36 @@ end
    jit.opt.start()
 end
 
+function traced_metamethod_length(Value, Count):num
+   local total = 0
+   for i in {1 into Count} do
+      total += #Value
+   end
+   return total
+end
+
+@Test function JITLenRejectsNonNumericMetamethodResult()
+   local metamethod_result:any = 4
+   local value = setmetatable({}, { __len = function(Self):any return metamethod_result end })
+
+   jit.flush()
+   jit.opt.start('hotloop=2', 'hotexit=1', 'minstitch=0')
+   assert(traced_metamethod_length(value, 20) is 80, 'The numeric __len result should trace normally')
+
+   metamethod_result = 'invalid'
+   try
+      traced_metamethod_length(value, 20)
+   except err
+      assert(tostring(err.message):find('__len metamethod must return a number'),
+         'A traced string __len result should report the numeric result requirement')
+   success
+      error('A traced string __len result should fail')
+   end
+
+   jit.on()
+   jit.opt.start()
+end
+
 @Test(hotpath=100) function ClearInHotCodeKeepsClassification()
    local t = { 1, 2 }
    t.name = 'x'

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -2806,3 +2806,62 @@ end
 
    t.free()
 end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- The permanent string-key classification governs '#table'.  A trace recorded while the flag is clear must guard the
+-- state and side-exit on the first clear-to-set transition rather than returning a stale numerical length.
+
+@Test(hotpath=100) function LengthTraceExitsOnFirstStringKey()
+   local t = { 1, 2, 3 }
+   local numeric_results = 0
+   for i in {0 to 200} do
+      if #t is 3 then numeric_results++ end
+   end
+   assert(numeric_results is 200, f"Hot pure table should report length 3 throughout, got {numeric_results}")
+
+   -- Introduce the first string key.  The recorded guard must fail rather than keep returning 3.
+   t.name = 'x'
+
+   local nil_results = 0
+   for i in {0 to 200} do
+      if #t is nil then nil_results++ end
+   end
+   assert(nil_results is 200, f"Hot classified table should report nil throughout, got {nil_results}")
+end
+
+@Test(hotpath=100) function LengthTraceOnAlreadyClassifiedTable()
+   local t = { 1, 2, 3, name = 'x' }
+   local nil_results = 0
+   for i in {0 to 200} do
+      if #t is nil then nil_results++ end
+   end
+   assert(nil_results is 200, f"An already-classified table should report nil on trace, got {nil_results}")
+end
+
+@Test(hotpath=100) function ComputedStringKeyStoreInHotCodeClassifies()
+   local t = { 1, 2, 3 }
+   for i in {0 to 200} do
+      local key = 'field' .. tostring(i % 4)
+      t[key] = i
+   end
+   assert(#t is nil, f"A hot computed string-key store should classify the table, got {tostring(#t)}")
+end
+
+@Test(hotpath=100) function ClearInHotCodeKeepsClassification()
+   local t = { 1, 2 }
+   t.name = 'x'
+   for i in {0 to 200} do
+      table.clear(t)
+      t[0] = i
+   end
+   assert(#t is nil, f"Clearing in hot code must not restore a numerical length, got {tostring(#t)}")
+end
+
+@Test(hotpath=100) function PureTableLengthRemainsNumericalOnTrace()
+   -- A table that is only ever addressed numerically must keep the fast numerical path on trace.
+   local t = {}
+   for i in {0 to 200} do
+      t[i % 8] = i
+   end
+   assert(#t is 8, f"A numerically addressed table should keep its length, got {tostring(#t)}")
+end

--- a/src/tiri/tests/test_metatables.tiri
+++ b/src/tiri/tests/test_metatables.tiri
@@ -244,6 +244,46 @@ end
    assert(#obj is 0, "__len returning 0 should override actual length")
 end
 
+@Test function MetaLenOverridesStringKeyClassification()
+   -- A table addressed with a string key normally has no length, but __len takes precedence.
+   local obj = setmetatable({ 1, 2 }, { __len = function(Self):num return 7 end })
+   obj.name = 'x'
+   assert(#obj is 7, "__len should override the string-key classification, got " .. tostring(#obj))
+
+   -- Removing the string entry does not change either behaviour.
+   obj.name = nil
+   assert(#obj is 7, "__len should still take precedence after the entry is removed")
+
+   -- Removing the metatable exposes the permanent classification again.
+   setmetatable(obj, nil)
+   assert(#obj is nil, "Removing __len should expose the permanent nil result, got " .. tostring(#obj))
+end
+
+@Test function MetaLenAbsentLeavesPureTableNumerical()
+   -- A metatable without __len must not disturb the ordinary numerical length.
+   local obj = setmetatable({ 1, 2, 3 }, { __index = function(Self, Key) return nil end })
+   assert(#obj is 3, "A pure table with an unrelated metatable should keep its length, got " .. tostring(#obj))
+end
+
+@Test function IndexMetamethodDoesNotClassify()
+   -- String keys supplied by __index do not classify the target table, because no store reaches it.
+   local backing = { name = 'from index' }
+   local obj = setmetatable({ 1, 2, 3 }, { __index = backing })
+   assert(obj.name is 'from index', "__index should supply the string key")
+   assert(#obj is 3, "A read through __index must not classify the table, got " .. tostring(#obj))
+end
+
+@Test function NewIndexMetamethodClassifiesTheReceivingTable()
+   -- A __newindex that diverts the store classifies the table that actually receives it, not the proxy.
+   local backing = { 1, 2, 3 }
+   local proxy = setmetatable({ 1, 2, 3 }, {
+      __newindex = function(Self, Key, Value) rawset(backing, Key, Value) end
+   })
+   proxy.name = 'x'
+   assert(#proxy is 3, "The proxy should not be classified by a diverted store, got " .. tostring(#proxy))
+   assert(#backing is nil, "The receiving table should be classified, got " .. tostring(#backing))
+end
+
 @Test function MetaConcat()
    mt = {
       __concat = function(A, B):table

--- a/src/tiri/tests/test_metatables.tiri
+++ b/src/tiri/tests/test_metatables.tiri
@@ -244,6 +244,28 @@ end
    assert(#obj is 0, "__len returning 0 should override actual length")
 end
 
+@Test function MetaLenRejectsNonNumericResults()
+   local string_length = setmetatable({}, { __len = function(Self):any return 'invalid' end })
+   try
+      local result = #string_length
+   except err
+      assert(tostring(err.message):find('__len metamethod must return a number'),
+         'A string __len result should report the numeric result requirement')
+   success
+      error('A string __len result should fail')
+   end
+
+   local nil_length = setmetatable({}, { __len = function(Self):num return nil end })
+   try
+      local result = #nil_length
+   except err
+      assert(tostring(err.message):find('__len metamethod must return a number'),
+         'A nil __len result should report the numeric result requirement')
+   success
+      error('A nil __len result should fail')
+   end
+end
+
 @Test function MetaLenOverridesStringKeyClassification()
    -- A table addressed with a string key normally has no length, but __len takes precedence.
    local obj = setmetatable({ 1, 2 }, { __len = function(Self):num return 7 end })

--- a/src/tiri/tests/test_table.tiri
+++ b/src/tiri/tests/test_table.tiri
@@ -113,12 +113,13 @@ end
    assert(#t is 5, "Array with 5 elements should have length 5, got " .. #t)
 end
 
-@Test function TableLengthIgnoresHashPart()
-   -- Test that getn only counts array part
+@Test function TableLengthNilForStringKeyed()
+   -- A table addressed with a string key is permanently classified as associative and has no sequence length.
    t = { 'x', 'y' }
+   assert(#t is 2, "Pure array table should have length 2, got " .. tostring(#t))
    t.name = 'test'
    t.value = 42
-   assert(#t is 2, "getn should only count array elements, got " .. #t)
+   assert(#t is nil, "String-keyed table should have no length, got " .. tostring(#t))
 end
 
 @Test function TableLengthAfterInsertRemove()
@@ -419,12 +420,14 @@ end
 end
 
 @Test function ClearMixed()
-   -- Clear a table with both array and hash parts
+   -- Clear a table with both array and hash parts.  Clearing empties the table but does not restore its
+   -- classification, so the length operator continues to report nil.
    t = { 'x', 'y', name = 'test', value = 42 }
    table.clear(t)
-   assert(#t is 0, "Array part should be cleared")
+   assert(t[0] is nil, "Array part should be cleared")
    assert(t.name is nil, "Hash part should be cleared")
    assert(table.empty(t) is true, "Table should be completely empty")
+   assert(#t is nil, "Clearing must not restore a numerical length")
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -541,4 +544,106 @@ end
    t = {}
    result = table.toXML(t)
    assert(result is '', "Empty table should produce empty XML string, got '" .. result .. "'")
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Tests for the permanent string-key classification that governs the length operator
+
+@Test function LengthEmptyAndNumericTables()
+   -- Tables that have never been addressed with a string key retain the numerical sequence length.
+   assert(#{} is 0, "Empty table should have length 0")
+   assert(#{ 10, 20, 30 } is 3, "Numerical literal should have length 3")
+
+   t = {}
+   t[0] = 'a'
+   t[1] = 'b'
+   assert(#t is 2, "Numerical assignment should yield length 2, got " .. tostring(#t))
+end
+
+@Test function LengthNilForStringLiteral()
+   -- String-only and mixed literals are classified at construction.
+   assert(#{ name = 'x' } is nil, "String-only literal should have no length")
+   assert(#{ 1, 2, name = 'x' } is nil, "Mixed literal should have no length")
+end
+
+@Test function LengthNilAfterNamedAssignment()
+   t = { 1, 2 }
+   t.name = 'x'
+   assert(#t is nil, "Named field assignment should remove the length")
+end
+
+@Test function LengthNilAfterIndexedStringAssignment()
+   t = { 1, 2 }
+   t['name'] = 'x'
+   assert(#t is nil, "Indexed string assignment should remove the length")
+end
+
+@Test function LengthNilAfterComputedStringKey()
+   t = { 1, 2 }
+   key = 'na' .. 'me'
+   t[key] = 'x'
+   assert(#t is nil, "Computed string key should remove the length")
+end
+
+@Test function LengthNilAfterAssigningNilToStringKey()
+   -- Classification happens on the store, even when no live entry results.
+   t = { 1, 2 }
+   t.name = nil
+   assert(#t is nil, "Assigning nil through a string key should classify the table")
+end
+
+@Test function LengthClassificationIsPermanent()
+   t = { 1, 2 }
+   t.name = 'x'
+   t.name = nil
+   assert(#t is nil, "Deleting the last string entry must not restore the length")
+
+   table.clear(t)
+   assert(#t is nil, "table.clear() must not restore the length")
+
+   t[0] = 'a'
+   t[1] = 'b'
+   t[2] = 'c'
+   assert(#t is nil, "Adding numerical entries must not restore the length")
+end
+
+@Test function LengthClassifiesRegardlessOfValue()
+   -- Every value type stored under a string key classifies identically, including falsey values.
+   local stored: table = { false, 0, '', {}, print }
+   for i in {0 to 5} do
+      t = { 1, 2 }
+      t.field = stored[i]
+      assert(#t is nil, "Value at index " .. i .. " should have classified the table")
+   end
+end
+
+@Test function LengthUnaffectedByNonStringKeys()
+   -- Boolean, negative-number and table keys use the hash part but do not trigger this rule.
+   t = { 1, 2, 3 }
+   t[true] = 'bool'
+   t[-5] = 'negative'
+   t[9999] = 'sparse'
+   assert(#t is 3, "Non-string hash keys should preserve the length, got " .. tostring(#t))
+
+   u = { 1, 2, 3 }
+   u[{}] = 'table key'
+   assert(#u is 3, "A table key should preserve the length, got " .. tostring(#u))
+end
+
+@Test function LengthOfStringsAndArraysUnchanged()
+   assert(#'hello' is 5, "String length should be unchanged")
+   assert(#'' is 0, "Empty string length should be 0")
+
+   a = array<int> { 1, 2, 3, 4 }
+   assert(#a is 4, "Native array length should be unchanged, got " .. tostring(#a))
+end
+
+@Test function InternalLengthConsumersUnaffected()
+   -- table.insert(), table.remove() and table.empty() keep using the internal numerical length.
+   t = { 1, 2 }
+   t.name = 'x'
+   table.insert(t, 3)
+   assert(t[2] is 3, "insert should still append at the numerical length")
+   assert(table.remove(t) is 3, "remove should still operate on the sequence")
+   assert(table.empty(t) is false, "Table with entries should not be empty")
 end


### PR DESCRIPTION
* Added a permanent TAB_STRING_KEYED classification bit to GCtab::flags, set by lj_tab_setstr() and lj_tab_newkey(), inherited by lj_tab_dup() and never cleared by table.clear() or resizing
* Fixed GCtab field offsets with static_assert() checks because the VM backends encode them directly
* BC_LEN in the x64, ARM64 and PPC interpreters tests the classification bit and yields nil for string-keyed tables
* Recorded traces guard the classification via the new IRFL_TAB_FLAGS field, so the first string-key store side-exits and recompiles to nil
* TSETS raw stores publish the classification in both the interpreter and recorded traces
* Taught the memory optimiser to disambiguate IRFL_TAB_FLAGS loads per table
* Added Flute coverage across test_table.tiri, test_jit.tiri and test_metatables.tiri, including __len precedence and __newindex diversion, plus five C++ unit tests for the classification and struct layout