### PR TITLE
[Tiri] Corrected contextual dispatch for associated table functions

### DIFF
--- a/src/tiri/jit/BYTECODE.md
+++ b/src/tiri/jit/BYTECODE.md
@@ -780,20 +780,23 @@ boundary.
 
 ##### Contextual Call Layout (Gate C)
 
-Current-context access uses the dedicated `CTXGET` opcode. Table member calls use appended contextual variants of the
-existing call family. Their register layout reserves the slot immediately before the ordinary call base for the
-original receiver; the callable and written arguments otherwise retain the `CALL`/`CALLM` layout. `CTXENTER` performs
-the runtime table gate after member lookup and before argument evaluation. `CTXCALL` repeats the gate idempotently at
-the activation boundary, and `CTXLEAVE` restores the inherited context after a normal return. It shifts returned
-values down over the retained receiver slot so expression result allocation remains identical to an ordinary member
-call.
+Current-context access uses the dedicated `CTXGET` opcode. Potentially contextual member calls use appended variants
+of the existing call family. Their register layout reserves the slot immediately before the ordinary call base for
+the original receiver; the callable and written arguments otherwise retain the `CALL`/`CALLM` layout. `CTXENTER`
+performs the runtime gate after member lookup and before argument evaluation. The gate requires both a table receiver
+and a Lua function declared as table-associated. Dot-qualified declarations and function literals used directly as
+named or computed table fields carry this portable prototype attribute; independent function references merely
+stored in tables do not. `CTXCALL` repeats the gate idempotently at the activation boundary, and `CTXLEAVE` restores
+the inherited context after a normal return.  It shifts returned values down over the retained receiver slot so
+expression result allocation remains identical to an ordinary member call.
 
 Named and computed lookup continue to use the appropriate existing `TGET*` operation while retaining the original
 receiver. Safe calls branch around lookup, entry and argument evaluation on their `nil` path. Statically proved
 strings, arrays, ranges, structures and objects retain their specialised receiver dispatch without emitting context
 operations. Dynamically typed receivers use the contextual variants, whose runtime gate leaves non-table values and
-their visible argument layout unchanged. `CTXCALLT` transfers a prepared receiver from the discarded activation to
-the reused tail frame, replacing an override owned by that frame where necessary. Direct tail calls naturally retain
+independent callables unchanged without altering their visible argument layout.  `CTXCALLT` transfers a prepared
+receiver from the discarded activation to the reused tail frame, replacing an override owned by that frame where
+necessary.  Direct tail calls naturally retain
 their existing frame owner. Variable-argument contextual calls retain the ordinary call-and-return form so their
 multiple-result state does not cross a context helper boundary. Direct calls and compiler-managed module namespace
 calls retain their existing bytecode and overhead.

--- a/src/tiri/jit/src/bytecode/lj_bcread.cpp
+++ b/src/tiri/jit/src/bytecode/lj_bcread.cpp
@@ -502,7 +502,8 @@ static void bcread_signature(LexState *State, MSize Size, MSize NumParams, BCRea
    constexpr uint8_t known_flags = proto_signature_flag(ProtoSignatureFlag::ParameterVariadic) |
       proto_signature_flag(ProtoSignatureFlag::ResultVariadic) |
       proto_signature_flag(ProtoSignatureFlag::ExplicitResults) |
-      proto_signature_flag(ProtoSignatureFlag::DynamicResults);
+      proto_signature_flag(ProtoSignatureFlag::DynamicResults) |
+      proto_signature_flag(ProtoSignatureFlag::TableAssociated);
    if (flags & ~known_flags) bcread_error(State, ErrMsg::BCBAD);
 
    uint32_t parameter_count = 0;

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1380,12 +1380,15 @@ static void rec_context_enter(jit_State *J, BCREG CallBase)
       return;
    }
 
-   // Internal namespaces inherit the caller's context.  Record the exemption before the callable overwrites its
-   // receiver slot so CTXLEAVE can still perform result compaction without attempting to restore an activation.
-   if (lj_tab_is_context_exempt(tabV(&J->L->base[CallBase - 1]))) {
+   // Internal namespaces and independent callbacks inherit the caller's context. Record the exemption before the
+   // callable overwrites its receiver slot so CTXLEAVE can still compact results without restoring an activation.
+   if (lj_tab_is_context_exempt(tabV(&J->L->base[CallBase - 1])) or not tvisfunc(callable) or
+       not func_is_table_associated(funcV(callable))) {
       J->context_call_state[int32_t(J->baseslot) + int32_t(CallBase)] = CONTEXT_CALL_EXEMPT;
       return;
    }
+
+   J->base[CallBase] = rec_call_specialise(J, funcV(callable), getslot(J, CallBase), true);
 
    if (tail_call or native_target) rec_context_materialise(J);
 
@@ -1523,9 +1526,10 @@ static void rec_context_tailcall(jit_State *J, BCREG CallBase, ptrdiff_t Argumen
    TRef receiver = getslot(J, int32_t(CallBase) - 1);
    bool exempt_receiver = tvistab(&J->L->base[CallBase - 1]) and
       lj_tab_is_context_exempt(tabV(&J->L->base[CallBase - 1]));
+   bool associated_function = isluafunc(funcV(callable)) and func_is_table_associated(funcV(callable));
    rec_call_setup(J, CallBase, ArgumentCount);
 
-   if (tref_istab(receiver) and not exempt_receiver) {
+   if (tref_istab(receiver) and not exempt_receiver and associated_function) {
       IRBuilder ir(J);
       int32_t prepared_slot = int32_t(J->baseslot) + int32_t(CallBase) + 1 + LJ_FR2;
       TRef prepared_owner = rec_stack_slot_addr(J, ir, prepared_slot);

--- a/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
@@ -24,9 +24,34 @@ static bool contains_safe_nav_target(const ExprNode& Expr)
    }
 }
 
-static bool emit_identifier_name_is(GCstr *Name, std::string_view Text)
+static bool emit_identifier_is_script_namespace(LexState &State, GCstr *Name)
 {
-   return Name and std::string_view(strdata(Name), Name->len) IS Text;
+   if (not Name) return false;
+
+   ExpDesc resolved;
+   State.var_lookup_symbol(Name, &resolved);
+   return resolved.k IS ExpKind::Local and has_flag(State.vstack[resolved.u.s.aux].info,
+      VarInfoFlag::ScriptNamespace);
+}
+
+static bool emit_target_is_script_namespace_export(LexState &State, const ExprNode &Target)
+{
+   const ExprNode *receiver = emit_assignment_direct_receiver(Target);
+   if (not receiver or receiver->kind != AstNodeKind::IdentifierExpr) return false;
+
+   const auto *reference = std::get_if<NameRef>(&receiver->data);
+   if (not reference or not reference->identifier.symbol) return false;
+   return emit_identifier_name_is(reference->identifier.symbol, "_LIB") or
+      emit_identifier_is_script_namespace(State, reference->identifier.symbol);
+}
+
+static bool emit_target_initialises_script_namespace(const ExprNode &Target)
+{
+   const ExprNode *receiver = emit_assignment_direct_receiver(Target);
+   if (not receiver or receiver->kind != AstNodeKind::IdentifierExpr) return false;
+
+   const auto *reference = std::get_if<NameRef>(&receiver->data);
+   return reference and emit_identifier_name_is(reference->identifier.symbol, "_LIB");
 }
 
 static GCstr * emit_literal_string_key(const ExprNode &Expr)
@@ -287,6 +312,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_plain_assignment(std::vector<PreparedAs
             this->lex_state.lastline = node->span.line;
             value = this->emit_function_expr(std::get<FunctionExprPayload>(node->data), nullptr, true);
          }
+         else if (i < targets.size() and targets[i].initialises_script_namespace and
+            node->kind IS AstNodeKind::TableExpr) {
+            value = this->emit_table_expr(std::get<TableExprPayload>(node->data), false);
+         }
          else value = this->emit_expression(*node);
 
          if (not value.ok()) return value;
@@ -378,6 +407,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_plain_assignment(std::vector<PreparedAs
          if (target.pending_symbol) {
             this->update_local_binding(target.pending_symbol, base + i);
 
+            if (i.raw() < values.size() and emit_expression_is_script_namespace_lookup(*values[i.raw()])) {
+               this->func_state.var_get(base.raw() + i.raw()).info |= VarInfoFlag::ScriptNamespace;
+            }
+
             if (i.raw() < values.size()) {
                this->apply_inferred_local_type(base + i, *values[i.raw()]);
             }
@@ -395,6 +428,13 @@ ParserResult<IrEmitUnit> IrEmitter::emit_plain_assignment(std::vector<PreparedAs
       auto list = emit_assignment_values(nexps);
       if (not list.ok()) return ParserResult<IrEmitUnit>::failure(list.error_ref());
       tail = list.value_ref();
+   }
+
+   for (size_t i = 0; i < targets.size() and i < values.size(); ++i) {
+      if (targets[i].storage.k != ExpKind::Local) continue;
+      VarInfo &info = this->lex_state.vstack[targets[i].storage.u.s.aux];
+      if (emit_expression_is_script_namespace_lookup(*values[i])) info.info |= VarInfoFlag::ScriptNamespace;
+      else clear_flag(info.info, VarInfoFlag::ScriptNamespace);
    }
 
    RegisterAllocator allocator(&this->func_state);
@@ -441,6 +481,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_plain_assignment(std::vector<PreparedAs
          if (target.needs_var_add and target.pending_symbol) {
             // Create new local for this undeclared variable
             BCReg local_slot = this->finalise_pending_local_assignment(target);
+
+            if (i < values.size() and emit_expression_is_script_namespace_lookup(*values[i])) {
+               this->func_state.var_get(local_slot.raw()).info |= VarInfoFlag::ScriptNamespace;
+            }
 
             // Retain expression inference only when semantic analysis did not publish a binding result.
             if (this->func_state.var_get(local_slot.raw()).fixed_type IS TiriType::Unknown and
@@ -872,7 +916,11 @@ ParserResult<std::vector<PreparedAssignment>> IrEmitter::prepare_assignment_targ
       if (not lvalue.ok()) return ParserResult<std::vector<PreparedAssignment>>::failure(lvalue.error_ref());
 
       ExpDesc slot = lvalue.value_ref();
-      prepared.associates_function_literal = slot.k IS ExpKind::Indexed;
+      bool script_namespace_export = this->is_root_chunk and
+         emit_target_is_script_namespace_export(this->lex_state, *node);
+      prepared.initialises_script_namespace = this->is_root_chunk and
+         emit_target_initialises_script_namespace(*node);
+      prepared.associates_function_literal = slot.k IS ExpKind::Indexed and not script_namespace_export;
 
       // Check if this is an Unscoped variable that needs a new local
       // Keep it as Unscoped and defer local creation until after expression evaluation

--- a/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
@@ -269,6 +269,35 @@ ParserResult<IrEmitUnit> IrEmitter::emit_plain_assignment(std::vector<PreparedAs
    auto nvars = BCReg(BCREG(targets.size()));
    if (not nvars) return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
 
+   auto emit_assignment_values = [&](BCReg &Count) -> ParserResult<ExpDesc> {
+      Count = BCReg(0);
+      if (values.empty()) return ParserResult<ExpDesc>::success(ExpDesc(ExpKind::Void));
+
+      ExpDesc last(ExpKind::Void);
+      bool first = true;
+      for (size_t i = 0; i < values.size(); ++i) {
+         const ExprNodePtr &node = values[i];
+         if (not node) return this->unsupported_expr(AstNodeKind::ExpressionStmt, SourceSpan{});
+         if (not first) this->materialise_to_next_reg(last, "assignment expression list baton");
+
+         ParserResult<ExpDesc> value;
+         bool associate = i < targets.size() and targets[i].associates_function_literal and
+            node->kind IS AstNodeKind::FunctionExpr;
+         if (associate) {
+            this->lex_state.lastline = node->span.line;
+            value = this->emit_function_expr(std::get<FunctionExprPayload>(node->data), nullptr, true);
+         }
+         else value = this->emit_expression(*node);
+
+         if (not value.ok()) return value;
+         last = value.value_ref();
+         ++Count;
+         first = false;
+      }
+
+      return ParserResult<ExpDesc>::success(last);
+   };
+
    if (nvars IS BCReg(1) and targets.front().safe_nav_skip.valid()) {
       PreparedAssignment& target = targets.front();
       // Single-target safe-nav assignment keeps the stronger short-circuit semantics: if the guarded
@@ -276,7 +305,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_plain_assignment(std::vector<PreparedAs
       ExpDesc tail(ExpKind::Void);
       auto nexps = BCReg(0);
       if (not values.empty()) {
-         auto list = this->emit_expression_list(values, nexps);
+         auto list = emit_assignment_values(nexps);
          if (not list.ok()) return ParserResult<IrEmitUnit>::failure(list.error_ref());
          tail = list.value_ref();
       }
@@ -333,7 +362,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_plain_assignment(std::vector<PreparedAs
       ExpDesc tail(ExpKind::Void);
       auto nexps = BCReg(0);
       if (not values.empty()) {
-         auto list = this->emit_expression_list(values, nexps);
+         auto list = emit_assignment_values(nexps);
          if (not list.ok()) return ParserResult<IrEmitUnit>::failure(list.error_ref());
          tail = list.value_ref();
       }
@@ -363,7 +392,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_plain_assignment(std::vector<PreparedAs
    ExpDesc tail(ExpKind::Void);
    auto nexps = BCReg(0);
    if (not values.empty()) {
-      auto list = this->emit_expression_list(values, nexps);
+      auto list = emit_assignment_values(nexps);
       if (not list.ok()) return ParserResult<IrEmitUnit>::failure(list.error_ref());
       tail = list.value_ref();
    }
@@ -843,6 +872,7 @@ ParserResult<std::vector<PreparedAssignment>> IrEmitter::prepare_assignment_targ
       if (not lvalue.ok()) return ParserResult<std::vector<PreparedAssignment>>::failure(lvalue.error_ref());
 
       ExpDesc slot = lvalue.value_ref();
+      prepared.associates_function_literal = slot.k IS ExpKind::Indexed;
 
       // Check if this is an Unscoped variable that needs a new local
       // Keep it as Unscoped and defer local creation until after expression evaluation

--- a/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
@@ -82,6 +82,13 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_pipe(
          "piped runtime built-in method annotation has no direct receiver"));
    }
 
+   bool contextual_field = true;
+   if (receiver_node->static_value) {
+      TiriType receiver_type = this->ctx.descriptors().value(receiver_node->static_value).primary;
+      contextual_field = receiver_type IS TiriType::Unknown or receiver_type IS TiriType::Any or
+         receiver_type IS TiriType::Table or receiver_type IS TiriType::Nil;
+   }
+
    FuncState *state = &this->func_state;
    BCLine call_line = this->lex_state.lastline;
    BCReg call_base = state->free_reg();
@@ -114,7 +121,8 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_pipe(
       state, BCINS_AJP(BC_BMETH, call_base.raw(), NO_JMP, member_constant)));
 
    auto emit_branch = [&](bool BuiltinBranch) -> ParserResult<BCPos> {
-      state->freereg = call_base.raw() + 1 + LJ_FR2 + (BuiltinBranch ? 1 : 0);
+      BCReg branch_base = BuiltinBranch or not contextual_field ? call_base : BCReg(call_base.raw() + 1);
+      state->freereg = branch_base.raw() + 1 + LJ_FR2 + (BuiltinBranch ? 1 : 0);
       auto lhs_result = this->emit_expression(*Payload.lhs);
       if (not lhs_result.ok()) return ParserResult<BCPos>::failure(lhs_result.error_ref());
       ExpDesc lhs = lhs_result.value_ref();
@@ -141,15 +149,15 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_pipe(
 
       BCIns instruction;
       if (forward_multret and Call.arguments.empty()) {
-         instruction = BCINS_ABC(BC_CALLM, call_base.raw(), 2,
-            lhs.u.s.aux - call_base.raw() - 1 - LJ_FR2);
+         instruction = BCINS_ABC(BuiltinBranch or not contextual_field ? BC_CALLM : BC_CTXCALLM, branch_base.raw(), 2,
+            lhs.u.s.aux - branch_base.raw() - 1 - LJ_FR2);
       }
       else {
          if (arguments.k != ExpKind::Void) {
             this->materialise_to_next_reg(arguments, "runtime method pipe arguments");
          }
-         instruction = BCINS_ABC(BC_CALL, call_base.raw(), 2,
-            state->freereg - call_base.raw() - 1);
+         instruction = BCINS_ABC(BuiltinBranch or not contextual_field ? BC_CALL : BC_CTXCALL, branch_base.raw(), 2,
+            state->freereg - branch_base.raw() - 1);
       }
       this->lex_state.lastline = call_line;
       return ParserResult<BCPos>::success(BCPos(bcemit_INS(state, instruction)));
@@ -173,9 +181,17 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_pipe(
       field_nil_jump = this->control_flow.make_unconditional(BCPos(bcemit_jmp(state)));
    }
 
+   BCReg field_call_base = contextual_field ? BCReg(call_base.raw() + 1) : call_base;
+   if (contextual_field) {
+      bcemit_AD(state, BC_MOV, field_call_base.raw(), call_base.raw());
+      bcemit_AD(state, BC_MOV, call_base.raw(), receiver_slot);
+      bcemit_INS(state, BCINS_AD(BC_CTXENTER, field_call_base.raw(), 0));
+   }
+
    auto field_result = emit_branch(false);
    if (not field_result.ok()) return ParserResult<ExpDesc>::failure(field_result.error_ref());
    BCPos field_call = field_result.value_ref();
+   if (contextual_field) bcemit_INS(state, BCINS_AD(BC_CTXLEAVE, field_call_base.raw(), 1));
    skip_field.patch_here();
 
    if (Call.runtime_builtin_method->safe) {
@@ -493,6 +509,13 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_call(const CallExpr
          "runtime built-in method annotation has no direct receiver"));
    }
 
+   bool contextual_field = true;
+   if (receiver_node->static_value) {
+      TiriType receiver_type = this->ctx.descriptors().value(receiver_node->static_value).primary;
+      contextual_field = receiver_type IS TiriType::Unknown or receiver_type IS TiriType::Any or
+         receiver_type IS TiriType::Table or receiver_type IS TiriType::Nil;
+   }
+
    FuncState *state = &this->func_state;
    BCLine call_line = this->lex_state.lastline;
    BCReg call_base = state->free_reg();
@@ -525,7 +548,8 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_call(const CallExpr
       state, BCINS_AJP(BC_BMETH, call_base.raw(), NO_JMP, member_constant)));
 
    auto emit_branch_call = [&](bool BuiltinBranch) -> ParserResult<BCPos> {
-      state->freereg = call_base.raw() + 1 + LJ_FR2 + (BuiltinBranch ? 1 : 0);
+      BCReg branch_base = BuiltinBranch or not contextual_field ? call_base : BCReg(call_base.raw() + 1);
+      state->freereg = branch_base.raw() + 1 + LJ_FR2 + (BuiltinBranch ? 1 : 0);
       BCReg argument_count(0);
       ExpDesc arguments(ExpKind::Void);
       if (not Payload.arguments.empty()) {
@@ -538,16 +562,16 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_call(const CallExpr
       bool forward_tail = Payload.forwards_multret and arguments.k IS ExpKind::Call;
       if (forward_tail) {
          set_call_result_count(state, arguments, 0);
-         instruction = BCINS_ABC(BC_CALLM, call_base.raw(), 2,
-            arguments.u.s.aux - call_base.raw() - 1 - LJ_FR2);
+         instruction = BCINS_ABC(BuiltinBranch or not contextual_field ? BC_CALLM : BC_CTXCALLM, branch_base.raw(), 2,
+            arguments.u.s.aux - branch_base.raw() - 1 - LJ_FR2);
       }
       else {
          if (arguments.k != ExpKind::Void) {
             this->materialise_to_next_reg(arguments,
                BuiltinBranch ? "runtime built-in method arguments" : "runtime field-call arguments");
          }
-         instruction = BCINS_ABC(BC_CALL, call_base.raw(), 2,
-            state->freereg - call_base.raw() - 1);
+         instruction = BCINS_ABC(BuiltinBranch or not contextual_field ? BC_CALL : BC_CTXCALL, branch_base.raw(), 2,
+            state->freereg - branch_base.raw() - 1);
       }
       this->lex_state.lastline = call_line;
       return ParserResult<BCPos>::success(BCPos(bcemit_INS(state, instruction)));
@@ -574,9 +598,17 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_call(const CallExpr
       field_nil_jump = this->control_flow.make_unconditional(BCPos(bcemit_jmp(state)));
    }
 
+   BCReg field_call_base = contextual_field ? BCReg(call_base.raw() + 1) : call_base;
+   if (contextual_field) {
+      bcemit_AD(state, BC_MOV, field_call_base.raw(), call_base.raw());
+      bcemit_AD(state, BC_MOV, call_base.raw(), receiver_slot);
+      bcemit_INS(state, BCINS_AD(BC_CTXENTER, field_call_base.raw(), 0));
+   }
+
    auto field_call_result = emit_branch_call(false);
    if (not field_call_result.ok()) return ParserResult<ExpDesc>::failure(field_call_result.error_ref());
    BCPos field_call = field_call_result.value_ref();
+   if (contextual_field) bcemit_INS(state, BCINS_AD(BC_CTXLEAVE, field_call_base.raw(), 1));
    skip_field.patch_here();
 
    if (Payload.runtime_builtin_method->safe) {

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -7,7 +7,8 @@
 // For thunk functions, transforms into a wrapper that returns thunk userdata via AST transformation.
 // The optional funcname parameter sets the function's name for tostring() output.
 
-ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &Payload, GCstr *funcname)
+ParserResult<ExpDesc> IrEmitter::emit_function_expr(
+   const FunctionExprPayload &Payload, GCstr *FuncName, bool TableAssociated)
 {
    if (not Payload.body) return this->unsupported_expr(AstNodeKind::FunctionExpr, SourceSpan{});
 
@@ -84,7 +85,7 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
       // Recursively emit the wrapper function (which is now a regular function), then restore the source thunk so
       // another bytecode branch can emit it again.
 
-      auto result = this->emit_function_expr(wrapper_payload);
+      auto result = this->emit_function_expr(wrapper_payload, nullptr, TableAssociated);
       source_statements = std::move(lowered_body->statements);
       return result;
    }
@@ -95,6 +96,9 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
 
    // Create FuncState in container first
    FuncState &child_state = this->lex_state.fs_init();
+   if (TableAssociated) {
+      child_state.signature_flags |= proto_signature_flag(ProtoSignatureFlag::TableAssociated);
+   }
    FuncStateGuard fs_guard(&this->lex_state);  // Restore ls->fs on error
 
    ParserAllocator allocator = ParserAllocator::from(this->lex_state.L);
@@ -203,6 +207,7 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
 
    IrEmitter child_emitter(child_ctx);
    child_emitter.current_callable = Payload.callable;
+   child_emitter.is_root_chunk = false;
    for (auto i = BCReg(0); i < param_count; ++i) {
       const FunctionParameter &param = Payload.parameters[i.raw()];
       if (param.name.is_blank or param.name.symbol IS nullptr) continue;
@@ -238,7 +243,7 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
    // Copy explicit return types to the function state before emitting the body so return lowering can preserve
    // contracts, fixed arity and tail-call eligibility.
 
-   child_state.funcname = funcname;
+   child_state.funcname = FuncName;
    if (Payload.return_types.is_explicit) {
       child_state.return_contract_explicit = true;
       child_state.return_declared_count = Payload.return_types.count;
@@ -822,7 +827,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_function_stmt(const FunctionStmtPayload
    auto target_result = this->emit_function_lvalue(Payload.name);
    if (not target_result.ok()) return ParserResult<IrEmitUnit>::failure(target_result.error_ref());
    // Pass the function name for tostring() support
-   auto function_value = this->emit_function_expr(*Payload.function, funcname);
+   auto function_value = this->emit_function_expr(
+      *Payload.function, funcname, Payload.name.segments.size() > 1);
    if (not function_value.ok()) return ParserResult<IrEmitUnit>::failure(function_value.error_ref());
 
    ExpDesc target = target_result.value_ref();

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -827,8 +827,11 @@ ParserResult<IrEmitUnit> IrEmitter::emit_function_stmt(const FunctionStmtPayload
    auto target_result = this->emit_function_lvalue(Payload.name);
    if (not target_result.ok()) return ParserResult<IrEmitUnit>::failure(target_result.error_ref());
    // Pass the function name for tostring() support
+   bool direct_namespace_export = this->is_root_chunk and Payload.name.segments.size() IS 2 and
+      (emit_identifier_name_is(Payload.name.segments.front().symbol, "_LIB") or
+       emit_identifier_is_script_namespace(this->lex_state, Payload.name.segments.front().symbol));
    auto function_value = this->emit_function_expr(
-      *Payload.function, funcname, Payload.name.segments.size() > 1);
+      *Payload.function, funcname, Payload.name.segments.size() > 1 and not direct_namespace_export);
    if (not function_value.ok()) return ParserResult<IrEmitUnit>::failure(function_value.error_ref());
 
    ExpDesc target = target_result.value_ref();

--- a/src/tiri/jit/src/parser/ir_emitter/emit_table.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_table.cpp
@@ -64,7 +64,13 @@ ParserResult<ExpDesc> IrEmitter::emit_table_expr(const TableExprPayload &Payload
          }
       }
 
-      auto value_result = this->emit_expression(*field.value);
+      ParserResult<ExpDesc> value_result;
+      if (field.kind != TableFieldKind::Array and field.value->kind IS AstNodeKind::FunctionExpr) {
+         this->lex_state.lastline = field.value->span.line;
+         value_result = this->emit_function_expr(
+            std::get<FunctionExprPayload>(field.value->data), nullptr, true);
+      }
+      else value_result = this->emit_expression(*field.value);
       if (not value_result.ok()) return value_result;
 
       ExpDesc val = value_result.value_ref();

--- a/src/tiri/jit/src/parser/ir_emitter/emit_table.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_table.cpp
@@ -5,7 +5,7 @@
 //********************************************************************************************************************
 // Emit bytecode for a table constructor expression ({key=value, [expr]=value, value}), optimising constant fields.
 
-ParserResult<ExpDesc> IrEmitter::emit_table_expr(const TableExprPayload &Payload)
+ParserResult<ExpDesc> IrEmitter::emit_table_expr(const TableExprPayload &Payload, bool AssociateFunctions)
 {
    FuncState* fs = &this->func_state;
    GCtab* template_table = nullptr;
@@ -68,7 +68,7 @@ ParserResult<ExpDesc> IrEmitter::emit_table_expr(const TableExprPayload &Payload
       if (field.kind != TableFieldKind::Array and field.value->kind IS AstNodeKind::FunctionExpr) {
          this->lex_state.lastline = field.value->span.line;
          value_result = this->emit_function_expr(
-            std::get<FunctionExprPayload>(field.value->data), nullptr, true);
+            std::get<FunctionExprPayload>(field.value->data), nullptr, AssociateFunctions);
       }
       else value_result = this->emit_expression(*field.value);
       if (not value_result.ok()) return value_result;

--- a/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
@@ -396,7 +396,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_import_entry(const ImportEntryPayload &
 
       // Mark as const
       VarInfo* info = &fs->var_get(fs->varmap.size() - 1);
-      info->info |= VarInfoFlag::Const;
+      info->info |= VarInfoFlag::Const | VarInfoFlag::ScriptNamespace;
 
       // Update binding table
       this->update_local_binding(ns_id.symbol, BCReg(fs->varmap.size() - 1));

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1186,7 +1186,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
          bool forwards_current_contract = tail_call_forwards_current_contract(
             this->ctx, this->current_callable, *Payload.values.back());
          bool direct_tail_call = call_op IS BC_CALL or call_op IS BC_CALLM;
-         bool contextual_tail_call = has_context_leave and call_op IS BC_CTXCALL;
+         bool contextual_tail_call = not this->is_root_chunk and has_context_leave and call_op IS BC_CTXCALL;
          bool tail_call_eligible = this->func_state.try_depth IS 0 and not has_post_call_control_flow and
             not has_user_cleanup and (direct_tail_call or contextual_tail_call) and
             (forwards_current_contract or (not truncate_return_results and not has_return_contract));
@@ -1196,6 +1196,12 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
                "tail call is not the final expression instruction");
             this->func_state.pc -= contextual_tail_call ? 2 : 1;
             if (contextual_tail_call) {
+               if (last.alternate_call != NO_JMP) {
+                  BCIns *alternate = &this->func_state.bcbase[last.alternate_call].ins;
+                  lj_assertX(bc_op(*alternate) IS BC_CALL,
+                     "contextual runtime method tail branch is not a fixed ordinary call");
+                  *alternate = BCINS_AD(BC_CALLT, bc_a(*alternate), bc_c(*alternate));
+               }
                ins = BCINS_AD(BC_CTXCALLT, bc_a(*ip), bc_c(*ip));
             }
             else {

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -40,6 +40,29 @@ inline const TiriConstant * lookup_constant(const GCstr *Name)
 
 static bool is_named_external_global(GCstr *Name);
 
+static bool emit_identifier_name_is(GCstr *Name, std::string_view Text)
+{
+   return Name and std::string_view(strdata(Name), Name->len) IS Text;
+}
+
+static const ExprNode * emit_assignment_direct_receiver(const ExprNode &Target)
+{
+   if (Target.kind IS AstNodeKind::MemberExpr) return std::get<MemberExprPayload>(Target.data).table.get();
+   if (Target.kind IS AstNodeKind::IndexExpr) return std::get<IndexExprPayload>(Target.data).table.get();
+   if (Target.kind IS AstNodeKind::SafeMemberExpr) return std::get<SafeMemberExprPayload>(Target.data).table.get();
+   if (Target.kind IS AstNodeKind::SafeIndexExpr) return std::get<SafeIndexExprPayload>(Target.data).table.get();
+   return nullptr;
+}
+
+static bool emit_expression_is_script_namespace_lookup(const ExprNode &Expression)
+{
+   const ExprNode *receiver = emit_assignment_direct_receiver(Expression);
+   if (not receiver or receiver->kind != AstNodeKind::IdentifierExpr) return false;
+
+   const auto *reference = std::get_if<NameRef>(&receiver->data);
+   return reference and emit_identifier_name_is(reference->identifier.symbol, "_LIB");
+}
+
 //********************************************************************************************************************
 // Determine whether a constant integer range can use its visible value as the numeric loop induction variable.
 
@@ -1510,6 +1533,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
       VarInfo* info = &this->func_state.var_get(base.raw() + i.raw());
       info->binding_id = identifier.binding_id;
       info->static_value = identifier.static_value;
+      if (i.raw() < Payload.values.size() and
+          emit_expression_is_script_namespace_lookup(*Payload.values[i.raw()])) {
+         info->info |= VarInfoFlag::ScriptNamespace;
+      }
       if (identifier.binding_id) {
          const auto &binding = this->ctx.descriptors().binding(identifier.binding_id);
          info->static_callable = binding.callable;

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
@@ -118,6 +118,7 @@ struct PreparedAssignment {
    RegisterSpan reserved;
    bool newly_created = false;   // True if a new local was created for an undeclared variable
    bool needs_var_add = false;   // True if var_add() must be called after expression evaluation
+   bool associates_function_literal = false; // True when a direct function literal is stored in a table field
    GCstr* pending_symbol = nullptr;  // Symbol name for deferred var_add
    StaticBindingID binding_id = 0;
    BCLine pending_line = 0;      // Line number for deferred variable declaration

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
@@ -119,6 +119,7 @@ struct PreparedAssignment {
    bool newly_created = false;   // True if a new local was created for an undeclared variable
    bool needs_var_add = false;   // True if var_add() must be called after expression evaluation
    bool associates_function_literal = false; // True when a direct function literal is stored in a table field
+   bool initialises_script_namespace = false; // True when a table constructor is assigned directly into _LIB
    GCstr* pending_symbol = nullptr;  // Symbol name for deferred var_add
    StaticBindingID binding_id = 0;
    BCLine pending_line = 0;      // Line number for deferred variable declaration
@@ -221,7 +222,7 @@ private:
    ParserResult<ExpDesc> emit_runtime_builtin_method_pipe(
       const PipeExprPayload& payload, const CallExprPayload& call);
    ParserResult<ExpDesc> emit_result_filter_expr(const ResultFilterPayload& payload);
-   ParserResult<ExpDesc> emit_table_expr(const TableExprPayload& payload);
+   ParserResult<ExpDesc> emit_table_expr(const TableExprPayload& payload, bool AssociateFunctions = true);
    ParserResult<ExpDesc> emit_range_expr(const RangeExprPayload& payload);
    ParserResult<ExpDesc> emit_choose_expr(const ChooseExprPayload& payload);
    ParserResult<ExpDesc> emit_function_expr(const FunctionExprPayload& payload, GCstr* FuncName = nullptr,

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
@@ -159,6 +159,7 @@ private:
    LocalBindingTable binding_table;
    ConstantEvaluator constant_evaluator;
    StaticCallableHandle current_callable = 0;
+   bool is_root_chunk = true;
 
    ParserResult<IrEmitUnit> emit_block(const BlockStmt& block, FuncScopeFlag flags = FuncScopeFlag::None);
    ParserResult<IrEmitUnit> emit_block_with_bindings(const BlockStmt& block, FuncScopeFlag flags, std::span<const BlockBinding> bindings);
@@ -222,7 +223,8 @@ private:
    ParserResult<ExpDesc> emit_table_expr(const TableExprPayload& payload);
    ParserResult<ExpDesc> emit_range_expr(const RangeExprPayload& payload);
    ParserResult<ExpDesc> emit_choose_expr(const ChooseExprPayload& payload);
-   ParserResult<ExpDesc> emit_function_expr(const FunctionExprPayload& payload, GCstr* funcname = nullptr);
+   ParserResult<ExpDesc> emit_function_expr(const FunctionExprPayload& payload, GCstr* FuncName = nullptr,
+      bool TableAssociated = false);
    ParserResult<IrEmitUnit> emit_annotation_registration(BCReg func_reg, const std::vector<AnnotationEntry>& annotations, GCstr* funcname);
    ParserResult<ExpDesc> emit_expression_list(const ExprNodeList& expressions, BCReg& count);
    ParserResult<ExpDesc> emit_lvalue_expr(

--- a/src/tiri/jit/src/parser/parse_types.h
+++ b/src/tiri/jit/src/parser/parse_types.h
@@ -79,7 +79,8 @@ enum class VarInfoFlag : uint8_t {
    Defer = 0x08u,
    DeferArg = 0x10u,
    Close = 0x20u,
-   Const = 0x40u  // Variable is const (cannot be reassigned)
+   Const = 0x40u,  // Variable is const (cannot be reassigned)
+   ScriptNamespace = 0x80u // Local binding loaded from the script namespace registry
 };
 
 // Transient parser-side form of a runtime contract.  The raw structure definition is used only while compiling;

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1875,7 +1875,12 @@ static bool test_table_association_metadata_roundtrip(kt::Log &Log)
       "   literal = function():str return .name end\n"
       "}\n"
       "function holder.declared():str return .name end\n"
-      "return independent, holder.literal, holder.declared\n";
+      "local assigned = { name = 'assigned' }\n"
+      "assigned.literal = function():str return .name end\n"
+      "local key = 'computed'\n"
+      "assigned[key] = function():str return .name end\n"
+      "assigned.callback = independent\n"
+      "return independent, holder.literal, holder.declared, assigned.literal, assigned.computed\n";
 
    if (lua_load(lua, source, "table-association-roundtrip")) {
       Log.error("failed to compile table-association source: %s", lua_tostring(lua, -1));
@@ -1890,18 +1895,21 @@ static bool test_table_association_metadata_roundtrip(kt::Log &Log)
    }
 
    auto verify = [&](std::string_view Label) {
-      if (lua_pcall(lua, 0, 3, 0)) {
+      if (lua_pcall(lua, 0, 5, 0)) {
          Log.error("failed to execute %.*s table-association fixture: %s", int(Label.size()), Label.data(),
             lua_tostring(lua, -1));
          return false;
       }
-      bool valid = tvisfunc(lua->top - 3) and tvisfunc(lua->top - 2) and tvisfunc(lua->top - 1) and
-         not func_is_table_associated(funcV(lua->top - 3)) and
+      bool valid = tvisfunc(lua->top - 5) and tvisfunc(lua->top - 4) and tvisfunc(lua->top - 3) and
+         tvisfunc(lua->top - 2) and tvisfunc(lua->top - 1) and
+         not func_is_table_associated(funcV(lua->top - 5)) and
+         func_is_table_associated(funcV(lua->top - 4)) and
+         func_is_table_associated(funcV(lua->top - 3)) and
          func_is_table_associated(funcV(lua->top - 2)) and
          func_is_table_associated(funcV(lua->top - 1));
-      lua_pop(lua, 3);
+      lua_pop(lua, 5);
       if (not valid) {
-         Log.error("%.*s bytecode did not distinguish independent, literal and declared functions",
+         Log.error("%.*s bytecode did not preserve function association across declaration and assignment forms",
             int(Label.size()), Label.data());
       }
       return valid;

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1923,6 +1923,51 @@ static bool test_table_association_metadata_roundtrip(kt::Log &Log)
    return verify("reloaded");
 }
 
+static bool test_script_namespace_function_association(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *lua = state.get();
+   lua_newtable(lua);
+   lua_setglobal(lua, "_LIB");
+   constexpr std::string_view source =
+      "namespace 'association_fixture'\n"
+      "_LIB[_NS] = function() end\n"
+      "local registry_callable = _LIB[_NS]\n"
+      "_LIB[_NS] = { initialised = function() end, client = { initialised = function() end } }\n"
+      "exports = _LIB[_NS]\n"
+      "exports.assigned = function() end\n"
+      "function exports.declared() end\n"
+      "local key = 'computed'\n"
+      "exports[key] = function() end\n"
+      "exports.direct_client = { initialised = function() end }\n"
+      "exports.client.assigned = function() end\n"
+      "function exports.client.declared() end\n"
+      "return registry_callable, exports.initialised, exports.assigned, exports.declared, exports.computed, "
+         "exports.client.initialised, exports.direct_client.initialised, exports.client.assigned, "
+         "exports.client.declared\n";
+
+   if (lua_load(lua, source, "@script-namespace-association.tiri") or lua_pcall(lua, 0, 9, 0)) {
+      Log.error("failed to execute script namespace association fixture: %s", lua_tostring(lua, -1));
+      return false;
+   }
+
+   bool valid = true;
+   for (int i = 0; i < 9; ++i) valid = valid and tvisfunc(lua->top - 9 + i);
+   std::array<bool, 9> associated;
+   for (int i = 0; i < 9; ++i) associated[i] = func_is_table_associated(funcV(lua->top - 9 + i));
+   for (int i = 0; i < 5; ++i) valid = valid and not associated[i];
+   for (int i = 5; i < 9; ++i) valid = valid and associated[i];
+   lua_pop(lua, 9);
+
+   if (not valid) {
+      Log.error("script namespace association metadata was registry=%d initialised=%d assigned=%d declared=%d "
+         "computed=%d nested-initialised=%d direct-client=%d nested-assigned=%d nested-declared=%d", int(associated[0]),
+         int(associated[1]), int(associated[2]), int(associated[3]), int(associated[4]), int(associated[5]),
+         int(associated[6]), int(associated[7]), int(associated[8]));
+   }
+   return valid;
+}
+
 static bool test_malformed_signature_rejected(kt::Log &Log)
 {
    LuaStateHolder state;
@@ -7347,7 +7392,7 @@ static bool test_builtin_callable_bytecode(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 65> tests = { {
+   constexpr std::array<TestCase, 66> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -7375,6 +7420,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "bytecode_equivalence", test_bytecode_equivalence },
       { "signature_metadata_roundtrip", test_signature_metadata_roundtrip },
       { "table_association_metadata_roundtrip", test_table_association_metadata_roundtrip },
+      { "script_namespace_function_association", test_script_namespace_function_association },
       { "forward_declaration_signature_validation", test_forward_declaration_signature_validation },
       { "old_bytecode_versions_rejected", test_old_bytecode_versions_rejected },
       { "unmatched_context_entry_rejected", test_unmatched_context_entry_rejected },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1863,6 +1863,58 @@ static bool test_signature_void_and_bare_return(kt::Log &Log)
    return true;
 }
 
+static bool test_table_association_metadata_roundtrip(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *lua = state.get();
+   constexpr std::string_view source =
+      "local independent = function():str return 'callback' end\n"
+      "local holder = {\n"
+      "   name = 'holder',\n"
+      "   callback = independent,\n"
+      "   literal = function():str return .name end\n"
+      "}\n"
+      "function holder.declared():str return .name end\n"
+      "return independent, holder.literal, holder.declared\n";
+
+   if (lua_load(lua, source, "table-association-roundtrip")) {
+      Log.error("failed to compile table-association source: %s", lua_tostring(lua, -1));
+      return false;
+   }
+
+   GCproto *root = funcproto(funcV(lua->top - 1));
+   std::string dump;
+   if (lj_bcwrite(lua, root, bytecode_writer, &dump, 1) != 0) {
+      Log.error("failed to write table-association bytecode");
+      return false;
+   }
+
+   auto verify = [&](std::string_view Label) {
+      if (lua_pcall(lua, 0, 3, 0)) {
+         Log.error("failed to execute %.*s table-association fixture: %s", int(Label.size()), Label.data(),
+            lua_tostring(lua, -1));
+         return false;
+      }
+      bool valid = tvisfunc(lua->top - 3) and tvisfunc(lua->top - 2) and tvisfunc(lua->top - 1) and
+         not func_is_table_associated(funcV(lua->top - 3)) and
+         func_is_table_associated(funcV(lua->top - 2)) and
+         func_is_table_associated(funcV(lua->top - 1));
+      lua_pop(lua, 3);
+      if (not valid) {
+         Log.error("%.*s bytecode did not distinguish independent, literal and declared functions",
+            int(Label.size()), Label.data());
+      }
+      return valid;
+   };
+
+   if (not verify("source")) return false;
+   if (lua_load(lua, std::string_view(dump.data(), dump.size()), "table-association-roundtrip")) {
+      Log.error("failed to reload table-association bytecode: %s", lua_tostring(lua, -1));
+      return false;
+   }
+   return verify("reloaded");
+}
+
 static bool test_malformed_signature_rejected(kt::Log &Log)
 {
    LuaStateHolder state;
@@ -5532,8 +5584,10 @@ static bool test_builtin_method_bytecode_emission(kt::Log &Log)
       "local body = { values={} }\nbody.values.insert(1)\nreturn body.values[0]\n", true, error);
    const BCIns *dynamic_dispatch = dynamic ? find_opcode(*dynamic, BC_BMETH) : nullptr;
    if (not dynamic or not dynamic_dispatch or count_opcode(*dynamic, BC_BMETH) != 1 or
-       count_opcode(*dynamic, BC_CALL) != 2 or count_opcode(*dynamic, BC_JMP) != 1 or
-       count_opcode(*dynamic, BC_BFUNC) != 0 or bc_j(*dynamic_dispatch) <= 0) {
+       count_opcode(*dynamic, BC_CALL) != 1 or count_opcode(*dynamic, BC_CTXCALL) != 1 or
+       count_opcode(*dynamic, BC_CTXENTER) != 1 or count_opcode(*dynamic, BC_CTXLEAVE) != 1 or
+       count_opcode(*dynamic, BC_JMP) != 1 or count_opcode(*dynamic, BC_BFUNC) != 0 or
+       bc_j(*dynamic_dispatch) <= 0) {
       Log.error("unproved dot call did not emit the two-branch runtime method shape: %s", error.c_str());
       return false;
    }
@@ -5542,17 +5596,30 @@ static bool test_builtin_method_bytecode_emission(kt::Log &Log)
    auto userdata = compile_snapshot(L,
       "local function use(Handle:userdata)\nHandle.write('x')\nHandle.close()\nend\n", true, error);
    if (not userdata or count_opcode_tree(*userdata, BC_BMETH) != 2 or
-       count_opcode_tree(*userdata, BC_CALL) != 4) {
+       count_opcode_tree(*userdata, BC_CALL) != 4 or count_opcode_tree(*userdata, BC_CTXCALL) != 0 or
+       count_opcode_tree(*userdata, BC_CTXENTER) != 0 or count_opcode_tree(*userdata, BC_CTXLEAVE) != 0) {
       Log.error("proved userdata calls did not emit runtime method dispatch: %s", error.c_str());
       return false;
    }
 
    error.clear();
    auto dynamic_tail = compile_snapshot(L,
-      "local Values:any = {}\nreturn Values.insert(1)\n", true, error);
+      "local Values:any = {}\nlocal function forward():<any, ...> return Values.insert(1) end\nreturn forward()\n",
+      true, error);
    if (not dynamic_tail or count_opcode_tree(*dynamic_tail, BC_BMETH) != 1 or
-       count_opcode_tree(*dynamic_tail, BC_CALLT) != 2) {
+       count_opcode_tree(*dynamic_tail, BC_CALLT) != 2 or count_opcode_tree(*dynamic_tail, BC_CTXCALLT) != 1 or
+       count_opcode_tree(*dynamic_tail, BC_CTXENTER) != 1) {
       Log.error("runtime built-in method tail branches did not both use CALLT: %s", error.c_str());
+      return false;
+   }
+
+   error.clear();
+   auto dynamic_root_tail = compile_snapshot(L,
+      "local Values:any = {}\nreturn Values.insert(1)\n", true, error);
+   if (not dynamic_root_tail or count_opcode_tree(*dynamic_root_tail, BC_CTXCALLT) != 0 or
+       count_opcode_tree(*dynamic_root_tail, BC_CTXCALL) != 1 or
+       count_opcode_tree(*dynamic_root_tail, BC_CTXLEAVE) != 1) {
+      Log.error("root runtime method call used an ownership-transferring tail frame: %s", error.c_str());
       return false;
    }
 
@@ -5560,7 +5627,8 @@ static bool test_builtin_method_bytecode_emission(kt::Log &Log)
    auto dynamic_forwarded = compile_snapshot(L,
       "local function item():num return 2 end\nlocal Values:any = {}\nValues.insert(item())\n", true, error);
    if (not dynamic_forwarded or count_opcode(*dynamic_forwarded, BC_BMETH) != 1 or
-       count_opcode(*dynamic_forwarded, BC_CALLM) != 2) {
+       count_opcode(*dynamic_forwarded, BC_CALLM) != 1 or
+       count_opcode(*dynamic_forwarded, BC_CTXCALLM) != 1) {
       Log.error("runtime built-in method argument forwarding lost either CALLM branch: %s", error.c_str());
       return false;
    }
@@ -5569,7 +5637,8 @@ static bool test_builtin_method_bytecode_emission(kt::Log &Log)
    auto dynamic_thunk = compile_snapshot(L,
       "local Values:any = {}\nValues.insert(thunk():num return 1 end)\n", true, error);
    if (not dynamic_thunk or count_opcode(*dynamic_thunk, BC_BMETH) != 1 or
-       count_opcode(*dynamic_thunk, BC_CALL) != 2) {
+       count_opcode(*dynamic_thunk, BC_CALL) != 2 or count_opcode(*dynamic_thunk, BC_CALLM) != 1 or
+       count_opcode(*dynamic_thunk, BC_CTXCALLM) != 1) {
       Log.error("runtime built-in method could not emit a thunk argument for both branches: %s", error.c_str());
       return false;
    }
@@ -5578,7 +5647,8 @@ static bool test_builtin_method_bytecode_emission(kt::Log &Log)
    auto dynamic_safe = compile_snapshot(L,
       "local maybe:any = nil\nmaybe?.insert(1)\nreturn maybe\n", true, error);
    if (not dynamic_safe or count_opcode(*dynamic_safe, BC_BMETH) != 1 or
-       count_opcode(*dynamic_safe, BC_ISEQP) != 2 or count_opcode(*dynamic_safe, BC_CALL) != 2) {
+       count_opcode(*dynamic_safe, BC_ISEQP) != 2 or count_opcode(*dynamic_safe, BC_CALL) != 1 or
+       count_opcode(*dynamic_safe, BC_CTXCALL) != 1) {
       Log.error("unproved safe dot call lost runtime dispatch or nil short-circuiting: %s", error.c_str());
       return false;
    }
@@ -5587,7 +5657,8 @@ static bool test_builtin_method_bytecode_emission(kt::Log &Log)
    auto dynamic_pipe = compile_snapshot(L,
       "local body = { values={} }\n1 |> body.values.insert()\nreturn body.values[0]\n", true, error);
    if (not dynamic_pipe or count_opcode(*dynamic_pipe, BC_BMETH) != 1 or
-       count_opcode(*dynamic_pipe, BC_CALL) != 2) {
+       count_opcode(*dynamic_pipe, BC_CALL) != 1 or count_opcode(*dynamic_pipe, BC_CTXCALL) != 1 or
+       count_opcode(*dynamic_pipe, BC_CTXENTER) != 1 or count_opcode(*dynamic_pipe, BC_CTXLEAVE) != 1) {
       Log.error("unproved piped dot call did not emit both runtime call frames: %s", error.c_str());
       return false;
    }
@@ -7268,7 +7339,7 @@ static bool test_builtin_callable_bytecode(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 64> tests = { {
+   constexpr std::array<TestCase, 65> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -7295,6 +7366,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "ast_call_lowering", test_ast_call_lowering },
       { "bytecode_equivalence", test_bytecode_equivalence },
       { "signature_metadata_roundtrip", test_signature_metadata_roundtrip },
+      { "table_association_metadata_roundtrip", test_table_association_metadata_roundtrip },
       { "forward_declaration_signature_validation", test_forward_declaration_signature_validation },
       { "old_bytecode_versions_rejected", test_old_bytecode_versions_rejected },
       { "unmatched_context_entry_rejected", test_unmatched_context_entry_rejected },

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -661,7 +661,8 @@ enum class ProtoSignatureFlag : uint8_t {
    ParameterVariadic = 1 << 0,
    ResultVariadic = 1 << 1,
    ExplicitResults = 1 << 2,
-   DynamicResults = 1 << 3
+   DynamicResults = 1 << 3,
+   TableAssociated = 1 << 4
 };
 
 inline constexpr uint8_t PROTO_TYPE_NULLABLE = 1 << 0;
@@ -1059,6 +1060,14 @@ typedef union GCfunc {
 
 [[nodiscard]] inline GCproto* funcproto(const GCfunc* fn) noexcept {
    return check_exp(isluafunc(fn), (GCproto*)(mref<char>(fn->l.pc) - sizeof(GCproto)));
+}
+
+[[nodiscard]] inline bool func_is_table_associated(const GCfunc *Function) noexcept
+{
+   if (not Function or not isluafunc(Function)) return false;
+   const ProtoSignature *signature = proto_signature(funcproto(Function));
+   return signature and
+      (signature->flags & proto_signature_flag(ProtoSignatureFlag::TableAssociated)) != 0;
 }
 
 [[nodiscard]] constexpr inline size_t sizeCfunc(MSize n) noexcept {

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -252,7 +252,8 @@ extern "C" void lj_context_enter_call(lua_State *L, uint32_t CallBase)
    if (not L->context_stack.empty() and L->context_stack.back().owner_base IS owner_base) return;
 
    TValue *receiver = L->base + CallBase - 1;
-   if (lj_context_receiver_establishes(receiver)) {
+   TValue *callable = L->base + CallBase;
+   if (lj_context_call_establishes(receiver, callable)) {
       lj_context_push(L, tabV(receiver), L->base + CallBase + 1 + LJ_FR2);
    }
 }
@@ -260,7 +261,8 @@ extern "C" void lj_context_enter_call(lua_State *L, uint32_t CallBase)
 extern "C" uint32_t lj_context_prepare_call(lua_State *L, uint32_t CallBase, uint32_t ArgumentCount)
 {
    TValue *receiver = L->base + CallBase - 1;
-   if (lj_context_receiver_establishes(receiver)) {
+   TValue *callable = L->base + CallBase;
+   if (lj_context_call_establishes(receiver, callable)) {
       lj_context_enter_call(L, CallBase);
    }
    return ArgumentCount;
@@ -291,7 +293,8 @@ extern "C" void lj_context_leave_call(
 extern "C" uint32_t lj_context_prepare_tail_call(lua_State *L, uint32_t CallBase, uint32_t ArgumentCount)
 {
    TValue *receiver = L->base + CallBase - 1;
-   if (not lj_context_receiver_establishes(receiver)) return ArgumentCount;
+   TValue *callable = L->base + CallBase;
+   if (not lj_context_call_establishes(receiver, callable)) return ArgumentCount;
 
    ptrdiff_t prepared_owner = savestack(L, L->base + CallBase + 1 + LJ_FR2);
    lj_assertL(not L->context_stack.empty() and L->context_stack.back().owner_base IS prepared_owner,

--- a/src/tiri/jit/src/runtime/lj_state.h
+++ b/src/tiri/jit/src/runtime/lj_state.h
@@ -43,6 +43,12 @@ LJ_FUNC void lj_state_free(global_State* g, lua_State* L);
    return tvistab(Receiver) and not lj_tab_is_context_exempt(tabV(Receiver));
 }
 
+[[nodiscard]] inline bool lj_context_call_establishes(const TValue *Receiver, const TValue *Callable) noexcept
+{
+   return lj_context_receiver_establishes(Receiver) and tvisfunc(Callable) and
+      func_is_table_associated(funcV(Callable));
+}
+
 LJ_FUNC [[nodiscard]] GCtab * lj_context_current(lua_State *L) noexcept;
 extern "C" LJ_FUNC void lj_context_load(lua_State *L, TValue *Destination) noexcept;
 extern "C" LJ_FUNC GCtab * lj_context_current_jit(lua_State *L) noexcept;

--- a/src/tiri/tests/context_namespace_fixture.tiri
+++ b/src/tiri/tests/context_namespace_fixture.tiri
@@ -1,0 +1,42 @@
+namespace 'context_namespace_fixture'
+
+_LIB[_NS] = {
+   initialised = function():str
+      return .glContextualNamespaceName
+   end,
+   client = {
+      glContextualNamespaceName = 'client table',
+      initialised = function():str
+         return .glContextualNamespaceName
+      end
+   }
+}
+local namespace_exports = _LIB[_NS]
+
+namespace_exports.assigned = function():str
+   return .glContextualNamespaceName
+end
+
+function namespace_exports.declared():str
+   return .glContextualNamespaceName
+end
+
+local computed_name = 'computed'
+namespace_exports[computed_name] = function():str
+   return .glContextualNamespaceName
+end
+
+namespace_exports.direct_client = {
+   glContextualNamespaceName = 'direct client table',
+   initialised = function():str
+      return .glContextualNamespaceName
+   end
+}
+
+namespace_exports.client.assigned = function():str
+   return .glContextualNamespaceName
+end
+
+function namespace_exports.client.declared():str
+   return .glContextualNamespaceName
+end

--- a/src/tiri/tests/test_contextual_member_calls.tiri
+++ b/src/tiri/tests/test_contextual_member_calls.tiri
@@ -1,6 +1,7 @@
 -- Flute regression tests for table-gated contextual member calls.
 
 import 'json'
+import './context_namespace_fixture'
 module core as mCore
 
 @Test function NamedAndComputedTableCallsEstablishContext()
@@ -594,6 +595,29 @@ end
       'A function literal assigned to a computed table field should be associated with that table')
 
    .glContextualAssociationName = nil
+end
+
+@Test function ScriptNamespaceExportsInheritTheirCallerContext()
+   .glContextualNamespaceName = 'root context'
+
+   assert(context_namespace_fixture.initialised() is 'root context',
+      'A script namespace export created in its table initialiser should not establish namespace context')
+   assert(context_namespace_fixture.assigned() is 'root context',
+      'A directly assigned script namespace export should not establish the namespace as context')
+   assert(context_namespace_fixture.declared() is 'root context',
+      'A declared script namespace export should not establish the namespace as context')
+   assert(context_namespace_fixture.computed() is 'root context',
+      'A computed script namespace export should not establish the namespace as context')
+   assert(context_namespace_fixture.client.initialised() is 'client table',
+      'A nested client method created in a namespace table initialiser should remain table-associated')
+   assert(context_namespace_fixture.direct_client.initialised() is 'direct client table',
+      'A client table assigned to a namespace export should retain associated functions from its initialiser')
+   assert(context_namespace_fixture.client.assigned() is 'client table',
+      'A nested client method assigned within a namespace library should remain table-associated')
+   assert(context_namespace_fixture.client.declared() is 'client table',
+      'A nested client method declared within a namespace library should remain table-associated')
+
+   .glContextualNamespaceName = nil
 end
 
 @Test function StaticStructureMemberCallsBypassContextBytecode()

--- a/src/tiri/tests/test_contextual_member_calls.tiri
+++ b/src/tiri/tests/test_contextual_member_calls.tiri
@@ -31,6 +31,81 @@ module core as mCore
       'A computed contextual call should compact table and multiple results into the expression destination')
 end
 
+@Test function DynamicallyResolvedTableCallsEstablishContext()
+   local account_factory = {}
+
+   function account_factory.new(Name:str):table
+      local account = { name = Name, balance = 0 }
+
+      function account.deposit(Amount:num):num
+         .balance += Amount
+         return .balance
+      end
+
+      return account
+   end
+
+   local account = account_factory.new('paul')
+   assert(account.deposit(10) is 10,
+      'A local inferred from a member-call result should establish its table receiver context')
+
+   local wrapper = { nested = account_factory.new('nested') }
+   assert(wrapper.nested.deposit(7) is 7,
+      'A nested member receiver should establish its resolved table as context')
+
+   function deposit_any(Receiver:any, Amount:num):num
+      return Receiver.deposit(Amount)
+   end
+
+   function deposit_untyped(Receiver, Amount:num):num
+      return Receiver.deposit(Amount)
+   end
+
+   assert(deposit_any(account, 4) is 14,
+      'A table passed through an any parameter should establish its runtime receiver context')
+   assert(deposit_untyped(account, 6) is 20,
+      'A table passed through an unannotated parameter should establish its runtime receiver context')
+end
+
+@Test function DynamicFluentAndPipedCallsPreserveContextAndResults()
+   local builder = { value = '' }
+
+   function builder.add(Value:str):table
+      .value ..= Value
+      return builder
+   end
+
+   builder.add('a').add('b')
+   assert(builder.value is 'ab', 'Each dynamically resolved receiver in a fluent chain should establish context')
+
+   local holder = { target = { total = 0 } }
+   function holder.target.add(Value:num):num
+      .total += Value
+      return .total
+   end
+
+   assert(9 |> holder.target.add() is 9,
+      'A piped dynamically resolved field call should preserve its context and result layout')
+   assert(holder.target.total is 9, 'A piped field call should update its runtime table receiver')
+end
+
+@Test function DynamicTailAndMultipleResultCallsPreserveContext()
+   local receiver = { name = 'dynamic', value = 27 }
+
+   function receiver.describe():<str, num>
+      return .name, .value
+   end
+
+   function forward(Receiver:any):<any, ...>
+      return Receiver.describe()
+   end
+
+   local name, value = forward(receiver)
+   assert(name is 'dynamic' and value is 27,
+      'A runtime-resolved contextual tail call should preserve every returned value')
+   assert(.name is nil, 'A runtime-resolved contextual tail call should restore the root context')
+end
+
 @Test function DirectCallsInheritAndNestedTableCallsRestoreContext()
    local outer = { name = 'outer' }
    local inner = { name = 'inner' }
@@ -416,10 +491,11 @@ end
 end
 
 @Test function MetatableLookupKeepsOriginalReceiver()
-   local implementation = function():str
-      return .name
-   end
-   local prototype = { inherited = implementation }
+   local prototype = {
+      inherited = function():str
+         return .name
+      end
+   }
    local receiver = setmetatable({ name = 'receiver' }, { __index = prototype })
 
    assert(receiver.inherited() is 'receiver',
@@ -465,6 +541,39 @@ end
    local callback = receiver.read
    assert(callback() is 'root', 'An extracted member should inherit invocation-time context without binding its table')
    .glContextualExtractionName = nil
+end
+
+@Test function TableAssociationDistinguishesMethodsFromStoredCallbacks()
+   .glContextualAssociationName = 'root'
+
+   function independent_callback():str
+      return .glContextualAssociationName
+   end
+
+   local callback_holder = {
+      glContextualAssociationName = 'callback holder',
+      invoke = independent_callback
+   }
+   assert(callback_holder.invoke() is 'root',
+      'Storing an independent function reference in a table should not associate it with that table')
+
+   local literal_method = {
+      glContextualAssociationName = 'literal method',
+      invoke = function():str
+         return .glContextualAssociationName
+      end
+   }
+   assert(literal_method.invoke() is 'literal method',
+      'A function literal declared in a table field should be associated with that table')
+
+   local declared_method = { glContextualAssociationName = 'declared method' }
+   function declared_method.invoke():str
+      return .glContextualAssociationName
+   end
+   assert(declared_method.invoke() is 'declared method',
+      'A dot-qualified function declaration should be associated with its table')
+
+   .glContextualAssociationName = nil
 end
 
 @Test function StaticStructureMemberCallsBypassContextBytecode()
@@ -568,15 +677,11 @@ end
 end
 
 @Test(hotpath=80) function JITAlternatingReceiversUseRecordedContext()
-   local first = { value = 3 }
-   local second = { value = 7 }
-
-   function read_value():num
-      return .value
-   end
-
-   first.read = read_value
-   second.read = read_value
+   local first = {
+      value = 3,
+      read = function():num return .value end
+   }
+   local second = { value = 7, read = first.read }
 
    function run(Count:num):num
       local total = 0
@@ -602,15 +707,17 @@ end
 end
 
 @Test function JITVirtualContextRestoresAllocatedReceiverOnExit()
-   function read_allocated():num
-      if .alternate then return .value + 1 end
-      return .value
-   end
-
    function run(Count:num):num
       local total = 0
       for i in {0 to Count} do
-         local target = { value = i, alternate = i is 24, read = read_allocated }
+         local target = {
+            value = i,
+            alternate = i is 24,
+            read = function():num
+               if .alternate then return .value + 1 end
+               return .value
+            end
+         }
          total += target.read()
       end
       return total

--- a/src/tiri/tests/test_contextual_member_calls.tiri
+++ b/src/tiri/tests/test_contextual_member_calls.tiri
@@ -557,6 +557,11 @@ end
    assert(callback_holder.invoke() is 'root',
       'Storing an independent function reference in a table should not associate it with that table')
 
+   local assigned_callback_holder = { glContextualAssociationName = 'assigned callback holder' }
+   assigned_callback_holder.invoke = independent_callback
+   assert(assigned_callback_holder.invoke() is 'root',
+      'Assigning an independent function reference to a table should not associate it with that table')
+
    local literal_method = {
       glContextualAssociationName = 'literal method',
       invoke = function():str
@@ -572,6 +577,21 @@ end
    end
    assert(declared_method.invoke() is 'declared method',
       'A dot-qualified function declaration should be associated with its table')
+
+   local assigned_method = { glContextualAssociationName = 'assigned method' }
+   assigned_method.invoke = function():str
+      return .glContextualAssociationName
+   end
+   assert(assigned_method.invoke() is 'assigned method',
+      'A function literal assigned to a named table field should be associated with that table')
+
+   local computed_method = { glContextualAssociationName = 'computed method' }
+   local method_key = 'invoke'
+   computed_method[method_key] = function():str
+      return .glContextualAssociationName
+   end
+   assert(computed_method.invoke() is 'computed method',
+      'A function literal assigned to a computed table field should be associated with that table')
 
    .glContextualAssociationName = nil
 end


### PR DESCRIPTION
* Emitted contextual call variants for dynamically typed receivers and preserved receiver context across calls
* Distinguished table-associated declarations and direct function literals from independent stored callback references
* Persisted and guarded association metadata across bytecode and JIT execution with expanded parser and Flute regressions