### PR TITLE
[Tiri] The length operator now returns nil for tables addressed with any non-numeric key

### DIFF
--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -2777,9 +2777,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  cbnz TAB:CARG2, >9
     |3:
     |->BC_LEN_Z:
-    |  // An ordinary table that has ever been addressed with a string key has no sequence length.
+    |  // An ordinary table that has ever been addressed with a non-numeric key has no sequence length.
     |  ldrb TMP1w, TAB:CARG1->flags
-    |  tbnz TMP1w, #TAB_STRING_KEYED_BIT, >8
+    |  tbnz TMP1w, #TAB_ASSOCIATIVE_BIT, >8
     |  bl extern lj_tab_len		// (GCtab *t)
     |  // Returns uint32_t (but less than 2^31).
     |  b <1
@@ -3367,7 +3367,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  // The raw store commits here, so classify the receiving table (lj_tab_newkey() covers the new-key path
     |  // below).  A store diverted to __newindex never reaches this point.
     |  ldrb CARG4w, TAB:CARG2->flags
-    |  orr CARG4w, CARG4w, #TAB_STRING_KEYED
+    |  orr CARG4w, CARG4w, #TAB_ASSOCIATIVE
     |  strb CARG4w, TAB:CARG2->flags
     |   str TMP0, NODE:CARG3->val
     |    tbnz TMP2w, #2, >7		// isblack(table)

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -4052,9 +4052,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  bne >9
     |3:
     |->BC_LEN_Z:
-    |  // An ordinary table that has ever been addressed with a string key has no sequence length.
+    |  // An ordinary table that has ever been addressed with a non-numeric key has no sequence length.
     |  lbz TMP0, TAB:CARG1->flags
-    |  andix. TMP0, TMP0, TAB_STRING_KEYED
+    |  andix. TMP0, TMP0, TAB_ASSOCIATIVE
     |  bne >8
     |  bl extern lj_tab_len		// (GCtab *t)
     |  // Returns uint32_t (but less than 2^31).
@@ -5002,7 +5002,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  // The raw store commits here, so classify the receiving table (lj_tab_newkey() covers the new-key path
     |  // below).  A store diverted to __newindex never reaches this point.
     |  lbz CARG1, TAB:RB->flags
-    |  ori CARG1, CARG1, TAB_STRING_KEYED
+    |  ori CARG1, CARG1, TAB_ASSOCIATIVE
     |  stb CARG1, TAB:RB->flags
     |  andix. TMP0, TMP3, LJ_GC_BLACK	// isblack(table)
     |.if FPU

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -3450,8 +3450,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  jnz >9
     |3:
     |->BC_LEN_Z:
-    |  // An ordinary table that has ever been addressed with a string key has no sequence length.
-    |  test byte TAB:CARG1->flags, TAB_STRING_KEYED
+    |  // An ordinary table that has ever been addressed with a non-numeric key has no sequence length.
+    |  test byte TAB:CARG1->flags, TAB_ASSOCIATIVE
     |  jnz >8
     |  mov RB, BASE        // Save BASE.
     |  call extern lj_tab_len    // (GCtab *t)
@@ -4091,7 +4091,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  jnz >7
     |3:  // Set node value.  The raw store commits here, so classify the receiving table (lj_tab_newkey() covers the
     |    // new-key path below).  A store diverted to __newindex never reaches this point.
-    |  or byte TAB:RB->flags, TAB_STRING_KEYED
+    |  or byte TAB:RB->flags, TAB_ASSOCIATIVE
     |  mov ITYPE, [BASE+RA*8]
     |  mov [TMPR], ITYPE
     |  ins_next

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1644,12 +1644,12 @@ static TRef rec_mm_len(jit_State *J, TRef tr, TValue* tv)
    else {
       if (tref_istab(tr)) {
          IRBuilder ir(J);
-         // A table that has ever been addressed with a string key has no sequence length.  The classification is
-         // one-way, so guarding the observed state is sufficient: the first string-keyed store side-exits the trace
+         // A table that has ever been addressed with a non-numeric key has no sequence length.  The classification is
+         // one-way, so guarding the observed state is sufficient: the first non-numeric store side-exits the trace
          // and the recompilation specialises to nil.
          TRef flags = ir.fload(tr, IRFL_TAB_FLAGS, IRT_U8);
-         TRef classified = ir.emit_int(IR_BAND, flags, ir.kint(TAB_STRING_KEYED));
-         if (tabV(tv)->flags & TAB_STRING_KEYED) {
+         TRef classified = ir.emit_int(IR_BAND, flags, ir.kint(TAB_ASSOCIATIVE));
+         if (tabV(tv)->flags & TAB_ASSOCIATIVE) {
             ir.guard_ne_int(classified, ir.kint(0));
             return TREF_NIL;
          }
@@ -2165,12 +2165,13 @@ handlemm:
          ir.emit(IRT(IR_FSTORE, IRT_U8), fref, ir.kint(0));
       }
 
-      // Publish the permanent string-key classification so that a concurrently recorded '#' guard observes it.
+      // Publish the permanent associative classification so that a concurrently recorded '#' guard observes it.  The
+      // recorded key is type-specialised, so a non-numeric key is a static fact for the lifetime of this trace.
 
-      if (tref_isstr(ix->key) and tref_istab(ix->tab)) {
+      if (tref_istab(ix->tab) and not tref_isnumber(ix->key)) {
          TRef fref = ir.emit(IRT(IR_FREF, IRT_PGC), ix->tab, IRFL_TAB_FLAGS);
          TRef flags = ir.fload(ix->tab, IRFL_TAB_FLAGS, IRT_U8);
-         ir.emit(IRT(IR_FSTORE, IRT_U8), fref, ir.emit_int(IR_BOR, flags, ir.kint(TAB_STRING_KEYED)));
+         ir.emit(IRT(IR_FSTORE, IRT_U8), fref, ir.emit_int(IR_BOR, flags, ir.kint(TAB_ASSOCIATIVE)));
       }
 
       J->needsnap = 1;

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -274,13 +274,19 @@ TValue * lj_meta_tset(lua_State *L, cTValue *o, cTValue *k)
          cTValue *tv = lj_tab_get(L, t, k);
          if (not tvisnil(tv)) [[likely]] {
             t->nomm = 0;  //  Invalidate negative metamethod cache.
+            // Overwriting a live slot commits a store, so classify here: the returning paths below bypass
+            // lj_tab_newkey() because the node already carries the key.
+            if (not tvisnumber(k)) t->flags |= TAB_ASSOCIATIVE;
             lj_gc_anybarriert(L, t);
             return (TValue *)tv;
          }
          else if (not (mo = lj_meta_fast(L, tabref(t->metatable), MM_newindex))) {
             t->nomm = 0;  //  Invalidate negative metamethod cache.
             lj_gc_anybarriert(L, t);
-            if (tv != niltv(L)) return (TValue *)tv;
+            if (tv != niltv(L)) {  // Resurrecting a dead node that still holds the key.
+               if (not tvisnumber(k)) t->flags |= TAB_ASSOCIATIVE;
+               return (TValue *)tv;
+            }
             if (tvisnil(k)) lj_err_msg(L, ErrMsg::NILIDX);
             else if (tvisint(k)) { setnumV(&tmp, (lua_Number)intV(k)); k = &tmp; }
             else if (tvisnum(k) and tvisnan(k)) lj_err_msg(L, ErrMsg::NANIDX);

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -969,8 +969,8 @@ static_assert(offsetof(Node, val) == 0);
 
 // GCtab::flags bits.  These record permanent facts about a table's usage history and are never cleared.
 
-inline constexpr uint32_t TAB_STRING_KEYED_BIT = 0;  // Bit index, for backends that test single bits.
-inline constexpr uint8_t  TAB_STRING_KEYED = (uint8_t)(1u << TAB_STRING_KEYED_BIT); // Ever addressed by a string key.
+inline constexpr uint32_t TAB_ASSOCIATIVE_BIT = 0;  // Bit index, for backends that test single bits.
+inline constexpr uint8_t  TAB_ASSOCIATIVE = (uint8_t)(1u << TAB_ASSOCIATIVE_BIT); // Ever addressed by a non-numeric key
 
 typedef struct GCtab {
    GCHeader;

--- a/src/tiri/jit/src/runtime/lj_tab.cpp
+++ b/src/tiri/jit/src/runtime/lj_tab.cpp
@@ -461,9 +461,10 @@ genlookup:
 TValue * lj_tab_newkey(lua_State *L, GCtab *t, cTValue *key)
 {
    Node *n = hashkey(t, key);
-   // Catch store routes that reach the hash part without passing through lj_tab_setstr(), such as the interpreter's
-   // inline BC_TSETS chain-miss path.
-   if (tvisstr(key)) t->flags |= TAB_STRING_KEYED;
+   // Every new hash-part key funnels through here, including store routes that bypass lj_tab_setstr(), such as the
+   // interpreter's inline BC_TSETS chain-miss path and the JIT's IRCALL_lj_tab_newkey.  Any key that is not a number
+   // makes the sequence length meaningless, so classify the table as associative.
+   if (not tvisnumber(key)) t->flags |= TAB_ASSOCIATIVE;
    if (not tvisnil(&n->val) or t->hmask == 0) {
       Node* nodebase = noderef(t->node);
       Node* collide, * freenode = getfreetop(t, nodebase);
@@ -558,7 +559,7 @@ TValue* lj_tab_setstr(lua_State* L, GCtab* t, const GCstr* key)
 {
    TValue k;
    Node* n = hashstr(t, key);
-   t->flags |= TAB_STRING_KEYED;  //  Permanently classify the table as associative.
+   t->flags |= TAB_ASSOCIATIVE;  //  Permanently classify the table as associative.
    do {
       if (tvisstr(&n->key) and strV(&n->key) == key) return &n->val;
    } while ((n = nextnode(n)));
@@ -582,6 +583,11 @@ TValue * lj_tab_set(lua_State *L, GCtab *t, cTValue *key)
       // Else use the generic lookup.
    }
    else if (tvisnil(key)) lj_err_msg(L, ErrMsg::NILIDX);
+
+   // Classify before the chain search, because resurrecting an existing node whose value went nil returns its slot
+   // directly and never reaches lj_tab_newkey().  Non-integral numbers land here too, but they remain numeric keys.
+
+   if (not tvisnumber(key)) t->flags |= TAB_ASSOCIATIVE;
 
    n = hashkey(t, key);
    do {

--- a/src/tiri/jit/src/runtime/unit_test_indexing.cpp
+++ b/src/tiri/jit/src/runtime/unit_test_indexing.cpp
@@ -556,7 +556,7 @@ static bool test_table_string_hash_keys_unchanged(kt::Log& Log)
    return true;
 }
 
-// The permanent string-key classification underpins the Tiri '#' operator returning nil for associative tables.
+// The permanent non-numeric key classification underpins the Tiri '#' operator returning nil for associative tables.
 
 static bool test_table_flags_initialise_clear(kt::Log& Log)
 {
@@ -596,15 +596,70 @@ static bool test_table_numeric_keys_do_not_classify(kt::Log& Log)
    TValue value;
    setnumV(&value, 1.0);
 
-   copyTV(L, lj_tab_setint(L, table, 0), &value);   // Array part.
-   copyTV(L, lj_tab_setint(L, table, 5000), &value); // Hash part.
+   copyTV(L, lj_tab_setint(L, table, 0), &value);     // Array part.
+   copyTV(L, lj_tab_setint(L, table, 5000), &value);  // Hash part, sparse.
+   copyTV(L, lj_tab_setint(L, table, -7), &value);    // Hash part, negative.
 
-   TValue bool_key;
-   setboolV(&bool_key, 1);
-   copyTV(L, lj_tab_set(L, table, &bool_key), &value);
+   TValue fractional;  // Non-integral numbers take the generic lj_tab_set() path.
+   setnumV(&fractional, 1.5);
+   copyTV(L, lj_tab_set(L, table, &fractional), &value);
 
-   if (table->flags & TAB_STRING_KEYED) {
-      Log.error("non-string keys incorrectly classified the table as string-keyed");
+   if (table->flags & TAB_ASSOCIATIVE) {
+      Log.error("numeric keys incorrectly classified the table as associative");
+      return false;
+   }
+
+   return true;
+}
+
+// Any key that is not a number must classify the table, not just strings.
+
+static bool test_table_non_numeric_keys_classify(kt::Log& Log)
+{
+   LuaStateHolder Holder;
+   lua_State* L = Holder.get();
+   if (not L) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   TValue value;
+   setnumV(&value, 1.0);
+
+   // Booleans, tables and functions all reach the hash part through lj_tab_set().
+
+   TValue keys[3];
+   setboolV(&keys[0], 1);
+   setboolV(&keys[1], 0);
+   settabV(L, &keys[2], lj_tab_new(L, 0, 0));
+
+   const char *names[3] = { "true", "false", "table" };
+
+   for (int i = 0; i < 3; i++) {
+      GCtab* table = lj_tab_new(L, 4, 3);
+      copyTV(L, lj_tab_setint(L, table, 0), &value);
+      copyTV(L, lj_tab_set(L, table, &keys[i]), &value);
+      if (not (table->flags & TAB_ASSOCIATIVE)) {
+         Log.error("a %s key did not classify the table as associative", names[i]);
+         return false;
+      }
+   }
+
+   // Resurrecting a nilled non-numeric key returns the existing node directly, bypassing lj_tab_newkey().
+
+   GCtab* revived = lj_tab_new(L, 4, 3);
+   TValue nil_value;
+   setnilV(&nil_value);
+   copyTV(L, lj_tab_set(L, revived, &keys[0]), &nil_value);
+   if (not (revived->flags & TAB_ASSOCIATIVE)) {
+      Log.error("assigning nil through a boolean key did not classify the table");
+      return false;
+   }
+
+   revived->flags = 0;  //  Force the resurrection path to re-establish the classification on its own.
+   copyTV(L, lj_tab_set(L, revived, &keys[0]), &value);
+   if (not (revived->flags & TAB_ASSOCIATIVE)) {
+      Log.error("resurrecting a boolean key did not classify the table");
       return false;
    }
 
@@ -626,7 +681,7 @@ static bool test_table_string_key_classifies(kt::Log& Log)
    setnumV(&value, 7.0);
    copyTV(L, lj_tab_setstr(L, table, key), &value);
 
-   if (not (table->flags & TAB_STRING_KEYED)) {
+   if (not (table->flags & TAB_ASSOCIATIVE)) {
       Log.error("string key did not classify the table");
       return false;
    }
@@ -636,7 +691,7 @@ static bool test_table_string_key_classifies(kt::Log& Log)
    TValue nil_value;
    setnilV(&nil_value);
    copyTV(L, lj_tab_setstr(L, table, key), &nil_value);
-   if (not (table->flags & TAB_STRING_KEYED)) {
+   if (not (table->flags & TAB_ASSOCIATIVE)) {
       Log.error("removing the string value cleared the classification");
       return false;
    }
@@ -644,7 +699,7 @@ static bool test_table_string_key_classifies(kt::Log& Log)
    GCtab* nil_only = lj_tab_new(L, 0, 3);
    GCstr* missing = lj_str_newlit(L, "missing");
    copyTV(L, lj_tab_setstr(L, nil_only, missing), &nil_value);
-   if (not (nil_only->flags & TAB_STRING_KEYED)) {
+   if (not (nil_only->flags & TAB_ASSOCIATIVE)) {
       Log.error("assigning nil through a string key did not classify the table");
       return false;
    }
@@ -668,19 +723,19 @@ static bool test_table_classification_survives_mutation(kt::Log& Log)
    copyTV(L, lj_tab_setstr(L, table, key), &value);
 
    lj_tab_clear(table);
-   if (not (table->flags & TAB_STRING_KEYED)) {
+   if (not (table->flags & TAB_ASSOCIATIVE)) {
       Log.error("lj_tab_clear() cleared the classification");
       return false;
    }
 
    lj_tab_resize(L, table, 32, 4);
-   if (not (table->flags & TAB_STRING_KEYED)) {
+   if (not (table->flags & TAB_ASSOCIATIVE)) {
       Log.error("lj_tab_resize() cleared the classification");
       return false;
    }
 
    GCtab* copy = lj_tab_dup(L, table);
-   if (not (copy->flags & TAB_STRING_KEYED)) {
+   if (not (copy->flags & TAB_ASSOCIATIVE)) {
       Log.error("lj_tab_dup() did not copy the classification");
       return false;
    }
@@ -689,7 +744,7 @@ static bool test_table_classification_survives_mutation(kt::Log& Log)
 
    GCtab* pure = lj_tab_new(L, 4, 0);
    GCtab* pure_copy = lj_tab_dup(L, pure);
-   if (pure_copy->flags & TAB_STRING_KEYED) {
+   if (pure_copy->flags & TAB_ASSOCIATIVE) {
       Log.error("lj_tab_dup() invented a classification for a pure table");
       return false;
    }
@@ -726,7 +781,7 @@ static bool test_table_layout_offsets_stable(kt::Log& Log)
 
 extern void indexing_unit_tests(int& Passed, int& Total)
 {
-   constexpr std::array<TestCase, 21> Tests = { {
+   constexpr std::array<TestCase, 22> Tests = { {
       { "array_first_element_access", test_array_first_element_access },
       { "table_length_operator", test_table_length_operator },
       { "ipairs_starting_index", test_ipairs_starting_index },
@@ -745,6 +800,7 @@ extern void indexing_unit_tests(int& Passed, int& Total)
       { "table_string_hash_keys_unchanged", test_table_string_hash_keys_unchanged },
       { "table_flags_initialise_clear", test_table_flags_initialise_clear },
       { "table_numeric_keys_do_not_classify", test_table_numeric_keys_do_not_classify },
+      { "table_non_numeric_keys_classify", test_table_non_numeric_keys_classify },
       { "table_string_key_classifies", test_table_string_key_classifies },
       { "table_classification_survives_mutation", test_table_classification_survives_mutation },
       { "table_layout_offsets_stable", test_table_layout_offsets_stable }

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -2850,6 +2850,64 @@ end
    assert(#t is nil, f"A hot computed string-key store should classify the table, got {tostring(#t)}")
 end
 
+@Test(hotpath=100) function BooleanKeyStoreInHotCodeClassifies()
+   local t = { 1, 2, 3 }
+   for i in {0 to 200} do
+      t[i % 2 is 0] = i
+   end
+   assert(#t is nil, f"A hot boolean-key store should classify the table, got {tostring(#t)}")
+end
+
+@Test(hotpath=100) function TableKeyStoreInHotCodeClassifies()
+   local t = { 1, 2, 3 }
+   local key = {}
+   for i in {0 to 200} do
+      t[key] = i
+   end
+   assert(#t is nil, f"A hot table-key store should classify the table, got {tostring(#t)}")
+end
+
+@Test(hotpath=100) function FunctionKeyStoreInHotCodeClassifies()
+   local t = { 1, 2, 3 }
+   for i in {0 to 200} do
+      t[print] = i
+   end
+   assert(#t is nil, f"A hot function-key store should classify the table, got {tostring(#t)}")
+end
+
+@Test(hotpath=100) function LengthTraceExitsOnFirstBooleanKey()
+   -- The recorded '#' guard proves the table is unclassified, so the first boolean key must side-exit.
+   local t = { 1, 2, 3 }
+   local numeric_results = 0
+   for i in {0 to 200} do
+      if #t is 3 then numeric_results++ end
+   end
+   assert(numeric_results is 200, f"Hot pure table should report length 3 throughout, got {numeric_results}")
+
+   t[true] = 'x'
+
+   local nil_results = 0
+   for i in {0 to 200} do
+      if #t is nil then nil_results++ end
+   end
+   assert(nil_results is 200, f"Hot boolean-keyed table should report nil throughout, got {nil_results}")
+end
+
+@Test(hotpath=100) function NumericHashKeyStoresStayNumericalOnTrace()
+   -- Negative, sparse and fractional keys live in the hash part but must not classify on a trace.
+   local negative = { 1, 2, 3 }
+   local sparse = { 1, 2, 3 }
+   local fractional = { 1, 2, 3 }
+   for i in {0 to 200} do
+      negative[-1 - (i % 4)] = i
+      sparse[9000 + (i % 4)] = i
+      fractional[0.5 + (i % 4)] = i
+   end
+   assert(#negative is 3, f"Negative keys should preserve the length on trace, got {tostring(#negative)}")
+   assert(#sparse is 3, f"Sparse keys should preserve the length on trace, got {tostring(#sparse)}")
+   assert(#fractional is 3, f"Fractional keys should preserve the length on trace, got {tostring(#fractional)}")
+end
+
 function string_keyed_tnew_value(Value):any
    local temporary = {}
    temporary.key = Value
@@ -2938,6 +2996,33 @@ end
    local tdup_result = string_keyed_side_exit(50, true)
    assert(tdup_result.key is 50, 'A restored TDUP should retain its string-keyed value')
    assert(#tdup_result is nil, 'A restored TDUP should retain its string-key classification')
+
+   jit.opt.start()
+end
+
+function boolean_keyed_side_exit(ExitAt, UseTemplate):any
+   for i in {0 to 100} do
+      local temporary = UseTemplate ? { 1 } :> {}
+      temporary[true] = i
+      if i is ExitAt then return temporary end
+   end
+   return nil
+end
+
+@Test function BooleanKeyedSunkTablesRestoreFlagsOnSideExit()
+   jit.flush()
+   jit.opt.start('hotloop=2', 'hotexit=1', 'minstitch=0')
+
+   assert(boolean_keyed_side_exit(-1, false) is nil, 'TNEW workload should record without taking the side exit')
+   local tnew_result = boolean_keyed_side_exit(50, false)
+   assert(tnew_result[true] is 50, 'A restored TNEW should retain its boolean-keyed value')
+   assert(#tnew_result is nil, 'A restored TNEW should retain its associative classification')
+
+   jit.flush()
+   assert(boolean_keyed_side_exit(-1, true) is nil, 'TDUP workload should record without taking the side exit')
+   local tdup_result = boolean_keyed_side_exit(50, true)
+   assert(tdup_result[true] is 50, 'A restored TDUP should retain its boolean-keyed value')
+   assert(#tdup_result is nil, 'A restored TDUP should retain its associative classification')
 
    jit.opt.start()
 end

--- a/src/tiri/tests/test_metatables.tiri
+++ b/src/tiri/tests/test_metatables.tiri
@@ -306,6 +306,38 @@ end
    assert(#backing is nil, "The receiving table should be classified, got " .. tostring(#backing))
 end
 
+@Test function NewIndexMetamethodClassifiesTheReceiverForNonNumericKeys()
+   -- The same diversion rule applies to any non-numeric key, not just strings.
+   local backing = { 1, 2, 3 }
+   local proxy = setmetatable({ 1, 2, 3 }, {
+      __newindex = function(Self, Key, Value) rawset(backing, Key, Value) end
+   })
+   proxy[true] = 'x'
+   assert(#proxy is 3, "The proxy should not be classified by a diverted store, got " .. tostring(#proxy))
+   assert(#backing is nil, "The receiving table should be classified, got " .. tostring(#backing))
+end
+
+@Test function MetaLenOverridesNonNumericKeyClassification()
+   -- __len takes precedence over the classification regardless of which key type caused it.
+   local obj = setmetatable({ 1, 2 }, { __len = function(Self):num return 7 end })
+   obj[true] = 'x'
+   assert(#obj is 7, "__len should override a boolean-key classification, got " .. tostring(#obj))
+
+   setmetatable(obj, nil)
+   assert(#obj is nil, "Removing __len should expose the permanent nil result, got " .. tostring(#obj))
+end
+
+@Test function RawSetWithNonNumericKeyClassifies()
+   -- rawset() bypasses metamethods but still commits a store, so it must classify.
+   local t = { 1, 2, 3 }
+   rawset(t, true, 'x')
+   assert(#t is nil, "rawset() with a boolean key should classify the table, got " .. tostring(#t))
+
+   local u = { 1, 2, 3 }
+   rawset(u, -4, 'x')
+   assert(#u is 3, "rawset() with a numeric key should preserve the length, got " .. tostring(#u))
+end
+
 @Test function MetaConcat()
    mt = {
       __concat = function(A, B):table

--- a/src/tiri/tests/test_table.tiri
+++ b/src/tiri/tests/test_table.tiri
@@ -617,17 +617,48 @@ end
    end
 end
 
-@Test function LengthUnaffectedByNonStringKeys()
-   -- Boolean, negative-number and table keys use the hash part but do not trigger this rule.
+@Test function LengthUnaffectedByNumericKeys()
+   -- Negative, sparse and fractional keys use the hash part but remain numeric, so the length survives.
    t = { 1, 2, 3 }
-   t[true] = 'bool'
    t[-5] = 'negative'
    t[9999] = 'sparse'
-   assert(#t is 3, "Non-string hash keys should preserve the length, got " .. tostring(#t))
+   t[1.5] = 'fractional'
+   assert(#t is 3, "Numeric hash keys should preserve the length, got " .. tostring(#t))
+end
+
+@Test function LengthNilAfterNonNumericKeys()
+   -- Any key that is not a number makes the sequence length meaningless.
+   t = { 1, 2, 3 }
+   t[true] = 'bool'
+   assert(#t is nil, "A boolean key should classify the table, got " .. tostring(#t))
 
    u = { 1, 2, 3 }
-   u[{}] = 'table key'
-   assert(#u is 3, "A table key should preserve the length, got " .. tostring(#u))
+   u[false] = 'bool'
+   assert(#u is nil, "A false key should classify the table, got " .. tostring(#u))
+
+   v = { 1, 2, 3 }
+   v[{}] = 'table key'
+   assert(#v is nil, "A table key should classify the table, got " .. tostring(#v))
+
+   w = { 1, 2, 3 }
+   w[print] = 'function key'
+   assert(#w is nil, "A function key should classify the table, got " .. tostring(#w))
+end
+
+@Test function LengthNilAfterNonNumericKeyInLiteral()
+   -- A constant non-numeric key in a table literal classifies the template, which duplicates inherit.
+   t = { 1, 2, [true] = 'bool' }
+   assert(#t is nil, "A boolean key in a literal should classify the table, got " .. tostring(#t))
+end
+
+@Test function LengthNilAfterResurrectingNonNumericKey()
+   -- Assigning nil then storing again resurrects the existing node without passing through new-key insertion.
+   t = { 1, 2, 3 }
+   t[true] = 'bool'
+   t[true] = nil
+   assert(#t is nil, "Removing a boolean key should not restore the length")
+   t[true] = 'bool again'
+   assert(#t is nil, "Resurrecting a boolean key should keep the table classified")
 end
 
 @Test function LengthOfStringsAndArraysUnchanged()


### PR DESCRIPTION
* Broadened the permanent table classification from string keys to every key that is not a number, so booleans, tables, functions and userdata all disqualify a table from reporting a sequence length
* Renamed the GCtab::flags bit from TAB_STRING_KEYED to TAB_ASSOCIATIVE across lj_obj.h, the x64, ARM64 and PPC interpreters and the trace recorder
* Classified in lj_tab_set() ahead of the chain search, because resurrecting a node whose value went nil returns its slot directly and never reaches lj_tab_newkey()
* Classified the two slot-returning paths in lj_meta_tset(), covering live-value overwrites and dead-node resurrection; BC_TSETV routes all non-integer, non-string keys through here
* Recorded traces publish the classification for any non-numeric key, using the type-specialised key as a static record-time fact
* Numeric keys never classify, so negative, sparse and fractional keys such as t[-5], t[9999] and t[1.5] retain the numerical length
* Added Flute coverage for hot-path stores under boolean, table and function keys, mid-trace side-exit on first classification, sunk TNEW/TDUP restoration, __newindex diversion, __len precedence and rawset(), plus a table_non_numeric_keys_classify C++ unit test