### PR TITLE
[Tiri] Removed string typename alias

### DIFF
--- a/scripts/benchmark.tiri
+++ b/scripts/benchmark.tiri
@@ -721,7 +721,7 @@ end
 bmark.comparisonReport = function(Comparison:table!):array<string>
    local msg = array<string>
 
-   local function formatChange(Change:num!, Improved:bool):string
+   local function formatChange(Change:num!, Improved:bool):str
       local sign = Change >= 0 and '+' or ''
       local indicator = Improved and '✓' or (math.abs(Change) > 5 and '✗' or '~')
       return string.format('%s%.1f%% %s', sign, Change, indicator)

--- a/src/tiri/jit/src/parser/ast/nodes.cpp
+++ b/src/tiri/jit/src/parser/ast/nodes.cpp
@@ -14,7 +14,6 @@ TiriType parse_type_name(std::string_view Name)
       { "num",       TiriType::Num },
       { "number",    TiriType::Num },
       { "str",       TiriType::Str },
-      { "string",    TiriType::Str },
       { "table",     TiriType::Table },
       { "array",     TiriType::Array },
       { "func",      TiriType::Func },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -2507,6 +2507,10 @@ static bool test_parser_diagnostics_reset_per_load(kt::Log &Log)
 
 static bool test_userdata_type_annotations(kt::Log &Log)
 {
+   if (parse_type_name("str") != TiriType::Str or parse_type_name("string") != TiriType::Unknown) {
+      Log.error("str must be the exclusive string type annotation name");
+      return false;
+   }
    if (parse_type_name("userdata") != TiriType::Userdata or type_name(TiriType::Userdata) != "userdata") {
       Log.error("userdata type name does not round-trip");
       return false;

--- a/src/tiri/tests/test_deferred_expr.tiri
+++ b/src/tiri/tests/test_deferred_expr.tiri
@@ -80,7 +80,7 @@ end
    function getValue()
       return 'computed'
    end
-   x = <string{ getValue() }>
+   x = <str{ getValue() }>
    result = resolve(x)
    assert(type(result) is 'string', 'Expected string type')
    assert(result is 'computed', 'Expected "computed"')
@@ -178,7 +178,7 @@ end
       return 'computed'
    end
 
-   x = <string{ getValue() }>
+   x = <str{ getValue() }>
    assert(type(x) is 'string', 'Expected type(x) to be "string" for explicitly typed deferred')
 
    y = <number{ 42 }>
@@ -190,7 +190,7 @@ end
 
 @Test function DeferredNested()
    inner = <{ 'inner' }>
-   outer = <string{ inner }>
+   outer = <str{ inner }>
    -- Resolving outer returns the inner deferred, which then needs resolving
    result = resolve(resolve(outer))
    assert(result is 'inner', 'Expected nested deferred to resolve to "inner"')
@@ -237,7 +237,7 @@ end
 
    -- Test that deferred message is NOT evaluated when assert succeeds
    evaluated = false
-   assert(true, <string{ makeMessage() }>)
+   assert(true, <str{ makeMessage() }>)
    assert(evaluated is false, 'Deferred message should NOT be evaluated when assert succeeds')
 end
 
@@ -246,7 +246,7 @@ end
    value = 42
 
    try
-      assert(false, <string{ 'Error in ' .. context .. ': value = ' .. tostring(value) }>)
+      assert(false, <str{ 'Error in ' .. context .. ': value = ' .. tostring(value) }>)
    except e
       assert(e.message != nil, 'Error message should not be nil')
       -- Verify the error message contains expected content

--- a/src/tiri/tests/test_return_types.tiri
+++ b/src/tiri/tests/test_return_types.tiri
@@ -708,11 +708,11 @@ end
    assert(getNumber() is 42, "number alias in return type should work")
 end
 
-@Test function ReturnTypeAliasString()
-   function getString():string
+@Test function ReturnTypeString()
+   function getString():str
       return "hello"
    end
-   assert(getString() is "hello", "string alias in return type should work")
+   assert(getString() is "hello", "str return type should work")
 end
 
 @Test function ReturnTypeAliasFunction()

--- a/src/tiri/tests/test_type_annotations.tiri
+++ b/src/tiri/tests/test_type_annotations.tiri
@@ -55,7 +55,6 @@ end
    assert_compiles("N:num")
    assert_compiles("Number:number")
    assert_compiles("S:str")
-   assert_compiles("String:string")
    assert_compiles("B:bool")
    assert_compiles("T:table")
    assert_compiles("F:func")
@@ -64,6 +63,16 @@ end
    assert_compiles("NilVal:nil")
    assert_compiles("StructVal:struct")
    assert_compiles("ObjVal:obj")
+end
+
+@Test function RemovedStringTypeRejected()
+   try
+      exec("local value:string = 'text'")
+   success
+      error("Expected string type name to be rejected")
+   end
+
+   assert(type('text') is 'string', "type() must continue to return the string runtime name")
 end
 
 @Test function ObjectTypeAliasRejected()

--- a/src/tiri/tests/test_type_fixing.tiri
+++ b/src/tiri/tests/test_type_fixing.tiri
@@ -233,11 +233,9 @@ end
    assert(n1 is 1, "num alias works")
    assert(n2 is 2, "number alias works")
 
-   -- str/string are aliases
+   -- str is the exclusive string type name
    local s1: str = "a"
-   local s2: string = "b"
-   assert(s1 is "a", "str alias works")
-   assert(s2 is "b", "string alias works")
+   assert(s1 is "a", "str type works")
 
    local b1: bool = true
    assert(b1 is true, "bool type works")


### PR DESCRIPTION
* Restricted string type annotations and deferred expressions to the str typename
* Added regression coverage while preserving the string result from type()