### PR TITLE
[Tiri] Added clear metamethod support for proxy tables

### DIFF
--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -1352,6 +1352,9 @@ static void build_subroutines(BuildCtx *ctx)
   |   str CFUNC:CARG4, [BASE, #-16]
   |  b ->fff_res
   |
+  |.ffunc_1 table_clear
+  |  b ->fff_fallback
+  |
   |//-- Base library: catch errors ----------------------------------------
   |
   |.ffunc pcall

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -1941,6 +1941,9 @@ static void build_subroutines(BuildCtx *ctx)
   |.endif
   |  b ->fff_res
   |
+  |.ffunc_1 table_clear
+  |  b ->fff_fallback
+  |
   |//-- Base library: catch errors ----------------------------------------
   |
   |.ffunc pcall

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -1728,6 +1728,9 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov RDd, 1+3
   |  jmp ->fff_res
   |
+  |.ffunc_1 table_clear
+  |  jmp ->fff_fallback
+  |
   |//-- Math library -------------------------------------------------------
   |
   |  .ffunc_1 math_abs

--- a/src/tiri/jit/src/lib/lib_table.cpp
+++ b/src/tiri/jit/src/lib/lib_table.cpp
@@ -17,6 +17,7 @@
 #include "lj_str.h"
 #include "lj_buf.h"
 #include "lj_tab.h"
+#include "lj_meta.h"
 #include "lj_ff.h"
 #include "lj_strfmt.h"
 #include "lib.h"
@@ -343,15 +344,22 @@ LJLIB_CF(table_size)
 
 //********************************************************************************************************************
 
-LJLIB_CF(table_clear)   LJLIB_REC(.)
+LJLIB_ASM(table_clear)   LJLIB_REC(.)
 {
    GCtab *table = lj_lib_checktab(L, 1);
    if (lj_tab_is_environment(table)) {
       lj_err_callermsg(L, "cannot clear a global environment");
    }
 
+   cTValue *metamethod = lj_meta_lookup(L, L->base, MM_clear);
+   if (not tvisnil(metamethod)) {
+      L->top = L->base + 1;
+      copyTV(L, L->base - 2, metamethod);
+      return FFH_TAILCALL;
+   }
+
    lj_tab_clear(table);
-   return 0;
+   return FFH_RES(0);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/lj_dispatch.h
+++ b/src/tiri/jit/src/lj_dispatch.h
@@ -20,7 +20,7 @@ constexpr int HOTCOUNT_LOOP = 2;
 constexpr int HOTCOUNT_CALL = 1;
 
 // This solves a circular dependency problem -- bump as needed. Sigh.
-constexpr int GG_NUM_ASMFF = 54;
+constexpr int GG_NUM_ASMFF = 55;
 
 constexpr int GG_LEN_DDISP = (BC__MAX + GG_NUM_ASMFF);
 constexpr int GG_LEN_SDISP = BC__MAX;

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -1746,6 +1746,7 @@ static void recff_table_clear(jit_State* J, RecordFFData* rd)
       if (lj_tab_is_environment(tabV(&rd->argv[0]))) lj_trace_err(J, LJ_TRERR_NYIFFU);
       TRef marker = emitir(IRT(IR_FLOAD, IRT_TAB), tr, IRFL_TAB_GCONTRACTS);
       emitir(IRTG(IR_EQ, IRT_TAB), marker, lj_ir_knull(J, IRT_TAB));
+      if (recff_metacall(J, rd, MM_clear)) return;
       rd->nres = 0;
       lj_ir_call(J, IRCALL_lj_tab_clear, tr);
       J->needsnap = 1;

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -1435,7 +1435,7 @@ enum {
   _(add) _(sub) _(mul) _(div) _(mod) _(pow) _(unm) \
   /* The following are used in the standard libraries. */ \
   _(metatable) _(tostring) \
-  _(close) MMDEF_FFI(_) MMDEF_PAIRS(_)
+  _(close) MMDEF_FFI(_) MMDEF_PAIRS(_) _(clear)
 
 // Metamethod IDs - uses typedef enum because MMDEF generates conditional members
 // and the X-macro pattern is required for string generation in lj_meta.cpp

--- a/src/tiri/tests/test_async.tiri
+++ b/src/tiri/tests/test_async.tiri
@@ -194,7 +194,7 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 -- Verify that async.pool.reset() removes all entries.
 
-@Test(priority=8) function PoolReset()
+@Test(priority=8) function PoolResetAndClear()
    async.pool.reset()
 
    async.pool.a = 1
@@ -206,6 +206,16 @@ end
    assert(async.pool.a is nil, 'Expected nil after reset')
    assert(async.pool.b is nil, 'Expected nil after reset')
    assert(async.pool.c is nil, 'Expected nil after reset')
+
+   local reset = async.pool.reset
+   async.pool.a = 1
+   async.pool.b = 2
+
+   async.pool.clear()
+
+   assert(async.pool.a is nil, 'Expected nil after clear')
+   assert(async.pool.b is nil, 'Expected nil after clear')
+   assert(async.pool.reset is reset, 'async.pool.clear() should preserve async.pool.reset()')
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -1940,6 +1940,29 @@ end
    assert(trace_found is true, "Expected array.clear() to produce a JIT trace")
 end
 
+@Test function TableClearMetamethodTraces()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   local calls = 0
+   local target = setmetatable({ value=42 }, {
+      ['__clear'] = function(Self)
+         calls += 1
+      end
+   })
+
+   local function clear_target(Target:table)
+      Target.clear()
+   end
+
+   for i in {0 to 80} do clear_target(target) end
+
+   assert(calls is 80, f"Expected __clear to run 80 times, got {calls}")
+   assert(target.value is 42, "Recorded __clear calls should not raw-clear the receiver")
+   assert(count_jit_traces(30) > 0, "Expected table.clear() with __clear to produce a JIT trace")
+end
+
 @Test(hotpath=80) function ArrayResizeTracesAndInvalidatesLength()
    jit.on()
    jit.flush()

--- a/src/tiri/tests/test_table.tiri
+++ b/src/tiri/tests/test_table.tiri
@@ -433,6 +433,42 @@ end
    assert(#t is nil, "Clearing must not restore a numerical length")
 end
 
+@Test function ClearMetamethod()
+   local target = { value=42 }
+   local expected = target
+   local calls = 0
+   setmetatable(target, {
+      ['__clear'] = function(Self)
+         calls += 1
+         assert(Self is expected, "__clear should receive the table being cleared")
+      end
+   })
+
+   target.clear()
+
+   assert(calls is 1, "table.clear() should invoke __clear exactly once")
+   assert(target.value is 42, "table.clear() should not raw-clear a table handled by __clear")
+end
+
+@Test function ClearMetamethodErrorPropagation()
+   local target = setmetatable({}, {
+      ['__clear'] = function(Self)
+         error('clear hook failed')
+      end
+   })
+   local caught = false
+
+   try
+      target.clear()
+   except e
+      caught = tostring(e).find('clear hook failed') != nil
+   success
+      error('Expected __clear failure to propagate')
+   end
+
+   assert(caught, "table.clear() should propagate errors raised by __clear")
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- Tests for table.sortByKeys() (extended)
 

--- a/src/tiri/tiri_async.cpp
+++ b/src/tiri/tiri_async.cpp
@@ -582,6 +582,8 @@ void register_async_class(lua_State *Lua)
    lua_setfield(Lua, -2, "__index");
    lua_pushcfunction(Lua, pool_set);
    lua_setfield(Lua, -2, "__newindex");
+   lua_pushcfunction(Lua, pool_reset);
+   lua_setfield(Lua, -2, "__clear");
    lua_pop(Lua, 1);
 
    lua_newtable(Lua);                          // Create the pool table


### PR DESCRIPTION
* Routed table.clear() through __clear across interpreter and JIT execution
* Connected async.pool clearing to shared storage without removing reset
* Added table, async pool and JIT regression coverage