### PR TITLE
[Tiri] Infer any return types for table index reads

### DIFF
--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -73,43 +73,6 @@
    return Function.body and Function.body->statements.empty();
 }
 
-// Reads from an untyped table yield 'any' because element types are not tracked.  Such a value is dynamic by nature
-// rather than by an unresolved ingress, so it must not lock the destination into requiring an annotation; demanding
-// one would only add a CONTRACT guard without unlocking a specialised opcode.  Struct fields and typed array elements
-// infer concrete types and never reach this path.
-
-[[nodiscard]] static bool is_table_read_expression(const ExprNode &Expr)
-{
-   switch (Expr.kind) {
-      case AstNodeKind::MemberExpr:
-      case AstNodeKind::IndexExpr:
-      case AstNodeKind::SafeMemberExpr:
-      case AstNodeKind::SafeIndexExpr:
-         return true;
-
-      // Binary expressions yield 'any' when a table read can invoke an overloaded operator.  This includes defaulted
-      // reads such as t[k] ?? fallback and arithmetic such as 0.5 + t.value.  Recurse so the exemption follows the
-      // value's origin.
-
-      case AstNodeKind::BinaryExpr: {
-         const auto *payload = std::get_if<BinaryExprPayload>(&Expr.data);
-         if (not payload) return false;
-         return (payload->left and is_table_read_expression(*payload->left)) or
-            (payload->right and is_table_read_expression(*payload->right));
-      }
-
-      // Unary negation can remain dynamic when its operand is a table read because the value may overload '-'.
-
-      case AstNodeKind::UnaryExpr: {
-         const auto *payload = std::get_if<UnaryExprPayload>(&Expr.data);
-         return payload and payload->operand and is_table_read_expression(*payload->operand);
-      }
-
-      default:
-         return false;
-   }
-}
-
 [[nodiscard]] static std::optional<std::string> function_signature_mismatch(
    const FunctionExprPayload &Expected, const FunctionExprPayload &Actual)
 {
@@ -276,6 +239,7 @@ private:
    [[nodiscard]] InferredType infer_expression_type(const ExprNode &);
    [[nodiscard]] InferredType refine_static_expression_type(const ExprNode &, InferredType) const;
    [[nodiscard]] bool is_explicit_variant_expression(const ExprNode &, size_t Position = 0) const;
+   [[nodiscard]] bool is_table_read_expression(const ExprNode &);
    [[nodiscard]] InferredType infer_call_return_type(const ExprNode &, size_t Position) const;
 
    // Symbol resolution - looks up variables and functions in scope stack
@@ -2440,6 +2404,52 @@ void TypeAnalyser::check_argument_type(
 // - Calls: Uses function's declared return type if available, otherwise Any
 // - Binary ops: Depends on operator (comparisons -> bool, arithmetic -> num, etc.)
 // - Unary ops: Depends on operator (not -> bool, negate -> num, length -> num)
+
+// Reads from a resolved untyped table yield 'any' because element types are not tracked.  Such a value is dynamic by
+// nature rather than by an unresolved ingress, so it must not lock the destination into requiring an annotation.
+// Struct fields and typed array elements infer concrete types and never reach this path.
+
+bool TypeAnalyser::is_table_read_expression(const ExprNode &Expr)
+{
+   const ExprNode *base = nullptr;
+
+   switch (Expr.kind) {
+      case AstNodeKind::MemberExpr:
+         base = std::get<MemberExprPayload>(Expr.data).table.get();
+         break;
+      case AstNodeKind::IndexExpr:
+         base = std::get<IndexExprPayload>(Expr.data).table.get();
+         break;
+      case AstNodeKind::SafeMemberExpr:
+         base = std::get<SafeMemberExprPayload>(Expr.data).table.get();
+         break;
+      case AstNodeKind::SafeIndexExpr:
+         base = std::get<SafeIndexExprPayload>(Expr.data).table.get();
+         break;
+
+      // Binary expressions yield 'any' when a table read can invoke an overloaded operator.  This includes defaulted
+      // reads such as t[k] ?? fallback and arithmetic such as 0.5 + t.value.  Recurse so the exemption follows the
+      // value's origin.
+
+      case AstNodeKind::BinaryExpr: {
+         const auto *payload = std::get_if<BinaryExprPayload>(&Expr.data);
+         return payload and ((payload->left and this->is_table_read_expression(*payload->left)) or
+            (payload->right and this->is_table_read_expression(*payload->right)));
+      }
+
+      // Unary negation can remain dynamic when its operand is a table read because the value may overload '-'.
+
+      case AstNodeKind::UnaryExpr: {
+         const auto *payload = std::get_if<UnaryExprPayload>(&Expr.data);
+         return payload and payload->operand and this->is_table_read_expression(*payload->operand);
+      }
+
+      default:
+         return false;
+   }
+
+   return base and this->infer_expression_type(*base).primary IS TiriType::Table;
+}
 
 InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
 {

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -3305,7 +3305,8 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
          }
 
          if (actual.primary IS TiriType::Any and
-             this->is_explicit_variant_expression(expression, expression_position)) {
+             (this->is_explicit_variant_expression(expression, expression_position) or
+              is_table_read_expression(expression))) {
             position.concrete = actual;
             position.concrete.primary = TiriType::Any;
             position.state = ReturnInferenceState::ExplicitAny;

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -238,7 +238,7 @@ private:
    // Type inference - determines types from expressions and context
    [[nodiscard]] InferredType infer_expression_type(const ExprNode &);
    [[nodiscard]] InferredType refine_static_expression_type(const ExprNode &, InferredType) const;
-   [[nodiscard]] bool is_explicit_variant_expression(const ExprNode &, size_t Position = 0) const;
+   [[nodiscard]] bool is_variant_expression(const ExprNode &, size_t Position = 0) const;
    [[nodiscard]] bool is_table_read_expression(const ExprNode &);
    [[nodiscard]] InferredType infer_call_return_type(const ExprNode &, size_t Position) const;
 
@@ -2837,7 +2837,7 @@ InferredType TypeAnalyser::refine_static_expression_type(const ExprNode &Expr, I
    return Type;
 }
 
-bool TypeAnalyser::is_explicit_variant_expression(const ExprNode &Expr, size_t Position) const
+bool TypeAnalyser::is_variant_expression(const ExprNode &Expr, size_t Position) const
 {
    if (Expr.kind IS AstNodeKind::IdentifierExpr) {
       const auto &reference = std::get<NameRef>(Expr.data);
@@ -2850,8 +2850,11 @@ bool TypeAnalyser::is_explicit_variant_expression(const ExprNode &Expr, size_t P
    }
    else if (Expr.kind IS AstNodeKind::CallExpr or Expr.kind IS AstNodeKind::SafeCallExpr) {
       const auto &call = std::get<CallExprPayload>(Expr.data);
+      if (Position IS 0 and call.result_type IS TiriType::Any) return true;
+
       const FunctionExprPayload *target = this->resolve_call_target(call);
-      return target and target->return_types.is_explicit and Position < target->return_types.count and
+      return target and (target->return_types.is_explicit or target->return_types.is_inferred) and
+         Position < target->return_types.count and
          target->return_types.types[Position] IS TiriType::Any;
    }
    return false;
@@ -3314,9 +3317,9 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
             continue;
          }
 
-         if (actual.primary IS TiriType::Any and
-             (this->is_explicit_variant_expression(expression, expression_position) or
-              is_table_read_expression(expression))) {
+         if (((actual.primary IS TiriType::Any or actual.primary IS TiriType::Unknown) and
+              this->is_variant_expression(expression, expression_position)) or
+             (actual.primary IS TiriType::Any and is_table_read_expression(expression))) {
             position.concrete = actual;
             position.concrete.primary = TiriType::Any;
             position.state = ReturnInferenceState::ExplicitAny;

--- a/src/tiri/tests/test_return_types.tiri
+++ b/src/tiri/tests/test_return_types.tiri
@@ -162,8 +162,14 @@ end
       return Values[0]
    end
 
+   function wrapped_entry(Values:table)
+      return first_entry(Values)
+   end
+
    assert(first_entry({ 42 }) is 42, 'an indexed table read should infer an any result')
    assert(first_entry({ 'value' }) is 'value', 'the inferred result should accept different table value types')
+   assert(wrapped_entry({ 42 }) is 42, 'a wrapper should preserve an inferred table variant result')
+   assert(wrapped_entry({ 'value' }) is 'value', 'a wrapped table variant should accept different value types')
 end
 
 @Test function UnknownTableIndexStillRequiresResultAnnotation()
@@ -189,6 +195,19 @@ end
       ]])
    success
       error('an unspecified dynamic return requires an explicit result annotation')
+   end
+end
+
+@Test function UnknownCallStillRequiresResultAnnotation()
+   try
+      exec([[
+         extern glUnspecifiedFunction
+         function unresolved_call()
+            return glUnspecifiedFunction()
+         end
+      ]])
+   success
+      error('an unresolved call result requires an explicit result annotation')
    end
 end
 

--- a/src/tiri/tests/test_return_types.tiri
+++ b/src/tiri/tests/test_return_types.tiri
@@ -166,6 +166,19 @@ end
    assert(first_entry({ 'value' }) is 'value', 'the inferred result should accept different table value types')
 end
 
+@Test function UnknownTableIndexStillRequiresResultAnnotation()
+   try
+      exec([[
+         extern glUnspecifiedValue
+         function unresolved_entry()
+            return glUnspecifiedValue[0]
+         end
+      ]])
+   success
+      error('an unresolved indexed return requires an explicit result annotation')
+   end
+end
+
 @Test function ImplicitDynamicStillRequiresResultAnnotation()
    try
       exec([[
@@ -175,7 +188,7 @@ end
          end
       ]])
    success
-      error('an unspecified dynamic return should still require an explicit result annotation')
+      error('an unspecified dynamic return requires an explicit result annotation')
    end
 end
 

--- a/src/tiri/tests/test_return_types.tiri
+++ b/src/tiri/tests/test_return_types.tiri
@@ -157,6 +157,15 @@ end
    assert(variant_first(42) is 42, 'explicit-any inference should be independent of return source order')
 end
 
+@Test function TableIndexReadInfersAnyResult()
+   function first_entry(Values:table)
+      return Values[0]
+   end
+
+   assert(first_entry({ 42 }) is 42, 'an indexed table read should infer an any result')
+   assert(first_entry({ 'value' }) is 'value', 'the inferred result should accept different table value types')
+end
+
 @Test function ImplicitDynamicStillRequiresResultAnnotation()
    try
       exec([[


### PR DESCRIPTION
* Treat table index reads as explicit dynamic results during return type inference
* Added coverage for indexed table results with different value types