### PR TITLE
[Tiri] Standardise bool type naming

### DIFF
--- a/.agents/skills/cloud-builds/SKILL.md
+++ b/.agents/skills/cloud-builds/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: cloud-builds
+description: Build and install Kōtuku in ephemeral cloud environments. Use when working in a cloud or container session where the build tree may be missing, when builds are slow and unnecessary modules should be disabled, or when origo is not yet installed at build/agents-install.
+---
+
+# Building Kōtuku in the Cloud
+
+When working in ephemeral cloud environments:
+
+- Prefer the pre-created build tree at `build/agents` and install tree at `build/agents-install` to avoid the expense
+  of repeated configuration.  If the directory exists you can update it with
+  `cmake --build build/agents --config Debug --parallel`.
+- If `origo` is not already installed at `build/agents-install` then performing the build and install process is
+  essential if intending to run `origo` for Tiri scripts and Flute tests.
+- If configuring a build, disabling unnecessary modules like Audio and Graphics features (if they are not relevant)
+  will speed up compilation.  If *certain* that the environment is cloud-based, you can consider including the
+  following with your CMake build configuration:
+  `-DDISABLE_AUDIO=ON -DDISABLE_X11=ON -DDISABLE_DISPLAY=ON -DDISABLE_FONT=ON`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ This file provides guidance to Agentic programs when working with code in this r
 - `cmake -S . -B build/agents -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=build/agents-install -DRUN_ANYWHERE=TRUE -DKOTUKU_STATIC=OFF -DUNIT_TESTS=ON -DORIGO_CONSOLE=ON`
 - Modular/Static builds: Use `-DKOTUKU_STATIC=OFF` for modular builds and `-DKOTUKU_STATIC=ON` for static.
 - Always use Debug builds unless the user requests otherwise.
+- `UNIT_TESTS=ON` enables compiled C++ unit tests and prolongs the build.  Note that this is not declared as a CMake
+  `option()`; it is consumed directly by `src/core/CMakeLists.txt`, so it will not appear in the options listing.
 
 **Build and install:**
 - Build and install: `cmake --build build/agents --config Debug --parallel && cmake --install build/agents --config Debug`
@@ -27,35 +29,10 @@ This file provides guidance to Agentic programs when working with code in this r
 **Verify:**
 - You can inspect the version, git commit hash and build type of the build by running `origo` with `--version`.
 
-### CMake Configuration Options
-
-Key build options (use with `-D` flag):
-- `KOTUKU_STATIC=ON/OFF` - Build as static libraries instead of modules
-- `BUILD_TESTS=ON/OFF` - Enable/disable Flute tests
-- `UNIT_TESTS=ON/OFF` - Enable compiled C++ unit tests (prolongs build)
-- `RUN_ANYWHERE=ON/OFF` - Build for local folder execution
-- `KOTUKU_VLOG=ON/OFF` - Enables trace level log messages via log.trace() in Debug builds (has no effect on Release builds).
-
-### Development in the Cloud
-
-When working in ephemeral cloud environments:
-
-- Prefer the pre-created build tree at `build/agents` and install tree at `build/agents-install` to avoid the expense of repeated configuration.  If the directory exists you can update it with `cmake --build build/agents --config Debug --parallel`.
-- If `origo` is not already installed at `build/agents-install` then performing the build and install process is essential if intending to run `origo` for Tiri scripts and Flute tests.
-- If configuring a build, disabling unnecessary modules like Audio and Graphics features (if they are not relevant) will speed up compilation.  If *certain* that the environment is cloud-based, you can consider including the following with your CMake build configuration: `-DDISABLE_AUDIO=ON -DDISABLE_X11=ON -DDISABLE_DISPLAY=ON -DDISABLE_FONT=ON`
-
 ## Architecture Overview
-
-### Core Framework Structure
-
-**Kōtuku** is an application framework with a core focus on building scalable user interfaces and highly efficient JIT compiled applications. The framework automatically handles display resolution and scaling concerns, allowing developers to focus on application logic rather than display technicalities.
 
 ### Module System
 
-Kōtuku uses a modular architecture where each major feature is implemented as a separate module:
-
-- Each module is in `src/[module_name]/` with its own `CMakeLists.txt`
-- Static builds link all modules into the core, while modular builds load them dynamically
 - Module definitions are stored in `.tdl` files which generate C++ headers and module `MOD_IDL` strings
 
 ### Object System and TDL Files
@@ -64,8 +41,6 @@ Kōtuku uses Interface Definition Language (IDL) files with `.tdl` extension to 
 
 - TDL files define classes, methods, fields, and constants
 - The `build_headers` target generates C/C++ headers and XML documentation from TDL using tools in `tools/idl/`
-- Class implementations are in `class_*.cpp` files
-- Generated headers go to `include/kotuku/` directory
 - Normal builds consume the existing generated headers.  After changing `.tdl` files, C++ blueprints or embedded documentation, run `build_headers` to regenerate headers and XML documentation.  Use `touch` on any `.tdl` file beforehand if needing to force regeneration of its downstream files.
 
 ### Scripting Integration
@@ -110,8 +85,6 @@ The build system heavily uses code generation:
 ### Multi-Platform Considerations
 
 - Core code is cross-platform (Windows/Linux/MacOS/Android) and is specifically optimised for 64-bit CPUs.  32-bit compatibility is redundant.
-- Platform-specific code is in subdirectories (`win32/`, `x11/`, etc.)
-- Build system auto-detects platform capabilities (X11, SSL, etc.)
 - Windows builds support the MSVC toolchain.  MinGW support is deprecated
 
 **Windows-Specific Notes:**

--- a/scripts/benchmark.tiri
+++ b/scripts/benchmark.tiri
@@ -711,7 +711,7 @@ end
 -- Check if results indicate a regression compared to baseline.
 -- Simple boolean check useful for CI/CD pipelines.
 
-bmark.hasRegression = function(Current:table, BaselinePath:str, Threshold:num):boolean
+bmark.hasRegression = function(Current:table, BaselinePath:str, Threshold:num):bool
    local comparison = bmark.compareToBaseline(Current, BaselinePath, Threshold)
    return not comparison.passed
 end
@@ -721,7 +721,7 @@ end
 bmark.comparisonReport = function(Comparison:table):array<string>
    local msg = array<string>
 
-   local function formatChange(Change:num, Improved:boolean):string
+   local function formatChange(Change:num, Improved:bool):string
       local sign = Change >= 0 and '+' or ''
       local indicator = Improved and '✓' or (math.abs(Change) > 5 and '✗' or '~')
       return string.format('%s%.1f%% %s', sign, Change, indicator)

--- a/scripts/config.tiri
+++ b/scripts/config.tiri
@@ -131,7 +131,7 @@ config.encode = function(Value:table):str
          key = validate_key_name(key, group_name)
 
          local value_type = type(value)
-         if value_type != 'string' and value_type != 'number' and value_type != 'boolean' then
+         if value_type != 'string' and value_type != 'number' and value_type != 'bool' then
             error(f'Config value for "{group_name}.{key}" has unsupported type "{value_type}".')
          end
 

--- a/scripts/json.tiri
+++ b/scripts/json.tiri
@@ -130,7 +130,7 @@ json.encode = function(Value:any, ErrorCallback:func, AsKey:bool):str
    elseif kind is 'number' then
       if AsKey then return '"' .. tostring(Value) .. '"' end
       return tostring(Value)
-   elseif kind is 'boolean' then
+   elseif kind is 'bool' then
       return tostring(Value)
    elseif kind is 'nil' then
       return 'null'

--- a/scripts/net/httpserver.tiri
+++ b/scripts/net/httpserver.tiri
@@ -1955,7 +1955,7 @@ hslib.start = function(Options)
    self.folder ?? error('The folder option is required')
 
    if Options.verbose then
-      if type(Options.verbose) is 'boolean' then
+      if type(Options.verbose) is 'bool' then
          self.verbose = Options.verbose
       else
          verbose = tostring(Options.verbose):lower()
@@ -1991,7 +1991,7 @@ hslib.start = function(Options)
    end
 
    if Options.autoIndex then
-      if type(Options.autoIndex) is 'boolean' then
+      if type(Options.autoIndex) is 'bool' then
          self.autoIndex = Options.autoIndex
       else
          autoindex = tostring(Options.autoIndex):lower()

--- a/scripts/net/proxyserver.tiri
+++ b/scripts/net/proxyserver.tiri
@@ -281,7 +281,7 @@ function createFlowManager(self)
 
       for name, value in pairs(Headers) do
          local value_type = type(value)
-         if value_type is 'string' or value_type is 'number' or value_type is 'boolean' then
+         if value_type is 'string' or value_type is 'number' or value_type is 'bool' then
             headers[tostring(name)] = value
          end
       end

--- a/scripts/options.tiri
+++ b/scripts/options.tiri
@@ -486,7 +486,7 @@ function convert_builtin(TypeName:str, Value:any, Param:table):any
       end
       return number
    elseif TypeName is 'bool' then
-      if type(Value) is 'boolean' then return Value end
+      if type(Value) is 'bool' then return Value end
 
       local text = tostring(Value):lower()
       if text is 'true' or text is '1' or text is 'yes' or text is 'on' then return true end

--- a/src/tiri/jit/src/lib/lib_base.cpp
+++ b/src/tiri/jit/src/lib/lib_base.cpp
@@ -161,8 +161,8 @@ static bool is_range_userdata(lua_State *L, GCudata *Userdata)
 }
 
 LJLIB_PUSH("nil")
-LJLIB_PUSH("boolean")
-LJLIB_PUSH(top-1)  //  boolean
+LJLIB_PUSH("bool")
+LJLIB_PUSH(top-1)  //  bool
 LJLIB_PUSH("userdata")
 LJLIB_PUSH("string")
 LJLIB_PUSH("upval")

--- a/src/tiri/jit/src/parser/ast/nodes.cpp
+++ b/src/tiri/jit/src/parser/ast/nodes.cpp
@@ -11,7 +11,6 @@ TiriType parse_type_name(std::string_view Name)
       { "any",       TiriType::Any },
       { "nil",       TiriType::Nil },
       { "bool",      TiriType::Bool },
-      { "boolean",   TiriType::Bool },
       { "num",       TiriType::Num },
       { "number",    TiriType::Num },
       { "str",       TiriType::Str },

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -649,7 +649,7 @@ void lj_meta_istype(lua_State *L, BCREG ra, BCREG tp)
       // Boolean check: accept both true and false
       // LJ_TFALSE = ~1, LJ_TTRUE = ~2
       TValue* o = L->base + ra - 1;
-      if (not tvisbool(o)) lj_err_assigntype(L, int(ra) - 1, "boolean");
+      if (not tvisbool(o)) lj_err_assigntype(L, int(ra) - 1, "bool");
    }
    else lj_err_assigntype(L, int(ra) - 1, lj_obj_itypename[tp]);
 }

--- a/src/tiri/jit/src/runtime/lj_obj.cpp
+++ b/src/tiri/jit/src/runtime/lj_obj.cpp
@@ -11,12 +11,12 @@
 // Object type names.
 
 LJ_DATADEF CSTRING const lj_obj_typename[] = {  // ORDER LUA_T
-  "no value", "nil", "boolean", "userdata", "number", "string",
+  "no value", "nil", "bool", "userdata", "number", "string",
   "table", "function", "userdata", "struct", "proto", "object", "array"
 };
 
 LJ_DATADEF CSTRING const lj_obj_itypename[] = {  // ORDER LJ_T
-  "nil", "boolean", "boolean", "userdata", "string", "upval", "struct",
+  "nil", "bool", "bool", "userdata", "string", "upval", "struct",
   "proto", "function", "trace", "object", "table", "userdata", "array", "number"
 };
 

--- a/src/tiri/tests/test_array_any.tiri
+++ b/src/tiri/tests/test_array_any.tiri
@@ -35,7 +35,7 @@ end
 
    assert(type(arr[0]) is 'number', "element 0 should be number")
    assert(type(arr[1]) is 'string', "element 1 should be string")
-   assert(type(arr[2]) is 'boolean', "element 2 should be boolean")
+   assert(type(arr[2]) is 'bool', "element 2 should be bool")
    assert(arr[3] is nil, "element 3 should be nil")
    assert(type(arr[4]) is 'table', "element 4 should be table")
    assert(type(arr[5]) is 'number', "element 5 should be number")

--- a/src/tiri/tests/test_bare_iteration.tiri
+++ b/src/tiri/tests/test_bare_iteration.tiri
@@ -155,7 +155,7 @@ end
       { source = 'local value:func = nil; for item in value do end', type_name = 'nil' },
       { source = 'local value:any = 7; for item in value do end', type_name = 'number' },
       { source = "local value:any = 'text'; for item in value do end", type_name = 'string' },
-      { source = 'local value:any = false; for item in value do end', type_name = 'boolean' }
+      { source = 'local value:any = false; for item in value do end', type_name = 'bool' }
    }
 
    for _, case in pairs(cases) do

--- a/src/tiri/tests/test_deferred_expr.tiri
+++ b/src/tiri/tests/test_deferred_expr.tiri
@@ -23,12 +23,12 @@ end
 @Test function InferredBooleanType()
    x = <{ true }>
    result = resolve(x)
-   assert(type(result) is 'boolean', 'Expected boolean type, got ' .. type(result))
+   assert(type(result) is 'bool', 'Expected bool type, got ' .. type(result))
    assert(result is true, 'Expected true')
 
    y = <{ false }>
    result2 = resolve(y)
-   assert(type(result2) is 'boolean', 'Expected boolean type')
+   assert(type(result2) is 'bool', 'Expected bool type')
    assert(result2 is false, 'Expected false')
 end
 
@@ -69,7 +69,7 @@ end
    b = 10
    x = <{ a < b }>
    result = resolve(x)
-   assert(type(result) is 'boolean', 'Expected boolean type from comparison')
+   assert(type(result) is 'bool', 'Expected bool type from comparison')
    assert(result is true, 'Expected true')
 end
 
@@ -124,7 +124,7 @@ end
    end
    x = <bool{ checkCondition() }>
    result = resolve(x)
-   assert(type(result) is 'boolean', 'Expected boolean type')
+   assert(type(result) is 'bool', 'Expected bool type')
    assert(result is true, 'Expected true')
 end
 
@@ -164,7 +164,7 @@ end
    assert(type(num) is 'number', 'Expected type(num) to be "number", got "' .. type(num) .. '"')
 
    bool = <{ true }>
-   assert(type(bool) is 'boolean', 'Expected type(bool) to be "boolean", got "' .. type(bool) .. '"')
+   assert(type(bool) is 'bool', 'Expected type(bool) to be "bool", got "' .. type(bool) .. '"')
 
    tbl = <{ {} }>
    assert(type(tbl) is 'table', 'Expected type(tbl) to be "table", got "' .. type(tbl) .. '"')

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -1433,7 +1433,7 @@ end
    -- Verify all values in the flags table are booleans
    for name, value in pairs(flags) do
       assert(type(name) is "string", "Flag keys should be strings")
-      assert(type(value) is "boolean", f"Flag '{name}' should be a boolean, got {type(value)}")
+      assert(type(value) is "bool", f"Flag '{name}' should be a bool, got {type(value)}")
    end
 
    -- Verify known optimisation flags are present

--- a/src/tiri/tests/test_processing.tiri
+++ b/src/tiri/tests/test_processing.tiri
@@ -25,7 +25,7 @@
    assert(diff < 0.0001, f'memoryMB ({stats.memoryMB}) should be consistent with KB+bytes ({expected_mb})')
 
    assert(stats.isRunning != nil, 'gcStats() should have isRunning field')
-   assert(type(stats.isRunning) is 'boolean', 'isRunning should be a boolean')
+   assert(type(stats.isRunning) is 'bool', 'isRunning should be a bool')
 
    assert(stats.pause != nil, 'gcStats() should have pause field')
    assert(type(stats.pause) is 'number', 'pause should be a number')

--- a/src/tiri/tests/test_return_types.tiri
+++ b/src/tiri/tests/test_return_types.tiri
@@ -674,13 +674,6 @@ end
    assert(getString() is "hello", "string alias in return type should work")
 end
 
-@Test function ReturnTypeAliasBoolean()
-   function getBoolean():boolean
-      return true
-   end
-   assert(getBoolean() is true, "boolean alias in return type should work")
-end
-
 @Test function ReturnTypeAliasFunction()
    -- 'function' is a keyword, so the alias 'func' should be used for return types
    function getFunction():func

--- a/src/tiri/tests/test_tempus.tiri
+++ b/src/tiri/tests/test_tempus.tiri
@@ -594,7 +594,7 @@ end
    assert(type(zone:nativeId()) is 'string' and #zone:nativeId() > 0, 'Local zone should expose a native ID')
    assert((zone:source() is 'win32') or (zone:source() is 'tzif') or (zone:source() is 'utc'),
       'Local zone source should come from Core')
-   assert(type(zone:isFallback()) is 'boolean', 'Local zone fallback state should be boolean')
+   assert(type(zone:isFallback()) is 'bool', 'Local zone fallback state should be bool')
    assert(tempus.isOffset(offset), 'Local zone offsetAt() should return an Offset value')
    assert(type(zone:nameAt(instant)) is 'string', 'Local zone nameAt() should return a string')
 end

--- a/src/tiri/tests/test_thunks.tiri
+++ b/src/tiri/tests/test_thunks.tiri
@@ -489,8 +489,8 @@ end
    result_true = is_positive(5)
    result_false = is_positive(-5)
 
-   assert(type(result_true) is "boolean", "type() should return 'boolean' for :bool thunk")
-   assert(type(result_false) is "boolean", "type() should return 'boolean' for :bool thunk")
+   assert(type(result_true) is "bool", "type() should return 'bool' for :bool thunk")
+   assert(type(result_false) is "bool", "type() should return 'bool' for :bool thunk")
 
    -- Note: Thunks are always truthy in conditionals (userdata are truthy)
    -- Must use resolve() or tostring() to get the actual boolean value

--- a/src/tiri/tests/test_type_annotations.tiri
+++ b/src/tiri/tests/test_type_annotations.tiri
@@ -57,7 +57,6 @@ end
    assert_compiles("S:str")
    assert_compiles("String:string")
    assert_compiles("B:bool")
-   assert_compiles("Boolean:boolean")
    assert_compiles("T:table")
    assert_compiles("F:func")
    assert_compiles("Function:function")
@@ -66,6 +65,20 @@ end
    assert_compiles("StructVal:struct")
    assert_compiles("ObjVal:obj")
    assert_compiles("ObjectVal:object")
+end
+
+@Test function RemovedBooleanTypeRejected()
+   function assert_rejected(Source:str, Context:str)
+      try
+         exec(Source)
+      success
+         error(f"Expected boolean type name to be rejected in {Context}")
+      end
+   end
+
+   assert_rejected("local value:boolean = true", "a local annotation")
+   assert_rejected("local function rejected(Value:boolean) return Value end", "a parameter annotation")
+   assert_rejected("local function rejected():boolean return true end", "a return annotation")
 end
 
 @Test function UnknownTypeRejected()

--- a/src/tiri/tests/test_type_fixing.tiri
+++ b/src/tiri/tests/test_type_fixing.tiri
@@ -74,7 +74,7 @@ end
    assert(type(data) is "string", "any should accept string")
 
    data = true
-   assert(type(data) is "boolean", "any should accept boolean")
+   assert(type(data) is "bool", "any should accept bool")
 
    data = { x = 1 }
    assert(type(data) is "table", "any should accept table")
@@ -239,11 +239,8 @@ end
    assert(s1 is "a", "str alias works")
    assert(s2 is "b", "string alias works")
 
-   -- bool/boolean are aliases
    local b1: bool = true
-   local b2: boolean = false
-   assert(b1 is true, "bool alias works")
-   assert(b2 is false, "boolean alias works")
+   assert(b1 is true, "bool type works")
 
    -- func/function are aliases
    local f1: func = function() return 1 end

--- a/tools/benchmark/benchmark_language.tiri
+++ b/tools/benchmark/benchmark_language.tiri
@@ -531,7 +531,7 @@ end
       local is_str = type(str) is "string"
       local is_tbl = type(tbl) is "table"
       local is_func = type(func) is "function"
-      local is_bool = type(bool_true) is "boolean"
+      local is_bool = type(bool_true) is "bool"
 
       -- Conditional based on type
       local val = i % 3 is 0 and str or (i % 3 is 1 and num_int or tbl)

--- a/tools/tiri_lsp/include/lsp_cache.tiri
+++ b/tools/tiri_lsp/include/lsp_cache.tiri
@@ -377,7 +377,7 @@ function serializeTable(Tbl:any, Indent):str
          return "'" .. escaped .. "'"
       elseif type(Tbl) is 'number' then
          return tostring(Tbl)
-      elseif type(Tbl) is 'boolean' then
+      elseif type(Tbl) is 'bool' then
          return Tbl and 'true' or 'false'
       else
          return 'nil'

--- a/tools/tiri_lsp/include/lsp_defs.tiri
+++ b/tools/tiri_lsp/include/lsp_defs.tiri
@@ -27,7 +27,7 @@ glBuiltins = {
 
    -- Type conversion/introspection
    ['type'] = {
-      comment = 'Returns the type of a value as a string.',
+      comment = 'Returns the canonical type name of a value as a string, including bool for true and false.',
       prototype = 'type(value)'
    },
    ['tonumber'] = {

--- a/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
+++ b/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
@@ -345,7 +345,7 @@
          "patterns": [
             {
                "name": "support.type.primitive.tiri",
-               "match": "\\b(any|bool|boolean|byte|char|cstr|double|float|func|int|int8|int16|int32|int64|integer|num|number|ptr|string|table|uint|uint8|uint16|uint32|uint64|void)\\b"
+               "match": "\\b(any|bool|byte|char|cstr|double|float|func|int|int8|int16|int32|int64|integer|num|number|ptr|string|table|uint|uint8|uint16|uint32|uint64|void)\\b"
             },
             {
                "name": "support.class.tiri",


### PR DESCRIPTION
* Removed the boolean type descriptor alias and made type() return bool consistently
* Updated scripts, tooling, benchmarks and regression coverage for canonical bool naming
* [AI] Moved cloud build guidance into a reusable skill and clarified unit test configuration