### PR TITLE
[Tiri] Accepted int8 as a synonym for the byte array element type

### DIFF
--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -567,6 +567,7 @@ static bool array_elemtype_from_string(GCstr *TypeStr, AET *Result)
    if (TypeStr->len IS 3 and memcmp(type_name, "int", 3) IS 0) *Result = AET::INT32;
    else if (TypeStr->len IS 4 and memcmp(type_name, "byte", 4) IS 0) *Result = AET::BYTE;
    else if (TypeStr->len IS 4 and memcmp(type_name, "char", 4) IS 0) *Result = AET::BYTE;
+   else if (TypeStr->len IS 4 and memcmp(type_name, "int8", 4) IS 0) *Result = AET::BYTE;
    else if (TypeStr->len IS 5 and memcmp(type_name, "int16", 5) IS 0) *Result = AET::INT16;
    else if (TypeStr->len IS 5 and memcmp(type_name, "int64", 5) IS 0) *Result = AET::INT64;
    else if (TypeStr->len IS 5 and memcmp(type_name, "float", 5) IS 0) *Result = AET::FLOAT;

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -3542,9 +3542,10 @@ static bool test_static_descriptor_model(kt::Log &Log)
       AET storage;
       TiriType logical_type;
    };
-   constexpr std::array<ArrayMapping, 14> mappings = { {
+   constexpr std::array<ArrayMapping, 15> mappings = { {
       { "byte", AET::BYTE, TiriType::Num },
       { "char", AET::BYTE, TiriType::Num },
+      { "int8", AET::BYTE, TiriType::Num },
       { "int16", AET::INT16, TiriType::Num },
       { "int", AET::INT32, TiriType::Num },
       { "int64", AET::INT64, TiriType::Num },

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -604,7 +604,9 @@ std::optional<ArrayElementDescriptor> describe_array_element(std::string_view Na
    ArrayElementDescriptor result;
    result.known = true;
 
-   if (Name IS "byte" or Name IS "char") result = { AET::BYTE, TiriType::Num, CLASSID::NIL, nullptr, true };
+   if (Name IS "byte" or Name IS "char" or Name IS "int8") {
+      result = { AET::BYTE, TiriType::Num, CLASSID::NIL, nullptr, true };
+   }
    else if (Name IS "int16") result = { AET::INT16, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "int") result = { AET::INT32, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "int64") result = { AET::INT64, TiriType::Num, CLASSID::NIL, nullptr, true };


### PR DESCRIPTION
* Extended describe_array_element() to map int8 to AET::BYTE, covering the array<int8, N> declaration syntax along with array.new() and array.of()
* Added int8 to the JIT recorder's element type table so that array.new() calls continue to compile instead of falling back to the interpreter
* Covered the new mapping in the static descriptor unit tests