### PR TITLE
[Tiri] Simplified struct construction and type annotations

### DIFF
--- a/src/tiri/jit/src/lib/lib_object.cpp
+++ b/src/tiri/jit/src/lib/lib_object.cpp
@@ -875,22 +875,14 @@ static int object_exists(lua_State *Lua)
       OBJECTPTR obj;
       access_object(def, obj); // Clears the stale UID and releases the wrapper's weak pin.
       lua_pushboolean(Lua, false);
-      return 1;
    }
-
-   if (def->is_pinned()) {
+   else if (def->is_pinned()) {
       // The weak pin guarantees the header remains valid, so not-dead means alive - no lock cycle required.
       lua_pushboolean(Lua, true);
-      return 1;
    }
+   else lua_pushboolean(Lua, CheckResourceExists(def->uid) IS ERR::True);
 
-   OBJECTPTR obj;
-   if (!access_object(def, obj)) {
-      release_object(def);
-      lua_pushboolean(Lua, true);
-      return 1;
-   }
-   return 0;
+   return 1;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/lib/lib_struct.cpp
+++ b/src/tiri/jit/src/lib/lib_struct.cpp
@@ -35,8 +35,8 @@ static const char * scalar_type_name(NativeStructType Type)
       case NativeStructType::UInt8: return "uint8";
       case NativeStructType::Int16: return "int16";
       case NativeStructType::UInt16: return "uint16";
-      case NativeStructType::Int32: return "int32";
-      case NativeStructType::UInt32: return "uint32";
+      case NativeStructType::Int32: return "int";
+      case NativeStructType::UInt32: return "uint";
       case NativeStructType::Int64: return "int64";
       case NativeStructType::UInt64: return "uint64";
       case NativeStructType::Float: return "float";

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -852,7 +852,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
       }
 
       case TokenKind::StructTyped: {
-         // Explicit struct construction: struct<Name> { fields }
+         // Explicit struct construction: struct<Name> or struct<Name> { fields }
          // Desugar to: struct.new('Name', { fields })
          // This is the only declaration-based construction form; declarations do not bind a constructor variable.
 
@@ -865,15 +865,14 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          }
          this->ctx.tokens().advance();
 
-         if (not this->ctx.check(TokenKind::LeftBrace)) {
-            return this->fail<ExprNodePtr>(ParserErrorCode::ExpectedToken, this->ctx.tokens().current(),
-               std::format("Expected '{{' to construct struct<{}>", struct_name));
-         }
-
-         auto table_result = this->parse_table_literal(false);
-         if (not table_result.ok()) return table_result;
-
          SourceSpan span = start.span();
+         ExprNodePtr initialiser;
+         if (this->ctx.check(TokenKind::LeftBrace)) {
+            auto table_result = this->parse_table_literal(false);
+            if (not table_result.ok()) return table_result;
+            initialiser = std::move(table_result.value_ref());
+         }
+         else initialiser = make_table_expr(span, {}, false);
 
          // Build struct.new('Name', { fields })
          Identifier struct_id = Identifier::from_keepstr(this->ctx.lex().keepstr("struct"), span);
@@ -885,7 +884,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
 
          ExprNodeList args;
          args.push_back(make_literal_expr(span, LiteralValue::string(name_str)));
-         args.push_back(std::move(table_result.value_ref()));
+         args.push_back(std::move(initialiser));
          node = make_call_expr(span, std::move(struct_new), std::move(args), false);
          break;
       }

--- a/src/tiri/jit/src/parser/ast/nodes.cpp
+++ b/src/tiri/jit/src/parser/ast/nodes.cpp
@@ -12,7 +12,6 @@ TiriType parse_type_name(std::string_view Name)
       { "nil",       TiriType::Nil },
       { "bool",      TiriType::Bool },
       { "num",       TiriType::Num },
-      { "number",    TiriType::Num },
       { "str",       TiriType::Str },
       { "table",     TiriType::Table },
       { "array",     TiriType::Array },

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -429,10 +429,10 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
          else if (element_name IS "uint16") {
             field.Type = FD_WORD|FD_UNSIGNED; field.NativeType = NativeStructType::UInt16;
          }
-         else if (element_name IS "int" or element_name IS "int32") {
+         else if (element_name IS "int") {
             field.Type = FD_INT; field.NativeType = NativeStructType::Int32;
          }
-         else if (element_name IS "uint" or element_name IS "uint32") {
+         else if (element_name IS "uint") {
             field.Type = FD_INT|FD_UNSIGNED; field.NativeType = NativeStructType::UInt32;
          }
          else if (element_name IS "int64") { field.Type = FD_INT64; field.NativeType = NativeStructType::Int64; }
@@ -499,10 +499,10 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
       else if (type_name IS "uint16") {
          field.Type = FD_WORD|FD_UNSIGNED; field.NativeType = NativeStructType::UInt16;
       }
-      else if (type_name IS "int" or type_name IS "int32") {
+      else if (type_name IS "int") {
          field.Type = FD_INT; field.NativeType = NativeStructType::Int32;
       }
-      else if (type_name IS "uint" or type_name IS "uint32") {
+      else if (type_name IS "uint") {
          field.Type = FD_INT|FD_UNSIGNED; field.NativeType = NativeStructType::UInt32;
       }
       else if (type_name IS "int64") { field.Type = FD_INT64; field.NativeType = NativeStructType::Int64; }
@@ -548,8 +548,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
                if (reference_name IS "bool" or reference_name IS "char" or reference_name IS "byte" or
                      reference_name IS "int8" or reference_name IS "uint8") field.Type |= FD_BYTE;
                else if (reference_name IS "int16" or reference_name IS "uint16") field.Type |= FD_WORD;
-               else if (reference_name IS "int" or reference_name IS "uint" or reference_name IS "int32" or
-                     reference_name IS "uint32") field.Type |= FD_INT;
+               else if (reference_name IS "int" or reference_name IS "uint") field.Type |= FD_INT;
                else if (reference_name IS "int64" or reference_name IS "uint64") field.Type |= FD_INT64;
                else if (reference_name IS "float") field.Type |= FD_FLOAT;
                else if (reference_name IS "double") field.Type |= FD_DOUBLE;

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -2507,6 +2507,10 @@ static bool test_parser_diagnostics_reset_per_load(kt::Log &Log)
 
 static bool test_userdata_type_annotations(kt::Log &Log)
 {
+   if (parse_type_name("num") != TiriType::Num or parse_type_name("number") != TiriType::Unknown) {
+      Log.error("num must be the exclusive numeric type annotation name");
+      return false;
+   }
    if (parse_type_name("str") != TiriType::Str or parse_type_name("string") != TiriType::Unknown) {
       Log.error("str must be the exclusive string type annotation name");
       return false;

--- a/src/tiri/tests/test_deferred_expr.tiri
+++ b/src/tiri/tests/test_deferred_expr.tiri
@@ -90,7 +90,7 @@ end
    function compute()
       return 42
    end
-   x = <number{ compute() }>
+   x = <num{ compute() }>
    result = resolve(x)
    assert(type(result) is 'number', 'Expected number type')
    assert(result is 42, 'Expected 42')
@@ -181,7 +181,7 @@ end
    x = <str{ getValue() }>
    assert(type(x) is 'string', 'Expected type(x) to be "string" for explicitly typed deferred')
 
-   y = <number{ 42 }>
+   y = <num{ 42 }>
    assert(type(y) is 'number', 'Expected type(y) to be "number" for explicitly typed deferred')
 end
 

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -37,8 +37,8 @@ struct JITPhaseFiveScalarFields
    Unsigned16: uint16
    Signed: int
    Unsigned: uint
-   Signed32: int32
-   Unsigned32: uint32
+   Signed32: int
+   Unsigned32: uint
    Signed64: int64
    Unsigned64: uint64
    Single: float
@@ -2462,7 +2462,7 @@ end
    value.Unsigned32 = 4294967295
    value.Unsigned64 = 18446744073709549568
    assert(traced_phase_five_unsigned32_read(value, 20) is 4294967295,
-      'A hot uint32 read should preserve values above the signed range')
+      'A hot uint read should preserve values above the signed range')
    assert(traced_phase_five_unsigned64_read(value, 20) is 18446744073709549568,
       'A hot uint64 read should preserve representable values above the signed range')
 

--- a/src/tiri/tests/test_return_types.tiri
+++ b/src/tiri/tests/test_return_types.tiri
@@ -701,11 +701,11 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- TYPE ALIASES IN RETURN DECLARATIONS
 
-@Test function ReturnTypeAliasNumber()
-   function getNumber():number
+@Test function ReturnTypeNum()
+   function getNumber():num
       return 42
    end
-   assert(getNumber() is 42, "number alias in return type should work")
+   assert(getNumber() is 42, "num return type should work")
 end
 
 @Test function ReturnTypeString()

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -21,7 +21,7 @@ end
 struct DeclaredLayout
    Bool: bool, Char: char, Byte: byte, Int8: int8, UInt8: uint8,
    Int16: int16, UInt16: uint16, Int: int, UInt: uint,
-   Int32: int32, UInt32: uint32, Int64: int64, UInt64: uint64,
+   Int32: int, UInt32: uint, Int64: int64, UInt64: uint64,
    Float: float, Double: double, String: string, CStr: cstr,
    Pointer: ptr, IntPointer: ptr<int>, IntList: ptr<int[]>, Object: obj, Callback: func, Buffer: char[7],
    Fixed: int[3], Child: struct<DeclaredChild>, ChildPointer: ptr<DeclaredChild>
@@ -36,7 +36,7 @@ end
 struct DeclaredVectorFields
    Bool: array<bool>, Char: array<char>, Byte: array<byte>, Int8: array<int8>, UInt8: array<uint8>,
    Int16: array<int16>, UInt16: array<uint16>, Int: array<int>, UInt: array<uint>,
-   Int32: array<int32>, UInt32: array<uint32>, Int64: array<int64>, UInt64: array<uint64>,
+   Int32: array<int>, UInt32: array<uint>, Int64: array<int64>, UInt64: array<uint64>,
    Float: array<float>, Double: array<double>, String: array<string>,
    Points: array<struct<DeclaredVectorElement>>
 end
@@ -54,7 +54,7 @@ function declared_user_age(Value: struct<DeclaredUser>):num
 end
 
 function create_declared_user():struct<DeclaredUser>
-   return struct<DeclaredUser> { }
+   return struct<DeclaredUser>
 end
 
 function expect_struct_error(Action:func, ExpectedCode:num, Description:str)
@@ -79,7 +79,8 @@ end
    assert(user.Enabled is true, 'Boolean fields should be exposed as Tiri booleans')
    assert(user.Initial is 65 and user.Buffer is 'hello', 'Character fields and buffers should round-trip')
    assert(declared_user_age(user) is 37, 'struct<Name> annotations should resolve declared layouts')
-   assert(create_declared_user().Age is 0, 'struct<Name> return annotations should parse and retain the layout')
+   assert(create_declared_user().Age is 0,
+      'struct<Name> without an initialiser should parse in returns and retain the layout')
    local typed_user:struct<DeclaredUser> = user
    assert(typed_user.Name is 'Paul', 'struct<Name> local annotations should resolve declared layouts')
    local constructed_user:struct<DeclaredUser> = struct<DeclaredUser> { Age=42 }
@@ -170,10 +171,10 @@ end
    expect_struct_error(() => do value.Int16 = 32768 end, ERR_OutOfRange, 'int16 should reject overflow')
    expect_struct_error(() => do value.UInt16 = -1 end, ERR_OutOfRange, 'uint16 should reject underflow')
    expect_struct_error(() => do value.UInt16 = 65536 end, ERR_OutOfRange, 'uint16 should reject overflow')
-   expect_struct_error(() => do value.Int32 = -2147483649 end, ERR_OutOfRange, 'int32 should reject underflow')
-   expect_struct_error(() => do value.Int32 = 2147483648 end, ERR_OutOfRange, 'int32 should reject overflow')
-   expect_struct_error(() => do value.UInt32 = -1 end, ERR_OutOfRange, 'uint32 should reject underflow')
-   expect_struct_error(() => do value.UInt32 = 4294967296 end, ERR_OutOfRange, 'uint32 should reject overflow')
+   expect_struct_error(() => do value.Int32 = -2147483649 end, ERR_OutOfRange, 'int should reject underflow')
+   expect_struct_error(() => do value.Int32 = 2147483648 end, ERR_OutOfRange, 'int should reject overflow')
+   expect_struct_error(() => do value.UInt32 = -1 end, ERR_OutOfRange, 'uint should reject underflow')
+   expect_struct_error(() => do value.UInt32 = 4294967296 end, ERR_OutOfRange, 'uint should reject overflow')
    expect_struct_error(() => do value.Int64 = 9223372036854775808 end, ERR_OutOfRange, 'int64 should reject overflow')
    expect_struct_error(() => do value.UInt64 = -2048 end, ERR_OutOfRange, 'uint64 should reject underflow')
    expect_struct_error(() => do value.UInt64 = 18446744073709551616 end, ERR_OutOfRange,
@@ -286,14 +287,11 @@ local value = RetiredCallSyntax()
       error('Constructing an unknown struct name should fail to compile')
    end
 
-   try
-      exec([[
-struct MissingInitialiser Value: int end
-local value = struct<MissingInitialiser>
+   exec([[
+struct OmittedInitialiser Value: int end
+local value = struct<OmittedInitialiser>
+assert(value.Value is 0, 'struct<Name> without an initialiser table should be zero-initialised')
 ]])
-   success
-      error('struct<Name> without an initialiser table should fail to compile')
-   end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -514,6 +512,42 @@ assert(value.Value is 12)
       exec([[struct BadUnknownType Value: mystery end]])
    success
       error('Unknown declaration field types should fail')
+   end
+
+   try
+      exec([[struct RetiredInt32 Value: int32 end]])
+   success
+      error('Struct declarations should reject the retired int32 alias')
+   end
+
+   try
+      exec([[struct RetiredUInt32 Value: uint32 end]])
+   success
+      error('Struct declarations should reject the retired uint32 alias')
+   end
+
+   try
+      exec([[struct RetiredInt32Array Values: array<int32> end]])
+   success
+      error('Struct array fields should reject the retired int32 alias')
+   end
+
+   try
+      exec([[struct RetiredUInt32Array Values: array<uint32> end]])
+   success
+      error('Struct array fields should reject the retired uint32 alias')
+   end
+
+   try
+      exec([[struct RetiredInt32Pointer Value: ptr<int32> end]])
+   success
+      error('Struct pointer fields should reject the retired int32 alias')
+   end
+
+   try
+      exec([[struct RetiredUInt32Pointer Value: ptr<uint32> end]])
+   success
+      error('Struct pointer fields should reject the retired uint32 alias')
    end
 
    try

--- a/src/tiri/tests/test_type_annotations.tiri
+++ b/src/tiri/tests/test_type_annotations.tiri
@@ -53,7 +53,6 @@ end
    end
 
    assert_compiles("N:num")
-   assert_compiles("Number:number")
    assert_compiles("S:str")
    assert_compiles("B:bool")
    assert_compiles("T:table")
@@ -63,6 +62,22 @@ end
    assert_compiles("NilVal:nil")
    assert_compiles("StructVal:struct")
    assert_compiles("ObjVal:obj")
+end
+
+@Test function RemovedNumberTypeRejected()
+   function assert_rejected(Source:str, Context:str)
+      try
+         exec(Source)
+      success
+         error(f"Expected number type name to be rejected in {Context}")
+      end
+   end
+
+   assert_rejected("local value:number = 1", "a local annotation")
+   assert_rejected("local function rejected(Value:number) return Value end", "a parameter annotation")
+   assert_rejected("local function rejected():number return 1 end", "a return annotation")
+   assert_rejected("local value = <number{ 1 }>", "a deferred expression")
+   assert_rejected("thunk rejected():number return 1 end", "a thunk return annotation")
 end
 
 @Test function RemovedStringTypeRejected()

--- a/src/tiri/tests/test_type_fixing.tiri
+++ b/src/tiri/tests/test_type_fixing.tiri
@@ -224,14 +224,12 @@ end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- TYPE ANNOTATION ALIASES
+-- TYPE ANNOTATIONS
 
 @Test function TypeAliases()
-   -- num/number are aliases
+   -- num is the exclusive numeric type name
    local n1: num = 1
-   local n2: number = 2
-   assert(n1 is 1, "num alias works")
-   assert(n2 is 2, "number alias works")
+   assert(n1 is 1, "num type works")
 
    -- str is the exclusive string type name
    local s1: str = "a"


### PR DESCRIPTION
* Allowed named structs to omit empty initialiser tables
* Removed number, int32 and uint32 annotation aliases in favour of num, int and uint
* Simplified object existence checks while preserving weak-pin handling
* Added parser and Flute coverage for the revised syntax