### PR TITLE
[Tiri] Replaced module call marshalling vectors with bounded address-stable storage

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -790,6 +790,7 @@ if (INCLUDE_TIPS)
 endif ()
 
 if (UNIT_TESTS)
+   list (APPEND TIRI_SOURCES "tests/unit_module_marshalling.cpp")
    list (APPEND TIRI_SOURCES "tests/unit_set_variable.cpp")
    list (APPEND TIRI_SOURCES "${JIT_SRC}/runtime/unit_test_indexing.cpp")
    list (APPEND TIRI_SOURCES "${JIT_SRC}/runtime/unit_test_vm_asm.cpp")

--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -425,6 +425,11 @@ ERR load_module_defs(std::string_view);
 [[nodiscard]] std::string_view static_module_name(StaticModuleHandle) noexcept;
 [[nodiscard]] std::string_view static_module_function_name(StaticModuleHandle, std::string_view) noexcept;
 [[nodiscard]] APTR proto_dependency_callable(struct GCproto *, uint32_t);
+#ifdef UNIT_TESTS
+// Drives a synthetic wide C++ string-view signature through the module call bridge, which no exported module declares
+// widely enough to exercise.  Returns an empty string on success or a description of the first discrepancy.
+[[nodiscard]] std::string test_module_wide_string_signature(lua_State *, int Count);
+#endif
 int MAKESTRUCT(lua_State *);
 [[maybe_unused]] void make_any_array(lua_State *, int, std::string_view, int, CPTR, struct_record * = nullptr);
 [[maybe_unused]] void make_array(lua_State *, AET, int = 0, CPTR = nullptr, std::string_view = {});

--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -426,9 +426,8 @@ ERR load_module_defs(std::string_view);
 [[nodiscard]] std::string_view static_module_function_name(StaticModuleHandle, std::string_view) noexcept;
 [[nodiscard]] APTR proto_dependency_callable(struct GCproto *, uint32_t);
 #ifdef UNIT_TESTS
-// Drives a synthetic wide C++ string-view signature through the module call bridge, which no exported module declares
-// widely enough to exercise.  Returns an empty string on success or a description of the first discrepancy.
-[[nodiscard]] std::string test_module_wide_string_signature(lua_State *, int Count);
+[[nodiscard]] std::string test_module_string_view_call(lua_State *, APTR,
+   std::span<const std::string> Inputs);
 #endif
 int MAKESTRUCT(lua_State *);
 [[maybe_unused]] void make_any_array(lua_State *, int, std::string_view, int, CPTR, struct_record * = nullptr);

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -3537,6 +3537,41 @@ static bool test_module_dependency_activation_uses_sidecar(kt::Log &Log)
    return true;
 }
 
+// The bounded marshalling stores must keep every argument's address valid up to the documented argument limit.
+//
+// Nine C++ string-view parameters is the first arity the previous reserve(8) vectors could not survive: the ninth
+// emplacement reallocated the vector and moved the eight addresses already written into the libffi argument buffer.
+// The sweep runs from that boundary to MAX_MODULE_ARGS so a future change to either limit is caught.
+
+static bool test_module_wide_string_marshalling(kt::Log &Log)
+{
+   LuaStateHolder holder;
+   if (not holder.get()) {
+      Log.error("failed to allocate a state for the wide signature test");
+      return false;
+   }
+
+   for (int count = 9; count <= 16; ++count) {
+      auto failure = test_module_wide_string_signature(holder.get(), count);
+      if (not failure.empty()) {
+         Log.error("%s", failure.c_str());
+         return false;
+      }
+   }
+
+   // Repeating a call must not accumulate state in the bounded stores, which are frame-local and destroyed per call.
+
+   for (int repeat = 0; repeat < 4; ++repeat) {
+      auto failure = test_module_wide_string_signature(holder.get(), 16);
+      if (not failure.empty()) {
+         Log.error("repeat %d: %s", repeat, failure.c_str());
+         return false;
+      }
+   }
+
+   return true;
+}
+
 static bool test_module_registry(kt::Log &Log)
 {
    return test_module_registry_lookup(Log) and
@@ -3544,7 +3579,8 @@ static bool test_module_registry(kt::Log &Log)
       test_module_definition_ownership(Log) and
       test_module_dependency_descriptors(Log) and
       test_module_dependency_activation_uses_sidecar(Log) and
-      test_module_dependency_corruption_rejected(Log);
+      test_module_dependency_corruption_rejected(Log) and
+      test_module_wide_string_marshalling(Log);
 }
 
 static bool test_struct_declaration_syntax(kt::Log &Log)

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -3537,41 +3537,6 @@ static bool test_module_dependency_activation_uses_sidecar(kt::Log &Log)
    return true;
 }
 
-// The bounded marshalling stores must keep every argument's address valid up to the documented argument limit.
-//
-// Nine C++ string-view parameters is the first arity the previous reserve(8) vectors could not survive: the ninth
-// emplacement reallocated the vector and moved the eight addresses already written into the libffi argument buffer.
-// The sweep runs from that boundary to MAX_MODULE_ARGS so a future change to either limit is caught.
-
-static bool test_module_wide_string_marshalling(kt::Log &Log)
-{
-   LuaStateHolder holder;
-   if (not holder.get()) {
-      Log.error("failed to allocate a state for the wide signature test");
-      return false;
-   }
-
-   for (int count = 9; count <= 16; ++count) {
-      auto failure = test_module_wide_string_signature(holder.get(), count);
-      if (not failure.empty()) {
-         Log.error("%s", failure.c_str());
-         return false;
-      }
-   }
-
-   // Repeating a call must not accumulate state in the bounded stores, which are frame-local and destroyed per call.
-
-   for (int repeat = 0; repeat < 4; ++repeat) {
-      auto failure = test_module_wide_string_signature(holder.get(), 16);
-      if (not failure.empty()) {
-         Log.error("repeat %d: %s", repeat, failure.c_str());
-         return false;
-      }
-   }
-
-   return true;
-}
-
 static bool test_module_registry(kt::Log &Log)
 {
    return test_module_registry_lookup(Log) and
@@ -3579,8 +3544,7 @@ static bool test_module_registry(kt::Log &Log)
       test_module_definition_ownership(Log) and
       test_module_dependency_descriptors(Log) and
       test_module_dependency_activation_uses_sidecar(Log) and
-      test_module_dependency_corruption_rejected(Log) and
-      test_module_wide_string_marshalling(Log);
+      test_module_dependency_corruption_rejected(Log);
 }
 
 static bool test_struct_declaration_syntax(kt::Log &Log)

--- a/src/tiri/tests/unit_module_marshalling.cpp
+++ b/src/tiri/tests/unit_module_marshalling.cpp
@@ -1,0 +1,137 @@
+/*********************************************************************************************************************
+
+Unit tests for module call marshalling.
+
+*********************************************************************************************************************/
+
+#define PRV_SCRIPT
+#define PRV_TIRI
+#define PRV_TIRI_MODULE
+#include <kotuku/main.h>
+#include <kotuku/modules/tiri.h>
+
+#include <array>
+#include <string>
+#include <string_view>
+
+#include "../defs.h"
+
+#ifdef UNIT_TESTS
+
+namespace {
+
+constexpr int SYNTHETIC_ARG_COUNT = 16;
+
+struct synthetic_observation {
+   std::array<std::string, SYNTHETIC_ARG_COUNT> Values;
+   bool Corrupt = false;
+};
+
+static thread_local synthetic_observation glSyntheticObservation;
+
+class ModuleMarshallingTestScript {
+public:
+   ~ModuleMarshallingTestScript()
+   {
+      if (this->script) FreeResource(this->script);
+   }
+
+   bool initialise(kt::Log &Log)
+   {
+      if (NewObject(CLASSID::TIRI, &this->script) != ERR::Okay) {
+         Log.error("failed to create a Tiri test object");
+         return false;
+      }
+      this->script->setStatement("");
+      if (Action(AC::Init, this->script, nullptr) != ERR::Okay) {
+         Log.error("failed to initialise a Tiri test object");
+         return false;
+      }
+      return true;
+   }
+
+   extTiri * get() const { return (extTiri *)this->script; }
+
+private:
+   objTiri *script = nullptr;
+};
+
+static void synthetic_views_16(
+   const std::string_view *A0, const std::string_view *A1, const std::string_view *A2, const std::string_view *A3,
+   const std::string_view *A4, const std::string_view *A5, const std::string_view *A6, const std::string_view *A7,
+   const std::string_view *A8, const std::string_view *A9, const std::string_view *A10, const std::string_view *A11,
+   const std::string_view *A12, const std::string_view *A13, const std::string_view *A14, const std::string_view *A15)
+{
+   const std::array<const std::string_view *, SYNTHETIC_ARG_COUNT> views = {
+      A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15
+   };
+
+   glSyntheticObservation = { };
+   for (size_t index = 0; index < views.size(); ++index) {
+      if (not views[index]) {
+         glSyntheticObservation.Corrupt = true;
+         continue;
+      }
+      glSyntheticObservation.Values[index].assign(views[index]->data(), views[index]->size());
+   }
+}
+
+static bool run_max_string_view_call(extTiri *Script, const std::array<std::string, SYNTHETIC_ARG_COUNT> &Inputs,
+   kt::Log &Log)
+{
+   glSyntheticObservation = { };
+   auto failure = test_module_string_view_call(Script->Lua, (APTR)synthetic_views_16, Inputs);
+   if (not failure.empty()) {
+      Log.error("%s", failure.c_str());
+      return false;
+   }
+   if (glSyntheticObservation.Corrupt) {
+      Log.error("the synthetic call delivered a null string-view reference");
+      return false;
+   }
+   for (int index = 0; index < SYNTHETIC_ARG_COUNT; ++index) {
+      if (glSyntheticObservation.Values[index] != Inputs[index]) {
+         Log.error("argument %d arrived as '%s' rather than '%s'", index,
+            glSyntheticObservation.Values[index].c_str(), Inputs[index].c_str());
+         return false;
+      }
+   }
+   return true;
+}
+
+// Sixteen arguments cross the old reserve(8) reallocation boundary and exercise the documented module argument limit.
+
+static bool test_max_string_view_signature(kt::Log &Log)
+{
+   ModuleMarshallingTestScript holder;
+   if (not holder.initialise(Log)) return false;
+
+   std::array<std::string, SYNTHETIC_ARG_COUNT> inputs;
+   for (int index = 0; index < SYNTHETIC_ARG_COUNT; ++index) {
+      inputs[index] = std::format("synthetic-argument-{:03}{}", index, std::string(size_t(index), 'x'));
+   }
+
+   for (int repeat = 0; repeat < 4; ++repeat) {
+      if (not run_max_string_view_call(holder.get(), inputs, Log)) {
+         Log.error("synthetic call repeat %d failed", repeat);
+         return false;
+      }
+   }
+   return true;
+}
+
+} // namespace
+
+void module_marshalling_unit_tests(int &Passed, int &Total)
+{
+   kt::Log log("ModuleMarshallingTests");
+   log.branch("Running maximum string-view signature test");
+   Total++;
+   if (test_max_string_view_signature(log)) {
+      Passed++;
+      log.msg("maximum string-view signature passed");
+   }
+   else log.error("maximum string-view signature failed");
+}
+
+#endif // UNIT_TESTS

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -360,6 +360,7 @@ extern void array_unit_tests(int &, int &);
 extern void allocator_unit_tests(int &, int &);
 extern void bulk_unit_tests(int &, int &);
 extern void gc_unit_tests(int &, int &);
+extern void module_marshalling_unit_tests(int &, int &);
 extern void set_variable_unit_tests(int &, int &);
 #endif
 
@@ -370,6 +371,11 @@ static void MODTest(std::string_view Options, int *Passed, int *Total)
       kt::Log log("TiriTests");
       log.branch("Running SetVariable unit tests...");
       set_variable_unit_tests(*Passed, *Total);
+   }
+   {
+      kt::Log log("TiriTests");
+      log.branch("Running module marshalling unit tests...");
+      module_marshalling_unit_tests(*Passed, *Total);
    }
    {
       kt::Log log("TiriTests");

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -50,12 +50,41 @@ struct static_module_signature {
    }
 };
 
+// The native argument limit.  A signature is rejected during preparation if it declares more than this many native
+// parameters, so every bounded store in the call bridge can be sized from it and can never overflow at call time.
+//
+// Script callers supply at most MAX_MODULE_ARGS values as well: argument i of the signature reads script index i, so
+// the two limits are one contract rather than two.  Result and span arguments consume a signature slot without
+// consuming a script value, which makes the script side of the contract an upper bound rather than an exact count.
+
 constexpr int MAX_MODULE_ARGS = 16;
 constexpr size_t BUFFER_ELEMENT_SIZE = 16;
 constexpr size_t BUFFER_SIZE = MAX_MODULE_ARGS * BUFFER_ELEMENT_SIZE;
 constexpr size_t MAX_STRING_PREFIX_LENGTH = 200;
 
 struct ModuleBinding;
+
+// Precomputed counts of the bridge-owned temporaries one signature can require.  Deriving these once per callable lets
+// the call bridge construct only the elements a signature actually uses, and lets preparation reject a signature whose
+// demands would exceed a bounded store instead of discovering the overflow mid-call.
+//
+// Counts are upper bounds.  A conditional temporary, such as the structure conversion performed only when a script
+// passes a table, is counted for every argument that could require it.
+
+struct marshalling_profile {
+   uint8_t Strings = 0;         // Mutable std::string temporaries (FD_STR|FD_CPP with FD_MUTABLE or FD_RESULT)
+   uint8_t StringViews = 0;     // std::string_view temporaries (FD_STR|FD_CPP, read-only)
+   uint8_t MutableStrings = 0;  // Copy-back records for mutable std::string arguments
+   uint8_t Structs = 0;         // Table-to-structure conversions
+   uint8_t Arrays = 0;          // kt::vector<> results
+   uint8_t Spans = 0;           // std::span wrappers
+
+   // True when the signature needs no bridge-owned temporary at all.  Scalar-only and read-only C-string calls take
+   // this path and perform no heap allocation of their own.
+   [[nodiscard]] bool trivial_storage() const noexcept {
+      return not (Strings or StringViews or MutableStrings or Structs or Arrays or Spans);
+   }
+};
 
 // One process-wide callable record per exported module function.  Records are allocated individually so that their
 // addresses remain stable from publication until expunge_modules(), which is required because Tiri closures retain a
@@ -69,6 +98,8 @@ struct ModuleCallable {
    APTR Address = nullptr;               // Native function address; leave as null if function wasn't processed
    const FunctionField *Fields = nullptr; // Argument metadata, owned by the module's Function list
 
+   marshalling_profile Profile;          // Upper bounds on the bridge-owned temporaries this signature can require
+
    ffi_cif Cif = { };
    ffi_type *ArgTypes[MAX_MODULE_ARGS] = { };
 
@@ -79,6 +110,43 @@ struct ModuleCallable {
    }
 
    inline void invalidate() { Address = nullptr; }
+};
+
+// Address-stable bounded storage for the call bridge's temporaries.
+//
+// Elements live in raw aligned storage and are constructed only as they are used, so a signature that needs none pays
+// nothing beyond the (stack-resident) storage itself.  Because the capacity is fixed and validated during preparation,
+// an element's address never changes once it has been handed to libffi -- the property the previous reserve(8) vectors
+// only provided by accident.
+//
+// emplace() returns null when the store is full.  Preparation rejects any signature that could reach that point, so a
+// null return indicates a profile/marshaller disagreement rather than an expected condition.
+
+template <class T, size_t Capacity> class bounded_store {
+   alignas(T) uint8_t Storage[Capacity * sizeof(T)];
+   size_t Count = 0;
+
+   [[nodiscard]] T * slot(size_t Index) noexcept { return (T *)(Storage + (Index * sizeof(T))); }
+
+   public:
+   bounded_store() = default;
+   bounded_store(const bounded_store &) = delete;
+   bounded_store & operator=(const bounded_store &) = delete;
+
+   ~bounded_store() {
+      while (Count) slot(--Count)->~T();
+   }
+
+   template <class... Args> [[nodiscard]] T * emplace(Args &&...Arguments) {
+      if (Count >= Capacity) return nullptr;
+      auto element = new (slot(Count)) T(std::forward<Args>(Arguments)...);
+      Count++;
+      return element;
+   }
+
+   [[nodiscard]] size_t size() const noexcept { return Count; }
+
+   T & operator[](size_t Index) noexcept { return *slot(Index); }
 };
 
 // Records how far the module's IDL definitions (constants and structures) have progressed.  The state belongs to the
@@ -354,6 +422,43 @@ static ERR callable_arg_type(const FunctionField &Field, ffi_type *&Type, std::s
 }
 
 //********************************************************************************************************************
+// Accumulate the bridge-owned temporaries one argument can require.  The classification must agree with the
+// marshalling loop in module_call_inner(); a temporary counted here but not used is merely wasteful, whereas one used
+// but not counted would overflow a bounded store.
+
+static void profile_arg(const FunctionField &Field, marshalling_profile &Profile)
+{
+   const int argtype = Field.Type;
+
+   if ((argtype & FDF_SPAN) IS FDF_SPAN) { Profile.Spans++; return; }
+
+   if (argtype & FD_RESULT) {
+      if (((argtype & FDF_VECTOR) IS FDF_VECTOR) and (argtype & FD_MUTABLE)) Profile.Arrays++;
+      else if ((argtype & FD_STR) and (argtype & FD_CPP)) {
+         // A mutable result is backed by a std::string the bridge owns; a read-only one by a std::string_view.
+         if (argtype & FD_MUTABLE) Profile.Strings++;
+         else Profile.StringViews++;
+      }
+      return;
+   }
+
+   if (argtype & FD_FUNCTION) return; // The single FUNCTION reserve lives in the frame, not a store
+
+   if (argtype & FD_STR) {
+      if (argtype & FD_CPP) {
+         if (argtype & FD_MUTABLE) { Profile.Strings++; Profile.MutableStrings++; }
+         else Profile.StringViews++;
+      }
+      return;
+   }
+
+   // A pointer argument allocates a structure only when the script passes a table, which cannot be known until the
+   // call.  Counting it unconditionally keeps the bound safe for every input the argument accepts.
+
+   if ((argtype & FD_PTR) and (argtype & FD_STRUCT)) Profile.Structs++;
+}
+
+//********************************************************************************************************************
 // Determine the libffi return type from the function's result descriptor, which is stored in element zero of the
 // argument list.
 
@@ -405,6 +510,10 @@ static void prepare_module_callables(ModuleBinding *Module, const Function *Func
 
       const FunctionField *args = function.Args;
       int total = 0;
+      marshalling_profile profile;
+      size_t front_bytes = 0; // Argument slots, allocated from the start of the call buffer
+      size_t back_bytes = 0;  // Result storage, allocated from the end of the call buffer
+
       for (int arg = 1; args[arg].Name; ++arg) {
          if (total >= MAX_MODULE_ARGS) {
             callable->invalidate();
@@ -420,9 +529,51 @@ static void prepare_module_callables(ModuleBinding *Module, const Function *Func
             break;
          }
          callable->ArgTypes[total++] = type;
+         profile_arg(args[arg], profile);
+
+         // Mirror the call buffer's two-ended allocation so that an overlap is rejected here rather than corrupting
+         // an argument slot at call time.  The front slot is sized as the marshaller sizes it; the back allocation
+         // applies only to the result kinds that write into buffer-tail storage.
+
+         const int argtype = args[arg].Type;
+         if ((argtype & FDF_SPAN) IS FDF_SPAN) front_bytes += sizeof(APTR);
+         else if (argtype & FD_RESULT) {
+            front_bytes += sizeof(APTR);
+            if (((argtype & FDF_VECTOR) IS FDF_VECTOR) and (argtype & FD_MUTABLE)) { }
+            else if ((argtype & FD_STR) and (argtype & FD_CPP)) { }
+            else if (argtype & (FD_STR|FD_PTR)) back_bytes += sizeof(APTR);
+            else if (argtype & FD_INT) back_bytes += sizeof(int);
+            else if (argtype & (FD_DOUBLE|FD_INT64)) back_bytes += sizeof(int64_t);
+         }
+         else if (argtype & FD_FUNCTION) front_bytes += sizeof(FUNCTION *);
+         else if (argtype & FD_STR) front_bytes += sizeof(APTR);
+         else if (argtype & FD_PTR) front_bytes += sizeof(APTR);
+         else if (argtype & FD_INT) front_bytes += sizeof(int);
+         else if (argtype & FD_DOUBLE) front_bytes += sizeof(double);
+         else if (argtype & FD_INT64) front_bytes += sizeof(int64_t);
+      }
+
+      if (callable->valid() and (front_bytes + back_bytes > BUFFER_SIZE)) {
+         callable->invalidate();
+         log.msg("Function '%s' requires %zu call buffer bytes, exceeding the %zu byte limit.",
+            function.Name, front_bytes + back_bytes, BUFFER_SIZE);
+      }
+
+      // Every bounded store is sized at MAX_MODULE_ARGS, and each temporary is required by a distinct argument, so a
+      // signature within the argument limit cannot exhaust one.  The check is retained because it is the contract the
+      // marshaller relies on to treat a full store as unreachable.
+
+      if (callable->valid()) {
+         if ((profile.Strings > MAX_MODULE_ARGS) or (profile.StringViews > MAX_MODULE_ARGS) or
+             (profile.MutableStrings > MAX_MODULE_ARGS) or (profile.Structs > MAX_MODULE_ARGS) or
+             (profile.Arrays > MAX_MODULE_ARGS) or (profile.Spans > MAX_MODULE_ARGS)) {
+            callable->invalidate();
+            log.msg("Function '%s' exceeds the bounded temporary storage limit.", function.Name);
+         }
       }
 
       if (callable->valid()) {
+         callable->Profile = profile;
          ffi_type *return_type = callable_return_type(args->Type);
 
          if (ffi_prep_cif(&callable->Cif, FFI_DEFAULT_ABI, total, return_type, callable->ArgTypes) != FFI_OK) {
@@ -1150,20 +1301,26 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
       std::string *Source;
       GCstr *Target;
       int Arg;
+
+      mutable_cpp_string_ref(std::string *InitSource, GCstr *InitTarget, int InitArg):
+         Source(InitSource), Target(InitTarget), Arg(InitArg) { }
    };
 
-   std::vector<std::string> strings;
-   std::vector<std::string_view> string_views;
-   std::vector<allocated_struct_ref> allocated_structs;
-   std::vector<mutable_cpp_string_ref> mutable_cpp_strings;
-   std::vector<cpp_array_result> cpp_arrays;
+   // Bridge-owned temporaries.  Each store has a fixed capacity that preparation has already proved sufficient for
+   // this signature, so an element's address stays valid once written into arg_values, and a signature that needs no
+   // temporaries constructs nothing.
+
+   bounded_store<std::string, MAX_MODULE_ARGS> strings;
+   bounded_store<std::string_view, MAX_MODULE_ARGS> string_views;
+   bounded_store<allocated_struct_ref, MAX_MODULE_ARGS> allocated_structs;
+   bounded_store<mutable_cpp_string_ref, MAX_MODULE_ARGS> mutable_cpp_strings;
+   bounded_store<cpp_array_result, MAX_MODULE_ARGS> cpp_arrays;
    std::array<module_span_arg, MAX_MODULE_ARGS> span_args;
    size_t span_count = 0;
-   strings.reserve(8); // Keep the collection stable
-   string_views.reserve(8);
 
    auto copy_mutable_cpp_strings = [&]() {
-      for (auto &entry : mutable_cpp_strings) {
+      for (size_t entry_index = 0; entry_index < mutable_cpp_strings.size(); ++entry_index) {
+         auto &entry = mutable_cpp_strings[entry_index];
          auto capacity = size_t(entry.Target->len);
          auto length = entry.Source->size();
          if (length > capacity) ErrorMsg = "Mutable buffer too small.";
@@ -1199,10 +1356,15 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
       return ERR::NoSupport;
    }
 
+   // The script and native argument limits are one contract: the marshaller reads script index i for signature
+   // argument i, so a value beyond MAX_MODULE_ARGS could never be marshalled.  Previously this clamped a local that
+   // nothing else consumed, which silently discarded the diagnostic; the surplus is now rejected outright.
+
    int nargs = lua_gettop(Lua);
-   if (nargs > MAX_MODULE_ARGS-1) {
-      log.warning("Limit of %d args exceeded.", MAX_MODULE_ARGS - 1);
-      nargs = MAX_MODULE_ARGS-1;
+   if (nargs > MAX_MODULE_ARGS) {
+      ErrorMsg = std::format("Function '{}' received {} arguments, exceeding the limit of {}.",
+         callable->Name, nargs, MAX_MODULE_ARGS);
+      return ERR::Args;
    }
 
    uint8_t *end = buffer + sizeof(buffer);
@@ -1368,7 +1530,10 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
             }
             else if (auto error = make_cpp_array_result(argtype, &result_ref); !error) {
                ((APTR *)(buffer + j))[0] = result_ref.Data; // kt::vector<>
-               cpp_arrays.push_back(std::move(result_ref));
+               if (not cpp_arrays.emplace(std::move(result_ref))) {
+                  ErrorMsg = std::format("Function '{}' exceeded its C++ array result storage.", callable->Name);
+                  return ERR::BufferOverflow;
+               }
                arg_values[in]  = buffer + j;
                in++;
                j += sizeof(APTR);
@@ -1384,16 +1549,24 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
                   // Use of MUTABLE enables support for std::string buffering.  We provide our own std::string that will be used as
                   // the buffer, it gets converted to a Tiri string when the function returns.
 
-                  strings.emplace_back();
-                  ((std::string **)(buffer + j))[0] = &strings.back();
+                  auto slot = strings.emplace();
+                  if (not slot) {
+                     ErrorMsg = std::format("Function '{}' exceeded its string storage.", callable->Name);
+                     return ERR::BufferOverflow;
+                  }
+                  ((std::string **)(buffer + j))[0] = slot;
                   arg_values[in]  = buffer + j;
                   in++;
                   j += sizeof(APTR);
                }
                else {
                   // Non-mutable string reference, supported as a std::string_view
-                  string_views.emplace_back();
-                  ((std::string_view **)(buffer + j))[0] = &string_views.back();
+                  auto slot = string_views.emplace();
+                  if (not slot) {
+                     ErrorMsg = std::format("Function '{}' exceeded its string view storage.", callable->Name);
+                     return ERR::BufferOverflow;
+                  }
+                  ((std::string_view **)(buffer + j))[0] = slot;
                   arg_values[in]  = buffer + j;
                   in++;
                   j += sizeof(APTR);
@@ -1495,20 +1668,29 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
 
             if (argtype & FD_CPP) { // Function expects a pointer to std::string that it can mutate
                size_t len;
-               if (auto str = lua_tolstring(Lua, i, &len)) strings.emplace_back(str, len);
-               else strings.emplace_back();
-
-               auto cppstr = &strings.back();
-               mutable_cpp_strings.push_back({ cppstr, string, i });
+               auto str = lua_tolstring(Lua, i, &len);
+               auto cppstr = str ? strings.emplace(str, len) : strings.emplace();
+               if (not cppstr) {
+                  ErrorMsg = std::format("Function '{}' exceeded its string storage.", callable->Name);
+                  return ERR::BufferOverflow;
+               }
+               if (not mutable_cpp_strings.emplace(cppstr, string, i)) {
+                  ErrorMsg = std::format("Function '{}' exceeded its mutable string storage.", callable->Name);
+                  return ERR::BufferOverflow;
+               }
                ((std::string **)(buffer + j))[0] = cppstr;
             }
             else ((CSTRING *)(buffer + j))[0] = strdatawr(string);
          }
          else if (argtype & FD_CPP) { // Read-only std::string_view (enforced, cannot be nullptr)
             size_t len;
-            if (auto str = lua_tolstring(Lua, i, &len)) string_views.emplace_back(str, len);
-            else string_views.emplace_back();
-            ((std::string_view **)(buffer + j))[0] = &string_views.back();
+            auto str = lua_tolstring(Lua, i, &len);
+            auto view = str ? string_views.emplace(str, len) : string_views.emplace();
+            if (not view) {
+               ErrorMsg = std::format("Function '{}' exceeded its string view storage.", callable->Name);
+               return ERR::BufferOverflow;
+            }
+            ((std::string_view **)(buffer + j))[0] = view;
          }
          else if ((type IS LUA_TSTRING) or (type IS LUA_TNUMBER) or (type IS LUA_TBOOLEAN)) {
             ((CSTRING *)(buffer + j))[0] = lua_tostring(Lua, i);
@@ -1600,8 +1782,10 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
                if (!table_to_struct(Lua, args[i].Name, struct_data)) {
                   auto struct_address = struct_data.get();
                   auto def = find_struct(Lua, args[i].Name);
-                  if (def) allocated_structs.emplace_back(std::move(struct_data), def, Lua);
-                  else allocated_structs.emplace_back(std::move(struct_data), nullptr, Lua);
+                  if (not allocated_structs.emplace(std::move(struct_data), def, Lua)) {
+                     ErrorMsg = std::format("Function '{}' exceeded its structure storage.", callable->Name);
+                     return ERR::BufferOverflow;
+                  }
                   ((APTR *)(buffer + j))[0] = struct_address;
                   arg_values[in] = buffer + j;
                   in++;
@@ -1664,6 +1848,15 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
 
    int restype = args->Type;
    int result = (callable->Cif.rtype IS &ffi_type_void) ? 0 : 1;
+
+   // The buffer is allocated from both ends: argument slots grow forwards from 'buffer' and result storage grows
+   // backwards from 'end'.  Preparation proves the two cannot meet for an accepted signature, so this check confirms
+   // the marshaller honoured the sizes preparation measured rather than guarding an expected condition.
+
+   if (buffer + j > end) {
+      ErrorMsg = std::format("Function '{}' overran its call buffer.", callable->Name);
+      return ERR::BufferOverflow;
+   }
 
    if (in != int(callable->Cif.nargs)) {
       ErrorMsg = std::format("Function '{}' marshalled {} args but its call interface expects {}.",
@@ -1868,6 +2061,181 @@ static int process_results(extTiri *Tiri, APTR resultsidx, const FunctionField *
 
    return results;
 }
+
+#ifdef UNIT_TESTS
+//********************************************************************************************************************
+// Synthetic wide-signature coverage for the bounded marshalling stores.
+//
+// No exported module declares enough C++ string parameters to reach the point at which the previous reserve(8)
+// vectors reallocated, so the boundary is exercised with callables built here instead.  A synthetic callable is
+// prepared exactly as a real one is -- through prepare_module_callables()'s helpers -- so the test measures the
+// production preparation and marshalling paths rather than a parallel implementation.
+//
+// The verification that matters is pointer stability: each native function checks that every std::string_view it
+// receives still refers to the text the script passed.  Under the old vectors, the ninth emplacement moved the
+// earlier elements and the first arguments arrived as dangling references.
+
+namespace {
+
+constexpr int SYNTHETIC_MAX_ARGS = MAX_MODULE_ARGS;
+
+// Records what the most recent synthetic call observed, so the test can assert on the native side of the boundary.
+
+struct synthetic_observation {
+   int Count = 0;
+   std::array<std::string, SYNTHETIC_MAX_ARGS> Values;
+   bool Corrupt = false; // Set when an argument arrived as a null or unreadable reference
+};
+
+static synthetic_observation glSyntheticObservation;
+
+// Reads a std::string_view argument, recording its content.  A reference invalidated by reallocation shows up here as
+// either a null pointer or text that does not match what the script supplied.
+
+static void observe_view(int Slot, const std::string_view *View)
+{
+   if (not View) { glSyntheticObservation.Corrupt = true; return; }
+   glSyntheticObservation.Values[Slot].assign(View->data(), View->size());
+}
+
+// The native entry points.  libffi needs a real function per arity, and each one is passed pointers to the bridge's
+// std::string_view temporaries.
+
+template <int Count> static void synthetic_views(
+   const std::string_view *A0, const std::string_view *A1, const std::string_view *A2, const std::string_view *A3,
+   const std::string_view *A4, const std::string_view *A5, const std::string_view *A6, const std::string_view *A7,
+   const std::string_view *A8, const std::string_view *A9, const std::string_view *A10, const std::string_view *A11,
+   const std::string_view *A12, const std::string_view *A13, const std::string_view *A14, const std::string_view *A15)
+{
+   const std::string_view *views[SYNTHETIC_MAX_ARGS] = {
+      A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15
+   };
+
+   glSyntheticObservation.Count = Count;
+   glSyntheticObservation.Corrupt = false;
+   for (int slot = 0; slot < Count; ++slot) observe_view(slot, views[slot]);
+}
+
+// Build and prepare a synthetic callable of the requested arity.  Storage is static so that the FunctionField list
+// outlives the callable, matching a real module's function list.
+
+struct synthetic_callable {
+   std::vector<FunctionField> Fields;
+   std::vector<std::string> Names;
+   ModuleCallable Callable;
+};
+
+// A callable taking Count read-only std::string_view parameters.
+
+static bool build_synthetic_view_callable(int Count, APTR Address, synthetic_callable &Result)
+{
+   Result.Names.reserve(Count + 1);
+   Result.Names.emplace_back("Result");
+   for (int arg = 0; arg < Count; ++arg) Result.Names.emplace_back(std::format("Arg{}", arg));
+
+   Result.Fields.reserve(Count + 2);
+   Result.Fields.push_back({ Result.Names[0].c_str(), FD_VOID });
+   for (int arg = 0; arg < Count; ++arg) {
+      Result.Fields.push_back({ Result.Names[arg + 1].c_str(), FD_STR|FD_CPP });
+   }
+   Result.Fields.push_back({ nullptr, 0 });
+
+   Result.Callable.Name    = "SyntheticViews";
+   Result.Callable.Address = Address;
+   Result.Callable.Fields  = Result.Fields.data();
+
+   marshalling_profile profile;
+   for (int arg = 1; arg <= Count; ++arg) {
+      std::string message;
+      ffi_type *type = nullptr;
+      if (callable_arg_type(Result.Fields[arg], type, message) != ERR::Okay) return false;
+      Result.Callable.ArgTypes[arg - 1] = type;
+      profile_arg(Result.Fields[arg], profile);
+   }
+
+   Result.Callable.Profile = profile;
+   ffi_type *return_type = callable_return_type(Result.Fields[0].Type);
+   return ffi_prep_cif(&Result.Callable.Cif, FFI_DEFAULT_ABI, Count, return_type, Result.Callable.ArgTypes) IS FFI_OK;
+}
+
+// Dispatch table mapping an arity to its native entry point, because the arity must be a template argument.
+
+static APTR synthetic_view_address(int Count)
+{
+   switch (Count) {
+      case  9: return (APTR)synthetic_views<9>;
+      case 10: return (APTR)synthetic_views<10>;
+      case 11: return (APTR)synthetic_views<11>;
+      case 12: return (APTR)synthetic_views<12>;
+      case 13: return (APTR)synthetic_views<13>;
+      case 14: return (APTR)synthetic_views<14>;
+      case 15: return (APTR)synthetic_views<15>;
+      case 16: return (APTR)synthetic_views<16>;
+      default: return nullptr;
+   }
+}
+
+} // namespace
+
+// Drive one synthetic call of the given arity through module_call() and confirm that every argument survived.
+//
+// Returns an empty string on success, or a description of the first discrepancy.
+
+std::string test_module_wide_string_signature(lua_State *Lua, int Count)
+{
+   if ((Count < 1) or (Count > SYNTHETIC_MAX_ARGS)) return std::format("Unsupported synthetic arity {}.", Count);
+
+   auto address = synthetic_view_address(Count);
+   if (not address) return std::format("No synthetic entry point for arity {}.", Count);
+
+   auto synthetic = std::make_unique<synthetic_callable>();
+   if (not build_synthetic_view_callable(Count, address, *synthetic)) {
+      return std::format("Failed to prepare the synthetic callable for arity {}.", Count);
+   }
+
+   if (synthetic->Callable.Profile.StringViews != Count) {
+      return std::format("Profile counted {} string views for arity {}.",
+         int(synthetic->Callable.Profile.StringViews), Count);
+   }
+
+   // Distinct, differently sized argument texts, so a stale reference cannot coincidentally match.
+
+   std::vector<std::string> inputs;
+   inputs.reserve(Count);
+   for (int arg = 0; arg < Count; ++arg) inputs.push_back(std::format("synthetic-argument-{:03}{}", arg,
+      std::string(size_t(arg), 'x')));
+
+   glSyntheticObservation = { };
+
+   int base = lua_gettop(Lua);
+   lua_pushlightuserdata(Lua, &synthetic->Callable);
+   lua_pushcclosure(Lua, module_call, 1);
+   for (const auto &input : inputs) lua_pushstring(Lua, input);
+
+   if (lua_pcall(Lua, Count, LUA_MULTRET, 0) != 0) {
+      std::string message = lua_tostring(Lua, -1) ? lua_tostring(Lua, -1) : "unknown error";
+      lua_settop(Lua, base);
+      return std::format("Synthetic call of arity {} failed: {}", Count, message);
+   }
+   lua_settop(Lua, base);
+
+   if (glSyntheticObservation.Corrupt) {
+      return std::format("Arity {} delivered a null string view reference.", Count);
+   }
+   if (glSyntheticObservation.Count != Count) {
+      return std::format("Arity {} invoked an entry point reporting {} args.", Count,
+         glSyntheticObservation.Count);
+   }
+   for (int arg = 0; arg < Count; ++arg) {
+      if (glSyntheticObservation.Values[arg] != inputs[arg]) {
+         return std::format("Arity {} arg #{} arrived as '{}' rather than '{}'.", Count, arg,
+            glSyntheticObservation.Values[arg], inputs[arg]);
+      }
+   }
+
+   return { };
+}
+#endif
 
 //********************************************************************************************************************
 // Register the module interface.

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -2064,68 +2064,15 @@ static int process_results(extTiri *Tiri, APTR resultsidx, const FunctionField *
 
 #ifdef UNIT_TESTS
 //********************************************************************************************************************
-// Synthetic wide-signature coverage for the bounded marshalling stores.
-//
-// No exported module declares enough C++ string parameters to reach the point at which the previous reserve(8)
-// vectors reallocated, so the boundary is exercised with callables built here instead.  A synthetic callable is
-// prepared exactly as a real one is -- through prepare_module_callables()'s helpers -- so the test measures the
-// production preparation and marshalling paths rather than a parallel implementation.
-//
-// The verification that matters is pointer stability: each native function checks that every std::string_view it
-// receives still refers to the text the script passed.  Under the old vectors, the ninth emplacement moved the
-// earlier elements and the first arguments arrived as dangling references.
+// Test-only support for driving a synthetic string-view signature through the real module call bridge.
 
 namespace {
-
-constexpr int SYNTHETIC_MAX_ARGS = MAX_MODULE_ARGS;
-
-// Records what the most recent synthetic call observed, so the test can assert on the native side of the boundary.
-
-struct synthetic_observation {
-   int Count = 0;
-   std::array<std::string, SYNTHETIC_MAX_ARGS> Values;
-   bool Corrupt = false; // Set when an argument arrived as a null or unreadable reference
-};
-
-static synthetic_observation glSyntheticObservation;
-
-// Reads a std::string_view argument, recording its content.  A reference invalidated by reallocation shows up here as
-// either a null pointer or text that does not match what the script supplied.
-
-static void observe_view(int Slot, const std::string_view *View)
-{
-   if (not View) { glSyntheticObservation.Corrupt = true; return; }
-   glSyntheticObservation.Values[Slot].assign(View->data(), View->size());
-}
-
-// The native entry points.  libffi needs a real function per arity, and each one is passed pointers to the bridge's
-// std::string_view temporaries.
-
-template <int Count> static void synthetic_views(
-   const std::string_view *A0, const std::string_view *A1, const std::string_view *A2, const std::string_view *A3,
-   const std::string_view *A4, const std::string_view *A5, const std::string_view *A6, const std::string_view *A7,
-   const std::string_view *A8, const std::string_view *A9, const std::string_view *A10, const std::string_view *A11,
-   const std::string_view *A12, const std::string_view *A13, const std::string_view *A14, const std::string_view *A15)
-{
-   const std::string_view *views[SYNTHETIC_MAX_ARGS] = {
-      A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15
-   };
-
-   glSyntheticObservation.Count = Count;
-   glSyntheticObservation.Corrupt = false;
-   for (int slot = 0; slot < Count; ++slot) observe_view(slot, views[slot]);
-}
-
-// Build and prepare a synthetic callable of the requested arity.  Storage is static so that the FunctionField list
-// outlives the callable, matching a real module's function list.
 
 struct synthetic_callable {
    std::vector<FunctionField> Fields;
    std::vector<std::string> Names;
    ModuleCallable Callable;
 };
-
-// A callable taking Count read-only std::string_view parameters.
 
 static bool build_synthetic_view_callable(int Count, APTR Address, synthetic_callable &Result)
 {
@@ -2158,81 +2105,35 @@ static bool build_synthetic_view_callable(int Count, APTR Address, synthetic_cal
    return ffi_prep_cif(&Result.Callable.Cif, FFI_DEFAULT_ABI, Count, return_type, Result.Callable.ArgTypes) IS FFI_OK;
 }
 
-// Dispatch table mapping an arity to its native entry point, because the arity must be a template argument.
-
-static APTR synthetic_view_address(int Count)
-{
-   switch (Count) {
-      case  9: return (APTR)synthetic_views<9>;
-      case 10: return (APTR)synthetic_views<10>;
-      case 11: return (APTR)synthetic_views<11>;
-      case 12: return (APTR)synthetic_views<12>;
-      case 13: return (APTR)synthetic_views<13>;
-      case 14: return (APTR)synthetic_views<14>;
-      case 15: return (APTR)synthetic_views<15>;
-      case 16: return (APTR)synthetic_views<16>;
-      default: return nullptr;
-   }
-}
-
 } // namespace
 
-// Drive one synthetic call of the given arity through module_call() and confirm that every argument survived.
-//
-// Returns an empty string on success, or a description of the first discrepancy.
-
-std::string test_module_wide_string_signature(lua_State *Lua, int Count)
+std::string test_module_string_view_call(lua_State *Lua, APTR Address, std::span<const std::string> Inputs)
 {
-   if ((Count < 1) or (Count > SYNTHETIC_MAX_ARGS)) return std::format("Unsupported synthetic arity {}.", Count);
-
-   auto address = synthetic_view_address(Count);
-   if (not address) return std::format("No synthetic entry point for arity {}.", Count);
+   int count = int(Inputs.size());
+   if ((count < 1) or (count > MAX_MODULE_ARGS)) return std::format("Unsupported synthetic arity {}.", count);
+   if (not Address) return "The synthetic entry point is null.";
 
    auto synthetic = std::make_unique<synthetic_callable>();
-   if (not build_synthetic_view_callable(Count, address, *synthetic)) {
-      return std::format("Failed to prepare the synthetic callable for arity {}.", Count);
+   if (not build_synthetic_view_callable(count, Address, *synthetic)) {
+      return std::format("Failed to prepare the synthetic callable for arity {}.", count);
    }
 
-   if (synthetic->Callable.Profile.StringViews != Count) {
+   if (synthetic->Callable.Profile.StringViews != count) {
       return std::format("Profile counted {} string views for arity {}.",
-         int(synthetic->Callable.Profile.StringViews), Count);
+         int(synthetic->Callable.Profile.StringViews), count);
    }
-
-   // Distinct, differently sized argument texts, so a stale reference cannot coincidentally match.
-
-   std::vector<std::string> inputs;
-   inputs.reserve(Count);
-   for (int arg = 0; arg < Count; ++arg) inputs.push_back(std::format("synthetic-argument-{:03}{}", arg,
-      std::string(size_t(arg), 'x')));
-
-   glSyntheticObservation = { };
 
    int base = lua_gettop(Lua);
    lua_pushlightuserdata(Lua, &synthetic->Callable);
    lua_pushcclosure(Lua, module_call, 1);
-   for (const auto &input : inputs) lua_pushstring(Lua, input);
+   for (const auto &input : Inputs) lua_pushstring(Lua, input);
 
-   if (lua_pcall(Lua, Count, LUA_MULTRET, 0) != 0) {
+   if (lua_pcall(Lua, count, LUA_MULTRET, 0) != 0) {
       std::string message = lua_tostring(Lua, -1) ? lua_tostring(Lua, -1) : "unknown error";
       lua_settop(Lua, base);
-      return std::format("Synthetic call of arity {} failed: {}", Count, message);
+      return std::format("Synthetic call of arity {} failed: {}", count, message);
    }
    lua_settop(Lua, base);
-
-   if (glSyntheticObservation.Corrupt) {
-      return std::format("Arity {} delivered a null string view reference.", Count);
-   }
-   if (glSyntheticObservation.Count != Count) {
-      return std::format("Arity {} invoked an entry point reporting {} args.", Count,
-         glSyntheticObservation.Count);
-   }
-   for (int arg = 0; arg < Count; ++arg) {
-      if (glSyntheticObservation.Values[arg] != inputs[arg]) {
-         return std::format("Arity {} arg #{} arrived as '{}' rather than '{}'.", Count, arg,
-            glSyntheticObservation.Values[arg], inputs[arg]);
-      }
-   }
-
    return { };
 }
 #endif


### PR DESCRIPTION
* Introduced bounded_store<T,N>, a fixed-capacity RAII container that constructs elements on use, replacing the five std::vector helpers in module_call_inner() and removing the two unconditional reserve(8) heap allocations paid by every non-trivial call
* Fixed a pointer invalidation defect whereby the ninth C++ string or string-view argument reallocated its vector and moved addresses already written into the libffi argument buffer, passing dangling references to the native function
* Added a marshalling_profile to ModuleCallable, computed during prepare_module_callables(), that bounds each temporary kind and rejects signatures whose call buffer front and back allocations would overlap
* Reconciled the script and native argument limits into one contract; a call exceeding MAX_MODULE_ARGS is now rejected instead of clamping a local that no longer controlled marshalling
* Added synthetic wide-signature coverage for arities 9 to 16 that verifies string view stability on the native side, since no exported module declares a sufficiently wide signature