### PR TITLE
[Tiri] Added a dedicated parser for typed array initialisers

### DIFF
--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -135,6 +135,7 @@ private:
    ParserResult<ExprNodePtr> parse_function_literal(
       const Token &, bool IsThunk = false, GCstr *FunctionName = nullptr);
    ParserResult<ExprNodePtr> parse_table_literal(bool AllowRange = true);
+   ParserResult<ExprNodeList> parse_array_initialiser();
    ParserResult<ReturnStmtPayload> parse_return_payload(const Token &, bool same_line_only);
    ParserResult<FunctionReturnTypes> parse_return_type_annotation();
 

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -678,27 +678,10 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          bool has_initialiser = false;
          if (this->ctx.check(TokenKind::LeftBrace)) {
             has_initialiser = true;
-            // Parse the table literal to extract values
-            auto table_result = this->parse_table_literal(false);
-            if (not table_result.ok()) return table_result;
-
-            // Extract array-style values from table literal
-            // The table should contain only sequential integer-keyed entries
-            if (table_result.value_ref()->kind IS AstNodeKind::TableExpr) {
-               auto *table_payload = std::get_if<TableExprPayload>(&table_result.value_ref()->data);
-               if (table_payload) {
-                  for (auto &field : table_payload->fields) {
-                     if (field.kind IS TableFieldKind::Array and field.value) {
-                        init_values.push_back(std::move(field.value));
-                     }
-                     else {
-                        // Non-array field in array initialiser - emit error
-                        return this->fail<ExprNodePtr>(ParserErrorCode::UnexpectedToken, start,
-                           "Array initialiser can only contain sequential values, not key-value pairs");
-                     }
-                  }
-               }
-            }
+            // Positional values are parsed directly into an expression list; no temporary table AST is built.
+            auto values = this->parse_array_initialiser();
+            if (not values.ok()) return ParserResult<ExprNodePtr>::failure(values.error_ref());
+            init_values = std::move(values.value_ref());
          }
 
          SourceSpan span = start.span();

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -75,6 +75,61 @@ ParserResult<ExprNodePtr> AstBuilder::parse_table_literal(bool AllowRange)
 }
 
 //********************************************************************************************************************
+// Parses the braced initialiser of a typed array: array<Type> { Value, Value, ... }
+//
+// Typed arrays are positional by construction, so this parser returns the values directly instead of building a
+// throw-away table literal.  Avoiding parse_table_fields() also avoids allocating a TableField per value and hashing
+// a canonical key that is sequential by definition.
+//
+// Range scanning is deliberately absent: `to` and `into` are ordinary identifiers inside these braces, matching the
+// previous parse_table_literal(false) behaviour.  Separators are consumed through the normal token stream, because
+// peeking across one can pre-expand an f-string value into the lexer's buffered tokens and corrupt later parsing.
+
+ParserResult<ExprNodeList> AstBuilder::parse_array_initialiser()
+{
+   ExprNodeList values;
+
+   if (not this->ctx.match(TokenKind::LeftBrace).ok()) {
+      return this->fail<ExprNodeList>(ParserErrorCode::ExpectedToken, this->ctx.tokens().current(),
+         "Expected '{' to open array initialiser");
+   }
+
+   while (not this->ctx.check(TokenKind::RightBrace)) {
+      Token current = this->ctx.tokens().current();
+
+      // Reject keyed syntax at the offending field rather than at the array type token.  Lookahead is limited to the
+      // start of the field so that buffered interpolation tokens are never disturbed.
+
+      const bool record_key = current.is_identifier_or_future_reserved() and
+         this->ctx.tokens().peek(1).kind() IS TokenKind::Equals;
+
+      if (record_key or current.kind() IS TokenKind::LeftBracket) {
+         return this->fail<ExprNodeList>(ParserErrorCode::UnexpectedToken, current,
+            "Array initialiser can only contain sequential values, not key-value pairs");
+      }
+
+      auto value = this->parse_expression();
+      if (not value.ok()) return ParserResult<ExprNodeList>::failure(value.error_ref());
+
+      values.push_back(std::move(value.value_ref()));
+
+      // Separators are optional; adjacent values are accepted for source compatibility.  In diagnose mode a failed
+      // expression parse can leave the stream stationary, so guarantee forward progress rather than looping forever.
+
+      if (this->ctx.match(TokenKind::Comma).ok() or this->ctx.match(TokenKind::Semicolon).ok()) continue;
+
+      if (this->ctx.tokens().current().kind() IS current.kind() and
+          this->ctx.tokens().current().span().offset IS current.span().offset) {
+         return this->fail<ExprNodeList>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
+            "Expected a value or '}' in array initialiser");
+      }
+   }
+
+   this->ctx.consume(TokenKind::RightBrace, ParserErrorCode::ExpectedToken);
+   return ParserResult<ExprNodeList>::success(std::move(values));
+}
+
+//********************************************************************************************************************
 // Parses comma-separated lists of expressions.
 
 ParserResult<ExprNodeList> AstBuilder::parse_expression_list()
@@ -383,9 +438,9 @@ struct ConstantKey {
    {
       if (kind != Other.kind) return false;
       switch (kind) {
-         case Kind::Number:  return number == Other.number;
-         case Kind::String:  return text == Other.text;
-         case Kind::Boolean: return boolean == Other.boolean;
+         case Kind::Number:  return number IS Other.number;
+         case Kind::String:  return text IS Other.text;
+         case Kind::Boolean: return boolean IS Other.boolean;
       }
       return false;
    }

--- a/src/tiri/tests/test_array_typed_syntax.tiri
+++ b/src/tiri/tests/test_array_typed_syntax.tiri
@@ -627,3 +627,106 @@ end
    obj_one.free()
    obj_two.free()
 end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Initialiser grammar: separators, adjacency, nesting and diagnostics.  These cases pin the accepted syntax of the
+-- dedicated typed-array initialiser parser so that it cannot silently diverge from table-literal field parsing.
+
+function array_init_no_results() end
+
+function array_init_two_results():<num, num>
+   return 7, 8
+end
+
+@Test function ArrayInitialiserEmptyBraces()
+   -- An empty braced initialiser must still produce a correctly typed empty array.
+   arr = array<int> {}
+   assert(#arr is 0, "Empty initialiser should have length 0, got " .. #arr)
+   assert(arr:type() is 'int', "Empty initialiser should retain its element type")
+end
+
+@Test function ArrayInitialiserSemicolonSeparators()
+   arr = array<int> { 1; 2; 3 }
+   assert(#arr is 3, "Semicolon separators should yield 3 elements, got " .. #arr)
+   assert(arr[0] is 1, "First element should be 1")
+   assert(arr[2] is 3, "Third element should be 3")
+end
+
+@Test function ArrayInitialiserTrailingSeparators()
+   local trailing_comma = array<int> { 1, 2, }
+   assert(#trailing_comma is 2, "A trailing comma should not add an element, got " .. #trailing_comma)
+   assert(trailing_comma[1] is 2, "Trailing comma should preserve the last value")
+
+   local trailing_semicolon = array<int> { 4; 5; }
+   assert(#trailing_semicolon is 2, "A trailing semicolon should not add an element, got " .. #trailing_semicolon)
+   assert(trailing_semicolon[1] is 5, "Trailing semicolon should preserve the last value")
+end
+
+@Test function ArrayInitialiserAdjacentExpressions()
+   -- Values without an intervening separator are accepted, matching the historic table-field loop.
+   arr = array<int> { 1 2 3 }
+   assert(#arr is 3, "Adjacent values should yield 3 elements, got " .. #arr)
+   assert(arr[0] is 1, "First adjacent value should be 1")
+   assert(arr[2] is 3, "Third adjacent value should be 3")
+end
+
+@Test function ArrayInitialiserNestedLiterals()
+   local tables = array<table> { { 10, 20 }, { x = 1 } }
+   assert(#tables is 2, "Nested table values should yield 2 elements, got " .. #tables)
+   assert(tables[0][1] is 20, "Nested table array part should be preserved")
+   assert(tables[1].x is 1, "Nested table record part should be preserved")
+
+   local arrays = array<array> { array<int> { 1, 2 }, array<int> { 3 } }
+   assert(#arrays is 2, "Nested typed arrays should yield 2 elements, got " .. #arrays)
+   assert(#arrays[0] is 2, "First nested array should retain 2 elements")
+   assert(arrays[1][0] is 3, "Second nested array should retain its value")
+end
+
+@Test function ArrayInitialiserConsecutiveFormattedStrings()
+   -- Separator handling must not peek into the buffered tokens produced by an interpolated string.
+   local port = 18952
+   local args = array<string> { f'url=http://127.0.0.1:{port}/echo', f'proxy=127.0.0.1:{port}', 'timeout=5' }
+   assert(#args is 3, "Formatted string values should yield 3 elements, got " .. #args)
+   assert(args[0] is 'url=http://127.0.0.1:18952/echo', "First formatted string should parse intact")
+   assert(args[1] is 'proxy=127.0.0.1:18952', "Second formatted string should parse intact")
+   assert(args[2] is 'timeout=5', "Trailing plain string should parse intact")
+end
+
+@Test function ArrayInitialiserTailCallContributesOneValue()
+   -- Unlike a table constructor, a final call contributes exactly one value and must not expand.
+   local expanded = array<int> { 1, array_init_two_results() }
+   assert(#expanded is 2, "A multi-result tail call should contribute one value, got " .. #expanded)
+   assert(expanded[1] is 7, "The tail call should contribute its first result only")
+
+   local empty_tail = array<int> { 1, array_init_no_results() }
+   assert(#empty_tail is 2, "A zero-result tail call should still occupy one slot, got " .. #empty_tail)
+   assert(empty_tail[1] is 0, "A zero-result tail call should default its slot")
+end
+
+@Test function ArrayInitialiserNestedRangeExpressionsRemainValid()
+   -- Range syntax is disabled for the outer braces, but nested range expressions are ordinary values.
+   arr = array<any> { 2 in {0 to 5}, 9 in {0 to 5} }
+   assert(#arr is 2, "Nested range membership tests should yield 2 elements, got " .. #arr)
+   assert(arr[0] is true, "2 should be within {0 to 5}")
+   assert(arr[1] is false, "9 should be outside {0 to 5}")
+end
+
+@Test function ArrayInitialiserRangeSyntaxRemainsDisabled()
+   -- 'to' is not a range keyword inside typed-array braces; it resolves as an ordinary identifier.
+   local result = debug.validate("x = array<int> { 0 to 3 }")
+   assert(result.success is false, "Range syntax should not be accepted in a typed-array initialiser")
+end
+
+function assert_array_key_rejected(Source:str, Context:str)
+   local result = debug.validate(Source)
+   assert(result.success is false, Context .. ': source should fail validation')
+   assert(string.find(result.diagnostics[0].message, 'Array initialiser', 0, true) != nil,
+      Context .. ': expected an array-initialiser diagnostic, got: ' .. tostring(result.diagnostics[0].message))
+end
+
+@Test function ArrayInitialiserRejectsKeyedFields()
+   assert_array_key_rejected("x = array<int> { value = 1 }", 'named key')
+   assert_array_key_rejected("x = array<int> { [0] = 1 }", 'computed key')
+   assert_array_key_rejected("x = array<int> { 1, 2, value = 3 }", 'named key after positional values')
+   assert_array_key_rejected("x = array<int> { 1, [2] = 3 }", 'computed key after positional values')
+end


### PR DESCRIPTION
* Typed array braces are now parsed straight into an expression list, removing the temporary table literal and its per-value TableField allocation and key hashing
* Keyed fields are rejected at the offending field rather than at the array type token, and lookahead is confined to the start of each field so that buffered interpolation tokens are left intact
* Guaranteed forward progress in the value loop so that a stationary token stream in diagnose mode cannot spin indefinitely
* Extended test_array_typed_syntax.tiri with initialiser grammar coverage for separators, adjacency, nesting, tail calls, formatted strings and keyed-field diagnostics