### PR TITLE
[Tiri] Add current table context and contextual member calls

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -870,6 +870,7 @@ set (TIRI_TESTS
    module_namespaces builtin_methods
    object_pinning import_type_analysis global_types type_contracts thunk_contract_argument type_signature_dumps
    type_guided_emission type_guided_jit_signatures
+   context_access contextual_member_calls
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/jit/BYTECODE.md
+++ b/src/tiri/jit/BYTECODE.md
@@ -748,6 +748,72 @@ validity, so every name is revalidated against the registry at resolution.
 The process-wide ownership, publication and lock contract is documented in
 [MODULE_REGISTRY.md](../MODULE_REGISTRY.md).
 
+#### Current Table Context
+
+| Opcode | Format | Description |
+|--------|--------|-------------|
+| `CTXGET` | A | Load the state-local current table context into R(A) |
+| `CTXENTER` | A | Enter the table receiver retained in R(A-1), if present, before argument evaluation |
+| `CTXCALL` | ABC | Invoke a contextual fixed-argument call with the ordinary `CALL` B/C layout |
+| `CTXCALLM` | ABC | Invoke a contextual multiple-argument call with the ordinary `CALLM` B/C layout |
+| `CTXLEAVE` | A | Restore the inherited context and normalise results after a contextual call |
+| `CTXCALLT` | AD | Transfer context ownership and invoke a fixed-argument tail call |
+
+`CTXGET` is appended to the opcode set so existing opcode numbers remain stable. An empty physical context stack is
+the permanent root sentinel and resolves dynamically through `L->env`; consequently a supported environment
+replacement is visible to the next `CTXGET`. Leading-dot access lowers to `CTXGET` followed by ordinary `TGET*` or
+`TSET*` operations. Root writes therefore cross the same marked-environment mutation boundary as `_G` writes and
+cannot bypass protected-global, const or sticky-type contracts.
+
+Phase 2 deliberately stops recording a trace at `CTXGET`; Phase 5 will model context in recorder state and snapshots.
+
+##### Context Ownership Layout (Gate B)
+
+Each `lua_State` owns an explicit vector of non-root overrides. An entry stores a `GCRef` to a table and the owning
+activation base as a stack-relative byte offset. Current-context lookup is constant time from the final entry. The
+relative owner survives stack relocation, the GC traverses all entries, and state destruction releases the vector.
+The root is never stored or popped and is always resolved from `L->env`.
+
+This layout was selected over frame annotations because it does not change the architecture-specific frame layout,
+keeps root environment replacement dynamic, and gives later error unwinding and tail transfer an explicit ownership
+boundary.
+
+##### Contextual Call Layout (Gate C)
+
+Current-context access uses the dedicated `CTXGET` opcode. Table member calls use appended contextual variants of the
+existing call family. Their register layout reserves the slot immediately before the ordinary call base for the
+original receiver; the callable and written arguments otherwise retain the `CALL`/`CALLM` layout. `CTXENTER` performs
+the runtime table gate after member lookup and before argument evaluation. `CTXCALL` repeats the gate idempotently at
+the activation boundary, and `CTXLEAVE` restores the inherited context after a normal return. It shifts returned
+values down over the retained receiver slot so expression result allocation remains identical to an ordinary member
+call.
+
+Named and computed lookup continue to use the appropriate existing `TGET*` operation while retaining the original
+receiver. Safe calls branch around lookup, entry and argument evaluation on their `nil` path. Statically proved
+strings, arrays, ranges, structures and objects retain their specialised receiver dispatch without emitting context
+operations. Dynamically typed receivers use the contextual variants, whose runtime gate leaves non-table values and
+their visible argument layout unchanged. `CTXCALLT` transfers a prepared receiver from the discarded activation to
+the reused tail frame, replacing an override owned by that frame where necessary. Direct tail calls naturally retain
+their existing frame owner. Variable-argument contextual calls retain the ordinary call-and-return form so their
+multiple-result state does not cross a context helper boundary. Direct calls and compiler-managed module namespace
+calls retain their existing bytecode and overhead.
+
+Dedicated contextual call variants were selected because lowering through an ordinary call frame would lose the
+receiver association before activation ownership can be established. The Phase 3 opcodes occupy values 122 through
+125 after `CTXGET`; Phase 4 appends `CTXCALLT` at value 126, preserving all earlier opcode numbers.
+
+##### Restoration and Tail Ownership (Gate D)
+
+Fixed, zero and fixed-multiple returns release an override owned by the returning VM frame. `CTXLEAVE` remains
+responsible for result normalisation and is idempotent with that release. Error unwinding prunes overrides above the
+surviving activation and restores each owning frame before its `<close>` handlers run. Protected calls therefore
+retain their caller context while abandoned callees cannot leak a receiver into a handler.
+
+Asynchronous callback entry may suspend the interrupted context stack and expose the dynamic `L->env` root for the
+callback's duration. Synchronous `lua_call()` and `lua_pcall()` re-entry does not use this boundary and inherits the
+active context. Fixed-argument contextual tail calls use `CTXCALLT`; direct and variable-argument calls preserve their
+existing tail or call-and-return paths respectively.
+
 ## 11. Testing, Debugging, and Tooling
 
 ### 11.1 Using Flute and Tiri Tests

--- a/src/tiri/jit/src/bytecode/lj_bc.h
+++ b/src/tiri/jit/src/bytecode/lj_bc.h
@@ -280,7 +280,14 @@ constexpr uint8_t  NO_REG = BCMAX_A;
   /* Immutable state-local built-in callable load. Appended to preserve existing opcode numbers. */ \
   _(BFUNC,     dst,  ___, lit, ___) \
   /* Runtime built-in method resolution. P32 is the member string constant; D is the field fallback edge. */ \
-  _(BMETH,     dst,  ___, jump, ___)
+  _(BMETH,     dst,  ___, jump, ___) \
+  /* Current table context. */ \
+  _(CTXGET,    dst,  ___, ___, ___) \
+  _(CTXCALLM,  base, lit, lit, call) \
+  _(CTXCALL,   base, lit, lit, call) \
+  _(CTXLEAVE,  base, ___, lit, ___) \
+  _(CTXENTER,  base, ___, ___, ___) \
+  _(CTXCALLT,  base, ___, lit, call)
 
 // Bytecode opcode numbers.
 // Explicitly enumerated for debugger visibility and easy value lookup.
@@ -442,7 +449,15 @@ typedef enum {
    BC_BFUNC = 121,
    BC_BMETH = 122,
 
-   BC__MAX   = 123
+   // Current table context
+   BC_CTXGET = 123,
+   BC_CTXCALLM = 124,
+   BC_CTXCALL = 125,
+   BC_CTXLEAVE = 126,
+   BC_CTXENTER = 127,
+   BC_CTXCALLT = 128,
+
+   BC__MAX   = 129
 } BCOp;
 
 [[nodiscard]] inline constexpr bool bc_is_func_header(BCOp Op) noexcept

--- a/src/tiri/jit/src/bytecode/lj_bcread.cpp
+++ b/src/tiri/jit/src/bytecode/lj_bcread.cpp
@@ -295,6 +295,8 @@ static void bcread_knum(LexState *State, GCproto *pt, MSize sizekn)
 static void bcread_bytecode(LexState *State, GCproto *pt, MSize sizebc)
 {
    BCIns* bc = proto_bc(pt);
+   BCREG context_entries[BCMAX_A + 1];
+   MSize context_entry_depth = 0;
    bc[0] = BCINS_AD((pt->flags & PROTO_VARARG) ? BC_FUNCV : BC_FUNCF,
       pt->framesize, 0);
    bcread_block(State, bc + 1, (sizebc - 1) * (MSize)sizeof(BCIns));
@@ -324,6 +326,17 @@ static void bcread_bytecode(LexState *State, GCproto *pt, MSize sizebc)
          BCREG call_base = bc_a(bc[i]);
          if (call_base IS 0 or call_base >= pt->framesize) bcread_error(State, ErrMsg::BCBAD);
 
+         if (op IS BC_CTXENTER) {
+            if (context_entry_depth >= BCMAX_A + 1) bcread_error(State, ErrMsg::BCBAD);
+            context_entries[context_entry_depth++] = call_base;
+         }
+         else if (op IS BC_CTXCALL or op IS BC_CTXCALLM or op IS BC_CTXCALLT) {
+            if (context_entry_depth IS 0 or context_entries[context_entry_depth - 1] != call_base) {
+               bcread_error(State, ErrMsg::BCBAD);
+            }
+            --context_entry_depth;
+         }
+
          if (op IS BC_CTXCALL or op IS BC_CTXCALLM) {
             if (i + 1 >= sizebc or bc_op(bc[i + 1]) != BC_CTXLEAVE or bc_a(bc[i + 1]) != call_base) {
                bcread_error(State, ErrMsg::BCBAD);
@@ -339,6 +352,7 @@ static void bcread_bytecode(LexState *State, GCproto *pt, MSize sizebc)
          }
       }
    }
+   if (context_entry_depth != 0) bcread_error(State, ErrMsg::BCBAD);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/bytecode/lj_bcread.cpp
+++ b/src/tiri/jit/src/bytecode/lj_bcread.cpp
@@ -319,6 +319,25 @@ static void bcread_bytecode(LexState *State, GCproto *pt, MSize sizebc)
       if (op IS BC_MRSAVE or op IS BC_MRRESTORE) {
          pt->flags |= PROTO_NOJIT;
       }
+      else if (op IS BC_CTXENTER or op IS BC_CTXCALL or op IS BC_CTXCALLM or op IS BC_CTXLEAVE or
+               op IS BC_CTXCALLT) {
+         BCREG call_base = bc_a(bc[i]);
+         if (call_base IS 0 or call_base >= pt->framesize) bcread_error(State, ErrMsg::BCBAD);
+
+         if (op IS BC_CTXCALL or op IS BC_CTXCALLM) {
+            if (i + 1 >= sizebc or bc_op(bc[i + 1]) != BC_CTXLEAVE or bc_a(bc[i + 1]) != call_base) {
+               bcread_error(State, ErrMsg::BCBAD);
+            }
+         }
+         else if (op IS BC_CTXLEAVE) {
+            if (i IS 1 or (bc_op(bc[i - 1]) != BC_CTXCALL and bc_op(bc[i - 1]) != BC_CTXCALLM) or
+                bc_a(bc[i - 1]) != call_base) {
+               bcread_error(State, ErrMsg::BCBAD);
+            }
+            BCREG result_shift = bc_d(bc[i]);
+            if (result_shift > call_base) bcread_error(State, ErrMsg::BCBAD);
+         }
+      }
    }
 }
 

--- a/src/tiri/jit/src/debug/lj_err.cpp
+++ b/src/tiri/jit/src/debug/lj_err.cpp
@@ -146,9 +146,9 @@ extern "C" void lj_err_prepare_foreign_exception(lua_State *L, const char *Messa
 
 static TValue * unwind_close_handlers(lua_State *L, TValue *frame, TValue *errobj)
 {
-   ptrdiff_t frame_offset = savestack(L, frame);
-   ptrdiff_t current_err_offset = errobj ? savestack(L, errobj) : 0;
+   const ptrdiff_t frame_offset = savestack(L, frame);
    bool has_current_err = errobj != nullptr;
+   ptrdiff_t current_err_offset = has_current_err ? savestack(L, errobj) : 0;
 
    // Get the function from this frame
    GCfunc *fn = frame_func(frame);
@@ -193,9 +193,9 @@ static TValue * unwind_close_handlers(lua_State *L, TValue *frame, TValue *errob
             // Per Lua 5.4: error in __close replaces the original error.
             // The new error is at L->top - 1 after the failed pcall.
             // Continue calling other __close handlers with the new error.
-            current_err = L->top - 1;
-            current_err_offset = savestack(L, current_err);
             has_current_err = true;
+            current_err_offset = savestack(L, L->top - 1);
+            current_err = restorestack(L, current_err_offset);
             // Update _G.__close_err with the new error
             if (env) {
                GCstr *key = lj_str_newlit(L, "__close_err");
@@ -217,9 +217,9 @@ static TValue * unwind_close_handlers(lua_State *L, TValue *frame, TValue *errob
 
 static TValue* unwind_close_try_block(lua_State *L, TValue* frame, TValue* errobj, int min_slot_index)
 {
-   ptrdiff_t frame_offset = savestack(L, frame);
-   ptrdiff_t current_err_offset = errobj ? savestack(L, errobj) : 0;
+   const ptrdiff_t frame_offset = savestack(L, frame);
    bool has_current_err = errobj != nullptr;
+   ptrdiff_t current_err_offset = has_current_err ? savestack(L, errobj) : 0;
 
    GCfunc *fn = frame_func(frame);
    if (!isluafunc(fn)) return errobj;
@@ -248,7 +248,7 @@ static TValue* unwind_close_try_block(lua_State *L, TValue* frame, TValue* errob
    // Call lj_meta_close for each slot with <close> attribute in LIFO order.
    // Only process slots >= min_slot_index (created inside the try block)
 
-   TValue *base = frame + 1;
+   TValue *base = restorestack(L, frame_offset) + 1;
    lj_assertL(frame >= tvref(L->stack) and frame < tvref(L->maxstack), "unwind_close_try_block: frame out of range (%p)", frame);
    lj_assertL(base >= tvref(L->stack) and base <= tvref(L->maxstack), "unwind_close_try_block: base out of range (%p)", base);
 
@@ -269,9 +269,9 @@ static TValue* unwind_close_try_block(lua_State *L, TValue* frame, TValue* errob
       if (o >= base and o < L->top and !tvisnil(o) and !tvisfalse(o)) {
          int errcode = lj_meta_close(L, o, current_err);
          if (errcode != 0) {
-            current_err = L->top - 1;
-            current_err_offset = savestack(L, current_err);
             has_current_err = true;
+            current_err_offset = savestack(L, L->top - 1);
+            current_err = restorestack(L, current_err_offset);
             if (env) {
                GCstr *key = lj_str_newlit(L, "__close_err");
                TValue *slot_tv = lj_tab_setstr(L, env, key);
@@ -301,8 +301,8 @@ static TValue* unwind_close_try_block(lua_State *L, TValue* frame, TValue* errob
 
 static void unwind_close_all(lua_State *L, TValue *From, TValue *To)
 {
+   const ptrdiff_t to_offset = savestack(L, To);
    ptrdiff_t frame_offset = savestack(L, From);
-   ptrdiff_t target_offset = savestack(L, To);
    bool has_error = L->top > To;
    ptrdiff_t error_offset = has_error ? savestack(L, L->top - 1) : 0;
    int count = 0;
@@ -311,33 +311,37 @@ static void unwind_close_all(lua_State *L, TValue *From, TValue *To)
    // that LuaJIT enforces, so any valid frame chain should terminate well before this.
    // The limit guards against stack corruption causing infinite loops.
 
-   while (restorestack(L, frame_offset) >= restorestack(L, target_offset) and count < LUAI_MAXCSTACK) {
+   while (restorestack(L, frame_offset) >= restorestack(L, to_offset) and count < LUAI_MAXCSTACK) {
       count++;
-
-      // unwind_close_handlers may return a different error if a __close threw
 
       TValue *frame = restorestack(L, frame_offset);
       TValue *errobj = has_error ? restorestack(L, error_offset) : nullptr;
+
+      // A cleanup handler runs in the context of the activation that owns it.  Discard contexts belonging to frames
+      // already abandoned while retaining an override owned by this frame itself.
+
+      lj_context_unwind(L, frame + 1);
+
+      // unwind_close_handlers may return a different error if a __close threw
+
       TValue *new_err = unwind_close_handlers(L, frame, errobj);
-      errobj = has_error ? restorestack(L, error_offset) : nullptr;
-      if (new_err != nullptr and errobj != nullptr and savestack(L, new_err) != error_offset) {
+      const bool has_new_error = new_err != nullptr;
+      const ptrdiff_t new_error_offset = has_new_error ? savestack(L, new_err) : 0;
+      if (has_new_error and has_error and new_error_offset != error_offset) {
          // A __close handler threw - update the error at the original location
+         errobj = restorestack(L, error_offset);
          copyTV(L, errobj, new_err);
-         new_err = errobj;
       }
 
-      if (new_err) {
-         error_offset = savestack(L, new_err);
-         has_error = true;
-      }
+      has_error = has_new_error;
+      if (has_error) error_offset = new_error_offset;
 
       // Move to previous frame based on type
 
       frame = restorestack(L, frame_offset);
       int ftype = frame_type(frame);
-      if (ftype IS FRAME_LUA or ftype IS FRAME_LUAP) frame = frame_prevl(frame);
-      else frame = frame_prevd(frame);
-      frame_offset = savestack(L, frame);
+      TValue *previous = (ftype IS FRAME_LUA or ftype IS FRAME_LUAP) ? frame_prevl(frame) : frame_prevd(frame);
+      frame_offset = savestack(L, previous);
    }
 
    // If we hit the limit, the frame chain is likely corrupt. Log an assertion
@@ -360,6 +364,7 @@ static void unwind_close_all(lua_State *L, TValue *From, TValue *To)
 
 LJ_NOINLINE static void unwindstack(lua_State *L, TValue *Top)
 {
+   lj_context_unwind(L, Top);
    lj_func_closeuv(L, Top);
    if (Top < L->top - 1) {
       copyTV(L, Top, L->top - 1);
@@ -566,12 +571,13 @@ extern "C" void setup_try_handler(lua_State *L)
 
    TValue *errobj = (L->top > saved_top) ? L->top - 1 : nullptr;
    unwind_close_all(L, L->base - 1, saved_base);  // Close nested frames first
+   saved_base = restorestack(L, try_frame->frame_base);
+   saved_top = restorestack(L, try_frame->saved_top);
+   lj_context_unwind(L, saved_base);
 
    // After unwind_close_all(), re-read the error from L->top - 1 as it may have been updated
    // by a __close handler that threw. unwind_close_all() updates the error in-place via copyTV().
 
-   saved_base = restorestack(L, try_frame->frame_base);
-   saved_top = restorestack(L, try_frame->saved_top);
    errobj = (L->top > saved_top) ? L->top - 1 : nullptr;
 
    // Now close <close> variables created inside the try block itself (in the try block's frame).
@@ -581,6 +587,8 @@ extern "C" void setup_try_handler(lua_State *L)
    TValue *try_frame_ptr = saved_base - 1;  // Frame pointer for the function containing try
    int min_slot_index = int(try_frame->saved_nactvar);  // Slots >= this were created inside try
    TValue *final_err = unwind_close_try_block(L, try_frame_ptr, errobj, min_slot_index);
+   const bool has_final_err = final_err != nullptr;
+   const ptrdiff_t final_err_offset = has_final_err ? savestack(L, final_err) : 0;
 
    saved_base = restorestack(L, try_frame->frame_base);
    saved_top = restorestack(L, try_frame->saved_top);
@@ -590,7 +598,7 @@ extern "C" void setup_try_handler(lua_State *L)
    // The error may have been updated by handlers in nested frames (unwind_close_all)
    // or in the try block's frame (unwind_close_try_block).
 
-   TValue *current_err = final_err ? final_err : errobj;
+   TValue *current_err = has_final_err ? restorestack(L, final_err_offset) : errobj;
    GCstr *error_msg = nullptr;
    GCstr *error_source = nullptr;
    int line = 0;
@@ -620,10 +628,11 @@ extern "C" void setup_try_handler(lua_State *L)
       }
    }
 
+   saved_top = restorestack(L, try_frame->saved_top);
    lj_func_closeuv(L, saved_top); // Close upvalues and restore stack state
 
-   L->base = saved_base;
-   L->top = saved_top;
+   L->base = restorestack(L, try_frame->frame_base);
+   L->top = restorestack(L, try_frame->saved_top);
    L->try_stack.depth--; // Pop try frame
 
    // Build exception table and place in handler's register (pass pending_trace, which may be null)
@@ -665,7 +674,11 @@ void * err_unwind(lua_State *L, void *StopCatchFrame, int errcode)
          TValue *top = restorestack(L, -nres);
          if (frame < top) {  // Frame reached?
             if (errcode) {
+               const ptrdiff_t frame_offset = savestack(L, frame);
+               const ptrdiff_t top_offset = savestack(L, top);
                unwind_close_all(L, L->base - 1, top);
+               frame = restorestack(L, frame_offset);
+               top = restorestack(L, top_offset);
                lj_meta_multres_unwind(L, top);
                L->base = frame + 1;
                L->cframe = cframe_prev(cf);
@@ -688,7 +701,11 @@ void * err_unwind(lua_State *L, void *StopCatchFrame, int errcode)
    #if LJ_UNWIND_EXT
             if (errcode) {
                TValue* target = frame - LJ_FR2;
+               const ptrdiff_t frame_offset = savestack(L, frame);
+               const ptrdiff_t target_offset = savestack(L, target);
                unwind_close_all(L, L->base - 1, target);
+               frame = restorestack(L, frame_offset);
+               target = restorestack(L, target_offset);
                lj_meta_multres_unwind(L, target);
                L->base = frame_prevd(frame) + 1;
                L->cframe = cframe_prev(cf);
@@ -744,7 +761,9 @@ void * err_unwind(lua_State *L, void *StopCatchFrame, int errcode)
                // Call __close handlers BEFORE modifying L->base
 
                TValue *target = frame_prevd(frame) + 1;
+               const ptrdiff_t target_offset = savestack(L, target);
                unwind_close_all(L, L->base - 1, target);
+               target = restorestack(L, target_offset);
                lj_meta_multres_unwind(L, target);
                L->base = target;
                L->cframe = cf;
@@ -759,7 +778,9 @@ void * err_unwind(lua_State *L, void *StopCatchFrame, int errcode)
 
    if (errcode) {
       TValue* target = tvref(L->stack) + 1 + LJ_FR2;
+      const ptrdiff_t target_offset = savestack(L, target);
       unwind_close_all(L, L->base - 1, target);
+      target = restorestack(L, target_offset);
       lj_meta_multres_unwind(L, target);
       L->base = target;
       L->cframe = nullptr;

--- a/src/tiri/jit/src/debug/lj_jit.h
+++ b/src/tiri/jit/src/debug/lj_jit.h
@@ -498,6 +498,7 @@ struct jit_State {
   TRef context_call_receiver[LJ_MAX_JSLOTS+LJ_STACK_EXTRA];
   TRef context_call_result[LJ_MAX_JSLOTS+LJ_STACK_EXTRA];
   uint8_t context_call_state[LJ_MAX_JSLOTS+LJ_STACK_EXTRA];
+  uint16_t context_call_activation_count;
   int32_t context_virtual_slot;
 
   int32_t param[JIT_P__MAX];  //  JIT engine parameters.

--- a/src/tiri/jit/src/debug/lj_jit.h
+++ b/src/tiri/jit/src/debug/lj_jit.h
@@ -184,6 +184,8 @@ struct MCLink {
 struct SnapShot {
   uint32_t mapofs;   //  Offset into snapshot map.
   IRRef1 ref;      //  First IR ref for this snapshot.
+  IRRef1 context_ref; // Virtual contextual receiver restored on trace exit, or zero.
+  uint16_t context_owner_slot; // Root-frame slot owning the virtual contextual activation.
   uint16_t mcofs;   //  Offset into machine code in MCode units.
   uint8_t nslots;   //  Number of valid slots.
   uint8_t topslot;   //  Maximum frame extent.
@@ -491,6 +493,12 @@ struct jit_State {
 
   IRRef1 chain[IR__MAX];  //  IR instruction skip-list chain anchors.
   TRef slot[LJ_MAX_JSLOTS+LJ_STACK_EXTRA];  //  Stack slot map.
+  // Callable, receiver and result refs retained across contextual calls and result shifts.
+  TRef context_call_func[LJ_MAX_JSLOTS+LJ_STACK_EXTRA];
+  TRef context_call_receiver[LJ_MAX_JSLOTS+LJ_STACK_EXTRA];
+  TRef context_call_result[LJ_MAX_JSLOTS+LJ_STACK_EXTRA];
+  uint8_t context_call_state[LJ_MAX_JSLOTS+LJ_STACK_EXTRA];
+  int32_t context_virtual_slot;
 
   int32_t param[JIT_P__MAX];  //  JIT engine parameters.
 

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -338,6 +338,17 @@ static void build_subroutines(BuildCtx *ctx)
   |   str TMP0, [RA, #-8]!		// Prepend true to results.
   |
   |->vm_returnc:
+  |  ldr L, SAVE_L
+  |  ldrb TMP0w, L->context_active
+  |  cbz TMP0w, >9
+  |  str BASE, L->base
+  |  mov CARG1, L
+  |  mov CARG2, BASE
+  |  mov CARG3w, RCw
+  |  bl extern lj_context_leave_native_frame
+  |  ldr BASE, L->base
+  |  mov RC, CRET1
+  |9:
   |  adds RC, RC, #8			// RC = (nresults+1)*8.
   |  mov CRET1, #LUA_YIELD
   |  beq ->vm_unwind_c_eh
@@ -1431,6 +1442,17 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov RC, #(1+1)*8
   |->fff_res:
   |  // RC = (nresults+1)*8, PC = return.
+  |  ldr L, SAVE_L
+  |  ldrb TMP0w, L->context_active
+  |  cbz TMP0w, >9
+  |  str BASE, L->base
+  |  mov CARG1, L
+  |  mov CARG2, BASE
+  |  mov CARG3w, RCw
+  |  bl extern lj_context_leave_native_frame
+  |  ldr BASE, L->base
+  |  mov RC, CRET1
+  |9:
   |  ands CARG1, PC, #FRAME_TYPE
   |   str RCw, SAVE_MULTRES
   |   sub RA, BASE, #16
@@ -1881,6 +1903,11 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov CARG2, PC
   |  // SAVE_PC must hold the _previous_ PC. The callee updates it with PC.
   |  bl extern lj_dispatch_ins		// (lua_State *L, const BCIns *pc)
+  |  ldrb TMP0w, [PC, #-8]
+  |  cmp TMP0w, #BC_CTXLEAVE
+  |  bne >6
+  |  str CRET1w, SAVE_MULTRES
+  |6:
   |3:
   |  ldr BASE, L->base
   |4:  // Re-dispatch to static ins.
@@ -1982,6 +2009,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  add CARG1, GL, #GG_G2J
   |  mov CARG2, PC
   |  bl extern lj_dispatch_stitch	// (jit_State *J, const BCIns *pc)
+  |  str CRET1w, SAVE_MULTRES
   |  ldr BASE, L->base
   |  b ->cont_nop
   |
@@ -3802,6 +3830,45 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_call
     break;
 
+  case BC_CTXCALLM:
+    |  ldr TMP0w, SAVE_MULTRES
+    |  decode_RC8RD NARGS8:RC, RC
+    |  add NARGS8:RC, NARGS8:RC, TMP0
+    |  b >1
+    break;
+  case BC_CTXCALL:
+    |  decode_RC8RD NARGS8:RC, RC
+    |1:
+    |  ldr L, SAVE_L
+    |  str BASE, L->base
+    |  mov CARG1, L
+    |  mov CARG2w, RAw
+    |  lsr CARG3, NARGS8:RC, #3
+    |  bl extern lj_context_prepare_call
+    |  lsl NARGS8:RC, CRET1, #3
+    |  ldr BASE, L->base
+    |  mov RB, BASE
+    |  add BASE, BASE, RA, lsl #3
+    |  ldr CARG3, [BASE]
+    |   sub NARGS8:RC, NARGS8:RC, #8
+    |   add BASE, BASE, #16
+    |  checkfunc CARG3, ->vmeta_call
+    |  ins_call
+    break;
+
+  case BC_CTXCALLT:
+    |  decode_RC8RD NARGS8:RC, RC
+    |  ldr L, SAVE_L
+    |  str BASE, L->base
+    |  mov CARG1, L
+    |  mov CARG2w, RAw
+    |  lsr CARG3, NARGS8:RC, #3
+    |  bl extern lj_context_prepare_tail_call
+    |  lsl NARGS8:RC, CRET1, #3
+    |  ldr BASE, L->base
+    |  b ->BC_CALLT_CONTEXT_Z
+    break;
+
   case BC_CALLMT:
     |  // RA = base, (RB = 0,) RC = extra_nargs
     |  ldr TMP0w, SAVE_MULTRES
@@ -3812,6 +3879,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  lsl NARGS8:RC, RC, #3
     |  // RA = base, (RB = 0,) RC = (nargs+1)*8
     |->BC_CALLT1_Z:
+    |->BC_CALLT_CONTEXT_Z:
     |  add RA, BASE, RA, lsl #3
     |  ldr TMP1, [RA]
     |   sub NARGS8:RC, NARGS8:RC, #8
@@ -4120,13 +4188,34 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
   case BC_RETM:
     |  // RA = results, RC = extra results
     |  ldr TMP0w, SAVE_MULTRES
-    |   ldr PC, [BASE, FRAME_PC]
-    |    add RA, BASE, RA, lsl #3
     |  add RC, TMP0, RC, lsl #3
+    |  ldr L, SAVE_L
+    |  ldrb TMP0w, L->context_active
+    |  cbz TMP0w, >9
+    |  str BASE, L->base
+    |  mov CARG1, L
+    |  mov CARG2, BASE
+    |  mov CARG3w, RCw
+    |  bl extern lj_context_leave_frame
+    |  ldr BASE, L->base
+    |  mov RC, CRET1
+    |9:
+    |  ldr PC, [BASE, FRAME_PC]
+    |   add RA, BASE, RA, lsl #3
     |  b ->BC_RETM_Z
     break;
 
   case BC_RET:
+    |  ldr L, SAVE_L
+    |  ldrb TMP0w, L->context_active
+    |  cbz TMP0w, >9
+    |  str BASE, L->base
+    |  mov CARG1, L
+    |  mov CARG2, BASE
+    |  mov CARG3w, wzr
+    |  bl extern lj_context_leave_frame
+    |  ldr BASE, L->base
+    |9:
     |  // RA = results, RC = nresults+1
     |  ldr PC, [BASE, FRAME_PC]
     |   lsl RC, RC, #3
@@ -4182,6 +4271,16 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     break;
 
   case BC_RET0: case BC_RET1:
+    |  ldr L, SAVE_L
+    |  ldrb TMP0w, L->context_active
+    |  cbz TMP0w, >9
+    |  str BASE, L->base
+    |  mov CARG1, L
+    |  mov CARG2, BASE
+    |  mov CARG3w, wzr
+    |  bl extern lj_context_leave_frame
+    |  ldr BASE, L->base
+    |9:
     |  // RA = results, RC = nresults+1
     |  ldr PC, [BASE, FRAME_PC]
     |   lsl RC, RC, #3
@@ -4656,6 +4755,39 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mov CARG1, L
     |  str PC, SAVE_PC
     |  bl extern tiri_module_activate
+    |  ldr BASE, L->base
+    |  ins_next
+    break;
+
+  case BC_CTXGET:
+    |  ldr L, SAVE_L
+    |  str BASE, L->base
+    |  add CARG2, BASE, RA, lsl #3
+    |  mov CARG1, L
+    |  bl extern lj_context_load
+    |  ldr BASE, L->base
+    |  ins_next
+    break;
+
+  case BC_CTXLEAVE:
+    |  ldr L, SAVE_L
+    |  str BASE, L->base
+    |  mov CARG1, L
+    |  mov CARG2w, RAw
+    |  sub CARG3, PC, #16
+    |  ldr CARG4w, SAVE_MULTRES
+    |  lsr CARG4w, CARG4w, #3
+    |  bl extern lj_context_leave_call
+    |  ldr BASE, L->base
+    |  ins_next
+    break;
+
+  case BC_CTXENTER:
+    |  ldr L, SAVE_L
+    |  str BASE, L->base
+    |  mov CARG1, L
+    |  mov CARG2w, RAw
+    |  bl extern lj_context_enter_call
     |  ldr BASE, L->base
     |  ins_next
     break;

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -549,6 +549,18 @@ static void build_subroutines(BuildCtx *ctx)
   |   stwu TMP1, FRAME_PC(RA)		// Prepend true to results.
   |
   |->vm_returnc:
+  |  lwz L, SAVE_L
+  |  lbz TMP0, L->context_active
+  |  cmpwi TMP0, 0
+  |  beq >9
+  |  stp BASE, L->base
+  |  mr CARG1, L
+  |  mr CARG2, BASE
+  |  mr CARG3, RD
+  |  bl extern lj_context_leave_native_frame
+  |  lp BASE, L->base
+  |  mr RD, CRET1
+  |9:
   |  addi RD, RD, 8			// RD = (nresults+1)*8.
   |   andix. TMP0, PC, FRAME_TYPE
   |  cmpwi cr1, RD, 0
@@ -2033,6 +2045,18 @@ static void build_subroutines(BuildCtx *ctx)
   |  li RD, (1+1)*8
   |->fff_res:
   |  // RA = results, RD = (nresults+1)*8, PC = return.
+  |  lwz L, SAVE_L
+  |  lbz TMP0, L->context_active
+  |  cmpwi TMP0, 0
+  |  beq >9
+  |  stp BASE, L->base
+  |  mr CARG1, L
+  |  mr CARG2, BASE
+  |  mr CARG3, RD
+  |  bl extern lj_context_leave_native_frame
+  |  lp BASE, L->base
+  |  mr RD, CRET1
+  |9:
   |  andix. TMP0, PC, FRAME_TYPE
   |   mr MULTRES, RD
   |  bney ->vm_return
@@ -2859,6 +2883,11 @@ static void build_subroutines(BuildCtx *ctx)
   |   stp BASE, L->base
   |  // SAVE_PC must hold the _previous_ PC. The callee updates it with PC.
   |  bl extern lj_dispatch_ins		// (lua_State *L, const BCIns *pc)
+  |  lbz TMP0, -8(PC)
+  |  cmpwi TMP0, BC_CTXLEAVE
+  |  bne >6
+  |  mr MULTRES, CRET1
+  |6:
   |3:
   |  lp BASE, L->base
   |4:  // Re-dispatch to static ins.
@@ -2973,6 +3002,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  addi CARG1, DISPATCH, GG_DISP2J
   |  mr CARG2, PC
   |  bl extern lj_dispatch_stitch	// (jit_State *J, const BCIns *pc)
+  |  mr MULTRES, CRET1
   |  lp BASE, L->base
   |  b ->cont_nop
   |
@@ -5533,6 +5563,43 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_call
     break;
 
+  case BC_CTXCALLM: case BC_CTXCALL:
+    |  lwz L, SAVE_L
+    |  ld INS, -8(PC)
+    |  decode_RC8 RC, INS
+    if (op IS BC_CTXCALLM) {
+      |  add NARGS8:RC, NARGS8:RC, MULTRES
+    }
+    |  stp BASE, L->base
+    |  mr CARG1, L
+    |  srwi CARG2, RA, 3
+    |  srwi CARG3, NARGS8:RC, 3
+    |  bl extern lj_context_prepare_call
+    |  slwi NARGS8:RC, CRET1, 3
+    |  lp BASE, L->base
+    |  mr TMP2, BASE
+    |  lwzux TMP0, BASE, RA
+    |   lwz LFUNC:RB, 4(BASE)
+    |    subi NARGS8:RC, NARGS8:RC, 8
+    |   addi BASE, BASE, 8
+    |  checkfunc TMP0; bne ->vmeta_call
+    |  ins_call
+    break;
+
+  case BC_CTXCALLT:
+    |  lwz L, SAVE_L
+    |  ld INS, -8(PC)
+    |  decode_RC8 RC, INS
+    |  stp BASE, L->base
+    |  mr CARG1, L
+    |  srwi CARG2, RA, 3
+    |  srwi CARG3, NARGS8:RC, 3
+    |  bl extern lj_context_prepare_tail_call
+    |  slwi NARGS8:RC, CRET1, 3
+    |  lp BASE, L->base
+    |  b ->BC_CALLT_CONTEXT_Z
+    break;
+
   case BC_CALLMT:
     |  // RA = base*8, (RB = 0,) RC = extra_nargs*8
     |  add NARGS8:RC, NARGS8:RC, MULTRES
@@ -5540,6 +5607,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     break;
   case BC_CALLT:
     |  // RA = base*8, (RB = 0,) RC = (nargs+1)*8
+    |->BC_CALLT_CONTEXT_Z:
     |  lwzux TMP0, RA, BASE
     |   lwz LFUNC:RB, 4(RA)
     |    subi NARGS8:RC, NARGS8:RC, 8
@@ -5962,10 +6030,41 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
   case BC_RETM:
     |  // RA = results*8, RD = extra_nresults*8
     |  add RD, RD, MULTRES		// MULTRES >= 8, so RD >= 8.
-    |  // Fall through. Assumes BC_RET follows.
+    |  lwz L, SAVE_L
+    |  lbz TMP0, L->context_active
+    |  cmpwi TMP0, 0
+    |  beq >9
+    |  stp BASE, L->base
+    |  mr CARG1, L
+    |  mr CARG2, BASE
+    |  mr CARG3, RD
+    |  bl extern lj_context_leave_frame
+    |  lp BASE, L->base
+    |  mr RD, CRET1
+    |  ld INS, -8(PC)
+    |  decode_RA8 RA, INS
+    |9:
+    |  b ->BC_RET_CONTEXT_Z
     break;
 
   case BC_RET:
+    if (op != BC_RETM) {
+      |  lwz L, SAVE_L
+      |  lbz TMP0, L->context_active
+      |  cmpwi TMP0, 0
+      |  beq >9
+      |  stp BASE, L->base
+      |  mr CARG1, L
+      |  mr CARG2, BASE
+      |  li CARG3, 0
+      |  bl extern lj_context_leave_frame
+      |  lp BASE, L->base
+      |  ld INS, -8(PC)
+      |  decode_RA8 RA, INS
+      |  decode_RD8 RD, INS
+      |9:
+    }
+    |->BC_RET_CONTEXT_Z:
     |  // RA = results*8, RD = (nresults+1)*8
     |  lwz PC, FRAME_PC(BASE)
     |   add RA, BASE, RA
@@ -6047,6 +6146,20 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     break;
 
   case BC_RET0: case BC_RET1:
+    |  lwz L, SAVE_L
+    |  lbz TMP0, L->context_active
+    |  cmpwi TMP0, 0
+    |  beq >9
+    |  stp BASE, L->base
+    |  mr CARG1, L
+    |  mr CARG2, BASE
+    |  li CARG3, 0
+    |  bl extern lj_context_leave_frame
+    |  lp BASE, L->base
+    |  ld INS, -8(PC)
+    |  decode_RA8 RA, INS
+    |  decode_RD8 RD, INS
+    |9:
     |  // RA = results*8, RD = (nresults+1)*8
     |  lwz PC, FRAME_PC(BASE)
     |   add RA, BASE, RA
@@ -6693,6 +6806,38 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mr CARG1, L
     |  stw PC, SAVE_PC
     |  bl extern tiri_module_activate
+    |  lp BASE, L->base
+    |  ins_next
+    break;
+
+  case BC_CTXGET:
+    |  lwz L, SAVE_L
+    |  stp BASE, L->base
+    |  add CARG2, BASE, RA
+    |  mr CARG1, L
+    |  bl extern lj_context_load
+    |  lp BASE, L->base
+    |  ins_next
+    break;
+
+  case BC_CTXLEAVE:
+    |  lwz L, SAVE_L
+    |  stp BASE, L->base
+    |  mr CARG1, L
+    |  srwi CARG2, RA, 3
+    |  subi CARG3, PC, 16
+    |  srwi CARG4, MULTRES, 3
+    |  bl extern lj_context_leave_call
+    |  lp BASE, L->base
+    |  ins_next
+    break;
+
+  case BC_CTXENTER:
+    |  lwz L, SAVE_L
+    |  stp BASE, L->base
+    |  mr CARG1, L
+    |  srwi CARG2, RA, 3
+    |  bl extern lj_context_enter_call
     |  lp BASE, L->base
     |  ins_next
     break;

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -426,6 +426,19 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov aword [BASE+RA], ITYPE     // Prepend true to results.
   |
   |->vm_returnc:
+  |  mov L:RB, SAVE_L
+  |  cmp byte L:RB->context_active, 0
+  |  je >9
+  |  mov TMP1, RA
+  |  mov L:RB->base, BASE
+  |  mov CARG2, BASE
+  |  mov CARG3d, RDd
+  |  mov L:CARG1, L:RB
+  |  call extern lj_context_leave_native_frame
+  |  mov BASE, L:RB->base
+  |  mov RA, TMP1
+  |  mov RDd, RCd
+  |9:
   |  add RDd, 1            // RD = nresults+1
   |  jz ->vm_unwind_yield
   |  mov MULTRES, RDd
@@ -1771,6 +1784,17 @@ static void build_subroutines(BuildCtx *ctx)
   |->fff_res:
   |  mov MULTRES, RDd
   |->fff_res_:
+  |  mov L:RB, SAVE_L
+  |  cmp byte L:RB->context_active, 0
+  |  je >9
+  |  mov L:RB->base, BASE
+  |  mov CARG2, BASE
+  |  mov CARG3d, RDd
+  |  mov L:CARG1, L:RB
+  |  call extern lj_context_leave_native_frame
+  |  mov BASE, L:RB->base
+  |  mov RDd, RCd
+  |9:
   |  test PCd, FRAME_TYPE
   |  jnz >7
   |5:
@@ -2330,6 +2354,10 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov CARG1, L:RB
   |  // SAVE_PC must hold the _previous_ PC. The callee updates it with PC.
   |  call extern lj_dispatch_ins // (lua_State *L, const BCIns *pc)
+  |  cmp PC_OP, BC_CTXLEAVE
+  |  jne >6
+  |  mov MULTRES, RDd
+  |6:
   |3:
   |  mov BASE, L:RB->base
   |4:
@@ -2440,6 +2468,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  lea CARG1, [DISPATCH+GG_DISP2J]
   |  mov aword [DISPATCH+DISPATCH_J(L)], L:RB
   |  call extern lj_dispatch_stitch // (jit_State *J, const BCIns *pc)
+  |  mov MULTRES, RDd
   |  mov BASE, L:RB->base
   |  jmp ->cont_nop
   |
@@ -4686,6 +4715,44 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_call
     break;
 
+  case BC_CTXCALL: case BC_CTXCALLM:
+    |  ins_A_C
+    if (op IS BC_CTXCALLM) {
+      |  add NARGS:RDd, MULTRES
+    }
+    |  mov L:RB, SAVE_L
+    |  mov L:RB->base, BASE
+    |  mov CARG2d, RAd
+    |  mov CARG3d, NARGS:RDd
+    |  mov L:CARG1, L:RB
+    |  call extern lj_context_prepare_call
+    |  mov BASE, L:RB->base
+    |  mov RBd, RCd
+    |  mov RC, [PC-8]
+    |  movzx RAd, RCH
+    |  mov NARGS:RDd, RBd
+    |  mov LFUNC:RB, [BASE+RA*8]
+    |  checkfunc LFUNC:RB, ->vmeta_call_ra
+    |  lea BASE, [BASE+RA*8+16]
+    |  ins_call
+    break;
+
+  case BC_CTXCALLT:
+    |  ins_AD
+    |  mov L:RB, SAVE_L
+    |  mov L:RB->base, BASE
+    |  mov CARG2d, RAd
+    |  mov CARG3d, NARGS:RDd
+    |  mov L:CARG1, L:RB
+    |  call extern lj_context_prepare_tail_call
+    |  mov BASE, L:RB->base
+    |  mov RBd, RCd
+    |  mov RC, [PC-8]
+    |  movzx RAd, RCH
+    |  mov NARGS:RDd, RBd
+    |  jmp ->BC_CALLT_CONTEXT_Z
+    break;
+
   case BC_CALLMT:
     |  ins_AD  // RA = base, RD = extra_nargs
     |  add NARGS:RDd, MULTRES
@@ -4693,6 +4760,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     break;
   case BC_CALLT:
     |  ins_AD  // RA = base, RD = nargs+1
+    |->BC_CALLT_CONTEXT_Z:
     |  lea RA, [BASE+RA*8+16]
     |  mov KBASE, BASE        // Use KBASE for move + vmeta_call hint.
     |  mov LFUNC:RB, [RA-16]
@@ -5031,11 +5099,38 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
   case BC_RETM:
     |  ins_AD  // RA = results, RD = extra_nresults
     |  add RDd, MULTRES       // MULTRES >=1, so RD >=1.
-    |  // Fall through. Assumes BC_RET follows and ins_AD is a no-op.
+    |  mov L:RB, SAVE_L
+    |  cmp byte L:RB->context_active, 0
+    |  je >9
+    |  mov L:RB->base, BASE
+    |  mov CARG2, BASE
+    |  mov CARG3d, RDd
+    |  mov L:CARG1, L:RB
+    |  call extern lj_context_leave_frame
+    |  mov BASE, L:RB->base
+    |  mov RDd, RCd
+    |  movzx RAd, byte [PC-7]
+    |9:
+    |  jmp ->BC_RET_CONTEXT_Z
     break;
 
   case BC_RET: case BC_RET0: case BC_RET1:
-    |  ins_AD  // RA = results, RD = nresults+1
+    if (op != BC_RETM) {
+      |  mov L:RB, SAVE_L
+      |  cmp byte L:RB->context_active, 0
+      |  je >9
+      |  mov L:RB->base, BASE
+      |  mov CARG2, BASE
+      |  mov CARG3d, MULTRES
+      |  mov L:CARG1, L:RB
+      |  call extern lj_context_leave_frame
+      |  mov BASE, L:RB->base
+      |  mov RC, [PC-8]
+      |  movzx RAd, RCH
+      |  shr RC, 16  // RA = results, RD = nresults+1
+      |9:
+    }
+    |->BC_RET_CONTEXT_Z:
     if (op != BC_RET0) {
       |  shl RAd, 3
     }
@@ -5659,6 +5754,41 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mov L:CARG1, L:RB
     |  mov SAVE_PC, PC
     |  call extern tiri_module_activate
+    |  mov BASE, L:RB->base
+    |  ins_next
+    break;
+
+  case BC_CTXGET:
+    |  ins_AD
+    |  mov L:RB, SAVE_L
+    |  mov L:RB->base, BASE
+    |  lea CARG2, [BASE+RA*8]
+    |  mov L:CARG1, L:RB
+    |  call extern lj_context_load
+    |  mov BASE, L:RB->base
+    |  ins_next
+    break;
+
+  case BC_CTXLEAVE:
+    |  ins_AD
+    |  mov L:RB, SAVE_L
+    |  mov L:RB->base, BASE
+    |  mov CARG2d, RAd
+    |  lea CARG3, [PC-16]
+    |  mov CARG4d, MULTRES
+    |  mov L:CARG1, L:RB
+    |  call extern lj_context_leave_call
+    |  mov BASE, L:RB->base
+    |  ins_next
+    break;
+
+  case BC_CTXENTER:
+    |  ins_AD
+    |  mov L:RB, SAVE_L
+    |  mov L:RB->base, BASE
+    |  mov CARG2d, RAd
+    |  mov L:CARG1, L:RB
+    |  call extern lj_context_enter_call
     |  mov BASE, L:RB->base
     |  ins_next
     break;

--- a/src/tiri/jit/src/lib/lib.cpp
+++ b/src/tiri/jit/src/lib/lib.cpp
@@ -108,6 +108,10 @@ void lj_lib_register(lua_State *L, const char* libname, const uint8_t* p, const 
    lj_gc_anybarriert(L, tab);
    tab->nomm = 0;
 
+   // Internal namespaces are implementation interfaces rather than client tables.  Calls through them inherit the
+   // caller's context; _G remains the permanent root context.
+   if (not libname or strcmp(libname, "_G") != 0) lj_tab_mark_context_exempt(tab);
+
    for (;;) {
       uint32_t tag = *p++;
       MSize len = tag & LIBINIT_LENMASK;

--- a/src/tiri/jit/src/lj_api.cpp
+++ b/src/tiri/jit/src/lj_api.cpp
@@ -1446,6 +1446,7 @@ static TValue * api_call_base(lua_State *L, int nargs)
 
 extern void lua_call(lua_State *L, int nargs, int nresults)
 {
+   size_t context_depth = lj_context_depth(L);
    lj_checkapi(L->status IS LUA_OK or L->status IS LUA_ERRERR, "thread called in wrong state %d", L->status);
    lj_checkapi_slot(nargs + 1);
 
@@ -1456,6 +1457,7 @@ extern void lua_call(lua_State *L, int nargs, int nresults)
    lj_checkapi(L->top <= tvref(L->maxstack), "stack overflow");
 
    lj_vm_call(L, api_call_base(L, nargs), nresults + 1);
+   lj_assertL(lj_context_depth(L) IS context_depth, "lua_call returned with unbalanced contextual activations");
 }
 
 //********************************************************************************************************************
@@ -1463,6 +1465,7 @@ extern void lua_call(lua_State *L, int nargs, int nresults)
 
 extern int lua_pcall(lua_State *L, int nargs, int nresults, int errfunc)
 {
+   size_t context_depth = lj_context_depth(L);
    global_State* g = G(L);
    uint8_t oldh = hook_save(g);
    ptrdiff_t ef;
@@ -1484,6 +1487,7 @@ extern int lua_pcall(lua_State *L, int nargs, int nresults, int errfunc)
    }
    status = lj_vm_pcall(L, api_call_base(L, nargs), nresults + 1, ef);
    if (status) hook_restore(g, oldh);
+   lj_assertL(lj_context_depth(L) IS context_depth, "lua_pcall returned with unbalanced contextual activations");
    return status;
 }
 

--- a/src/tiri/jit/src/lj_asm.cpp
+++ b/src/tiri/jit/src/lj_asm.cpp
@@ -967,6 +967,7 @@ static void asm_snap_alloc(ASMState* as, int snapno)
    SnapEntry* map = &as->T->snapmap[snap->mapofs];
    MSize n, nent = snap->nent;
    as->snapfilt1 = as->snapfilt2 = 0;
+   if (snap->context_ref and not irref_isk(snap->context_ref)) asm_snap_alloc1(as, snap->context_ref);
    for (n = 0; n < nent; n++) {
       SnapEntry sn = map[n];
       IRRef ref = snap_ref(sn);
@@ -2042,7 +2043,7 @@ static void asm_tail_link(ASMState* as)
       emit_loadu64(as, RID_LPC, u64ptr(pc));
       mres = (int32_t)(snap->nslots - baseslot - LJ_FR2);
       switch (bc_op(*pc)) {
-      case BC_CALLM: case BC_CALLMT:
+      case BC_CALLM: case BC_CALLMT: case BC_CTXCALLM:
          mres -= (int32_t)(1 + LJ_FR2 + bc_a(*pc) + bc_c(*pc)); break;
       case BC_RETM: mres -= (int32_t)(bc_a(*pc) + bc_d(*pc)); break;
       case BC_TSETM: mres -= (int32_t)bc_a(*pc); break;

--- a/src/tiri/jit/src/lj_dispatch.cpp
+++ b/src/tiri/jit/src/lj_dispatch.cpp
@@ -130,8 +130,10 @@ void lj_dispatch_update(global_State* g)
       if ((oldmode ^ mode) & (DISPMODE_PROF | DISPMODE_REC | DISPMODE_INS)) {
          // Need to update the whole table.
          if (!(mode & DISPMODE_INS)) {  // No ins dispatch?
-            // Copy static dispatch table to dynamic dispatch table.
-            memcpy(&disp[0], &disp[GG_LEN_DDISP], GG_LEN_SDISP * sizeof(ASMFunction));
+            // Restore ordinary instructions without disturbing an independently active call hook.
+            for (uint32_t i = 0; i < BC__MAX; i++) {
+               if (not bc_is_func_header((BCOp)i)) disp[i] = disp[GG_LEN_DDISP + i];
+            }
             // Overwrite with dynamic return dispatch.
             if ((mode & DISPMODE_RET)) {
                disp[BC_RETM] = lj_vm_rethook;
@@ -145,9 +147,8 @@ void lj_dispatch_update(global_State* g)
             ASMFunction f = (mode & DISPMODE_PROF) ? lj_vm_profhook :
                (mode & DISPMODE_REC) ? lj_vm_record : lj_vm_inshook;
             uint32_t i;
-            for (i = 0; i < GG_LEN_SDISP; i++) disp[i] = f;
-            for (i = BC_FUNCF; i <= BC_FUNCCW; ++i) {
-               disp[i] = (mode & DISPMODE_CALL) ? lj_vm_callhook : makeasmfunc(lj_bc_ofs[i]);
+            for (i = 0; i < BC__MAX; i++) {
+               if (not bc_is_func_header((BCOp)i)) disp[i] = f;
             }
          }
       }
@@ -177,13 +178,13 @@ void lj_dispatch_update(global_State* g)
 
       if ((oldmode ^ mode) & DISPMODE_CALL) {  // Update the whole table?
          uint32_t i;
-         if ((mode & DISPMODE_CALL) IS 0) {  // No call hooks?
-            for (i = BC_FUNCF; i <= BC_FUNCCW; ++i) disp[i] = makeasmfunc(lj_bc_ofs[i]);
-            for (i = BC__MAX; i < GG_LEN_DDISP; ++i) disp[i] = makeasmfunc(lj_bc_ofs[i]);
+         if ((mode & DISPMODE_CALL) == 0) {  // No call hooks?
+            for (i = BC_FUNCF; i <= BC_FUNCCW; i++) disp[i] = makeasmfunc(lj_bc_ofs[i]);
+            for (i = BC__MAX; i < GG_LEN_DDISP; i++) disp[i] = makeasmfunc(lj_bc_ofs[i]);
          }
          else {
-            for (i = BC_FUNCF; i <= BC_FUNCCW; ++i) disp[i] = lj_vm_callhook;
-            for (i = BC__MAX; i < GG_LEN_DDISP; ++i) disp[i] = lj_vm_callhook;
+            for (i = BC_FUNCF; i <= BC_FUNCCW; i++) disp[i] = lj_vm_callhook;
+            for (i = BC__MAX; i < GG_LEN_DDISP; i++) disp[i] = lj_vm_callhook;
          }
       }
 
@@ -359,7 +360,13 @@ static BCREG cur_topslot(GCproto* pt, const BCIns* pc, uint32_t nres)
    BCIns ins = pc[-1];
    if (bc_op(ins) == BC_UCLO) ins = pc[bc_j(ins)];
    switch (bc_op(ins)) {
-      case BC_CALLM: case BC_CALLMT: return bc_a(ins) + bc_c(ins) + nres - 1 + 1 + LJ_FR2;
+      case BC_CALLM: case BC_CALLMT: case BC_CTXCALLM:
+         return bc_a(ins) + bc_c(ins) + nres - 1 + 1 + LJ_FR2;
+      case BC_CTXLEAVE: {
+         BCIns call_ins = pc[-2];
+         if (bc_b(call_ins) or not nres) return pt->framesize;
+         return bc_a(ins) + nres - 1;
+      }
       case BC_RETM: return bc_a(ins) + bc_d(ins) + nres - 1;
       case BC_TSETM: return bc_a(ins) + nres - 1;
       default: return pt->framesize;
@@ -369,7 +376,7 @@ static BCREG cur_topslot(GCproto* pt, const BCIns* pc, uint32_t nres)
 //********************************************************************************************************************
 // Instruction dispatch. Used by instr/line/return hooks or when recording.
 
-void lj_dispatch_ins(lua_State* L, const BCIns* pc)
+uint32_t lj_dispatch_ins(lua_State* L, const BCIns* pc)
 {
    ERRNO_SAVE
    GCfunc *fn = curr_func(L);
@@ -378,6 +385,7 @@ void lj_dispatch_ins(lua_State* L, const BCIns* pc)
    const BCIns* oldpc = cframe_pc(cf);
    global_State* g = G(L);
    BCREG slots;
+   uint32_t multres = cframe_multres(cf);
    setcframe_pc(cf, pc);
    slots = cur_topslot(pt, pc, cframe_multres_n(cf));
    L->top = L->base + slots;  //  Fix top.
@@ -414,6 +422,7 @@ void lj_dispatch_ins(lua_State* L, const BCIns* pc)
 
    if ((g->hookmask & LUA_MASKRET) and bc_isret(bc_op(pc[-1]))) callhook(L, LUA_HOOKRET, -1);
    ERRNO_RESTORE
+   return multres;
 }
 
 //********************************************************************************************************************
@@ -489,16 +498,27 @@ out :
 //********************************************************************************************************************
 // Stitch a new trace.
 
-void lj_dispatch_stitch(jit_State* J, const BCIns* pc)
+uint32_t lj_dispatch_stitch(jit_State* J, const BCIns* pc)
 {
    ERRNO_SAVE
    lua_State* L = J->L;
    void* cf = cframe_raw(L->cframe);
+   uint32_t multres = cframe_multres(cf);
    const BCIns* oldpc = cframe_pc(cf);
    setcframe_pc(cf, pc);
    // Before dispatch, have to bias PC by 1.
    L->top = L->base + cur_topslot(curr_proto(L), pc + 1, cframe_multres_n(cf));
-   lj_trace_stitch(J, pc - 1);  //  Point to the CALL instruction.
+   BCIns call_ins = pc[-1];
+   if ((bc_op(call_ins) IS BC_CTXCALL or bc_op(call_ins) IS BC_CTXCALLM) and bc_b(call_ins) IS 0) {
+      // A stitched trace has no IR value for the dynamic result count consumed by CTXLEAVE. Blacklist this link until
+      // MULTRES becomes explicit trace state; fixed-result contextual calls remain eligible for stitching.
+      GCtrace *trace = traceref(J, J->exitno);
+      trace->link = trace->traceno;
+   }
+   else {
+      lj_trace_stitch(J, pc - 1);  //  Point to the CALL instruction.
+   }
    setcframe_pc(cf, oldpc);
    ERRNO_RESTORE
+   return multres;
 }

--- a/src/tiri/jit/src/lj_dispatch.h
+++ b/src/tiri/jit/src/lj_dispatch.h
@@ -75,9 +75,9 @@ LJ_FUNC void lj_dispatch_init_hotcount(global_State* g);
 LJ_FUNC void lj_dispatch_update(global_State* g);
 
 // Instruction dispatch callback for hooks or when recording.
-LJ_FUNCA void lj_dispatch_ins(lua_State* L, const BCIns* pc);
+LJ_FUNCA uint32_t lj_dispatch_ins(lua_State* L, const BCIns* pc);
 LJ_FUNCA ASMFunction lj_dispatch_call(lua_State* L, const BCIns* pc);
-LJ_FUNCA void lj_dispatch_stitch(jit_State* J, const BCIns* pc);
+LJ_FUNCA uint32_t lj_dispatch_stitch(jit_State* J, const BCIns* pc);
 
 #define ERRNO_SAVE
 #define ERRNO_RESTORE

--- a/src/tiri/jit/src/lj_ir.cpp
+++ b/src/tiri/jit/src/lj_ir.cpp
@@ -18,6 +18,7 @@
 #include "lj_ir.h"
 #include "lj_jit.h"
 #include "lj_ircall.h"
+#include "runtime/lj_state.h"
 #include "lj_iropt.h"
 #include "lj_trace.h"
 #include "lj_record.h"

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -227,6 +227,11 @@ typedef struct CCallInfo {
   /* Try-except exception handling */ \
   _(ANY,        lj_try_enter,      4,  FS, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_try_leave,      1,  FS, NIL, CCI_L) \
+  /* State-local table context */ \
+  _(ANY,        lj_context_current_jit,  1, FS, TAB, CCI_L) \
+  _(ANY,        lj_context_enter_jit,    3,  S, NIL, CCI_L) \
+  _(ANY,        lj_context_leave_jit,    2,  S, NIL, CCI_L) \
+  _(ANY,        lj_context_tail_jit,     4,  S, NIL, CCI_L) \
   /* Native object field access */ \
   _(ANY,        bc_object_getfield, 5, S, NIL, CCI_L|CCI_T) \
   _(ANY,        bc_object_setfield, 5, S, NIL, CCI_L|CCI_T) \

--- a/src/tiri/jit/src/lj_opt_dce.cpp
+++ b/src/tiri/jit/src/lj_opt_dce.cpp
@@ -25,6 +25,7 @@ static void dce_marksnap(jit_State* J)
    SnapNo i, nsnap = J->cur.nsnap;
    for (i = 0; i < nsnap; i++) {
       SnapShot* snap = &J->cur.snap[i];
+      if (snap->context_ref >= REF_FIRST) irt_setmark(IR(snap->context_ref)->t);
       SnapEntry* map = &J->cur.snapmap[snap->mapofs];
       MSize n, nent = snap->nent;
       for (n = 0; n < nent; n++) {

--- a/src/tiri/jit/src/lj_opt_fold.cpp
+++ b/src/tiri/jit/src/lj_opt_fold.cpp
@@ -2218,8 +2218,13 @@ LJFOLDF(fwd_sload)
       return tref_ref(tr) < J->chain[IR_RETF] ? EMITFOLD : tr;
    }
    else {
-      lj_assertJ(J->slot[fins->op1] != 0, "uninitialized slot accessed");
-      return J->slot[fins->op1];
+      TRef slot_ref = J->slot[fins->op1];
+      if (not slot_ref) {
+         slot_ref = irt_type(fins->t) IS IRT_FUNC ? J->context_call_func[fins->op1] :
+            J->context_call_result[fins->op1];
+      }
+      lj_assertJ(slot_ref != 0, "uninitialized slot accessed");
+      return slot_ref;
    }
 }
 

--- a/src/tiri/jit/src/lj_opt_loop.cpp
+++ b/src/tiri/jit/src/lj_opt_loop.cpp
@@ -227,10 +227,16 @@ static void loop_subst_snap(jit_State* J, SnapShot* osnap, SnapEntry* loopmap, I
    // Setup new snapshot.
    snap->mapofs = (uint32_t)nmapofs;
    snap->ref = (IRRef1)J->cur.nins;
+   snap->context_ref = osnap->context_ref;
+   if (snap->context_ref and not irref_isk(snap->context_ref)) {
+      lj_assertJ(subst[snap->context_ref] != REF_DROP, "virtual context dropped during loop substitution");
+      snap->context_ref = subst[snap->context_ref];
+   }
+   snap->context_owner_slot = osnap->context_owner_slot;
    snap->mcofs = 0;
    snap->nslots = nslots;
    snap->topslot = osnap->topslot;
-   snap->count = 0;
+   snap->count = snap->context_ref ? SNAPCOUNT_DONE : 0;
    nmap = &J->cur.snapmap[nmapofs];
    // Substitute snapshot slots.
    on = ln = nn = 0;
@@ -378,6 +384,21 @@ static void loop_unroll(LoopState* lps)
    *psentinel = J->cur.snapmap[J->cur.snap[0].nent];  //  Restore PC.
 
    loop_emit_phi(J, subst, phi, nphi, onsnap);
+
+   // Contextual calls remove their receiver slot after the call and retain the overwritten function/result refs for
+   // SLOAD forwarding.  Loop copy-substitution must advance those retained refs just like the ordinary slot map;
+   // otherwise they can point at an instruction number that the loop body has reused for a different value.
+   for (size_t slot = 0; slot < LJ_MAX_JSLOTS + LJ_STACK_EXTRA; slot++) {
+      TRef *retained_refs[] = {
+         &J->context_call_func[slot], &J->context_call_receiver[slot], &J->context_call_result[slot]
+      };
+      for (TRef *retained_ref : retained_refs) {
+         IRRef ref = tref_ref(*retained_ref);
+         if (ref >= REF_FIRST and ref < invar and subst[ref] != REF_DROP) {
+            *retained_ref = (*retained_ref & ~TREF_REFMASK) | subst[ref];
+         }
+      }
+   }
 }
 
 // Undo any partial changes made by the loop optimization.

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1311,11 +1311,152 @@ static void rec_call_setup(jit_State *J, BCREG func, ptrdiff_t nargs)
    J->maxslot = (BCREG)nargs;
 }
 
+// Record an ordinary contextual activation. The table reference remains live in IR and the owner address is derived
+// from REF_BASE, so stack relocation cannot invalidate context ownership. Guards at CTXENTER resume before entry;
+// guards in the call or callee resume with the activation already installed; guards after CTXLEAVE see it restored.
+
+static bool rec_context_is_tail_call(jit_State *J, BCREG CallBase)
+{
+   GCproto *current_proto = curr_proto(J->L);
+   const BCIns *limit = proto_bc(current_proto) + current_proto->sizebc;
+   for (const BCIns *pc = J->pc + 1; pc < limit; pc++) {
+      BCOp op = bc_op(*pc);
+      if ((op IS BC_CTXCALL or op IS BC_CTXCALLM or op IS BC_CTXCALLT) and bc_a(*pc) IS CallBase) {
+         return op IS BC_CTXCALLT;
+      }
+   }
+   return false;
+}
+
+static TRef rec_context_current(jit_State *J)
+{
+   for (int32_t slot = int32_t(J->baseslot) - 1; slot >= 0; slot--) {
+      if (J->context_call_receiver[slot]) return J->context_call_receiver[slot];
+   }
+   return lj_ir_call(J, IRCALL_lj_context_current_jit);
+}
+
+enum : uint8_t {
+   CONTEXT_CALL_NONE,
+   CONTEXT_CALL_VIRTUAL,
+   CONTEXT_CALL_MATERIALISED
+};
+
+static bool rec_context_has_activation(jit_State *J)
+{
+   for (uint8_t state : J->context_call_state) {
+      if (state != CONTEXT_CALL_NONE) return true;
+   }
+   return false;
+}
+
+static void rec_context_materialise(jit_State *J)
+{
+   int32_t function_slot = J->context_virtual_slot;
+   if (function_slot < 0) return;
+
+   TRef receiver = J->context_call_receiver[function_slot];
+   lj_assertJ(tref_istab(receiver), "virtual context receiver is not a table");
+   lj_assertJ(J->context_call_state[function_slot] IS CONTEXT_CALL_VIRTUAL,
+      "virtual context slot has inconsistent state");
+
+   IRBuilder ir(J);
+   int32_t owner_slot = function_slot + 1 + LJ_FR2;
+   TRef owner_base = rec_stack_slot_addr(J, ir, owner_slot);
+   lj_ir_call(J, IRCALL_lj_context_enter_jit, receiver, owner_base);
+   J->context_call_state[function_slot] = CONTEXT_CALL_MATERIALISED;
+   J->context_virtual_slot = -1;
+   // Guards emitted later in the same bytecode must not reuse a snapshot that still describes virtual state.
+   lj_snap_add(J);
+}
+
+static void rec_context_enter(jit_State *J, BCREG CallBase)
+{
+   cTValue *callable = &J->L->base[CallBase];
+   bool tail_call = rec_context_is_tail_call(J, CallBase);
+   bool native_target = (not tvisfunc(callable) or not isluafunc(funcV(callable))) and not tail_call;
+
+   TRef receiver = getslot(J, int32_t(CallBase) - 1);
+   if (not tref_istab(receiver)) {
+      return;
+   }
+
+   if (tail_call or native_target) rec_context_materialise(J);
+
+   int32_t function_slot = int32_t(J->baseslot) + int32_t(CallBase);
+   J->context_call_func[function_slot] = getslot(J, CallBase);
+   if (native_target) return;
+
+   if (not tail_call) {
+      J->context_call_receiver[function_slot] = receiver;
+      if (not J->L->context_active and not rec_context_has_activation(J)) {
+         J->context_call_state[function_slot] = CONTEXT_CALL_VIRTUAL;
+         J->context_virtual_slot = function_slot;
+         J->needsnap = 1;
+         return;
+      }
+      rec_context_materialise(J);
+      J->context_call_state[function_slot] = CONTEXT_CALL_MATERIALISED;
+   }
+   IRBuilder ir(J);
+   int32_t owner_slot = int32_t(J->baseslot) + int32_t(CallBase) + 1 + LJ_FR2;
+   TRef owner_base = rec_stack_slot_addr(J, ir, owner_slot);
+   lj_ir_call(J, IRCALL_lj_context_enter_jit, receiver, owner_base);
+   J->needsnap = 1;
+}
+
+// Restore an ordinary contextual activation and model the interpreter's removal of receiver/lookup temporaries from
+// the result layout. CTXLEAVE always follows CTXCALL/CTXCALLM, so the preceding call instruction defines result arity.
+
+static void rec_context_leave(jit_State *J, BCREG CallBase, const BCIns *LeavePc)
+{
+   int32_t function_slot = int32_t(J->baseslot) + int32_t(CallBase);
+   if (not J->context_call_func[function_slot]) {
+      lj_record_stop(J, TraceLink::INTERP, 0);
+      return;
+   }
+   uint8_t context_state = J->context_call_state[function_slot];
+   if (context_state IS CONTEXT_CALL_VIRTUAL) {
+      lj_assertJ(J->context_virtual_slot IS function_slot, "virtual context leave has inconsistent owner");
+      J->context_virtual_slot = -1;
+   }
+   else {
+      IRBuilder ir(J);
+      int32_t owner_slot = int32_t(J->baseslot) + int32_t(CallBase) + 1 + LJ_FR2;
+      TRef owner_base = rec_stack_slot_addr(J, ir, owner_slot);
+      lj_ir_call(J, IRCALL_lj_context_leave_jit, owner_base);
+   }
+   J->context_call_state[function_slot] = CONTEXT_CALL_NONE;
+
+   BCIns call_ins = LeavePc[-1];
+   lj_assertJ(bc_op(call_ins) IS BC_CTXCALL or bc_op(call_ins) IS BC_CTXCALLM,
+      "CTXLEAVE does not follow an ordinary contextual call");
+   ptrdiff_t result_count = bc_b(call_ins) ? ptrdiff_t(bc_b(call_ins)) - 1 :
+      ptrdiff_t(J->maxslot) - ptrdiff_t(CallBase);
+   int32_t result_shift = int32_t(bc_d(*LeavePc));
+   if (result_shift IS 0) result_shift = 1;
+   SlotView slots(J);
+   BCREG old_maxslot = slots.maxslot();
+   for (ptrdiff_t i = 0; i < result_count; i++) {
+      int32_t result_slot = int32_t(CallBase) + int32_t(i);
+      J->context_call_result[int32_t(J->baseslot) + result_slot] = getslot(J, result_slot);
+   }
+   if (result_count > 0) {
+      slots.copy(int32_t(CallBase) - result_shift, CallBase, result_count);
+   }
+   BCREG new_maxslot = BCREG(int32_t(CallBase) - result_shift + result_count);
+   if (old_maxslot > new_maxslot) slots.clear_range(new_maxslot, old_maxslot - new_maxslot);
+   slots.set_maxslot(new_maxslot);
+   J->needsnap = 1;
+}
+
 //********************************************************************************************************************
 // Record call.
 
 void lj_record_call(jit_State *J, BCREG func, ptrdiff_t nargs)
 {
+   cTValue *callable = &J->L->base[func];
+   if (not tvisfunc(callable) or not isluafunc(funcV(callable))) rec_context_materialise(J);
    rec_call_setup(J, func, nargs);
    FrameManager fm(J);
    // Bump frame.
@@ -1327,25 +1468,54 @@ void lj_record_call(jit_State *J, BCREG func, ptrdiff_t nargs)
 //********************************************************************************************************************
 // Record tail call.
 
-void lj_record_tailcall(jit_State *J, BCREG func, ptrdiff_t nargs)
+static void rec_tailcall_compact(jit_State *J, BCREG Func)
 {
-   rec_call_setup(J, func, nargs);
    FrameManager fm(J);
    if (frame_isvarg(J->L->base - 1)) {
       BCREG cbase = (BCREG)frame_delta(J->L->base - 1);
       if (FRC::dec_depth(J) < 0) lj_trace_err(J, LJ_TRERR_NYIRETL);
       fm.pop_delta_frame(cbase);
-      func += cbase;
+      Func += cbase;
    }
 
    // Move func + args down.
 
-   if (fm.at_root_baseslot()) J->base[func + 1] = TREF_FRAME;
-   fm.compact_tailcall(func, J->maxslot);
+   if (fm.at_root_baseslot()) J->base[Func + 1] = TREF_FRAME;
+   fm.compact_tailcall(Func, J->maxslot);
 
    // Note: the new TREF_FRAME is now at J->base[-1] (even for slot #0).
    // Tailcalls can form a loop, so count towards the loop unroll limit.
    if (++J->tailcalled > J->loopunroll) lj_trace_err(J, LJ_TRERR_LUNROLL);
+}
+
+void lj_record_tailcall(jit_State *J, BCREG func, ptrdiff_t nargs)
+{
+   rec_context_materialise(J);
+   rec_call_setup(J, func, nargs);
+   rec_tailcall_compact(J, func);
+}
+
+static void rec_context_tailcall(jit_State *J, BCREG CallBase, ptrdiff_t ArgumentCount)
+{
+   rec_context_materialise(J);
+   cTValue *callable = &J->L->base[CallBase];
+   if (not tvisfunc(callable)) {
+      lj_trace_err(J, LJ_TRERR_NYIBC);
+   }
+
+   TRef receiver = getslot(J, int32_t(CallBase) - 1);
+   rec_call_setup(J, CallBase, ArgumentCount);
+
+   if (tref_istab(receiver)) {
+      IRBuilder ir(J);
+      int32_t prepared_slot = int32_t(J->baseslot) + int32_t(CallBase) + 1 + LJ_FR2;
+      TRef prepared_owner = rec_stack_slot_addr(J, ir, prepared_slot);
+      TRef outgoing_owner = rec_stack_slot_addr(J, ir, int32_t(J->baseslot));
+      lj_ir_call(J, IRCALL_lj_context_tail_jit, receiver, prepared_owner, outgoing_owner);
+      J->needsnap = 1;
+   }
+
+   rec_tailcall_compact(J, CallBase);
 }
 
 //********************************************************************************************************************
@@ -1381,6 +1551,14 @@ void lj_record_ret(jit_State *J, BCREG rbase, ptrdiff_t gotresults)
    ptrdiff_t i;
    FrameManager fm(J);
    SlotView slots(J);
+
+   if (not J->L->context_stack.empty() and J->L->context_stack.back().tail_transfer and
+         J->L->context_stack.back().owner_base IS savestack(J->L, J->L->base)) {
+      IRBuilder ir(J);
+      TRef owner_base = rec_stack_slot_addr(J, ir, int32_t(J->baseslot));
+      lj_ir_call(J, IRCALL_lj_context_leave_jit, owner_base);
+   }
+
    for (i = 0; i < gotresults; i++) (void)getslot(J, rbase + i);  //  Ensure all results have a reference.
 
    while (frame_ispcall(frame)) {  // Immediately resolve pcall() returns.
@@ -1395,9 +1573,17 @@ void lj_record_ret(jit_State *J, BCREG rbase, ptrdiff_t gotresults)
       J->needsnap = 1;  //  Stop catching on-trace errors.
    }
 
-   // Return to lower frame via interpreter for unhandled cases.
+   bool contextual_caller = false;
+   if (frame_islua(frame)) {
+      BCOp caller_op = bc_op(*(frame_pc(frame) - 1));
+      contextual_caller = caller_op IS BC_CTXCALL or caller_op IS BC_CTXCALLM;
+   }
+
+   // A return-root trace has no CTXENTER metadata for a contextual caller below its root. Let the interpreter perform
+   // that return so it can restore the caller activation and compact the result slots before tracing resumes.
    if (FRC::at_root_depth(J) and J->pt and bc_isret(bc_op(*J->pc)) and
-      (not frame_islua(frame) or (J->parent IS 0 and J->exitno IS 0 and !bc_isret(bc_op(J->cur.startins))))) {
+      (not frame_islua(frame) or contextual_caller or
+       (J->parent IS 0 and J->exitno IS 0 and !bc_isret(bc_op(J->cur.startins))))) {
       // NYI: specialise to frame type and return directly, not via RET*.
       slots.clear_range(0, rbase);  //  Purge dead slots.
       slots.set_maxslot(rbase + (BCREG)gotresults);
@@ -4348,12 +4534,37 @@ void lj_record_ins(jit_State *J)
       lj_record_call(J, ra, (ptrdiff_t)rc - 1);
       break;
 
+   case BC_CTXCALLM:
+      rc = (BCREG)(J->L->top - J->L->base) - ra - 1;
+      [[fallthrough]];
+
+   case BC_CTXCALL: {
+      lj_record_call(J, ra, (ptrdiff_t)rc - 1);
+      break;
+   }
+
    case BC_CALLMT:
       rc = (BCREG)(J->L->top - J->L->base) - ra - 1;
       [[fallthrough]];
 
    case BC_CALLT:
       lj_record_tailcall(J, ra, (ptrdiff_t)rc - 1);
+      break;
+
+   case BC_CTXCALLT:
+      rec_context_tailcall(J, ra, (ptrdiff_t)rc - 1);
+      break;
+
+   case BC_CTXGET:
+      rc = rec_context_current(J);
+      break;
+
+   case BC_CTXENTER:
+      rec_context_enter(J, ra);
+      break;
+
+   case BC_CTXLEAVE:
+      rec_context_leave(J, ra, pc);
       break;
 
    case BC_VARG:
@@ -4468,9 +4679,8 @@ void lj_record_ins(jit_State *J)
    case BC_CHECK:
    case BC_RAISE:
    case BC_MODACT:
-      // These bytecodes throw exceptions or materialise GC closures and cannot be compiled into traces.
-      // Exit to interpreter to handle them. This avoids trace abort and ensures
-      // clean handoff without corrupting interpreter state.
+      // These bytecodes throw, materialise GC closures or access VM state not yet represented by the recorder.
+      // Exit to the interpreter so the handoff cannot corrupt interpreter state.
       lj_snap_add(J);
       lj_record_stop(J, TraceLink::INTERP, 0);
       break;
@@ -4606,6 +4816,11 @@ static const BCIns *rec_setup_root(jit_State *J)
          // No bytecode range check for stitched traces.
          pc++;
          break;
+      case BC_CTXCALLM:
+      case BC_CTXCALL: {
+         pc++;
+         break;
+      }
       default:
          lj_assertJ(0, "bad root trace start bytecode %d", bc_op(ins));
          break;
@@ -4622,6 +4837,11 @@ void lj_record_setup(jit_State *J)
 
    // Initialise state related to current trace.
    memset(J->slot, 0, sizeof(J->slot));
+   memset(J->context_call_func, 0, sizeof(J->context_call_func));
+   memset(J->context_call_receiver, 0, sizeof(J->context_call_receiver));
+   memset(J->context_call_result, 0, sizeof(J->context_call_result));
+   memset(J->context_call_state, 0, sizeof(J->context_call_state));
+   J->context_virtual_slot = -1;
    memset(J->trymat, 0, sizeof(J->trymat));
    memset(J->chain, 0, sizeof(J->chain));
    J->try_stores = 0;

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1241,6 +1241,7 @@ static void rec_isarr(jit_State *J, BCREG ra)
 // Record calls and returns
 
 // Dynamic and trusted inferred results specialise calls by prototype because their metadata describes the prototype.
+// Contextual calls also require prototype guards because their virtual snapshots cannot grow direct side traces.
 
 static bool rec_proto_specialise_by_prototype(const GCproto *Proto)
 {
@@ -1262,23 +1263,23 @@ static bool rec_proto_specialise_by_prototype(const GCproto *Proto)
 
 // Specialise to the runtime value of the called function or its prototype.
 
-static TRef rec_call_specialise(jit_State *J, GCfunc* fn, TRef tr)
+static TRef rec_call_specialise(jit_State *J, GCfunc *Function, TRef Ref, bool PrototypeSpecialisation)
 {
    IRBuilder ir(J);
    TRef kfunc;
-   if (isluafunc(fn)) {
-      GCproto* pt = funcproto(fn);
+   if (isluafunc(Function)) {
+      GCproto* pt = funcproto(Function);
       // Too many closures created? Probably not a monomorphic function.
-      if (rec_proto_specialise_by_prototype(pt)) {  // Specialise to prototype instead.
-         TRef trpt = ir.fload_ptr(tr, IRFL_FUNC_PC);
+      if (PrototypeSpecialisation or rec_proto_specialise_by_prototype(pt)) {  // Specialise to prototype instead.
+         TRef trpt = ir.fload_ptr(Ref, IRFL_FUNC_PC);
          ir.guard_eq(trpt, ir.kptr(proto_bc(pt)), IRT_PGC);
          (void)lj_ir_kgc(J, obj2gco(pt), IRT_PROTO);  //  Prevent GC of proto.
-         return tr;
+         return Ref;
       }
    }
    // Otherwise specialise to the function (closure) value itself.
-   kfunc = ir.kfunc(fn);
-   ir.guard_eq(tr, kfunc, IRT_FUNC);
+   kfunc = ir.kfunc(Function);
+   ir.guard_eq(Ref, kfunc, IRT_FUNC);
    return kfunc;
 }
 
@@ -1305,7 +1306,12 @@ static void rec_call_setup(jit_State *J, BCREG func, ptrdiff_t nargs)
       functv = &ix.mobjv;
    }
 
-   kfunc = rec_call_specialise(J, funcV(functv), fbase[0]);
+   BCOp call_op = bc_op(*J->pc);
+   bool contextual_call = call_op IS BC_CTXCALL or call_op IS BC_CTXCALLM or call_op IS BC_CTXCALLT;
+   // Virtual contextual activations cannot link side traces directly because their runtime state is materialised only
+   // when an exit resumes in the interpreter.  Guard Lua callees by prototype so fresh equivalent closures reuse the
+   // parent trace instead of repeatedly taking an exit whose snapshot cannot grow a side trace.
+   kfunc = rec_call_specialise(J, funcV(functv), fbase[0], contextual_call);
    fbase[0] = kfunc;
    fbase[1] = TREF_FRAME;
    J->maxslot = (BCREG)nargs;
@@ -1339,16 +1345,9 @@ static TRef rec_context_current(jit_State *J)
 enum : uint8_t {
    CONTEXT_CALL_NONE,
    CONTEXT_CALL_VIRTUAL,
-   CONTEXT_CALL_MATERIALISED
+   CONTEXT_CALL_MATERIALISED,
+   CONTEXT_CALL_EXEMPT
 };
-
-static bool rec_context_has_activation(jit_State *J)
-{
-   for (uint8_t state : J->context_call_state) {
-      if (state != CONTEXT_CALL_NONE) return true;
-   }
-   return false;
-}
 
 static void rec_context_materialise(jit_State *J)
 {
@@ -1381,6 +1380,13 @@ static void rec_context_enter(jit_State *J, BCREG CallBase)
       return;
    }
 
+   // Internal namespaces inherit the caller's context.  Record the exemption before the callable overwrites its
+   // receiver slot so CTXLEAVE can still perform result compaction without attempting to restore an activation.
+   if (lj_tab_is_context_exempt(tabV(&J->L->base[CallBase - 1]))) {
+      J->context_call_state[int32_t(J->baseslot) + int32_t(CallBase)] = CONTEXT_CALL_EXEMPT;
+      return;
+   }
+
    if (tail_call or native_target) rec_context_materialise(J);
 
    int32_t function_slot = int32_t(J->baseslot) + int32_t(CallBase);
@@ -1389,14 +1395,16 @@ static void rec_context_enter(jit_State *J, BCREG CallBase)
 
    if (not tail_call) {
       J->context_call_receiver[function_slot] = receiver;
-      if (not J->L->context_active and not rec_context_has_activation(J)) {
+      if (not J->L->context_active and not J->context_call_activation_count) {
          J->context_call_state[function_slot] = CONTEXT_CALL_VIRTUAL;
+         J->context_call_activation_count++;
          J->context_virtual_slot = function_slot;
          J->needsnap = 1;
          return;
       }
       rec_context_materialise(J);
       J->context_call_state[function_slot] = CONTEXT_CALL_MATERIALISED;
+      J->context_call_activation_count++;
    }
    IRBuilder ir(J);
    int32_t owner_slot = int32_t(J->baseslot) + int32_t(CallBase) + 1 + LJ_FR2;
@@ -1411,20 +1419,29 @@ static void rec_context_enter(jit_State *J, BCREG CallBase)
 static void rec_context_leave(jit_State *J, BCREG CallBase, const BCIns *LeavePc)
 {
    int32_t function_slot = int32_t(J->baseslot) + int32_t(CallBase);
-   if (not J->context_call_func[function_slot]) {
-      lj_record_stop(J, TraceLink::INTERP, 0);
-      return;
-   }
-   uint8_t context_state = J->context_call_state[function_slot];
-   if (context_state IS CONTEXT_CALL_VIRTUAL) {
-      lj_assertJ(J->context_virtual_slot IS function_slot, "virtual context leave has inconsistent owner");
-      J->context_virtual_slot = -1;
-   }
-   else {
-      IRBuilder ir(J);
-      int32_t owner_slot = int32_t(J->baseslot) + int32_t(CallBase) + 1 + LJ_FR2;
-      TRef owner_base = rec_stack_slot_addr(J, ir, owner_slot);
-      lj_ir_call(J, IRCALL_lj_context_leave_jit, owner_base);
+   bool exempt_call = J->context_call_state[function_slot] IS CONTEXT_CALL_EXEMPT;
+   if (not exempt_call) {
+      if (not J->context_call_func[function_slot]) {
+         lj_record_stop(J, TraceLink::INTERP, 0);
+         return;
+      }
+      uint8_t context_state = J->context_call_state[function_slot];
+      if (context_state IS CONTEXT_CALL_VIRTUAL) {
+         lj_assertJ(J->context_virtual_slot IS function_slot, "virtual context leave has inconsistent owner");
+         J->context_virtual_slot = -1;
+      }
+      else {
+         IRBuilder ir(J);
+         int32_t owner_slot = int32_t(J->baseslot) + int32_t(CallBase) + 1 + LJ_FR2;
+         TRef owner_base = rec_stack_slot_addr(J, ir, owner_slot);
+         lj_ir_call(J, IRCALL_lj_context_leave_jit, owner_base);
+      }
+      // Native calls retain CONTEXT_CALL_NONE on this branch because their explicit receiver handling does not create
+      // a recorder-managed activation.  CTXLEAVE still performs its existing restoration and result compaction.
+      if (context_state != CONTEXT_CALL_NONE) {
+         lj_assertJ(J->context_call_activation_count > 0, "context activation count underflow");
+         J->context_call_activation_count--;
+      }
    }
    J->context_call_state[function_slot] = CONTEXT_CALL_NONE;
 
@@ -1504,9 +1521,11 @@ static void rec_context_tailcall(jit_State *J, BCREG CallBase, ptrdiff_t Argumen
    }
 
    TRef receiver = getslot(J, int32_t(CallBase) - 1);
+   bool exempt_receiver = tvistab(&J->L->base[CallBase - 1]) and
+      lj_tab_is_context_exempt(tabV(&J->L->base[CallBase - 1]));
    rec_call_setup(J, CallBase, ArgumentCount);
 
-   if (tref_istab(receiver)) {
+   if (tref_istab(receiver) and not exempt_receiver) {
       IRBuilder ir(J);
       int32_t prepared_slot = int32_t(J->baseslot) + int32_t(CallBase) + 1 + LJ_FR2;
       TRef prepared_owner = rec_stack_slot_addr(J, ir, prepared_slot);
@@ -4841,6 +4860,7 @@ void lj_record_setup(jit_State *J)
    memset(J->context_call_receiver, 0, sizeof(J->context_call_receiver));
    memset(J->context_call_result, 0, sizeof(J->context_call_result));
    memset(J->context_call_state, 0, sizeof(J->context_call_state));
+   J->context_call_activation_count = 0;
    J->context_virtual_slot = -1;
    memset(J->trymat, 0, sizeof(J->trymat));
    memset(J->chain, 0, sizeof(J->chain));

--- a/src/tiri/jit/src/lj_snap.cpp
+++ b/src/tiri/jit/src/lj_snap.cpp
@@ -11,6 +11,7 @@
 **   - mapofs: Offset into snapmap where this snapshot's entries begin
 **   - nent:   Number of slot entries (NOT including frame links)
 **   - ref:    IR reference at which this snapshot was created
+**   - context_ref/context_owner_slot: Virtual contextual activation materialised on exit
 **   - nslots: Total number of stack slots
 **   - topslot: Top slot for stack sizing
 **
@@ -170,9 +171,20 @@ static void snapshot_stack(jit_State* J, SnapShot* snap, MSize nsnapmap)
    nent += snapshot_framelinks(J, p + nent, &snap->topslot);
    snap->mapofs = (uint32_t)nsnapmap;
    snap->ref = (IRRef1)J->cur.nins;
+   snap->context_ref = 0;
+   snap->context_owner_slot = 0;
    snap->mcofs = 0;
    snap->nslots = (uint8_t)nslots;
    snap->count = 0;
+   if (J->context_virtual_slot >= 0) {
+      int32_t function_slot = J->context_virtual_slot;
+      TRef receiver = J->context_call_receiver[function_slot];
+      lj_assertJ(tref_istab(receiver), "snapshot virtual context is not a table");
+      snap->context_ref = IRRef1(tref_ref(receiver));
+      snap->context_owner_slot = uint16_t(function_slot + 1 + LJ_FR2);
+      // Side traces cannot inherit virtual VM state. A guard exit materialises it and resumes in the interpreter.
+      snap->count = SNAPCOUNT_DONE;
+   }
    J->cur.nsnapmap = (uint32_t)(nsnapmap + nent);
 }
 
@@ -316,14 +328,29 @@ static BCREG snap_usedef(jit_State *J, uint8_t *udf, const BCIns *pc, BCREG maxs
             if (!(op IS BC_ISTC or op IS BC_ISFC)) DEF_SLOT(bc_a(ins));
             break;
          case BCMbase:
-            if (bc_is_call_or_iter(op)) {
-               BCREG top = (op IS BC_CALLM or op IS BC_CALLMT or bc_c(ins) IS 0) ?
+            if (op IS BC_CTXLEAVE) {
+               BCIns call_ins = pc[-2];
+               lj_assertJ(bc_op(call_ins) IS BC_CTXCALL or bc_op(call_ins) IS BC_CTXCALLM,
+                  "CTXLEAVE does not follow an ordinary contextual call");
+               BCREG call_base = bc_a(ins);
+               BCREG available_results = call_base < maxslot ? maxslot - call_base : 0;
+               BCREG result_count = bc_b(call_ins) ? bc_b(call_ins) - 1 : available_results;
+               if (result_count > available_results) result_count = available_results;
+               BCREG result_shift = bc_d(ins) ? bc_d(ins) : 1;
+               lj_assertJ(result_shift <= call_base, "CTXLEAVE result shift exceeds the call base");
+               for (s = call_base; s < call_base + result_count; s++) USE_SLOT(s);
+               for (s = call_base - result_shift; s < call_base - result_shift + result_count; s++) DEF_SLOT(s);
+            }
+            else if (bc_is_call_or_iter(op) or op IS BC_CTXCALL or op IS BC_CTXCALLM or op IS BC_CTXCALLT) {
+               bool contextual_call = op IS BC_CTXCALL or op IS BC_CTXCALLM or op IS BC_CTXCALLT;
+               BCREG top = (op IS BC_CALLM or op IS BC_CALLMT or op IS BC_CTXCALLM or bc_c(ins) IS 0) ?
                   maxslot : (bc_a(ins) + bc_c(ins) + LJ_FR2);
                DEF_SLOT(bc_a(ins) + 1);
-               s = bc_a(ins) - ((op IS BC_ITERC or op IS BC_ITERN or op IS BC_ITERA) ? 3 : 0);
+               s = bc_a(ins) - ((op IS BC_ITERC or op IS BC_ITERN or op IS BC_ITERA) ? 3 :
+                  (contextual_call ? 1 : 0));
                for (; s < top; s++) USE_SLOT(s);
                for (; s < maxslot; s++) DEF_SLOT(s);
-               if (op IS BC_CALLT or op IS BC_CALLMT) {
+               if (op IS BC_CALLT or op IS BC_CALLMT or op IS BC_CTXCALLT) {
                   for (s = 0; s < bc_a(ins); s++) DEF_SLOT(s);
                   return 0;
                }
@@ -916,6 +943,33 @@ const BCIns * lj_snap_restore(jit_State *J, void *exptr)
    L->base += base_adj;
    lj_assertJ(map + nent IS flinks, "inconsistent frames in snapshot");
 
+   if (snap->context_ref) {
+      TValue context;
+      TValue *context_owner = frame + snap->context_owner_slot;
+      // A root trace may be reused beneath an inherited context, and a deeper inlined activation may have been
+      // materialised after this snapshot. Preserve owners below this activation and discard owners abandoned by the
+      // restored frames before installing (or de-duplicating) the snapshot activation.
+      lj_context_unwind(L, context_owner);
+      IRIns *context_ir = &T->ir[snap->context_ref];
+      if (context_ir->r IS RID_SUNK) {
+         bool restored_slot = false;
+         for (n = 0; n < nent; n++) {
+            SnapEntry sn = map[n];
+            if (snap_ref(sn) IS snap->context_ref and not (sn & SNAP_NORESTORE)) {
+               copyTV(L, &context, &frame[snap_slot(sn)]);
+               restored_slot = true;
+               break;
+            }
+         }
+         if (not restored_slot) snap_unsink(J, T, ex, snapno, rfilt, context_ir, &context);
+      }
+      else {
+         snap_restoreval(J, T, ex, snapno, rfilt, snap->context_ref, &context);
+      }
+      lj_assertJ(tvistab(&context), "virtual context snapshot did not restore a table");
+      lj_context_enter_jit(L, tabV(&context), context_owner);
+   }
+
    // Compute current stack top.
    BCOp op = bc_op(*pc);
    switch (op) {
@@ -923,7 +977,7 @@ const BCIns * lj_snap_restore(jit_State *J, void *exptr)
       if (bc_is_func_header(op)) L->top = frame + snap->nslots;
       else L->top = curr_topL(L);
       break;
-   case BC_CALLM: case BC_CALLMT: case BC_RETM: case BC_TSETM:
+   case BC_CALLM: case BC_CALLMT: case BC_CTXCALLM: case BC_CTXLEAVE: case BC_RETM: case BC_TSETM:
       L->top = frame + snap->nslots;
       break;
    }

--- a/src/tiri/jit/src/lj_trace.cpp
+++ b/src/tiri/jit/src/lj_trace.cpp
@@ -584,7 +584,7 @@ static void trace_start(jit_State *J)
    }
    else {
       BCOp op = bc_op(*J->pc);
-      if (op IS BC_CALLM or op IS BC_CALL or op IS BC_ITERC) {
+      if (op IS BC_CALLM or op IS BC_CALL or op IS BC_CTXCALLM or op IS BC_CTXCALL or op IS BC_ITERC) {
          setintV(L->top++, J->exitno);  //  Parent of stitched trace.
          setintV(L->top++, -1);
       }
@@ -647,6 +647,8 @@ static void trace_stop(jit_State *J)
       break;
    case BC_CALLM:
    case BC_CALL:
+   case BC_CTXCALLM:
+   case BC_CTXCALL:
    case BC_ITERC:
       // Trace stitching: patch link of previous trace.
       traceref(J, J->exitno)->link = traceno;
@@ -1121,10 +1123,12 @@ int lj_trace_exit(jit_State *J, void *exptr)
    // Return MULTRES or 0.
    ERRNO_RESTORE
       switch (bc_op(*pc)) {
-      case BC_CALLM: case BC_CALLMT:
+      case BC_CALLM: case BC_CALLMT: case BC_CTXCALLM:
          return (int)((BCREG)(L->top - L->base) - bc_a(*pc) - bc_c(*pc) - LJ_FR2);
       case BC_RETM:
          return (int)((BCREG)(L->top - L->base) + 1 - bc_a(*pc) - bc_d(*pc));
+      case BC_CTXLEAVE:
+         return (int)((BCREG)(L->top - L->base) + 1 - bc_a(*pc));
       case BC_TSETM:
          return (int)((BCREG)(L->top - L->base) + 1 - bc_a(*pc));
       default:

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -527,6 +527,22 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          break;
       }
 
+      case TokenKind::Dot: {
+         Token dot_token = current;
+         this->ctx.tokens().advance();
+         Token member_token = this->ctx.tokens().current();
+         auto name_token = this->ctx.expect_name(ParserErrorCode::ExpectedIdentifier);
+         if (not name_token.ok()) {
+            return this->fail<ExprNodePtr>(ParserErrorCode::ExpectedIdentifier, member_token,
+               "expected a member name after leading '.' context access");
+         }
+
+         ExprNodePtr context = make_current_context_expr(dot_token.span());
+         node = make_member_expr(span_from(dot_token, name_token.value_ref()), std::move(context),
+            make_identifier(name_token.value_ref()));
+         break;
+      }
+
       case TokenKind::Dots:
          node = make_vararg_expr(current.span());
          this->ctx.tokens().advance();
@@ -1060,9 +1076,15 @@ ParserResult<ExprNodePtr> AstBuilder::parse_arrow_function(ExprNodeList paramete
 
 ParserResult<ExprNodePtr> AstBuilder::parse_suffixed(ExprNodePtr base)
 {
+   const BCLine base_line = base->span.line;
+   const BCLine base_column = base->span.column;
    while (true) {
       Token token = this->ctx.tokens().current();
       if (token.kind() IS TokenKind::Dot) {
+         // A dot on a later line at or before the base expression's indentation starts a contextual statement.
+         // A more deeply indented dot remains available for conventional multi-line member chaining.
+         if ((token.span().line != base_line) and (token.span().column <= base_column)) break;
+
          this->ctx.tokens().advance();
          auto name_token = this->ctx.expect_name(ParserErrorCode::ExpectedIdentifier);
          if (not name_token.ok()) return ParserResult<ExprNodePtr>::failure(name_token.error_ref());

--- a/src/tiri/jit/src/parser/ast/nodes.cpp
+++ b/src/tiri/jit/src/parser/ast/nodes.cpp
@@ -189,6 +189,10 @@ TiriType infer_expression_type(const ExprNode &Expr)
          return TiriType::Unknown;
       }
 
+      // Context is always a non-null table.  Other receiver types do not participate in context management.
+      case AstNodeKind::CurrentContextExpr:
+         return TiriType::Table;
+
       // For these, we cannot infer without runtime information
       case AstNodeKind::IdentifierExpr:
       case AstNodeKind::VarArgExpr:
@@ -259,6 +263,7 @@ struct CallTargetChildCounter {
 struct ExpressionChildCounter {
    [[nodiscard]] inline size_t operator()(const LiteralValue &) const { return 0; }
    [[nodiscard]] inline size_t operator()(const NameRef &) const { return 0; }
+   [[nodiscard]] inline size_t operator()(const CurrentContextExprPayload &) const { return 0; }
    [[nodiscard]] inline size_t operator()(const VarArgExprPayload &) const { return 0; }
 
    [[nodiscard]] inline size_t operator()(const UnaryExprPayload &Payload) const {
@@ -581,6 +586,15 @@ ExprNodePtr make_identifier_expr(SourceSpan Span, const NameRef &Reference)
    return node;
 }
 
+ExprNodePtr make_current_context_expr(SourceSpan Span)
+{
+   ExprNodePtr node = std::make_unique<ExprNode>();
+   node->kind = AstNodeKind::CurrentContextExpr;
+   node->span = Span;
+   node->data.emplace<CurrentContextExprPayload>();
+   return node;
+}
+
 ExprNodePtr make_vararg_expr(SourceSpan Span)
 {
    ExprNodePtr node = std::make_unique<ExprNode>();
@@ -760,11 +774,15 @@ ExprNodePtr make_call_expr(SourceSpan Span, ExprNodePtr callee, ExprNodeList arg
    if (callee->kind IS AstNodeKind::MemberExpr) {
       auto *member_payload = std::get_if<MemberExprPayload>(&callee->data);
       if (member_payload) member_payload->is_call_target = true;
+      payload.dispatch = CallDispatch::MemberNamed;
    }
    else if (callee->kind IS AstNodeKind::SafeMemberExpr) {
       auto *member_payload = std::get_if<SafeMemberExprPayload>(&callee->data);
       if (member_payload) member_payload->is_call_target = true;
+      payload.dispatch = CallDispatch::SafeMemberNamed;
    }
+   else if (callee->kind IS AstNodeKind::IndexExpr) payload.dispatch = CallDispatch::MemberComputed;
+   else if (callee->kind IS AstNodeKind::SafeIndexExpr) payload.dispatch = CallDispatch::SafeMemberComputed;
    DirectCallTarget target;
    target.callable = std::move(callee);
    payload.target = std::move(target);

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -210,7 +210,13 @@ enum class LoopStyle : uint8_t {
 
 enum class CallDispatch : uint8_t {
    Direct,
-   Method
+   // Member forms retain their receiver.  Runtime context management is gated on that receiver being a table.
+   MemberNamed,
+   MemberComputed,
+   SafeMemberNamed,
+   SafeMemberComputed,
+   LegacyMethod,
+   LegacySafeMethod
 };
 
 enum class CallArgumentSyntax : uint8_t {
@@ -326,6 +332,7 @@ struct DirectCallTarget {
 
 using CallTarget = std::variant<DirectCallTarget>;
 
+struct CurrentContextExprPayload {};
 struct VarArgExprPayload {};
 
 struct UnaryExprPayload {
@@ -417,6 +424,7 @@ struct CallExprPayload {
    CallExprPayload(CallExprPayload&&) noexcept = default;
    CallExprPayload& operator=(CallExprPayload&&) noexcept = default;
    CallTarget target;
+   CallDispatch dispatch = CallDispatch::Direct;
    ExprNodeList arguments;
    CallArgumentSyntax argument_syntax = CallArgumentSyntax::Synthetic;
    bool forwards_multret = false;
@@ -653,7 +661,7 @@ struct ExprNode {
    bool is_grouped = false;
    mutable StaticValueHandle static_value = 0;
    mutable StaticResultSetHandle static_results = 0;
-   std::variant<LiteralValue, NameRef, VarArgExprPayload, UnaryExprPayload,
+   std::variant<LiteralValue, NameRef, CurrentContextExprPayload, VarArgExprPayload, UnaryExprPayload,
       UpdateExprPayload, BinaryExprPayload, ComparisonChainExprPayload, TernaryExprPayload,
       PresenceExprPayload, PipeExprPayload, CallExprPayload, MemberExprPayload,
       IndexExprPayload, SafeMemberExprPayload, SafeIndexExprPayload,
@@ -1097,6 +1105,7 @@ struct BlockStmt {
 
 ExprNodePtr make_literal_expr(SourceSpan span, const LiteralValue& literal);
 ExprNodePtr make_identifier_expr(SourceSpan span, const NameRef& reference);
+ExprNodePtr make_current_context_expr(SourceSpan span);
 ExprNodePtr make_vararg_expr(SourceSpan span);
 ExprNodePtr make_unary_expr(SourceSpan span, AstUnaryOperator op, ExprNodePtr operand);
 ExprNodePtr make_update_expr(SourceSpan span, AstUpdateOperator op, bool is_postfix, ExprNodePtr target);

--- a/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
@@ -640,7 +640,11 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
 
    ExpDesc callee;
    auto base = BCReg(0);
+   auto context_result_base = BCReg(0);
    bool is_safe_callable = false;
+   bool is_contextual_call = false;
+   bool uses_specialised_member_dispatch = false;
+   ControlFlowEdge receiver_nil_jump;
    TiriType callee_return_type = TiriType::Unknown;  // First return type of callee (if known)
    CLASSID callee_object_class_id = CLASSID::NIL;  // CLASSID if return type is Object
    struct_record *callee_struct_def = nullptr;
@@ -676,9 +680,86 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
       is_safe_callable = (direct->callable->kind IS AstNodeKind::SafeMemberExpr) or
                          (direct->callable->kind IS AstNodeKind::SafeIndexExpr);
 
-      auto callee_result = this->emit_expression(*direct->callable);
-      if (not callee_result.ok()) return callee_result;
-      callee = callee_result.value_ref();
+      const ExprNode *receiver_node = nullptr;
+      const ExprNode *index_node = nullptr;
+      GCstr *member_name = nullptr;
+
+      if (const auto *member = std::get_if<MemberExprPayload>(&direct->callable->data)) {
+         receiver_node = member->table.get();
+         member_name = member->member.symbol;
+      }
+      else if (const auto *member = std::get_if<SafeMemberExprPayload>(&direct->callable->data)) {
+         receiver_node = member->table.get();
+         member_name = member->member.symbol;
+      }
+      else if (const auto *index = std::get_if<IndexExprPayload>(&direct->callable->data)) {
+         receiver_node = index->table.get();
+         index_node = index->index.get();
+      }
+      else if (const auto *index = std::get_if<SafeIndexExprPayload>(&direct->callable->data)) {
+         receiver_node = index->table.get();
+         index_node = index->index.get();
+      }
+
+      is_contextual_call = receiver_node != nullptr;
+      bool proved_specialised_receiver = false;
+      if (is_contextual_call and receiver_node->static_value) {
+         const auto &descriptor = this->ctx.descriptors().value(receiver_node->static_value);
+         if (descriptor.proved() and descriptor.primary != TiriType::Unknown and
+             descriptor.primary != TiriType::Any and descriptor.primary != TiriType::Table) {
+            is_contextual_call = false;
+            proved_specialised_receiver = descriptor.primary IS TiriType::Str or
+               descriptor.primary IS TiriType::Array or descriptor.primary IS TiriType::Range;
+         }
+      }
+
+      if (is_contextual_call) {
+         auto receiver_result = this->emit_expression(*receiver_node);
+         if (not receiver_result.ok()) return receiver_result;
+         ExpDesc receiver = receiver_result.value_ref();
+         this->materialise_to_next_reg(receiver, "contextual call receiver");
+         auto receiver_reg = BCReg(receiver.u.s.info);
+         context_result_base = receiver_reg;
+
+         if (is_safe_callable) {
+            ExpDesc nil_value(ExpKind::Nil);
+            bcemit_INS(&this->func_state, BCINS_AD(BC_ISEQP, receiver_reg, const_pri(&nil_value)));
+            receiver_nil_jump = this->control_flow.make_unconditional(
+               BCPos(bcemit_jmp(&this->func_state)));
+         }
+
+         if (member_name) {
+            ExpDesc key(member_name);
+            auto call_base = this->func_state.free_reg();
+            bcreg_reserve(&this->func_state, 1);
+            bcemit_tgets(
+               &this->func_state, call_base.raw(), receiver_reg.raw(), const_str(&this->func_state, &key));
+            callee.init(ExpKind::NonReloc, call_base.raw());
+         }
+         else {
+            if (not index_node) return this->unsupported_expr(AstNodeKind::CallExpr, direct->callable->span);
+            auto retained_receiver_reg = this->func_state.free_reg();
+            bcreg_reserve(&this->func_state, 1);
+            bcemit_AD(&this->func_state, BC_MOV, retained_receiver_reg, receiver_reg);
+
+            auto key_result = this->emit_expression(*index_node);
+            if (not key_result.ok()) return key_result;
+            ExpDesc key = key_result.value_ref();
+            ExpressionValue key_value(&this->func_state, key);
+            key_value.to_val();
+            key = key_value.legacy();
+            ExpDesc lookup(ExpKind::NonReloc, receiver_reg.raw());
+            lookup.static_value = receiver.static_value;
+            expr_index(&this->func_state, &lookup, &key);
+            this->materialise_to_next_reg(lookup, "contextual call callee");
+            callee = lookup;
+         }
+      }
+      else {
+         auto callee_result = this->emit_expression(*direct->callable);
+         if (not callee_result.ok()) return callee_result;
+         callee = callee_result.value_ref();
+      }
 
       // TEMPORARY: If the callee is IndexedObject or IndexedStruct, downgrade to Indexed.
       // Currently object methods and struct helpers are resolved via metamethods (__index), so we need
@@ -734,10 +815,12 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
          }
       }
 
-      this->materialise_to_next_reg(callee, "call callee");
-      // Reserve register for frame link
-      RegisterAllocator allocator(&this->func_state);
-      allocator.reserve(BCReg(1));
+      if (not uses_specialised_member_dispatch) {
+         if (not is_contextual_call) this->materialise_to_next_reg(callee, "call callee");
+         // Reserve register for frame link
+         RegisterAllocator allocator(&this->func_state);
+         allocator.reserve(BCReg(1));
+      }
       base = BCReg(callee.u.s.info);
    }
    else return this->unsupported_expr(AstNodeKind::CallExpr, SourceSpan{});
@@ -752,6 +835,8 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
       nil_jump = this->control_flow.make_unconditional(BCPos(bcemit_jmp(&this->func_state)));
    }
 
+   if (is_contextual_call) bcemit_INS(&this->func_state, BCINS_AD(BC_CTXENTER, base, 0));
+
    // Evaluate arguments only after the nil check, so if callable is nil we skip argument evaluation
    auto arg_count = BCReg(0);
    ExpDesc args(ExpKind::Void);
@@ -765,11 +850,13 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
    bool forward_tail = Payload.forwards_multret and (args.k IS ExpKind::Call);
    if (forward_tail) {
       set_call_result_count(&this->func_state, args, 0);
-      ins = BCINS_ABC(BC_CALLM, base, 2, args.u.s.aux - base - 1  - 1);
+      ins = BCINS_ABC(is_contextual_call ? BC_CTXCALLM : BC_CALLM,
+         base, 2, args.u.s.aux - base - 1  - 1);
    }
    else {
       if (not (args.k IS ExpKind::Void)) this->materialise_to_next_reg(args, "call arguments");
-      ins = BCINS_ABC(BC_CALL, base, 2, this->func_state.freereg - base  - 1);
+      ins = BCINS_ABC(is_contextual_call ? BC_CTXCALL : BC_CALL,
+         base, 2, this->func_state.freereg - base - 1);
    }
 
    // Restore the saved line number so the CALL instruction gets the correct line
@@ -777,6 +864,10 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
    this->lex_state.lastline = call_line;
 
    auto call_pc = BCPos(bcemit_INS(&this->func_state, ins));
+   if (is_contextual_call) {
+      bcemit_INS(&this->func_state,
+         BCINS_AD(BC_CTXLEAVE, base, BCREG(base.raw() - context_result_base.raw())));
+   }
 
    // For safe callable: emit the nil path and patch jumps
 
@@ -785,19 +876,20 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
 
       BCPos nil_path = BCPos(this->func_state.pc);
       nil_jump.patch_to(nil_path);
-      bcemit_nil(&this->func_state, base.raw(), 1);
+      if (not receiver_nil_jump.empty()) receiver_nil_jump.patch_to(nil_path);
+      bcemit_nil(&this->func_state, is_contextual_call ? context_result_base.raw() : base.raw(), 1);
 
       skip_nil.patch_to(BCPos(this->func_state.pc));
    }
 
    ExpDesc result;
    result.init(ExpKind::Call, call_pc);
-   result.u.s.aux = base;
+   result.u.s.aux = is_contextual_call ? context_result_base.raw() : base.raw();
    result.result_type = callee_return_type;  // Propagate known return type
    result.object_class_id = callee_object_class_id;  // Propagate object class ID for Object types
    result.struct_def = callee_struct_def;
    result.static_results = Payload.results;
-   this->func_state.freereg = base + 1;
+   this->func_state.freereg = is_contextual_call ? base : base + 1;
    return ParserResult<ExpDesc>::success(result);
 }
 

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1178,24 +1178,34 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
       if (count IS 1 and last.k IS ExpKind::Call) {
          BCIns* ip = ir_bcptr(&this->func_state, &last);
          BCOp call_op = bc_op(*ip);
-         bool has_post_call_control_flow = last.u.s.info + 1 != this->func_state.pc;
+         bool has_context_leave = (call_op IS BC_CTXCALL or call_op IS BC_CTXCALLM) and
+            bc_op(this->func_state.bcbase[last.u.s.info + 1].ins) IS BC_CTXLEAVE;
+         auto expected_end = last.u.s.info + (has_context_leave ? 2 : 1);
+         bool has_post_call_control_flow = expected_end != this->func_state.pc;
          bool has_user_cleanup = cleanup_temp_regs > 0;
          bool forwards_current_contract = tail_call_forwards_current_contract(
             this->ctx, this->current_callable, *Payload.values.back());
+         bool direct_tail_call = call_op IS BC_CALL or call_op IS BC_CALLM;
+         bool contextual_tail_call = has_context_leave and call_op IS BC_CTXCALL;
          bool tail_call_eligible = this->func_state.try_depth IS 0 and not has_post_call_control_flow and
-            not has_user_cleanup and (call_op IS BC_CALL or call_op IS BC_CALLM) and
+            not has_user_cleanup and (direct_tail_call or contextual_tail_call) and
             (forwards_current_contract or (not truncate_return_results and not has_return_contract));
          if (tail_call_eligible) {
             return_contract_forwarded = forwards_current_contract;
-            lj_assertX(last.u.s.info + 1 IS this->func_state.pc,
+            lj_assertX(last.u.s.info + (contextual_tail_call ? 2 : 1) IS this->func_state.pc,
                "tail call is not the final expression instruction");
-            this->func_state.pc--;
-            if (last.alternate_call != NO_JMP) {
-               BCIns *alternate = &this->func_state.bcbase[last.alternate_call].ins;
-               *alternate = BCINS_AD(
-                  bc_op(*alternate) - BC_CALL + BC_CALLT, bc_a(*alternate), bc_c(*alternate));
+            this->func_state.pc -= contextual_tail_call ? 2 : 1;
+            if (contextual_tail_call) {
+               ins = BCINS_AD(BC_CTXCALLT, bc_a(*ip), bc_c(*ip));
             }
-            ins = BCINS_AD(bc_op(*ip) - BC_CALL + BC_CALLT, bc_a(*ip), bc_c(*ip));
+            else {
+               if (last.alternate_call != NO_JMP) {
+                  BCIns *alternate = &this->func_state.bcbase[last.alternate_call].ins;
+                  *alternate = BCINS_AD(
+                     bc_op(*alternate) - BC_CALL + BC_CALLT, bc_a(*alternate), bc_c(*alternate));
+               }
+               ins = BCINS_AD(bc_op(*ip) - BC_CALL + BC_CALLT, bc_a(*ip), bc_c(*ip));
+            }
          }
          else if (truncate_return_results) {
             BCREG result_count = this->func_state.return_declared_count;
@@ -2614,6 +2624,9 @@ ParserResult<ExpDesc> IrEmitter::emit_expression(const ExprNode& expr)
       case AstNodeKind::IdentifierExpr:
          result = this->emit_identifier_expr(std::get<NameRef>(expr.data));
          break;
+      case AstNodeKind::CurrentContextExpr:
+         result = this->emit_current_context_expr();
+         break;
       case AstNodeKind::VarArgExpr:
          result = this->emit_vararg_expr();
          break;
@@ -2728,6 +2741,17 @@ ParserResult<ExpDesc> IrEmitter::emit_literal_expr(const LiteralValue& literal)
       case LiteralKind::Number:  expr = ExpDesc(literal.number_value); break;
       case LiteralKind::String:  expr = ExpDesc(literal.string_value); break;
    }
+   return ParserResult<ExpDesc>::success(expr);
+}
+
+//********************************************************************************************************************
+// Load the state-local table context.  The runtime resolves an empty override stack through the current L->env.
+
+ParserResult<ExpDesc> IrEmitter::emit_current_context_expr()
+{
+   ExpDesc expr;
+   expr.init(ExpKind::Relocable, bcemit_AD(&this->func_state, BC_CTXGET, 0, 0));
+   expr.result_type = TiriType::Table;
    return ParserResult<ExpDesc>::success(expr);
 }
 

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
@@ -195,6 +195,7 @@ private:
    ParserResult<ExpDesc> emit_expression(const ExprNode& expr);
    ParserResult<ExpDesc> emit_literal_expr(const LiteralValue& literal);
    ParserResult<ExpDesc> emit_identifier_expr(const NameRef& reference, bool AllowUnscoped = false);
+   ParserResult<ExpDesc> emit_current_context_expr();
    ParserResult<ExpDesc> emit_vararg_expr();
    ParserResult<ExpDesc> emit_unary_expr(const UnaryExprPayload& payload);
    ParserResult<ExpDesc> emit_update_expr(const UpdateExprPayload& payload);

--- a/src/tiri/jit/src/parser/parse_scope.cpp
+++ b/src/tiri/jit/src/parser/parse_scope.cpp
@@ -784,7 +784,7 @@ void LexState::fs_fixup_var(GCproto* Prototype, uint8_t* Buffer, size_t OffsetVa
 [[nodiscard]] inline int bcopisret(BCOp op)
 {
    switch (op) {
-      case BC_CALLMT: case BC_CALLT:
+      case BC_CALLMT: case BC_CALLT: case BC_CTXCALLT:
       case BC_RETM: case BC_RET: case BC_RET0: case BC_RET1:
          return 1;
       default:
@@ -847,7 +847,7 @@ static void fs_fixup_ret(FuncState *fs)
          BCIns ins = fs->bcbase[pc].ins;
          BCPOS offset;
          switch (bc_op(ins)) {
-            case BC_CALLMT: case BC_CALLT:
+            case BC_CALLMT: case BC_CALLT: case BC_CTXCALLT:
             case BC_RETM: case BC_RET: case BC_RET0: case BC_RET1:
                offset = bcemit_INS(fs, ins);  // Copy original instruction.
                fs->bcbase[offset].line = fs->bcbase[pc].line;

--- a/src/tiri/jit/src/parser/parser_context.h
+++ b/src/tiri/jit/src/parser/parser_context.h
@@ -45,6 +45,7 @@ struct ParserConfig {
    bool type_errors_are_fatal = true;      // Treat type mismatches as errors
    bool infer_local_types = true;          // Track types of local variables
    bool warn_unresolved_methods = false;   // Report dot-method receivers requiring runtime classification
+   bool reject_legacy_member_syntax = false; // Compatibility control retained for parser test harnesses
    ParserProfilingResult profiling_result;
 };
 

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -127,7 +127,7 @@ struct AstHarnessResult {
 //********************************************************************************************************************
 
 static AstHarnessResult build_ast_from_source(std::string_view source, bool Diagnose = false,
-   bool EnableTypeAnalysis = true)
+   bool EnableTypeAnalysis = true, bool RejectLegacyMemberSyntax = false)
 {
    AstHarnessResult result;
    result.state = std::make_unique<LuaStateHolder>();
@@ -147,6 +147,7 @@ static AstHarnessResult build_ast_from_source(std::string_view source, bool Diag
    config.abort_on_error = false;
    config.max_diagnostics = 32;
    config.enable_type_analysis = EnableTypeAnalysis;
+   config.reject_legacy_member_syntax = RejectLegacyMemberSyntax;
    ParserSession session(context, config);
 
    lex.next();
@@ -429,7 +430,7 @@ static bool test_global_callable_contract_without_type_analysis(kt::Log &Log)
    constexpr std::string_view source =
       "global function glParserContract() end\n"
       "global thunk glParserThunk():num end\n";
-   auto result = build_ast_from_source(source, false, false);
+   auto result = build_ast_from_source(source, false, true);
    if (not result.chunk.ok()) {
       Log.error("failed to parse global callable declarations with type analysis disabled");
       log_diagnostics(result.diagnostics, Log);
@@ -3766,6 +3767,196 @@ return value * 3
    return true;
 }
 
+static bool test_contextual_member_ast_foundations(kt::Log &Log)
+{
+   constexpr std::string_view source =
+      ".value = 1\n"
+      ".value += 2\n"
+      "local read = .child.name\n"
+      ".refresh(3, 4)\n"
+      "receiver.member(5)\n"
+      "receiver[key](6)\n"
+      "receiver?.member(7);\n"
+      "receiver?[key](8);\n"
+      "(receiver.member)(8)\n"
+      "local alias = receiver.member\n"
+      "alias(9)\n";
+
+   auto result = build_ast_from_source(source, false, false);
+   if (not result.chunk.ok() or result.chunk.value_ref()->statements.size() != 11) {
+      Log.error("failed to parse contextual member AST fixture (ok=%d, statements=%" PRId64 ")",
+         int(result.chunk.ok()), int64_t(result.chunk.ok() ? result.chunk.value_ref()->statements.size() : 0));
+      log_diagnostics(result.diagnostics, Log);
+      return false;
+   }
+
+   BlockStmt &block = *result.chunk.value_ref();
+   for (size_t i = 0; i < 2; ++i) {
+      const auto *assignment = std::get_if<AssignmentStmtPayload>(&block.statements[i]->data);
+      const auto *member = assignment and not assignment->targets.empty() ?
+         std::get_if<MemberExprPayload>(&assignment->targets.front()->data) : nullptr;
+      if (not member or not member->table or member->table->kind != AstNodeKind::CurrentContextExpr) {
+         Log.error("leading-dot assignment did not retain an explicit current-context receiver");
+         return false;
+      }
+      if (infer_expression_type(*member->table) != TiriType::Table) {
+         Log.error("current-context expression was not inferred as a table");
+         return false;
+      }
+   }
+
+   const auto &first_assignment = std::get<AssignmentStmtPayload>(block.statements[0]->data);
+   const auto &first_member = std::get<MemberExprPayload>(first_assignment.targets.front()->data);
+   if (first_member.table->span.line != first_member.member.span.line or
+       first_member.table->span.offset >= first_member.member.span.offset) {
+      Log.error("leading-dot access did not retain distinct context and member source spans");
+      return false;
+   }
+
+   const auto &read = std::get<LocalDeclStmtPayload>(block.statements[2]->data);
+   const auto *outer_member = read.values.empty() ? nullptr : std::get_if<MemberExprPayload>(&read.values[0]->data);
+   const auto *inner_member = outer_member and outer_member->table ?
+      std::get_if<MemberExprPayload>(&outer_member->table->data) : nullptr;
+   if (not inner_member or not inner_member->table or
+       inner_member->table->kind != AstNodeKind::CurrentContextExpr) {
+      Log.error("chained leading-dot access lost its current-context root");
+      return false;
+   }
+
+   constexpr std::array<CallDispatch, 7> expected_dispatch = {
+      CallDispatch::MemberNamed,
+      CallDispatch::MemberNamed,
+      CallDispatch::MemberComputed,
+      CallDispatch::SafeMemberNamed,
+      CallDispatch::SafeMemberComputed,
+      CallDispatch::MemberNamed,
+      CallDispatch::Direct
+   };
+   constexpr std::array<size_t, 7> statement_indices = { 3, 4, 5, 6, 7, 8, 10 };
+   constexpr std::array<size_t, 7> argument_counts = { 2, 1, 1, 1, 1, 1, 1 };
+   constexpr std::array<AstNodeKind, 7> target_kinds = {
+      AstNodeKind::MemberExpr,
+      AstNodeKind::MemberExpr,
+      AstNodeKind::IndexExpr,
+      AstNodeKind::SafeMemberExpr,
+      AstNodeKind::SafeIndexExpr,
+      AstNodeKind::MemberExpr,
+      AstNodeKind::IdentifierExpr
+   };
+
+   for (size_t i = 0; i < statement_indices.size(); ++i) {
+      const auto &statement = std::get<ExpressionStmtPayload>(block.statements[statement_indices[i]]->data);
+      const auto *call = statement.expression ? std::get_if<CallExprPayload>(&statement.expression->data) : nullptr;
+      const auto *target = call ? std::get_if<DirectCallTarget>(&call->target) : nullptr;
+      if (not call or call->dispatch != expected_dispatch[i] or call->arguments.size() != argument_counts[i] or
+          not target or not target->callable or target->callable->kind != target_kinds[i]) {
+         Log.error("contextual call AST lost dispatch or written-argument metadata at fixture index %" PRId64,
+            int64_t(i));
+         return false;
+      }
+   }
+
+   const auto &computed_statement = std::get<ExpressionStmtPayload>(block.statements[5]->data);
+   const auto &computed_call = std::get<CallExprPayload>(computed_statement.expression->data);
+   const auto &computed_target = std::get<DirectCallTarget>(computed_call.target);
+   const auto &computed_index = std::get<IndexExprPayload>(computed_target.callable->data);
+   if (not computed_index.table or not computed_index.index) {
+      Log.error("computed contextual call did not retain separate receiver and key evaluation components");
+      return false;
+   }
+
+   const auto &grouped_statement = std::get<ExpressionStmtPayload>(block.statements[8]->data);
+   const auto &grouped_call = std::get<CallExprPayload>(grouped_statement.expression->data);
+   const auto &grouped_target = std::get<DirectCallTarget>(grouped_call.target);
+   if (not grouped_target.callable or not grouped_target.callable->is_grouped) {
+      Log.error("parenthesised member call did not preserve its contextual association");
+      return false;
+   }
+
+   constexpr std::string_view multiline_source =
+      "receiver.member()\n"
+      "   .next()\n"
+      ".contextual()\n";
+   auto multiline = build_ast_from_source(multiline_source, false, false);
+   if (not multiline.chunk.ok() or multiline.chunk.value_ref()->statements.size() != 2) {
+      Log.error("multi-line member chain was split into contextual statements");
+      log_diagnostics(multiline.diagnostics, Log);
+      return false;
+   }
+
+   const auto &multiline_statement =
+      std::get<ExpressionStmtPayload>(multiline.chunk.value_ref()->statements[0]->data);
+   const auto *multiline_call = multiline_statement.expression ?
+      std::get_if<CallExprPayload>(&multiline_statement.expression->data) : nullptr;
+   const auto *multiline_target = multiline_call ? std::get_if<DirectCallTarget>(&multiline_call->target) : nullptr;
+   const auto *multiline_member = multiline_target and multiline_target->callable ?
+      std::get_if<MemberExprPayload>(&multiline_target->callable->data) : nullptr;
+   if (not multiline_member or not multiline_member->table or
+       multiline_member->table->kind != AstNodeKind::CallExpr) {
+      Log.error("indented multi-line member suffix did not retain the preceding call as its receiver");
+      return false;
+   }
+
+   const auto &contextual_statement =
+      std::get<ExpressionStmtPayload>(multiline.chunk.value_ref()->statements[1]->data);
+   const auto *contextual_call = contextual_statement.expression ?
+      std::get_if<CallExprPayload>(&contextual_statement.expression->data) : nullptr;
+   const auto *contextual_target = contextual_call ? std::get_if<DirectCallTarget>(&contextual_call->target) : nullptr;
+   const auto *contextual_member = contextual_target and contextual_target->callable ?
+      std::get_if<MemberExprPayload>(&contextual_target->callable->data) : nullptr;
+   if (not contextual_member or not contextual_member->table or
+       contextual_member->table->kind != AstNodeKind::CurrentContextExpr) {
+      Log.error("same-indent leading dot did not remain a contextual statement after a multi-line chain");
+      return false;
+   }
+
+   const auto &alias_decl = std::get<LocalDeclStmtPayload>(block.statements[9]->data);
+   if (alias_decl.values.empty() or alias_decl.values[0]->kind != AstNodeKind::MemberExpr) {
+      Log.error("member extraction did not remain an unbound member expression");
+      return false;
+   }
+
+   constexpr std::array<std::string_view, 2> invalid_context_sources = {
+      "local value = .\n",
+      "local value = .(123)\n"
+   };
+   for (std::string_view invalid_source : invalid_context_sources) {
+      auto invalid = build_ast_from_source(invalid_source, false, false);
+      bool found_leading_dot_diagnostic = false;
+      for (const ParserDiagnostic &diagnostic : invalid.diagnostics) {
+         if (diagnostic.code IS ParserErrorCode::ExpectedIdentifier and
+             diagnostic.message.find("leading '.' context access") != std::string::npos) {
+            found_leading_dot_diagnostic = true;
+         }
+      }
+      if (not found_leading_dot_diagnostic) {
+         Log.error("invalid leading-dot access did not produce its targeted diagnostic");
+         return false;
+      }
+   }
+
+   constexpr std::array<std::string_view, 2> legacy_sources = {
+      "receiver:member()\n",
+      "function receiver:member() end\n"
+   };
+   for (std::string_view legacy_source : legacy_sources) {
+      auto legacy = build_ast_from_source(legacy_source, false, false, true);
+      bool found_cutover_diagnostic = false;
+      for (const ParserDiagnostic &diagnostic : legacy.diagnostics) {
+         if (diagnostic.code IS ParserErrorCode::DeprecatedSyntax and
+             diagnostic.message.find("receiver.member") != std::string::npos) {
+            found_cutover_diagnostic = true;
+         }
+      }
+      if (not found_cutover_diagnostic) {
+         Log.error("colon syntax cut-over gate did not produce a dot-qualified replacement diagnostic");
+         return false;
+      }
+   }
+
+   return true;
+}
+
 static bool test_ast_call_lowering(kt::Log &log)
 {
    constexpr const char* source = R"(
@@ -7025,7 +7216,7 @@ static bool test_builtin_callable_bytecode(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 62> tests = { {
+   constexpr std::array<TestCase, 63> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -7048,6 +7239,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "return_lowering", test_return_lowering },
       { "tail_call_eligibility", test_tail_call_eligibility },
       { "multres_save_unwind", test_multres_save_unwind },
+      { "contextual_member_ast_foundations", test_contextual_member_ast_foundations },
       { "ast_call_lowering", test_ast_call_lowering },
       { "bytecode_equivalence", test_bytecode_equivalence },
       { "signature_metadata_roundtrip", test_signature_metadata_roundtrip },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1552,6 +1552,58 @@ static bool test_old_bytecode_versions_rejected(kt::Log &Log)
    return true;
 }
 
+static bool test_unmatched_context_entry_rejected(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *lua = state.get();
+   constexpr std::string_view source =
+      "local receiver = { name='receiver', read=function():str return .name end }\n"
+      "local value = receiver.read()\n"
+      "return value\n";
+   if (lua_load(lua, source, "unmatched-context-entry")) {
+      Log.error("failed to compile contextual bytecode fixture: %s", lua_tostring(lua, -1));
+      return false;
+   }
+
+   GCproto *prototype = funcproto(funcV(lua->top - 1));
+   BCIns *bytecode = proto_bc(prototype);
+   MSize call_position = 0;
+   for (MSize i = 1; i + 1 < prototype->sizebc; ++i) {
+      if ((bc_op(bytecode[i]) IS BC_CTXCALL or bc_op(bytecode[i]) IS BC_CTXCALLM) and
+          bc_op(bytecode[i + 1]) IS BC_CTXLEAVE) {
+         call_position = i;
+         break;
+      }
+   }
+   if (call_position IS 0) {
+      Log.error("contextual bytecode fixture did not emit a call-and-leave pair");
+      return false;
+   }
+
+   BCIns saved_call = bytecode[call_position];
+   BCIns saved_leave = bytecode[call_position + 1];
+   setbc_op(&bytecode[call_position], bc_op(saved_call) IS BC_CTXCALL ? BC_CALL : BC_CALLM);
+   setbc_op(&bytecode[call_position + 1], BC_MOV);
+
+   std::string dump;
+   bool wrote_dump = lj_bcwrite(lua, prototype, bytecode_writer, &dump, 1) IS 0;
+   bytecode[call_position] = saved_call;
+   bytecode[call_position + 1] = saved_leave;
+   lua_pop(lua, 1);
+   if (not wrote_dump) {
+      Log.error("failed to write unmatched contextual entry fixture");
+      return false;
+   }
+
+   if (lua_load(lua, std::string_view(dump.data(), dump.size()), "unmatched-context-entry") IS 0) {
+      Log.error("bytecode reader accepted an unmatched BC_CTXENTER");
+      lua_pop(lua, 1);
+      return false;
+   }
+   lua_pop(lua, 1);
+   return true;
+}
+
 static bool test_signature_static_inference(kt::Log &Log)
 {
    LuaStateHolder state;
@@ -7216,7 +7268,7 @@ static bool test_builtin_callable_bytecode(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 63> tests = { {
+   constexpr std::array<TestCase, 64> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -7245,6 +7297,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "signature_metadata_roundtrip", test_signature_metadata_roundtrip },
       { "forward_declaration_signature_validation", test_forward_declaration_signature_validation },
       { "old_bytecode_versions_rejected", test_old_bytecode_versions_rejected },
+      { "unmatched_context_entry_rejected", test_unmatched_context_entry_rejected },
       { "signature_static_inference", test_signature_static_inference },
       { "signature_void_and_bare_return", test_signature_void_and_bare_return },
       { "malformed_signature_rejected", test_malformed_signature_rejected },

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -904,6 +904,11 @@ private:
          TiriType generated_type = std::get<CallExprPayload>(receiver->data).result_type;
          if (generated_type != TiriType::Unknown and generated_type != TiriType::Any) receiver_type = generated_type;
       }
+      if (receiver_type IS TiriType::Table and
+          not get_method_prototype_by_hash(TiriType::Table, member->hash)) {
+         Call.builtin_method.reset();
+         return;
+      }
       if ((not descriptor.proved() and Call.argument_syntax != CallArgumentSyntax::Synthetic) or
           receiver_type IS TiriType::Any or receiver_type IS TiriType::Unknown or
           (descriptor.nullable and not safe and Call.argument_syntax != CallArgumentSyntax::Synthetic)) {
@@ -1295,6 +1300,11 @@ private:
       StaticValueDescriptor value;
       StaticResultSetHandle results = 0;
       switch (Expression.kind) {
+         case AstNodeKind::CurrentContextExpr:
+            value.primary = TiriType::Table;
+            value.nullable = false;
+            value.proof = StaticProof::Closed;
+            break;
          case AstNodeKind::LiteralExpr:
             value = this->literal_descriptor(std::get<LiteralValue>(Expression.data));
             break;

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -2499,6 +2499,10 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
    InferredType result;
 
    switch (Expr.kind) {
+      case AstNodeKind::CurrentContextExpr:
+         result.primary = TiriType::Table;
+         result.is_nullable = false;
+         break;
       case AstNodeKind::LiteralExpr: {
          auto *payload = std::get_if<LiteralValue>(&Expr.data);
          if (payload) return infer_literal_type(*payload);

--- a/src/tiri/jit/src/runtime/lj_gc.cpp
+++ b/src/tiri/jit/src/runtime/lj_gc.cpp
@@ -323,9 +323,23 @@ static void gc_mark_start(global_State *g)
    setgcrefnull(g->gc.weak);
    gc_markobj(g, mainthread(g));
    gc_markobj(g, tabref(mainthread(g)->env));
+   for (const lua_State::ContextFrame &context : mainthread(g)->context_stack) {
+      GCtab *table = tabref(context.table);
+      lj_assertG(table, "context stack contains a non-table root");
+      gc_markobj(g, table);
+   }
    gc_marktv(g, &g->registrytv);
    gc_mark_gcroot(g);
    g->gc.state = (GCPhase::Propagate);
+}
+
+//********************************************************************************************************************
+// Preserve a context override installed after the running thread was traversed in the current mark phase.
+
+void lj_gc_barriercontext(lua_State *L, GCtab *Table)
+{
+   global_State *g = G(L);
+   if (g->gc.state IS GCPhase::Propagate or g->gc.state IS GCPhase::Atomic) gc_markobj(g, Table);
 }
 
 //********************************************************************************************************************
@@ -675,6 +689,11 @@ static void gc_traverse_thread(global_State *g, lua_State* th)
          setnilV(o);
    }
    gc_markobj(g, tabref(th->env));
+   for (const lua_State::ContextFrame &context : th->context_stack) {
+      GCtab *table = tabref(context.table);
+      lj_assertG(table, "context stack contains a non-table root");
+      gc_markobj(g, table);
+   }
    if (th->pending_trace) {
       CapturedStackTrace *trace = th->pending_trace;
       for (uint16_t i = 0; i < trace->frame_count; i++) {

--- a/src/tiri/jit/src/runtime/lj_gc.h
+++ b/src/tiri/jit/src/runtime/lj_gc.h
@@ -165,6 +165,7 @@ extern "C" void lj_gc_barrierf(global_State* g, GCobj* o, GCobj* v);
 extern "C" void lj_gc_barrieruv(global_State* g, TValue* tv);
 extern "C" void lj_gc_closeuv(global_State* g, GCupval* uv);
 extern "C" void lj_gc_barriertrace(global_State* g, uint32_t traceno);
+LJ_FUNC void lj_gc_barriercontext(lua_State *L, GCtab *Table);
 
 // Move the GC propagation frontier back for tables (make it gray again).
 static LJ_AINLINE void lj_gc_barrierback(global_State* g, GCtab* t)

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -1303,6 +1303,14 @@ void lj_meta_call(lua_State *L, TValue *func, TValue *top)
 
 int lj_meta_close(lua_State *L, TValue *o, TValue *err)
 {
+   const ptrdiff_t object_offset = savestack(L, o);
+   const bool has_error = err != nullptr;
+   const ptrdiff_t error_offset = has_error ? savestack(L, err) : 0;
+
+   lj_state_checkstack(L, 4);
+   o = restorestack(L, object_offset);
+   err = has_error ? restorestack(L, error_offset) : nullptr;
+
    cTValue *mo = lj_meta_lookup(L, o, MM_close);
    if (tvisnil(mo)) return 0;  // No __close metamethod, nothing to do.
 

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -1093,6 +1093,8 @@ inline constexpr uint32_t TAB_SPARSE_BIT = 1;       // Bit index, for backends t
 inline constexpr uint8_t  TAB_SPARSE = (uint8_t)(1u << TAB_SPARSE_BIT); // Ever used with non-sequence numerical keys
 inline constexpr uint32_t TAB_METHOD_COMPATIBLE_BIT = 2; // Bit index for explicit-receiver userdata metatables.
 inline constexpr uint8_t  TAB_METHOD_COMPATIBLE = (uint8_t)(1u << TAB_METHOD_COMPATIBLE_BIT);
+inline constexpr uint32_t TAB_CONTEXT_EXEMPT_BIT = 3; // Bit index for internal namespace tables.
+inline constexpr uint8_t  TAB_CONTEXT_EXEMPT = (uint8_t)(1u << TAB_CONTEXT_EXEMPT_BIT);
 
 // Either flag makes the sequence length meaningless, so '#' reports nil and sequence library functions refuse to
 // infer a boundary.  Backends test this composite mask in one operation.
@@ -1150,6 +1152,8 @@ static_assert((1u << TAB_ASSOCIATIVE_BIT) IS TAB_ASSOCIATIVE);
 static_assert((1u << TAB_SPARSE_BIT) IS TAB_SPARSE);
 static_assert((1u << TAB_METHOD_COMPATIBLE_BIT) IS TAB_METHOD_COMPATIBLE);
 static_assert((TAB_METHOD_COMPATIBLE & TAB_NOT_SEQUENCE) IS 0);
+static_assert((1u << TAB_CONTEXT_EXEMPT_BIT) IS TAB_CONTEXT_EXEMPT);
+static_assert((TAB_CONTEXT_EXEMPT & (TAB_NOT_SEQUENCE | TAB_METHOD_COMPATIBLE)) IS 0);
 
 // Table classification helpers.  Every interpreter, library and C API path publishes classification through these so
 // that the semantics stay aligned; the JIT recorder mirrors them with equivalent IR.
@@ -1163,6 +1167,16 @@ static_assert((TAB_METHOD_COMPATIBLE & TAB_NOT_SEQUENCE) IS 0);
 {
    return (Table->flags & TAB_SPARSE) != 0;
 }
+
+// Internal namespace tables inherit their caller's context.  This flag is set once during library registration and
+// never cleared, so the interpreter and JIT can treat it as an invariant of the table identity.
+
+[[nodiscard]] inline bool lj_tab_is_context_exempt(const GCtab *Table) noexcept
+{
+   return (Table->flags & TAB_CONTEXT_EXEMPT) != 0;
+}
+
+inline void lj_tab_mark_context_exempt(GCtab *Table) noexcept { Table->flags |= TAB_CONTEXT_EXEMPT; }
 
 // True when the table's usage history remains inside the non-negative integral sequence domain.  This does not prove
 // that every index below the numerical boundary is currently populated: positive holes deliberately remain legal.

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -82,6 +82,7 @@ using GCSize = uint64_t; // NB: Can't be changed - would affect offsets in GC ob
 enum class AstNodeKind : uint16_t {
    LiteralExpr,
    IdentifierExpr,
+   CurrentContextExpr,
    VarArgExpr,
    UnaryExpr,
    BinaryExpr,
@@ -1608,6 +1609,21 @@ struct lua_State {
    bool   pending_exception_valid = false;      // True if pending exception metadata is current
    bool   pending_collection = false;           // A garbage collection cycle is pending
    ERR    CaughtError = ERR::Okay; // Catches ERR results from module functions.
+
+   struct ContextFrame {
+      GCRef table;                 // GC-visible context override owned by this state.
+      ptrdiff_t owner_base = 0;    // Stack-relative activation base; survives stack relocation.
+      bool tail_transfer = false;  // Recorded terminal returns must restore transferred frame ownership.
+   };
+
+   // An empty stack is the permanent root sentinel and resolves dynamically through env.  Contextual calls append
+   // table-only overrides; direct and non-table calls do not need an entry.
+   std::vector<ContextFrame> context_stack;
+   uint8_t context_active = 0; // Fast VM return gate; indicates a visible override above the active root floor.
+
+   // An asynchronous root boundary hides, but does not remove, suspended overrides. Keeping them in context_stack
+   // ensures that the collector continues to trace their tables while a callback runs and performs collection.
+   std::vector<size_t> context_root_floors;
 
    struct SavedMultresFrame {
       ptrdiff_t frame_base = 0;

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -252,13 +252,15 @@ extern "C" void lj_context_enter_call(lua_State *L, uint32_t CallBase)
    if (not L->context_stack.empty() and L->context_stack.back().owner_base IS owner_base) return;
 
    TValue *receiver = L->base + CallBase - 1;
-   if (tvistab(receiver)) lj_context_push(L, tabV(receiver), L->base + CallBase + 1 + LJ_FR2);
+   if (lj_context_receiver_establishes(receiver)) {
+      lj_context_push(L, tabV(receiver), L->base + CallBase + 1 + LJ_FR2);
+   }
 }
 
 extern "C" uint32_t lj_context_prepare_call(lua_State *L, uint32_t CallBase, uint32_t ArgumentCount)
 {
    TValue *receiver = L->base + CallBase - 1;
-   if (tvistab(receiver)) {
+   if (lj_context_receiver_establishes(receiver)) {
       lj_context_enter_call(L, CallBase);
    }
    return ArgumentCount;
@@ -289,7 +291,7 @@ extern "C" void lj_context_leave_call(
 extern "C" uint32_t lj_context_prepare_tail_call(lua_State *L, uint32_t CallBase, uint32_t ArgumentCount)
 {
    TValue *receiver = L->base + CallBase - 1;
-   if (not tvistab(receiver)) return ArgumentCount;
+   if (not lj_context_receiver_establishes(receiver)) return ArgumentCount;
 
    ptrdiff_t prepared_owner = savestack(L, L->base + CallBase + 1 + LJ_FR2);
    lj_assertL(not L->context_stack.empty() and L->context_stack.back().owner_base IS prepared_owner,

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -21,6 +21,7 @@
 #include "lj_dispatch.h"
 #include "lj_vm.h"
 #include "lj_prng.h"
+#include "../bytecode/lj_bc.h"
 #include "../parser/lexer.h"
 #include "../parser/parser_diagnostics.h"
 #include "../parser/parser_symbols.h"
@@ -174,6 +175,215 @@ void lj_state_growstack1(lua_State *L)
 }
 
 //********************************************************************************************************************
+// Table context management.  Stack-relative activation ownership avoids retaining TValue pointers across stack moves.
+
+static bool context_has_visible_override(const lua_State *L) noexcept
+{
+   size_t floor = L->context_root_floors.empty() ? 0 : L->context_root_floors.back();
+   return L->context_stack.size() > floor;
+}
+
+GCtab * lj_context_current(lua_State *L) noexcept
+{
+   lj_assertL(L, "missing state for context lookup");
+   size_t floor = L->context_root_floors.empty() ? 0 : L->context_root_floors.back();
+   GCtab *context = L->context_stack.size() IS floor ?
+      tabref(L->env) : tabref(L->context_stack.back().table);
+   lj_assertL(context, "current context is not a table");
+   return context;
+}
+
+extern "C" void lj_context_load(lua_State *L, TValue *Destination) noexcept
+{
+   lj_assertL(Destination >= tvref(L->stack) and Destination < tvref(L->maxstack),
+      "context destination is outside the state stack");
+   settabV(L, Destination, lj_context_current(L));
+}
+
+extern "C" GCtab * lj_context_current_jit(lua_State *L) noexcept
+{
+   return lj_context_current(L);
+}
+
+extern "C" void lj_context_enter_jit(lua_State *L, GCtab *Table, TValue *OwnerBase)
+{
+   lj_assertL(L and Table and OwnerBase, "invalid recorded contextual activation");
+   ptrdiff_t owner_base = savestack(L, OwnerBase);
+   if (not L->context_stack.empty() and L->context_stack.back().owner_base IS owner_base) {
+      lj_assertL(tabref(L->context_stack.back().table) IS Table,
+         "recorded context does not match the active activation");
+      return;
+   }
+   lj_context_push(L, Table, OwnerBase);
+}
+
+extern "C" void lj_context_leave_jit(lua_State *L, TValue *OwnerBase) noexcept
+{
+   lj_assertL(L and OwnerBase, "invalid recorded contextual activation owner");
+   ptrdiff_t owner_base = savestack(L, OwnerBase);
+   if (not L->context_stack.empty() and L->context_stack.back().owner_base IS owner_base) {
+      lj_context_pop(L, OwnerBase);
+   }
+}
+
+extern "C" void lj_context_tail_jit(
+   lua_State *L, GCtab *Table, TValue *PreparedOwner, TValue *OutgoingOwner)
+{
+   lj_assertL(L and Table and PreparedOwner and OutgoingOwner, "invalid recorded contextual tail transfer");
+   ptrdiff_t prepared_owner = savestack(L, PreparedOwner);
+   ptrdiff_t outgoing_owner = savestack(L, OutgoingOwner);
+   lj_assertL(not L->context_stack.empty() and L->context_stack.back().owner_base IS prepared_owner,
+      "recorded contextual tail call has no prepared activation");
+   if (L->context_stack.empty() or L->context_stack.back().owner_base != prepared_owner) return;
+   lj_assertL(tabref(L->context_stack.back().table) IS Table,
+      "recorded tail context does not match the prepared activation");
+
+   L->context_stack.pop_back();
+   if (not L->context_stack.empty() and L->context_stack.back().owner_base IS outgoing_owner) {
+      L->context_stack.pop_back();
+   }
+   lj_context_push(L, Table, OutgoingOwner);
+   L->context_stack.back().tail_transfer = true;
+}
+
+extern "C" void lj_context_enter_call(lua_State *L, uint32_t CallBase)
+{
+   ptrdiff_t owner_base = savestack(L, L->base + CallBase + 1 + LJ_FR2);
+   if (not L->context_stack.empty() and L->context_stack.back().owner_base IS owner_base) return;
+
+   TValue *receiver = L->base + CallBase - 1;
+   if (tvistab(receiver)) lj_context_push(L, tabV(receiver), L->base + CallBase + 1 + LJ_FR2);
+}
+
+extern "C" uint32_t lj_context_prepare_call(lua_State *L, uint32_t CallBase, uint32_t ArgumentCount)
+{
+   TValue *receiver = L->base + CallBase - 1;
+   if (tvistab(receiver)) {
+      lj_context_enter_call(L, CallBase);
+   }
+   return ArgumentCount;
+}
+
+extern "C" void lj_context_leave_call(
+   lua_State *L, uint32_t CallBase, const BCIns *CallInstruction, uint32_t ResultCountWithSentinel) noexcept
+{
+   ptrdiff_t owner_base = savestack(L, L->base + CallBase + 1 + LJ_FR2);
+   if (not L->context_stack.empty() and L->context_stack.back().owner_base IS owner_base) {
+      L->context_stack.pop_back();
+      L->context_active = context_has_visible_override(L);
+   }
+
+   uint32_t encoded_results = bc_b(*CallInstruction);
+   lj_assertL(encoded_results or ResultCountWithSentinel,
+      "dynamic contextual call lost its result-count sentinel");
+   uint32_t result_count = encoded_results ? encoded_results - 1 :
+      (ResultCountWithSentinel ? ResultCountWithSentinel - 1 : 0);
+   // D records every receiver/lookup temporary removed from the expression result layout. Older contextual chunks
+   // encoded zero and used the original single retained-receiver slot.
+   uint32_t result_shift = bc_d(CallInstruction[1]);
+   if (result_shift IS 0) result_shift = 1;
+   TValue *results = L->base + CallBase;
+   for (uint32_t i = 0; i < result_count; i++) copyTV(L, results + i - result_shift, results + i);
+}
+
+extern "C" uint32_t lj_context_prepare_tail_call(lua_State *L, uint32_t CallBase, uint32_t ArgumentCount)
+{
+   TValue *receiver = L->base + CallBase - 1;
+   if (not tvistab(receiver)) return ArgumentCount;
+
+   ptrdiff_t prepared_owner = savestack(L, L->base + CallBase + 1 + LJ_FR2);
+   lj_assertL(not L->context_stack.empty() and L->context_stack.back().owner_base IS prepared_owner,
+      "contextual tail call has no prepared activation");
+   if (L->context_stack.empty() or L->context_stack.back().owner_base != prepared_owner) return ArgumentCount;
+
+   GCtab *context = tabref(L->context_stack.back().table);
+   lj_assertL(tabV(receiver) IS context, "tail context does not match its receiver");
+   L->context_stack.pop_back();
+
+   ptrdiff_t outgoing_owner = savestack(L, L->base);
+   if (not L->context_stack.empty() and L->context_stack.back().owner_base IS outgoing_owner) {
+      L->context_stack.pop_back();
+   }
+   lj_context_push(L, context, L->base);
+   L->context_stack.back().tail_transfer = true;
+   return ArgumentCount;
+}
+
+void lj_context_push(lua_State *L, GCtab *Table, const TValue *OwnerBase)
+{
+   lj_assertL(L and Table and OwnerBase, "invalid contextual activation");
+   // Initial entries take Table from L's guarded operand stack; transfers take it from L's rooted context stack.
+   lj_assertL(Table->gct IS ~LJ_TTAB, "context is not a table");
+   TValue *stack = tvref(L->stack);
+   // A call frame base may temporarily occupy LuaJIT's reserved stack area before the function header grows the
+   // soft stack limit. Context owners are offsets only and remain valid throughout that interval.
+   TValue *stack_end = stack + L->stacksize;
+   lj_assertL(OwnerBase >= stack and OwnerBase < stack_end, "context owner is outside the state stack allocation");
+
+   lua_State::ContextFrame frame;
+   setgcref(frame.table, obj2gco(Table));
+   frame.owner_base = savestack(L, OwnerBase);
+   L->context_stack.push_back(frame);
+   L->context_active = 1;
+   lj_gc_barriercontext(L, Table);
+}
+
+void lj_context_pop(lua_State *L, const TValue *OwnerBase) noexcept
+{
+   lj_assertL(L and OwnerBase, "invalid contextual activation owner");
+   lj_assertL(not L->context_stack.empty(), "attempt to pop the permanent root context");
+   if (L->context_stack.empty()) return;
+
+   ptrdiff_t owner_base = savestack(L, OwnerBase);
+   lj_assertL(L->context_stack.back().owner_base IS owner_base, "unbalanced contextual activation");
+   if (L->context_stack.back().owner_base IS owner_base) {
+      L->context_stack.pop_back();
+      L->context_active = context_has_visible_override(L);
+   }
+}
+
+extern "C" uint32_t lj_context_leave_frame(
+   lua_State *L, TValue *FrameBase, uint32_t ReturnState) noexcept
+{
+   lj_assertL(L and FrameBase, "invalid contextual activation frame");
+   ptrdiff_t frame_base = savestack(L, FrameBase);
+   if (not L->context_stack.empty() and L->context_stack.back().owner_base IS frame_base) {
+      L->context_stack.pop_back();
+      L->context_active = context_has_visible_override(L);
+   }
+   return ReturnState;
+}
+
+extern "C" uint32_t lj_context_leave_native_frame(
+   lua_State *L, TValue *FrameBase, uint32_t ReturnState) noexcept
+{
+   ptrdiff_t frame_base = savestack(L, FrameBase);
+   if (not L->context_stack.empty() and L->context_stack.back().tail_transfer and
+      L->context_stack.back().owner_base IS frame_base) {
+      return lj_context_leave_frame(L, FrameBase, ReturnState);
+   }
+   return lj_context_leave_frame(L, FrameBase + 1 + LJ_FR2, ReturnState);
+}
+
+void lj_context_unwind(lua_State *L, const TValue *SurvivingBase) noexcept
+{
+   lj_assertL(L and SurvivingBase, "invalid contextual unwind boundary");
+   ptrdiff_t surviving_base = savestack(L, SurvivingBase);
+   size_t floor = L->context_root_floors.empty() ? 0 : L->context_root_floors.back();
+   while (L->context_stack.size() > floor and L->context_stack.back().owner_base > surviving_base) {
+      L->context_stack.pop_back();
+   }
+   L->context_active = context_has_visible_override(L);
+}
+
+size_t lj_context_depth(const lua_State *L) noexcept
+{
+   if (not L) return 0;
+   size_t floor = L->context_root_floors.empty() ? 0 : L->context_root_floors.back();
+   return L->context_stack.size() - floor + 1;
+}
+
+//********************************************************************************************************************
 // Allocate basic stack for new state.
 
 static void stack_init(lua_State *L1, lua_State *L)
@@ -216,6 +426,10 @@ static TValue * cpluaopen(lua_State *Lua, lua_CFunction dummy, void* ud)
 static void close_state(lua_State *L)
 {
    global_State *g = G(L);
+   // Teardown also covers states terminated while an activation or asynchronous root boundary is still live.
+   L->context_stack.clear();
+   L->context_active = 0;
+   L->context_root_floors.clear();
    if (L->parser_diagnostics) { delete (ParserDiagnostics*)L->parser_diagnostics; L->parser_diagnostics = nullptr; }
    if (L->parser_tips) { delete L->parser_tips; L->parser_tips = nullptr; }
    if (L->parser_symbols) { delete L->parser_symbols; L->parser_symbols = nullptr; }
@@ -362,6 +576,8 @@ void lj_state_free(global_State* g, lua_State *L)
 {
    lj_assertG(L != mainthread(g), "free of main thread");
    if (obj2gco(L) IS gcref(g->cur_L)) setgcrefnull(g->cur_L);
+   lj_assertG(L->context_stack.empty(), "state freed with active contextual activations");
+   lj_assertG(L->context_root_floors.empty(), "state freed with active asynchronous root boundaries");
 
    if (L->parser_diagnostics) { delete (ParserDiagnostics*)L->parser_diagnostics; L->parser_diagnostics = nullptr; }
    if (L->parser_tips) { delete L->parser_tips; L->parser_tips = nullptr; }

--- a/src/tiri/jit/src/runtime/lj_state.h
+++ b/src/tiri/jit/src/runtime/lj_state.h
@@ -34,6 +34,15 @@ static LJ_AINLINE void lj_state_checkstack(lua_State* L, MSize need)
 LJ_FUNC void lj_state_free(global_State* g, lua_State* L);
 
 // State-local table context.  The root is represented by an empty override stack and always resolves through L->env.
+
+// Client tables establish context.  Internal library namespaces are permanent implementation interfaces and inherit
+// the caller's context instead.  The interpreter and recorder share this predicate to keep their behaviour aligned.
+
+[[nodiscard]] inline bool lj_context_receiver_establishes(const TValue *Receiver) noexcept
+{
+   return tvistab(Receiver) and not lj_tab_is_context_exempt(tabV(Receiver));
+}
+
 LJ_FUNC [[nodiscard]] GCtab * lj_context_current(lua_State *L) noexcept;
 extern "C" LJ_FUNC void lj_context_load(lua_State *L, TValue *Destination) noexcept;
 extern "C" LJ_FUNC GCtab * lj_context_current_jit(lua_State *L) noexcept;

--- a/src/tiri/jit/src/runtime/lj_state.h
+++ b/src/tiri/jit/src/runtime/lj_state.h
@@ -33,6 +33,62 @@ static LJ_AINLINE void lj_state_checkstack(lua_State* L, MSize need)
 
 LJ_FUNC void lj_state_free(global_State* g, lua_State* L);
 
+// State-local table context.  The root is represented by an empty override stack and always resolves through L->env.
+LJ_FUNC [[nodiscard]] GCtab * lj_context_current(lua_State *L) noexcept;
+extern "C" LJ_FUNC void lj_context_load(lua_State *L, TValue *Destination) noexcept;
+extern "C" LJ_FUNC GCtab * lj_context_current_jit(lua_State *L) noexcept;
+extern "C" LJ_FUNC void lj_context_enter_jit(lua_State *L, GCtab *Table, TValue *OwnerBase);
+extern "C" LJ_FUNC void lj_context_leave_jit(lua_State *L, TValue *OwnerBase) noexcept;
+extern "C" LJ_FUNC void lj_context_tail_jit(
+   lua_State *L, GCtab *Table, TValue *PreparedOwner, TValue *OutgoingOwner);
+extern "C" LJ_FUNC void lj_context_enter_call(lua_State *L, uint32_t CallBase);
+extern "C" LJ_FUNC uint32_t lj_context_prepare_call(lua_State *L, uint32_t CallBase, uint32_t ArgumentCount);
+extern "C" LJ_FUNC void lj_context_leave_call(
+   lua_State *L, uint32_t CallBase, const BCIns *CallInstruction, uint32_t ResultCountWithSentinel) noexcept;
+extern "C" LJ_FUNC uint32_t lj_context_prepare_tail_call(
+   lua_State *L, uint32_t CallBase, uint32_t ArgumentCount);
+LJ_FUNC void lj_context_push(lua_State *L, GCtab *Table, const TValue *OwnerBase);
+LJ_FUNC void lj_context_pop(lua_State *L, const TValue *OwnerBase) noexcept;
+extern "C" LJ_FUNC uint32_t lj_context_leave_frame(
+   lua_State *L, TValue *FrameBase, uint32_t ReturnState) noexcept;
+extern "C" LJ_FUNC uint32_t lj_context_leave_native_frame(
+   lua_State *L, TValue *FrameBase, uint32_t ReturnState) noexcept;
+LJ_FUNC void lj_context_unwind(lua_State *L, const TValue *SurvivingBase) noexcept;
+LJ_FUNC [[nodiscard]] size_t lj_context_depth(const lua_State *L) noexcept;
+
+// Asynchronous callbacks are deliberately unbound.  Temporarily expose the dynamic root while retaining suspended
+// activations owned by the interrupted synchronous call chain.
+
+class LuaContextRootGuard {
+public:
+   explicit LuaContextRootGuard(lua_State *State) noexcept : state_(State)
+   {
+      lj_assertX(this->state_, "missing state for root context guard");
+      this->state_->context_root_floors.push_back(this->state_->context_stack.size());
+      this->state_->context_active = 0;
+   }
+
+   ~LuaContextRootGuard()
+   {
+      lj_assertG_(G(this->state_), not this->state_->context_root_floors.empty(),
+         "asynchronous callback lost its root context boundary");
+      size_t floor = this->state_->context_root_floors.back();
+      lj_assertG_(G(this->state_), this->state_->context_stack.size() IS floor,
+         "asynchronous callback leaked a contextual activation");
+      this->state_->context_stack.resize(floor);
+      this->state_->context_root_floors.pop_back();
+      size_t outer_floor = this->state_->context_root_floors.empty() ? 0 :
+         this->state_->context_root_floors.back();
+      this->state_->context_active = this->state_->context_stack.size() > outer_floor;
+   }
+
+   LuaContextRootGuard(const LuaContextRootGuard &) = delete;
+   LuaContextRootGuard & operator=(const LuaContextRootGuard &) = delete;
+
+private:
+   lua_State *state_;
+};
+
 // Function name registry for tostring() support on named functions.
 LJ_FUNC void lj_funcname_register(global_State* g, const GCproto* pt, const char* name, size_t len);
 LJ_FUNC const char* lj_funcname_lookup(global_State* g, const GCproto* pt, size_t* len);

--- a/src/tiri/jit/src/runtime/unit_tests_gc.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_gc.cpp
@@ -7,6 +7,10 @@
 
 #include "lua.h"
 #include "lauxlib.h"
+#include "lj_gc.h"
+#include "lj_state.h"
+#include "lj_str.h"
+#include "lj_tab.h"
 
 #include <array>
 #include <cstddef>
@@ -140,14 +144,84 @@ static bool test_shutdown_does_not_run_new_finalisers(kt::Log &Log)
    return true;
 }
 
+static bool test_context_root_tracks_environment_replacement(kt::Log &Log)
+{
+   lua_State *lua = luaL_newstate(nullptr);
+   if (not lua) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   GCtab *initial = tabref(lua->env);
+   GCtab *replacement = lj_tab_new(lua, 0, 1);
+   setgcref(lua->env, obj2gco(replacement));
+   bool passed = lj_context_depth(lua) IS 1 and lj_context_current(lua) IS replacement and replacement != initial;
+   if (not passed) Log.error("root context did not resolve through the replacement environment");
+   lua_close(lua);
+   return passed;
+}
+
+static bool test_nested_context_ownership_and_stack_relocation(kt::Log &Log)
+{
+   lua_State *lua = luaL_newstate(nullptr);
+   if (not lua) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   GCtab *outer = lj_tab_new(lua, 0, 1);
+   GCtab *inner = lj_tab_new(lua, 0, 1);
+   lj_context_push(lua, outer, lua->base);
+   lj_context_push(lua, inner, lua->base);
+   lj_state_growstack(lua, 256);
+
+   bool passed = lj_context_depth(lua) IS 3 and lj_context_current(lua) IS inner;
+   lj_context_pop(lua, lua->base);
+   passed = passed and lj_context_current(lua) IS outer;
+   lj_context_pop(lua, lua->base);
+   passed = passed and lj_context_depth(lua) IS 1 and lj_context_current(lua) IS tabref(lua->env);
+   if (not passed) Log.error("nested context ownership did not survive stack relocation or restore in order");
+   lua_close(lua);
+   return passed;
+}
+
+static bool test_active_context_survives_full_collection(kt::Log &Log)
+{
+   lua_State *lua = luaL_newstate(nullptr);
+   if (not lua) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   GCtab *context = lj_tab_new(lua, 0, 1);
+   GCstr *key = lj_str_newlit(lua, "context_gc_marker");
+   TValue *slot = lj_tab_setstr(lua, context, key);
+   setintV(slot, 73);
+   lj_context_push(lua, context, lua->base);
+   lj_gc_fullgc(lua);
+
+   cTValue *retained = lj_tab_getstr(lj_context_current(lua), key);
+   bool passed = retained and tvisnumber(retained) and numberVnum(retained) IS 73;
+   if (not passed) {
+      Log.error("active context table was not retained across a full collection (context=%p current=%p type=%d)",
+         context, lj_context_current(lua), retained ? int(itype(retained)) : 0);
+   }
+   lj_context_pop(lua, lua->base);
+   lua_close(lua);
+   return passed;
+}
+
 } // namespace
 
 extern void gc_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 2> Tests = { {
+   constexpr std::array<TestCase, 5> Tests = { {
       { "shutdown_drains_pre_registered_finalisers_after_error",
          test_shutdown_drains_pre_registered_finalisers_after_error },
-      { "shutdown_does_not_run_new_finalisers", test_shutdown_does_not_run_new_finalisers }
+      { "shutdown_does_not_run_new_finalisers", test_shutdown_does_not_run_new_finalisers },
+      { "context_root_tracks_environment_replacement", test_context_root_tracks_environment_replacement },
+      { "nested_context_ownership_and_stack_relocation", test_nested_context_ownership_and_stack_relocation },
+      { "active_context_survives_full_collection", test_active_context_survives_full_collection }
    } };
 
    for (const TestCase& Test : Tests) {

--- a/src/tiri/tests/test_context_access.tiri
+++ b/src/tiri/tests/test_context_access.tiri
@@ -1,0 +1,54 @@
+-- Flute regression tests for root current-context access.  Non-root contextual calls are introduced in Phase 3.
+
+function activate_context_statement(Statement:str):obj
+   local script = obj.new('tiri', { statement = Statement })
+   script.acActivate()
+   return script
+end
+
+@Test function RootContextReadsAndWritesGlobalEnvironment()
+   .glContextAccessValue = 11
+   assert(.glContextAccessValue is 11, 'Leading-dot reads should resolve through the root environment')
+   assert(_G.glContextAccessValue is 11, 'Leading-dot writes should update the root environment')
+
+   .glContextAccessValue += 4
+   assert(glContextAccessValue is 15, 'Leading-dot compound assignment should use ordinary environment storage')
+   .glContextAccessValue = nil
+end
+
+@Test function ChainedContextAccessUsesTheLoadedTable()
+   .glContextAccessTree = { child = { value = 27 } }
+   assert(.glContextAccessTree.child.value is 27,
+      'Chained leading-dot access should continue from the table loaded from current context')
+   .glContextAccessTree.child.value = 31
+   assert(glContextAccessTree.child.value is 31, 'Chained context stores should update the selected child table')
+   .glContextAccessTree = nil
+end
+
+@Test function DirectFunctionsInheritRootContext()
+   .glContextAccessInherited = 'root'
+   function read_context_value()
+      return .glContextAccessInherited
+   end
+
+   assert(read_context_value() is 'root', 'An ordinary direct call should inherit the root context')
+   .glContextAccessInherited = nil
+end
+
+@Test function ContextStoreCannotOverrideProtectedGlobal()
+   local script = activate_context_statement([[.tostring = 5]])
+   assert(script.error != ERR_Okay, 'A root context store should reject a protected global')
+   assert(string.find(script.errorMessage, 'cannot override built-in') != nil,
+      'A rejected context store should report the protected-global diagnostic: ' .. script.errorMessage)
+end
+
+@Test function ContextStoreHonoursStickyGlobalContract()
+   local script = activate_context_statement([[
+global glContextContract:num = 3
+local replacement:any = 'wrong'
+.glContextContract = replacement
+]])
+   assert(script.error != ERR_Okay, 'A root context store should reject a value that violates a global contract')
+   assert(string.find(script.errorMessage, 'expected num') != nil,
+      'A rejected context store should report the global contract: ' .. script.errorMessage)
+end

--- a/src/tiri/tests/test_contextual_member_calls.tiri
+++ b/src/tiri/tests/test_contextual_member_calls.tiri
@@ -1,0 +1,958 @@
+-- Flute regression tests for table-gated contextual member calls.
+
+import 'json'
+
+@Test function NamedAndComputedTableCallsEstablishContext()
+   local point = { name = 'point', value = 0 }
+
+   function point.set(Value:num):num
+      .value = Value
+      return .value
+   end
+
+   function point.read():str
+      return .name
+   end
+
+   function point.describe():<table, num>
+      return { name = .name, value = .value }, 2
+   end
+
+   assert(point.set(17) is 17, 'A named table call should pass only its written arguments')
+   assert(point.value is 17, 'A named table call should expose its receiver through leading-dot access')
+
+   local key = 'read'
+   assert(point[key]() is 'point', 'A computed table call should establish the original receiver as context')
+
+   key = 'describe'
+   local description, result_count = point[key]()
+   assert(description.name is 'point' and description.value is 17 and result_count is 2,
+      'A computed contextual call should compact table and multiple results into the expression destination')
+end
+
+@Test function DirectCallsInheritAndNestedTableCallsRestoreContext()
+   local outer = { name = 'outer' }
+   local inner = { name = 'inner' }
+
+   function read_context_name():str
+      return .name
+   end
+
+   function inner.read():str
+      return read_context_name()
+   end
+
+   function outer.read_nested():<str, str>
+      local nested_name = inner.read()
+      return nested_name, read_context_name()
+   end
+
+   function outer.forward_nested():str
+      return inner.read()
+   end
+
+   local nested_name, restored_name = outer.read_nested()
+   assert(nested_name is 'inner', 'A nested table call should replace the inherited context')
+   assert(restored_name is 'outer', 'A completed nested table call should restore its caller context')
+   assert(outer.forward_nested() is 'inner',
+      'A returned contextual call should complete restoration before returning to its caller')
+end
+
+@Test function ReturnAritiesRestoreContext()
+   local receiver = { name = 'receiver' }
+
+   function receiver.return_none()
+      assert(.name is 'receiver', 'A zero-result call should execute in its receiver context')
+   end
+
+   function receiver.return_one():str
+      return .name
+   end
+
+   function receiver.return_many():<str, num, bool>
+      return .name, 17, true
+   end
+
+   receiver.return_none()
+   assert(.receiver is nil, 'A zero-result return should restore the root context')
+   assert(receiver.return_one() is 'receiver', 'A fixed-result return should retain its value')
+   assert(.receiver is nil, 'A fixed-result return should restore the root context')
+
+   local name, value, enabled = receiver.return_many()
+   assert(name is 'receiver' and value is 17 and enabled is true,
+      'A multiple-result return should retain all returned values')
+   assert(.receiver is nil, 'A multiple-result return should restore the root context')
+end
+
+@Test function VariableResultReturnsRestoreContext()
+   local receiver = { name = 'variable receiver' }
+
+   function receiver.forward(...):<any, ...>
+      assert(.name is 'variable receiver', 'A variable-result callee should observe its receiver context')
+      return ...
+   end
+
+   local first, second, third = receiver.forward('first', 42, true)
+   assert(first is 'first' and second is 42 and third is true,
+      'A contextual variable-result return should preserve every returned value')
+
+   local empty = receiver.forward()
+   assert(empty is nil, 'A zero-value contextual variable-result return should produce nil in a fixed result slot')
+   assert(.name is nil, 'Variable-result returns should restore the root context')
+end
+
+@Test function ErrorsAndProtectedReentryRestoreContext()
+   local outer = { name = 'outer' }
+   local inner = { name = 'inner' }
+
+   function inner.fail()
+      assert(.name is 'inner', 'The failing function should observe its receiver context')
+      error('context failure')
+   end
+
+   function outer.catch_inner():str
+      try
+         inner.fail()
+      except e
+         assert(e.message.find('context failure') != nil, 'The expected nested error should be caught')
+         return .name
+      end
+      return 'uncaught'
+   end
+
+   function outer.exec_in_context():str
+      return exec([[return .name]])
+   end
+
+   function outer.exec_native_tail():num
+      return exec([[function forward():num return math.abs(-19) end; return forward()]])
+   end
+
+   assert(outer.catch_inner() is 'outer', 'A caught error should restore the handler activation context')
+   assert(outer.exec_in_context() is 'outer', 'Synchronous lua_pcall re-entry should inherit the active context')
+   assert(outer.exec_native_tail() is 19,
+      'A protected re-entry ending in a native contextual tail call should preserve its result')
+   assert(.name is nil, 'Protected calls should restore the root context after returning')
+end
+
+@Test function ErrorCleanupHandlersObserveOwningContexts()
+   local observed = {}
+   local outer = { name = 'outer' }
+   local inner = { name = 'inner' }
+
+   function make_resource(Label:str):table
+      return setmetatable({}, {
+         __close = function()
+            observed[#observed] = Label .. ':' .. .name
+         end
+      })
+   end
+
+   function inner.fail()
+      local resource <close> = make_resource('inner')
+      error('cleanup failure')
+   end
+
+   function outer.run()
+      local resource <close> = make_resource('outer')
+      inner.fail()
+   end
+
+   try
+      outer.run()
+   except e
+      assert(e.message.find('cleanup failure') != nil, 'The cleanup fixture should preserve the original error')
+   end
+
+   assert(observed[0] is 'inner:inner', 'An inner error cleanup should retain the inner activation context')
+   assert(observed[1] is 'outer:outer', 'An outer error cleanup should restore the outer activation context')
+   assert(.name is nil, 'Error cleanup should finish in the root context')
+end
+
+@Test function DelayedCallbacksAreUnbound()
+   .glDelayedContextName = 'root'
+   .glDelayedObservedContext = nil
+   local receiver = { glDelayedContextName = 'receiver' }
+
+   function receiver.schedule()
+      processing.delayedCall(function()
+         .glDelayedObservedContext = .glDelayedContextName
+         processing.signal()
+      end)
+   end
+
+   receiver.schedule()
+   check processing.sleep(1.0)
+   assert(.glDelayedObservedContext is 'root',
+      'A delayed callback should begin unbound in the state root context')
+   .glDelayedContextName = nil
+   .glDelayedObservedContext = nil
+end
+
+@Test function ContextualTailCallsTransferOwnership()
+   local outer = { name = 'outer' }
+   local inner = { name = 'inner' }
+   local recursive = { name = 'recursive' }
+
+   function inherited_helper(Value:num):<str, num>
+      return .name, Value
+   end
+
+   function outer.to_direct(Value:num):<str, num>
+      return inherited_helper(Value)
+   end
+
+   function outer.to_same():str
+      return outer.read()
+   end
+
+   function outer.read():str
+      return .name
+   end
+
+   function outer.to_different():str
+      return inner.read()
+   end
+
+   function inner.read():str
+      return .name
+   end
+
+   function recursive.read(Count:num):str
+      if Count <= 0 then return .name end
+      return recursive.read(Count - 1)
+   end
+
+   local inherited_name, inherited_value = outer.to_direct(31)
+   assert(inherited_name is 'outer' and inherited_value is 31,
+      'A direct tail helper should retain the outgoing activation context')
+   assert(outer.to_same() is 'outer', 'A same-receiver tail call should retain its receiver')
+   assert(outer.to_different() is 'inner', 'A different-receiver tail call should replace its receiver')
+   assert(recursive.read(40) is 'recursive', 'Contextual tail recursion should retain context ownership')
+   assert(.name is nil, 'Completed contextual tail calls should restore the root context')
+end
+
+@Test function DirectCallerContextualTailCallRestoresRoot()
+   local script = obj.new('tiri', { statement = [[
+local target = { name = 'tail target' }
+
+function target.read()
+   return .name
+end
+
+function forward():<any, ...>
+   return target.read()
+end
+
+assert(forward() is 'tail target', 'The contextual tail target should retain its receiver')
+assert(.name is nil, 'A contextual tail call from a direct function should restore the root context')
+]] })
+   check script.acQuery()
+   check script.acActivate()
+   local _, disassembly = script.mtDebugLog('disasm')
+   assert(disassembly.find('CTXCALLT') != nil,
+      'An eligible fixed-argument contextual return should emit ownership-transferring tail bytecode')
+end
+
+@Test function ComputedVariadicAndNativeTailCallsRestoreContext()
+   local outer = { name = 'outer' }
+   local target = { name = 'target' }
+
+   function target.collect(...):str
+      local first = ...
+      return .name .. ':' .. tostring(first)
+   end
+
+   function outer.forward(Key:str, ...):str
+      return target[Key](...)
+   end
+
+   function outer.native_tail():<any, ...>
+      return math.abs(-12)
+   end
+
+   assert(outer.forward('collect', 7, 'eight') is 'target:7',
+      'A computed variadic contextual call should preserve its receiver and forwarded arguments')
+   assert(outer.native_tail() is 12, 'A contextual tail call into a native namespace should preserve its result')
+   assert(.name is nil, 'Native and variadic contextual tail calls should restore the root context')
+end
+
+@Test function ReceiverKeyAndArgumentsPreserveEvaluationOrder()
+   local events = {}
+   local target = { name = 'ordered' }
+
+   function target.invoke(Value:num):num
+      events[#events] = 'call'
+      assert(.name is 'ordered', 'The callable should observe the original receiver')
+      return Value
+   end
+
+   function evaluate_receiver():table
+      events[#events] = 'receiver'
+      return target
+   end
+
+   function evaluate_key():str
+      events[#events] = 'key'
+      return 'invoke'
+   end
+
+   function evaluate_argument():num
+      events[#events] = 'argument'
+      assert(.name is 'ordered', 'Arguments should be evaluated after contextual entry')
+      return 23
+   end
+
+   assert(evaluate_receiver()[evaluate_key()](evaluate_argument()) is 23,
+      'A computed contextual call should return the callable result')
+   assert(#events is 4, 'Receiver, key, argument and callable should each be evaluated exactly once')
+   assert(events[0] is 'receiver' and events[1] is 'key' and events[2] is 'argument' and events[3] is 'call',
+      'Contextual calls should preserve receiver, key, argument and invocation order')
+end
+
+@Test function MetatableLookupKeepsOriginalReceiver()
+   local implementation = function():str
+      return .name
+   end
+   local prototype = { inherited = implementation }
+   local receiver = setmetatable({ name = 'receiver' }, { __index = prototype })
+
+   assert(receiver.inherited() is 'receiver',
+      'A callable returned through __index should retain the original table receiver as context')
+end
+
+@Test function SafeContextualCallsShortCircuitAndEstablishContext()
+   local key_calls = 0
+   local argument_calls = 0
+   local missing = nil
+
+   function evaluate_key():str
+      key_calls += 1
+      return 'invoke'
+   end
+
+   function evaluate_argument():num
+      argument_calls += 1
+      return 5
+   end
+
+   local result = missing?[evaluate_key()](evaluate_argument())
+   assert(result is nil, 'A safe computed call should return nil for a nil receiver')
+   assert(key_calls is 0 and argument_calls is 0,
+      'A safe computed call should not evaluate its key or arguments on the nil path')
+
+   local receiver = { name = 'safe' }
+   function receiver.invoke():str
+      return .name
+   end
+
+   assert(receiver?.invoke() is 'safe', 'A safe named table call should establish context on its non-nil path')
+end
+
+@Test function ExtractedMembersRemainUnbound()
+   .glContextualExtractionName = 'root'
+   local receiver = { glContextualExtractionName = 'receiver' }
+
+   function receiver.read():str
+      return .glContextualExtractionName
+   end
+
+   local callback = receiver.read
+   assert(callback() is 'root', 'An extracted member should inherit invocation-time context without binding its table')
+   .glContextualExtractionName = nil
+end
+
+@Test function StaticStructureMemberCallsBypassContextBytecode()
+   local script = obj.new('tiri', { statement = [[
+struct ContextualDisassemblyRecord
+   Value: int
+end
+
+function call_structure_member(Value:struct<ContextualDisassemblyRecord>)
+   Value.probe()
+end
+]] })
+   check script.acQuery()
+   check script.acActivate()
+   local _, disassembly = script.mtDebugLog('disasm')
+   assert(disassembly.find('CTXENTER') is nil and disassembly.find('CTXCALL') is nil,
+      'A statically known structure receiver should not emit contextual call bytecode')
+end
+
+@Test function NonTableReceiversDoNotReplaceContext()
+   .glContextualExemption = 'root'
+
+   function context_argument(Value:any):any
+      assert(.glContextualExemption is 'root', 'A non-table member call should leave argument context unchanged')
+      return Value
+   end
+
+   local text:str = 'needle stack'
+   local values:array<any> = array<string> { 'needle' }
+   local indexes:range = {0 to 3}
+   assert(text.startsWith(context_argument('needle')) is true,
+      'String member dispatch should retain its existing behaviour')
+   assert(values.contains(context_argument('needle')) is true,
+      'Array member dispatch should retain its existing behaviour')
+   assert(indexes.contains(2) is true, 'Range member dispatch should retain its existing behaviour')
+
+   local script = obj.find('self')
+   local err, state = script.mtDebugLog(context_argument('state'))
+   assert(err is ERR_Okay and state != nil, 'Object member dispatch should retain its visible argument layout')
+
+   local probe = function(Value:any):any
+      assert(.glContextualExemption is 'root', 'A non-table metatable function should inherit the current context')
+      return Value
+   end
+
+   local callable = function() end
+   local callable_metatable = debug.getMetatable(callable)
+   debug.setMetatable(callable, { __index = { probe = probe } })
+   assert(callable.probe(context_argument('callable')) is 'callable',
+      'Callable member dispatch should not replace the current table context')
+   debug.setMetatable(callable, callable_metatable)
+
+   local scalar:num = 9
+   local scalar_metatable = debug.getMetatable(scalar)
+   debug.setMetatable(scalar, { __index = { probe = probe } })
+   assert(scalar.probe(context_argument('scalar')) is 'scalar',
+      'Scalar member dispatch should not replace the current table context')
+   debug.setMetatable(scalar, scalar_metatable)
+   .glContextualExemption = nil
+end
+
+@Test(hotpath=80) function JITHotNestedContextsAndSideExitsMatchInterpreter()
+   local outer = { name = 'jit outer' }
+   local inner = { name = 'jit inner', alternate = false }
+
+   function inner.read(Value:num):str
+      if .alternate then return .name .. ':alternate:' .. tostring(Value) end
+      return .name .. ':primary:' .. tostring(Value)
+   end
+
+   function outer.run(Target:table, Count:num):str
+      local result = ''
+      for i in {0 to Count} do
+         if i is 24 then Target.alternate = true end
+         result = Target.read(i)
+         assert(.name is 'jit outer', 'A recorded contextual return should restore its caller context')
+      end
+      return result
+   end
+
+   jit.off()
+   inner.alternate = false
+   local interpreted = outer.run(inner, 64)
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   inner.alternate = false
+   local recorded = outer.run(inner, 64)
+   jit.off()
+   local trace_count = 0
+   for trace_no in {1 into 40} do
+      if jit.util.traceInfo(trace_no) != nil then trace_count++ end
+   end
+   jit.opt.start()
+
+   assert(recorded is interpreted,
+      'Recorded nested contexts and their forced branch side exit should match the interpreter')
+   assert(trace_count > 0, 'The contextual hot workload should produce at least one recorded trace')
+   assert(.name is nil, 'A completed recorded contextual workload should restore the root context')
+end
+
+@Test(hotpath=80) function JITAlternatingReceiversUseRecordedContext()
+   local first = { value = 3 }
+   local second = { value = 7 }
+
+   function read_value():num
+      return .value
+   end
+
+   first.read = read_value
+   second.read = read_value
+
+   function run(Count:num):num
+      local total = 0
+      for i in {0 to Count} do
+         local target = i % 2 is 0 ? first :> second
+         total += target.read()
+      end
+      return total
+   end
+
+   jit.off()
+   local interpreted = run(200)
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   local recorded = run(200)
+   jit.off()
+   jit.opt.start()
+
+   assert(recorded is interpreted and recorded is 1000,
+      'A recorded contextual call should use the loop-selected receiver rather than a retained earlier table')
+   assert(.value is nil, 'Alternating recorded receivers should restore the root context')
+end
+
+@Test function JITVirtualContextRestoresAllocatedReceiverOnExit()
+   function read_allocated():num
+      if .alternate then return .value + 1 end
+      return .value
+   end
+
+   function run(Count:num):num
+      local total = 0
+      for i in {0 to Count} do
+         local target = { value = i, alternate = i is 24, read = read_allocated }
+         total += target.read()
+      end
+      return total
+   end
+
+   jit.off()
+   local interpreted = run(64)
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   local recorded = run(64)
+   jit.off()
+   jit.opt.start()
+
+   assert(recorded is interpreted,
+      'A virtual context side exit should restore a receiver allocated by the recorded loop')
+   assert(.value is nil, 'An allocated virtual receiver should no longer be current after contextual restoration')
+end
+
+@Test function JITVirtualExitPreservesMaterialisedCallerContext()
+   local outer = { name = 'materialised outer' }
+   local target = { value = 3, alternate = false }
+
+   function target.read():num
+      if .alternate then return .value + 1 end
+      return .value
+   end
+
+   function run(Target:table, Count:num):num
+      local total = 0
+      for _ in {0 to Count} do total += Target.read() end
+      return total
+   end
+
+   function outer.invoke(Target:table, Count:num):<num, str>
+      local total = run(Target, Count)
+      return total, .name
+   end
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   local root_total = run(target, 64)
+   target.alternate = true
+   local nested_total, restored_name = outer.invoke(target, 64)
+   jit.off()
+   jit.opt.start()
+
+   assert(root_total is 192 and nested_total is 256,
+      'A reused virtual trace should preserve receiver results on both guarded paths')
+   assert(restored_name is 'materialised outer',
+      'A virtual side exit should preserve the materialised context inherited by the reused trace')
+   assert(.name is nil, 'The reused trace should restore the root context after its caller returns')
+end
+
+@Test(hotpath=80) function JITContextualResultAritiesAndNestedRestorationMatchInterpreter()
+   local outer = { name = 'arity outer' }
+   local target = { name = 'arity target', calls = 0, alternate = false }
+
+   function target.zero()
+      .calls++
+   end
+
+   function target.fixed(Value:num):str
+      if .alternate then return .name .. ':alternate:' .. tostring(Value) end
+      return .name .. ':primary:' .. tostring(Value)
+   end
+
+   function target.multiple(Value:num):<str, num>
+      return .name, Value
+   end
+
+   function outer.run(Target:table, Count:num):str
+      local result = ''
+      for i in {0 to Count} do
+         Target.zero()
+         if i is 24 then Target.alternate = true end
+         local fixed = Target.fixed(i)
+         local name, value = Target.multiple(i)
+         result = fixed .. ':' .. name .. ':' .. tostring(value)
+         assert(.name is 'arity outer', 'Every contextual result arity should restore the outer context')
+      end
+      return result
+   end
+
+   jit.off()
+   target.calls = 0
+   target.alternate = false
+   local interpreted = outer.run(target, 64)
+   local interpreted_calls = target.calls
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   target.calls = 0
+   target.alternate = false
+   local recorded = outer.run(target, 64)
+   jit.off()
+   jit.opt.start()
+
+   assert(recorded is interpreted,
+      'Recorded zero, fixed and multiple-result contextual calls should match the interpreter')
+   assert(target.calls is interpreted_calls,
+      'A recorded zero-result contextual call should execute exactly once per source invocation')
+   assert(.name is nil, 'Recorded contextual result arities should finish in the root context')
+end
+
+@Test function JITContextualVariableResultsMatchInterpreter()
+   local outer = { name = 'variable outer' }
+   local target = { name = 'variable target' }
+
+   function target.forward(...):<any, ...>
+      return ...
+   end
+
+   function outer.run(Target:table, Count:num):num
+      local result = 0
+      for i in {0 to Count} do
+         local first, second = Target.forward(i, i + 1)
+         result = first + second
+         assert(.name is 'variable outer', 'A contextual RETM return should restore its recorded caller context')
+      end
+      return result
+   end
+
+   jit.off()
+   local interpreted = outer.run(target, 64)
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   local recorded = outer.run(target, 64)
+   jit.off()
+
+   local trace_count = 0
+   for trace_no in {1 into 40} do
+      if jit.util.traceInfo(trace_no) != nil then trace_count++ end
+   end
+   jit.opt.start()
+
+   assert(recorded is interpreted, 'Recorded contextual variable-result returns should match the interpreter')
+   assert(trace_count > 0, 'The contextual variable-result workload should produce at least one recorded trace')
+   assert(.name is nil, 'Recorded contextual variable-result returns should finish in the root context')
+end
+
+@Test function JITComputedContextualResultsMatchInterpreter()
+   local outer = { name = 'computed outer' }
+   local target = { name = 'computed target' }
+
+   function target.describe(Value:num):<table, num>
+      return { name = .name, value = Value }, Value + 1
+   end
+
+   function outer.run(Target:table, Count:num):num
+      local result = 0
+      local key = 'describe'
+      for i in {0 to Count} do
+         local description, next_value = Target[key](i)
+         result = description.value + next_value
+         assert(description.name is 'computed target',
+            'A recorded computed contextual call should preserve its table result')
+         assert(.name is 'computed outer',
+            'A recorded computed contextual call should restore its caller context')
+      end
+      return result
+   end
+
+   jit.off()
+   local interpreted = outer.run(target, 64)
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   local recorded = outer.run(target, 64)
+   jit.off()
+
+   local trace_count = 0
+   for trace_no in {1 into 40} do
+      if jit.util.traceInfo(trace_no) != nil then trace_count++ end
+   end
+   jit.opt.start()
+
+   assert(recorded is interpreted, 'Recorded computed contextual results should match the interpreter')
+   assert(trace_count > 0, 'The computed contextual result workload should produce at least one recorded trace')
+   assert(.name is nil, 'Recorded computed contextual calls should finish in the root context')
+end
+
+@Test function JITNativeContextualResultsRemainLoopCarried()
+   local methods = { decode = array.getString }
+   local bytes = array<byte> { 65, 66, 67 }
+   local expected = { [0] = 'A', [1] = 'B', [2] = 'C' }
+
+   function run(Count:num):str
+      local result = ''
+      for i in {0 to Count} do
+         local index = i % 3
+         result = methods.decode(bytes, index, 1)
+         assert(result is expected[index],
+            'A recorded native contextual result should change with its loop-carried arguments')
+      end
+      return result
+   end
+
+   jit.off()
+   local interpreted = run(97)
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   local recorded = run(97)
+   jit.off()
+
+   local trace_count = 0
+   for trace_no in {1 into 40} do
+      if jit.util.traceInfo(trace_no) != nil then trace_count++ end
+   end
+   jit.opt.start()
+
+   assert(recorded is interpreted, 'A recorded native contextual result should match the interpreter')
+   assert(trace_count > 0, 'The native contextual result workload should produce at least one recorded trace')
+   assert(.decode is nil, 'Recorded native contextual calls should finish in the root context')
+end
+
+@Test function JITNestedContextualReturnRootsPreserveCallerArguments()
+   local payload = {
+      start = { line = 0, character = 0 },
+      ['end'] = { line = 0, character = 3 }
+   }
+
+   jit.off()
+   local interpreted = json.encode(payload)
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   local recorded
+   for _ in {0 to 8} do recorded = json.encode(payload) end
+   jit.off()
+
+   local trace_count = 0
+   for trace_no in {1 into 40} do
+      if jit.util.traceInfo(trace_no) != nil then trace_count++ end
+   end
+   jit.opt.start()
+
+   assert(recorded is interpreted,
+      'A nested return trace below a contextual caller should preserve recursive arguments and results')
+   assert(trace_count > 0, 'The nested contextual return workload should produce at least one recorded trace')
+   assert(.start is nil, 'Nested contextual return roots should finish in the root context')
+end
+
+@Test(hotpath=80) function JITContextualTailTransferMatchesInterpreter()
+   local receiver = { name = 'jit tail' }
+   local target = { name = 'jit target' }
+
+   function target.read():str
+      return .name
+   end
+
+   function receiver.forward():str
+      return target.read()
+   end
+
+   function run_tail_workload(Count:num):str
+      local result = ''
+      for i in {0 to Count} do result = receiver.forward() end
+      return result
+   end
+
+   jit.off()
+   local interpreted = run_tail_workload(80)
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   local recorded = run_tail_workload(80)
+   jit.off()
+   jit.opt.start()
+
+   assert(recorded is interpreted and recorded is 'jit target',
+      'A recorded contextual tail transfer should preserve the transferred receiver')
+   assert(.name is nil, 'A completed contextual tail transfer should restore the root context')
+end
+
+@Test(hotpath=80) function JITContextualTailTransferCoversOwnershipAndSideExits()
+   local outer = { name = 'tail outer' }
+   local target = { name = 'tail target', alternate = false }
+
+   function target.read(Value:num):str
+      assert(.name is 'tail target', 'A transferred tail context should be visible in the target')
+      if .alternate then return .name .. ':alternate:' .. tostring(Value) end
+      return .name .. ':primary:' .. tostring(Value)
+   end
+
+   function outer.read(Value:num):str
+      assert(.name is 'tail outer', 'A same-receiver tail transfer should retain its context')
+      return .name .. ':' .. tostring(Value)
+   end
+
+   function outer.forward(Target:table, Value:num):str
+      return Target.read(Value)
+   end
+
+   function outer.same(Value:num):str
+      return outer.read(Value)
+   end
+
+   function direct_forward(Target:table, Value:num):str
+      return Target.read(Value)
+   end
+
+   function run_tail_transfers(Count:num):str
+      local result = ''
+      for i in {0 to Count} do
+         if i is 24 then target.alternate = true end
+         result = outer.forward(target, i)
+      end
+      return result
+   end
+
+   function run_same_tail_transfers(Count:num):str
+      local result = ''
+      for i in {0 to Count} do result = outer.same(i) end
+      return result
+   end
+
+   function run_direct_tail_transfers(Count:num):str
+      local result = ''
+      for i in {0 to Count} do result = direct_forward(target, i) end
+      return result
+   end
+
+   jit.off()
+   target.alternate = false
+   local interpreted = run_tail_transfers(64)
+   local interpreted_same = run_same_tail_transfers(64)
+   local interpreted_direct = run_direct_tail_transfers(64)
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   target.alternate = false
+   local recorded = run_tail_transfers(64)
+   local recorded_same = run_same_tail_transfers(64)
+   local recorded_direct = run_direct_tail_transfers(64)
+   jit.off()
+
+   local trace_count = 0
+   for trace_no in {1 into 60} do
+      if jit.util.traceInfo(trace_no) != nil then trace_count++ end
+   end
+   jit.opt.start()
+
+   assert(recorded is interpreted, 'Recorded contextual tail transfers should match the interpreter')
+   assert(recorded_same is interpreted_same, 'Recorded same-receiver tail transfers should match the interpreter')
+   assert(recorded_direct is interpreted_direct,
+      'A recorded contextual tail transfer from a direct caller should match the interpreter')
+   assert(trace_count > 0, 'Contextual tail transfers should produce at least one recorded trace')
+   assert(.name is nil, 'All recorded contextual tail transfers should restore the root context')
+end
+
+@Test(hotpath=80) function JITNativeContextualTailTransferRestoresContext()
+   local native_target = { absolute = math.abs }
+   local native_forwarder = { name = 'native forwarder' }
+
+   function native_forwarder.run():num
+      return native_target.absolute(-7)
+   end
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   local native_result = 0
+   for _ in {0 to 80} do
+      native_result = native_forwarder.run()
+   end
+   jit.off()
+   jit.opt.start()
+
+   assert(native_result is 7, 'A recorded native contextual tail transfer should preserve its result')
+   assert(.name is nil, 'The native contextual tail transfer should restore the root context')
+end
+
+@Test(hotpath=80) function JITRecursiveContextualTailTransferHandlesAbortsAndSideExits()
+   local recursive = { name = 'recursive tail', visits = 0, alternate = false }
+
+   function recursive.run(Count:num):<any, ...>
+      .visits++
+      if Count <= 0 then
+         if .alternate then return .name .. ':alternate:' .. tostring(.visits) end
+         return .name .. ':primary:' .. tostring(.visits)
+      end
+      return recursive.run(Count - 1)
+   end
+
+   function run_recursive(Depth:num):<any, ...>
+      recursive.visits = 0
+      return recursive.run(Depth)
+   end
+
+   jit.off()
+   recursive.alternate = false
+   local interpreted = run_recursive(12)
+   local exhausted_interpreted = run_recursive(20)
+
+   local compiled = 0
+   local aborted = 0
+   local function trace_event(Event)
+      if Event is 'stop' then compiled++
+      elseif Event is 'abort' then aborted++
+      end
+   end
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0', 'loopunroll=2')
+   jit.attach(trace_event, 'trace')
+
+   local result:any = nil
+   for _ in {0 to 40} do result = run_recursive(20) end
+   local exhausted_recorded = result
+
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0', 'loopunroll=30')
+   for _ in {0 to 80} do
+      recursive.alternate = false
+      result = run_recursive(12)
+   end
+   local primary_recorded = result
+
+   recursive.alternate = true
+   for _ in {0 to 30} do result = run_recursive(12) end
+   local alternate_recorded = result
+
+   jit.attach(trace_event)
+   jit.off()
+   jit.opt.start()
+
+   assert(exhausted_recorded is exhausted_interpreted,
+      'Recorder unroll exhaustion should preserve recursive contextual tail results')
+   assert(primary_recorded is interpreted,
+      'Recorded self-recursive contextual tail completion should match the interpreter')
+   assert(alternate_recorded is 'recursive tail:alternate:13',
+      'A forced side exit should retain the recursive receiver, result and visit count')
+   assert(aborted > 0, 'A low tail unroll limit should exercise recorder abort cleanup')
+   assert(compiled > 0, 'Retrying with a sufficient tail unroll limit should compile recursive traces')
+   assert(.name is nil, 'Recursive tail completion, aborts and side exits should restore the root context')
+end

--- a/src/tiri/tests/test_contextual_member_calls.tiri
+++ b/src/tiri/tests/test_contextual_member_calls.tiri
@@ -58,6 +58,24 @@ end
       'A returned contextual call should complete restoration before returning to its caller')
 end
 
+@Test function InternalNamespacesInheritCurrentContext()
+   local outer = { name = 'namespace outer' }
+
+   function read_namespace_argument():num
+      assert(.name is 'namespace outer', 'Namespace argument evaluation should inherit the caller context')
+      return -19
+   end
+
+   function outer.run():<num, str>
+      local result = math.abs(read_namespace_argument())
+      return result, .name
+   end
+
+   local result, restored_name = outer.run()
+   assert(result is 19, 'A context-exempt math call should preserve its result')
+   assert(restored_name is 'namespace outer', 'A namespace call should not replace its caller context')
+end
+
 @Test function ReturnAritiesRestoreContext()
    local receiver = { name = 'receiver' }
 
@@ -523,6 +541,43 @@ end
    assert(recorded is interpreted,
       'A virtual context side exit should restore a receiver allocated by the recorded loop')
    assert(.value is nil, 'An allocated virtual receiver should no longer be current after contextual restoration')
+end
+
+@Test function JITFreshContextualClosuresReusePrototypeTrace()
+   function run_factory(Offset:num, Count:num):num
+      local target = {
+         value = 3,
+         read = function():num return .value + Offset end
+      }
+      local total = 0
+      for _ in {0 to Count} do total += target.read() end
+      return total
+   end
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   local total = 0
+   for offset in {0 to 12} do total += run_factory(offset, 128) end
+
+   local prototype_guard = false
+   for trace_no in {1 into 30} do
+      local info = jit.util.traceInfo(trace_no)
+      if info is nil then continue end
+      for instruction in {1 into info.nins} do
+         local _, ir_ot, _, ir_op2 = jit.util.traceIR(trace_no, instruction)
+         -- IR_FLOAD is opcode 69 and IRFL_FUNC_PC is field 2 in the append-only IR definitions.
+         if ir_ot != nil and (ir_ot >> 8) is 69 and ir_op2 is 2 then prototype_guard = true end
+      end
+   end
+
+   jit.off()
+   jit.opt.start()
+
+   assert(total is 13056, 'Prototype-specialised contextual closures should retain their individual upvalues')
+   assert(prototype_guard,
+      'Fresh contextual closures should record a reusable prototype guard instead of an exact closure guard')
 end
 
 @Test function JITVirtualExitPreservesMaterialisedCallerContext()

--- a/src/tiri/tests/test_contextual_member_calls.tiri
+++ b/src/tiri/tests/test_contextual_member_calls.tiri
@@ -1,6 +1,7 @@
 -- Flute regression tests for table-gated contextual member calls.
 
 import 'json'
+module core as mCore
 
 @Test function NamedAndComputedTableCallsEstablishContext()
    local point = { name = 'point', value = 0 }
@@ -205,6 +206,41 @@ end
       'A delayed callback should begin unbound in the state root context')
    .glDelayedContextName = nil
    .glDelayedObservedContext = nil
+end
+
+@Test function ActionCallbacksAreUnbound()
+   .glActionContextName = 'root'
+   .glActionObservedContext = nil
+   local receiver = { glActionContextName = 'receiver' }
+   local file = obj.new('file')
+   local timer
+   local file_freed = false
+
+   defer
+      if timer then check mCore.UpdateTimer(timer, 0) end
+      if not file_freed then file.free() end
+      .glActionContextName = nil
+      .glActionObservedContext = nil
+   end
+
+   function receiver.wait_for_free()
+      file.subscribe('free', function()
+         .glActionObservedContext = .glActionContextName
+         processing.signal()
+      end)
+
+      local err
+      err, timer = mCore.SubscribeTimer(0.01, function()
+         file_freed = true
+         file.free()
+      end)
+      check err
+      check processing.sleep(1.0)
+   end
+
+   receiver.wait_for_free()
+   assert(.glActionObservedContext is 'root',
+      'An out-of-band action callback should begin unbound in the state root context')
 end
 
 @Test function ContextualTailCallsTransferOwnership()

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -661,16 +661,18 @@ end
    jit.opt.start('hotloop=3', 'hotexit=1', 'minstitch=0')
 
    local keys = array<string> { 'alpha', 'missing', 'bravo', 'missing' }
+   local mismatch = ''
    for iteration in {0 to 500} do
       local key = keys[iteration % #keys]
       local expected = key is 'alpha' ? 'keyword' :> key is 'bravo' ? 'annotation' :> 'missing'
       local result = resolve_safe_index_join(key)
       if result != expected then
-         assert(false,
-            f'Safe-index join failed at iteration {iteration}: key={key}, expected={expected}, result={result}')
+         mismatch = f'Safe-index join failed at iteration {iteration}: key={key}, expected={expected}, result={result}'
+         break
       end
    end
 
+   assert(mismatch is '', mismatch)
    assert(count_jit_traces(30) > 0, 'Alternating safe-index branches should execute through a compiled trace')
    jit.opt.start()
 end
@@ -1134,13 +1136,16 @@ function jit_try_forced_materialisation_probe(Count)
 end
 
 function build_try_materialisation_trace()
-   jit.on()
+   jit.off()
    jit.flush()
    jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+   jit.on()
 
-   for i in {0 to 100} do
+   local i = 0
+   while i < 100 do
       local result = jit_try_forced_materialisation_probe(i)
       assert(result is "entry", f"Expected materialisation probe to return entry local, got '{result}'")
+      i++
    end
 
    for trace_no in {0 to 30} do
@@ -1167,7 +1172,7 @@ jit.off(build_try_materialisation_trace)
       f"Expected at least {info.tryStores} XSTORE instructions, found {xstore_count}")
 end
 
-@Test(hotpath=80) function JITTryMaterialisationTraceSnapshotsStayBounded()
+@Test function JITTryMaterialisationTraceSnapshotsStayBounded()
    local trace_no, info = build_try_materialisation_trace()
 
    assert(info.nexit > 0, "Try materialisation trace should expose snapshots")

--- a/src/tiri/tiri_async.cpp
+++ b/src/tiri/tiri_async.cpp
@@ -23,6 +23,7 @@ additional functionality in the future.
 #include "lib.h"
 #include "lauxlib.h"
 #include "lj_obj.h"
+#include "lj_state.h"
 #include "defs.h"
 #include "lj_proto_registry.h"
 
@@ -55,6 +56,7 @@ static void msg_thread_complete(ACTIONID ActionID, OBJECTPTR Object, ERR Error, 
    auto lua = tiri->Lua;
 
    if (Msg->Callback != LUA_NOREF) {
+      LuaContextRootGuard context_guard(lua);
       if ((Object) and (Object->baseClassID() IS CLASSID::SCRIPT)) {
          auto args = std::to_array<ScriptArg>({
             { "Object", Object, FD_OBJECTPTR }

--- a/src/tiri/tiri_class.cpp
+++ b/src/tiri/tiri_class.cpp
@@ -30,6 +30,7 @@ The Tiri class provides functionality for running scripts written in the Tiri pr
 #include "lua.hpp"
 
 #include "lj_obj.h"
+#include "lj_state.h"
 #include "parser/parser_diagnostics.h"
 #include "jit/src/debug/dump_bytecode.h"
 #include "lj_proto_registry.h"
@@ -237,6 +238,7 @@ void notify_action(OBJECTPTR Object, ACTIONID ActionID, ERR Result, APTR Args)
 
    for (auto &scan : Self->ActionList) {
       if ((Object->UID IS scan.ObjectID) and (ActionID IS scan.ActionID)) {
+         LuaContextRootGuard context_guard(Self->Lua);
          int depth = GetResource(RES::LOG_DEPTH); // Required because thrown errors cause the debugger to lose its branch
 
          {
@@ -367,6 +369,7 @@ static ERR TIRI_DataFeed(extTiri *Self, struct acDataFeed *Args)
 
       for (auto it = Self->Requests.begin(); it != Self->Requests.end(); ) {
          if ((Args->Object) and (it->SourceID IS Args->Object->UID)) {
+            LuaContextRootGuard context_guard(Self->Lua);
             // Execute the callback associated with this input subscription: function({Items...})
 
             int step = GetResource(RES::LOG_DEPTH); // Required as thrown errors cause the debugger to lose its step position

--- a/src/tiri/tiri_functions.cpp
+++ b/src/tiri/tiri_functions.cpp
@@ -14,6 +14,7 @@
 
 #include "lua.h"
 #include "lj_obj.h"
+#include "lj_state.h"
 #include "parser/parser_diagnostics.h"
 
 #include "defs.h"
@@ -89,6 +90,7 @@ static void receive_event(kt::Event *Info, int InfoSize, APTR CallbackMeta)
 {
    auto tiri = (extTiri *)CurrentContext();
    auto lua = tiri->Lua;
+   LuaContextRootGuard context_guard(lua);
 
    kt::Log log(__FUNCTION__);
    log.trace("Received event $%.8x%.8x", (int)((Info->EventID>>32) & 0xffffffff), (int)(Info->EventID & 0xffffffff));

--- a/src/tiri/tiri_input.cpp
+++ b/src/tiri/tiri_input.cpp
@@ -40,6 +40,7 @@ For drag and drop operations, data can be requested from a source as follows:
 #include "lib.h"
 #include "lauxlib.h"
 #include "lj_obj.h"
+#include "lj_state.h"
 #include "defs.h"
 #include "lj_proto_registry.h"
 
@@ -66,6 +67,7 @@ static void release_input_subscription(lua_State *Lua, struct finput *Input)
    kt::Log log(__FUNCTION__);
 
    auto Self = (extTiri *)CurrentContext();
+   LuaContextRootGuard context_guard(Self->Lua);
 
    auto list = Self->InputList;
    for (; (list) and (list->InputHandle != Handle); list=list->Next);
@@ -457,6 +459,7 @@ static void key_event(evKey *Event, int Size, struct finput *Input)
    log.traceBranch("Incoming keyboard input");
 
    auto lua = tiri->Lua;
+   LuaContextRootGuard context_guard(lua);
    int depth = GetResource(RES::LOG_DEPTH); // Required because thrown errors cause the debugger to lose its step position
    int top = lua_gettop(lua);
    lua_rawgeti(lua, LUA_REGISTRYINDEX, Input->Callback); // Get the function reference in Lua and place it on the stack

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -11,6 +11,7 @@
 #include "lua.h"
 #include "lauxlib.h"
 #include "lj_obj.h"
+#include "lj_state.h"
 #include "defs.h"
 #include "lj_proto_registry.h"
 
@@ -460,6 +461,7 @@ ERR delayed_msg_handler(APTR Meta, int MsgID, MSGID MsgType, std::span<std::byte
    luaL_unref(lua, LUA_REGISTRYINDEX, msg->ref); // Remove it
 
    kt::SwitchContext ctx(lua->script);
+   LuaContextRootGuard context_guard(lua);
    if (lua_pcall(lua, 0, 0, 0)) {
       process_error(lua->script, "delayedCall()");
    }

--- a/tools/benchmark/benchmark_func.tiri
+++ b/tools/benchmark/benchmark_func.tiri
@@ -284,76 +284,76 @@ end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Goal: Call ordinary callable fields with explicit receivers
+-- Goal: Call contextual methods on tables
 
 @Test function FunctionMethodCalls()
    -- Create object-like tables with methods
    local Counter = {
       value = 0,
-      increment = function(Self):num
-         Self.value++
-         return Self.value
+      increment = function():num
+         .value++
+         return .value
       end,
-      decrement = function(Self):num
-         Self.value -= 1
-         return Self.value
+      decrement = function():num
+         .value -= 1
+         return .value
       end,
-      add = function(Self, n):num
-         Self.value += n
-         return Self.value
+      add = function(n):num
+         .value += n
+         return .value
       end,
-      getValue = function(Self):num
-         return Self.value
+      getValue = function():num
+         return .value
       end,
-      reset = function(Self)
-         Self.value = 0
+      reset = function()
+         .value = 0
       end
    }
 
    local Point = {
       x = 0,
       y = 0,
-      set = function(Self, x, y)
-         Self.x = x
-         Self.y = y
+      set = function(x, y)
+         .x = x
+         .y = y
       end,
-      translate = function(Self, dx, dy)
-         Self.x += dx
-         Self.y += dy
+      translate = function(dx, dy)
+         .x += dx
+         .y += dy
       end,
-      distance = function(Self)
-         return math.sqrt(Self.x * Self.x + Self.y * Self.y)
+      distance = function()
+         return math.sqrt(.x * .x + .y * .y)
       end
    }
 
    local checksum = 0.0
    for i in {0 to 10000} do
-      Counter.reset(Counter)
-      Counter.increment(Counter)
-      Counter.increment(Counter)
-      Counter.add(Counter, 5)
-      local v1 = Counter.getValue(Counter)
-      Counter.decrement(Counter)
+      Counter.reset()
+      Counter.increment()
+      Counter.increment()
+      Counter.add(5)
+      local v1 = Counter.getValue()
+      Counter.decrement()
 
       -- Multiple method calls in sequence
-      Point.set(Point, i % 100, i % 50)
-      Point.translate(Point, 1, 2)
-      Point.translate(Point, -1, 1)
-      local d = Point.distance(Point)
+      Point.set(i % 100, i % 50)
+      Point.translate(1, 2)
+      Point.translate(-1, 1)
+      local d = Point.distance()
 
       -- Create new instances
       local instance = { value = 0 }
       setmetatable(instance, { __index = Counter })
-      instance.increment(instance)
-      instance.add(instance, 10)
-      local v2 = instance.getValue(instance)
+      instance.increment()
+      instance.add(10)
+      local v2 = instance.getValue()
 
       -- Chain-like method usage
-      Counter.reset(Counter)
+      Counter.reset()
       for j in {0 to 10} do
-         Counter.increment(Counter)
+         Counter.increment()
       end
-      local final = Counter.getValue(Counter)
+      local final = Counter.getValue()
       checksum += v1 + d + v2 + final
    end
    return checksum

--- a/tools/idl/include/parser.tiri
+++ b/tools/idl/include/parser.tiri
@@ -69,8 +69,8 @@ global glOfficialTags = {
 ----------------------------------------------------------------------------------------------------------------------
 -- Parse and validate comma or newline-separated documentation tags for the supplied context.
 
-function parseTags(Tags:str, Context:str):array<string>
-   result = array<string>
+function parseTags(Tags:str, Context:str):array<str>
+   result = array<str>
    Tags ?! return result
 
    for item in values(Tags.replace('\n', ',').split(',')) do
@@ -91,8 +91,8 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Apply automatic documentation tags to a tag list based on a field definition.
 
-global function addTag(Tags:array<string>, Tag:str):array<string>
-   Tags ?= array<string>
+global function addTag(Tags:array<str>, Tag:str):array<str>
+   Tags ?= array<str>
 
    for existing_tag in values(Tags) do
       if existing_tag is Tag then return Tags end
@@ -105,9 +105,9 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Apply automatic documentation tags to a tag list based on a field definition.
 
-global function getTagsFromField(Field:table, Tags:array<string>):array<string>
+global function getTagsFromField(Field:table, Tags:array<str>):array<str>
    Field ?! return Tags
-   Tags ?= array<string>
+   Tags ?= array<str>
 
    if Field.allocated then addTag(Tags, 'caller-owns-result') end
    if Field.flags and Field.flags has FD_ALLOC then addTag(Tags, 'caller-owns-result') end
@@ -122,8 +122,8 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Apply automatic documentation tags for every field or parameter in a collection.
 
-global function getTagsFromCollection(Tags:array<string>, Fields:any):array<string>
-   Tags ?= array<string>
+global function getTagsFromCollection(Tags:array<str>, Fields:any):array<str>
+   Tags ?= array<str>
    Fields ?! return Tags
 
    for field in values(Fields) do


### PR DESCRIPTION
## Summary

- Add leading-dot access to the current table context and contextual dotted member calls.
- Preserve context across nested, persistent, tail, native, error-unwind, asynchronous, and JIT execution paths.
- Add bytecode, parser, runtime, GC, snapshot, recorder, and cross-platform VM support.
- Exempt registered internal namespaces from context activation and use constant-time JIT activation bookkeeping.
- Specialise contextual Lua calls by prototype so fresh closures reuse compiled traces while retaining closure-specific upvalues.
- Expand parser, runtime, JIT, ownership, side-exit, and result-arity coverage.
- Migrate the function-method benchmark to contextual syntax.

## Motivation

Contextual member calls allow table methods to access their receiver through a leading-dot field prefix without passing an explicit self parameter. Context remains available for the duration of the call and is restored correctly on every exit path.

The initial implementation exposed two important performance issues. Internal namespaces such as `math` unnecessarily paid context activation costs even though they never consumed client table context. Virtual-context snapshots also prevented direct side traces, while exact closure guards rejected freshly constructed but prototype-equivalent methods. Namespace exemption and first-recording prototype specialisation remove those costs without weakening contextual semantics.

## Impact

Tiri code can define and call contextual table methods directly:

```lua
local counter = {
   value = 0,
   increment = function():num
      .value++
      return .value
   end
}

counter.increment()
```

Internal library calls retain their specialised paths, and fresh contextual closures now reuse compiled traces while reading their own upvalues.

## Validation

- Debug modular `tiri` build and installation succeeded.
- `tiri_math`, `tiri_jit`, `tiri_builtin_methods`, `tiri_context_access`, and `tiri_contextual_member_calls` all passed.
- The contextual member-call Flute suite passes all 31 tests under shuffled ordering.
- `git diff --check` passed.
- Release `FunctionMethodCalls` improved from 21.48 ms to approximately 2.02 ms and reports fully optimised traces.
- A fresh-contextual-closure stress case improved from 30.8 seconds to 45 ms, matching the ordinary-call version at 46 ms.
