### PR TITLE
[Tiri] Eliminated redundant current-context call setup

### DIFF
--- a/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
@@ -702,6 +702,11 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
       }
 
       is_contextual_call = receiver_node != nullptr;
+      // A leading-dot receiver is the current context by construction. Ordinary calls inherit that context, so
+      // retaining and re-entering the same table would only add contextual call and result-compaction overhead.
+      if (is_contextual_call and receiver_node->kind IS AstNodeKind::CurrentContextExpr) {
+         is_contextual_call = false;
+      }
       bool proved_specialised_receiver = false;
       if (is_contextual_call and receiver_node->static_value) {
          const auto &descriptor = this->ctx.descriptors().value(receiver_node->static_value);

--- a/src/tiri/tests/test_contextual_member_calls.tiri
+++ b/src/tiri/tests/test_contextual_member_calls.tiri
@@ -59,6 +59,57 @@ end
       'A returned contextual call should complete restoration before returning to its caller')
 end
 
+@Test function CurrentContextMemberCallsUseOrdinaryCallBytecode()
+   .glCurrentContextCallName = 'root'
+   .glCurrentContextCallRead = function(Value:str):str
+      assert(.glCurrentContextCallName is 'root', 'A root leading-dot call should inherit the root context')
+      return Value
+   end
+   assert(.glCurrentContextCallRead('root') is 'root',
+      'A root leading-dot member call should execute without a contextual override')
+   .glCurrentContextCallRead = nil
+   .glCurrentContextCallName = nil
+
+   local receiver = { name = 'receiver' }
+
+   function receiver.read(Value:str):str
+      assert(.name is 'receiver', 'An inherited current-context call should retain its receiver')
+      return Value
+   end
+
+   function receiver.forward(Value:str):str
+      return .read(Value)
+   end
+
+   assert(receiver.forward('ordinary') is 'ordinary',
+      'A leading-dot member call should inherit the active context without re-entering it')
+
+   local script = obj.new('tiri', { statement = [[
+local receiver = {}
+
+function receiver.read(Value:str):str
+   return Value
+end
+
+function receiver.invoke(Value:str)
+   .read(Value)
+end
+
+function receiver.forward(Value:str):<any, ...>
+   return .read(Value)
+end
+]] })
+   check script.acQuery()
+   check script.acActivate()
+   local _, disassembly = script.mtDebugLog('disasm')
+   assert(disassembly.find('CTXGET') != nil and disassembly.find('CALL      A=') != nil and
+      disassembly.find('CALLT') != nil,
+      'Leading-dot calls should load the context and use ordinary call bytecode')
+   assert(disassembly.find('CTXENTER') is nil and disassembly.find('CTXCALL') is nil and
+      disassembly.find('CTXLEAVE') is nil,
+      'A leading-dot member call should not emit redundant contextual call bytecode')
+end
+
 @Test function InternalNamespacesInheritCurrentContext()
    local outer = { name = 'namespace outer' }
 


### PR DESCRIPTION
* Lowered leading-dot member calls through ordinary call bytecode when the receiver already represents the active context
* Added root, nested, ordinary and tail-call regression coverage for current-context invocation