### PR TITLE
[Tiri] Virtualised contextual calls and standalone current-context expressions

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -870,7 +870,7 @@ set (TIRI_TESTS
    module_namespaces builtin_methods
    object_pinning import_type_analysis global_types type_contracts thunk_contract_argument type_signature_dumps
    type_guided_emission type_guided_jit_signatures
-   context_access contextual_member_calls contextual_designation context_blocks
+   context_access contextual_member_calls contextual_designation context_blocks context_materialisation
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/jit/BYTECODE.md
+++ b/src/tiri/jit/BYTECODE.md
@@ -761,9 +761,10 @@ The process-wide ownership, publication and lock contract is documented in
 
 `CTXGET` is appended to the opcode set so existing opcode numbers remain stable. An empty physical context stack is
 the permanent root sentinel and resolves dynamically through `L->env`; consequently a supported environment
-replacement is visible to the next `CTXGET`.  `&name` current-context access lowers to `CTXGET` followed by ordinary `TGET*` or
-`TSET*` operations. Root writes therefore cross the same marked-environment mutation boundary as `_G` writes and
-cannot bypass protected-global, const or sticky-type contracts.
+replacement is visible to the next `CTXGET`.  The standalone `&&` current-context expression lowers directly to
+`CTXGET`.  `&name` and the equivalent `&&.name` access lower to `CTXGET` followed by ordinary `TGET*` or `TSET*`
+operations. Root writes therefore cross the same marked-environment mutation boundary as `_G` writes and cannot
+bypass protected-global, const or sticky-type contracts.
 
 Phase 2 deliberately stops recording a trace at `CTXGET`; Phase 5 will model context in recorder state and snapshots.
 

--- a/src/tiri/jit/src/debug/lj_ff.h
+++ b/src/tiri/jit/src/debug/lj_ff.h
@@ -85,3 +85,5 @@ union GCfunc;
 
 void lj_builtin_register(lua_State *L, BuiltinCallableID Id, GCfunc *Function);
 [[nodiscard]] GCfunc *lj_builtin_callable(lua_State *L, BuiltinCallableID Id) noexcept;
+void lj_builtin_set_context_independent(lua_State *L, BuiltinCallableID Id);
+[[nodiscard]] bool lj_builtin_context_independent(lua_State *L, const GCfunc *Function) noexcept;

--- a/src/tiri/jit/src/debug/lj_jit.h
+++ b/src/tiri/jit/src/debug/lj_jit.h
@@ -181,15 +181,25 @@ struct MCLink {
 };
 
 // Stack snapshot header.
+
+constexpr size_t LJ_MAX_VIRTUAL_CONTEXTS = 8;
+
+enum ContextCallState : uint8_t {
+  CONTEXT_CALL_NONE,
+  CONTEXT_CALL_VIRTUAL,
+  CONTEXT_CALL_MATERIALISED,
+  CONTEXT_CALL_EXEMPT
+};
 struct SnapShot {
   uint32_t mapofs;   //  Offset into snapshot map.
   IRRef1 ref;      //  First IR ref for this snapshot.
-  IRRef1 context_ref; // Virtual contextual receiver restored on trace exit, or zero.
-  uint16_t context_owner_slot; // Root-frame slot owning the virtual contextual activation.
+  IRRef1 context_refs[LJ_MAX_VIRTUAL_CONTEXTS]; // Virtual contextual receivers restored outermost first.
+  uint16_t context_owner_slots[LJ_MAX_VIRTUAL_CONTEXTS]; // Root-frame slots owning virtual activations.
   uint16_t mcofs;   //  Offset into machine code in MCode units.
   uint8_t nslots;   //  Number of valid slots.
   uint8_t topslot;   //  Maximum frame extent.
   uint8_t nent;      //  Number of compressed entries.
+  uint8_t context_count; // Number of virtual contextual activations reconstructed on exit.
   uint8_t count;   //  Count of taken exits for this snapshot.
 };
 

--- a/src/tiri/jit/src/lib/lib.cpp
+++ b/src/tiri/jit/src/lib/lib.cpp
@@ -51,6 +51,20 @@ GCfunc *lj_builtin_callable(lua_State *L, BuiltinCallableID Id) noexcept
    return callable and callable->gch.gct IS uint8_t(~LJ_TFUNC) ? gco_to_function(callable) : nullptr;
 }
 
+void lj_builtin_set_context_independent(lua_State *L, BuiltinCallableID Id)
+{
+   if (not builtin_callable_valid(Id) or not lj_builtin_callable(L, Id)) {
+      lj_err_callermsg(L, "invalid context-independent built-in registration");
+   }
+   L2GG(L)->builtin_context_independent[builtin_callable_index(Id)] = 1;
+}
+
+bool lj_builtin_context_independent(lua_State *L, const GCfunc *Function) noexcept
+{
+   if (not Function or not isffunc(Function) or Function->c.ffid >= BUILTIN_CALLABLE_CAPACITY) return false;
+   return L2GG(L)->builtin_context_independent[Function->c.ffid] != 0;
+}
+
 static GCtab * lib_create_table(lua_State *L, const char *libname, int hsize)
 {
    if (libname) {

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -2720,20 +2720,20 @@ extern "C" int luaopen_array(lua_State *L)
    reg_iface_method(L, "array", "concat", TiriType::Array, builtin_callable_id(FastFunc::array_concat),
       { TiriType::Str }, { TiriType::Array, TiriType::Str, TiriType::Str, TiriType::Num, TiriType::Num });
    reg_iface_method(L, "array", "contains", TiriType::Array, builtin_callable_id(FastFunc::array_contains),
-      { TiriType::Bool }, { TiriType::Array, TiriType::Any });
+      { TiriType::Bool }, { TiriType::Array, TiriType::Any }, FProtoFlags::ContextIndependent);
    reg_iface_method(L, "array", "first", TiriType::Array, builtin_callable_id(FastFunc::array_first),
-      { TiriType::Any }, { TiriType::Array, TiriType::Func });
+      { TiriType::Any }, { TiriType::Array, TiriType::Func }, FProtoFlags::ContextIndependent);
    reg_iface_method(L, "array", "last", TiriType::Array, builtin_callable_id(FastFunc::array_last),
-      { TiriType::Any }, { TiriType::Array, TiriType::Func });
+      { TiriType::Any }, { TiriType::Array, TiriType::Func }, FProtoFlags::ContextIndependent);
    reg_iface_method(L, "array", "clear", TiriType::Array, builtin_callable_id(FastFunc::array_clear), {},
       { TiriType::Array });
    reg_iface_method(L, "array", "resize", TiriType::Array, builtin_callable_id(FastFunc::array_resize), {},
       { TiriType::Array, TiriType::Num });
    reg_iface_method(L, "array", "push", TiriType::Array, builtin_callable_id(FastFunc::array_push), {},
-      { TiriType::Array, TiriType::Any });
+      { TiriType::Array, TiriType::Any }, FProtoFlags::ContextIndependent);
 
    reg_iface_method(L, "array", "pop", TiriType::Array, builtin_callable_id(FastFunc::array_pop),
-      { TiriType::Any }, { TiriType::Array });
+      { TiriType::Any }, { TiriType::Array }, FProtoFlags::ContextIndependent);
    reg_iface_method(L, "array", "copy", TiriType::Array, builtin_callable_id(FastFunc::array_copy), {},
       { TiriType::Array, TiriType::Any, TiriType::Num, TiriType::Num, TiriType::Num });
    reg_iface_method(L, "array", "getString", TiriType::Array, builtin_callable_id(FastFunc::array_getString),

--- a/src/tiri/jit/src/lib/lib_jit.cpp
+++ b/src/tiri/jit/src/lib/lib_jit.cpp
@@ -19,6 +19,7 @@
 #include "lj_ir.h"
 #include "lj_jit.h"
 #include "lj_ircall.h"
+#include "lj_ff.h"
 #include "lj_iropt.h"
 #include "lj_target.h"
 #include "lj_trace.h"
@@ -176,6 +177,13 @@ static void setintfield(lua_State* L, GCtab* t, CSTRING name, int32_t val)
 {
    setintV(lj_tab_setstr(L, t, lj_str_newz(L, name)), val);
 }
+
+#ifdef LUA_USE_ASSERT
+static void setcounterfield(lua_State *L, GCtab *Table, CSTRING Name, uint64_t Value)
+{
+   setnumV(lj_tab_setstr(L, Table, lj_str_newz(L, Name)), lua_Number(Value));
+}
+#endif
 
 //********************************************************************************************************************
 // local info = jit.util.funcInfo(func [,pc])
@@ -449,6 +457,66 @@ LJLIB_CF(jit_util_irCallAddr)
 }
 
 //********************************************************************************************************************
+// local counters = jit.util.contextStats([reset])
+// Return state-local context materialisation counters in Debug builds. Passing true resets them before querying.
+
+static int jit_util_contextStats(lua_State *L)
+{
+#ifdef LUA_USE_ASSERT
+   if (L->base < L->top and tvistrue(L->base)) lj_context_debug_reset(L);
+   ContextDebugCounters *counters = lj_context_debug_get(L, true);
+   lua_createtable(L, 0, 18);
+   GCtab *result = tabV(L->top - 1);
+   setboolV(lj_tab_setstr(L, result, lj_str_newlit(L, "enabled")), 1);
+   setcounterfield(L, result, "virtualActivationsCreated", counters->virtual_activations_created);
+   setcounterfield(L, result, "virtualActivationsRetired", counters->virtual_activations_retired);
+   setcounterfield(L, result, "physicalContextEntries", counters->physical_context_entries);
+   setcounterfield(L, result, "physicalContextLeaves", counters->physical_context_leaves);
+   setcounterfield(L, result, "jitEnterCalls", counters->jit_enter_calls);
+   setcounterfield(L, result, "jitLeaveCalls", counters->jit_leave_calls);
+   setcounterfield(L, result, "jitCurrentCalls", counters->jit_current_calls);
+   setcounterfield(L, result, "maximumVirtualDepth", counters->maximum_virtual_depth);
+   setcounterfield(L, result, "maximumPhysicalDepth", counters->maximum_physical_depth);
+   setcounterfield(L, result, "traceStarts", counters->trace_starts);
+   setcounterfield(L, result, "traceCompilations", counters->trace_compilations);
+   setcounterfield(L, result, "traceAborts", counters->trace_aborts);
+   setcounterfield(L, result, "sideExits", counters->side_exits);
+
+   lua_createtable(L, 0, size_t(ContextMaterialisationReason::Count));
+   GCtab *reasons = tabV(L->top - 1);
+   static constexpr std::array<CSTRING, size_t(ContextMaterialisationReason::Count)> reason_names = {
+      "nestedLuaCall", "nativeCall", "tailCall", "snapshot", "sideExit", "unsupportedBoundary"
+   };
+   for (size_t i = 0; i < reason_names.size(); i++) {
+      setcounterfield(L, reasons, reason_names[i], counters->materialisations[i]);
+   }
+   lua_setfield(L, -2, "materialisations");
+
+   lua_createtable(L, 0, FF__MAX);
+   GCtab *fast_functions = tabV(L->top - 1);
+   for (size_t i = FF_C_ + 1; i < FF__MAX; i++) {
+      if (not counters->native_fast_functions[i]) continue;
+      CSTRING name = glBuiltinCallableNames[i];
+      if (name) setcounterfield(L, fast_functions, name, counters->native_fast_functions[i]);
+   }
+   lua_setfield(L, -2, "nativeFastFunctions");
+
+   lua_createtable(L, 0, counters->native_c_functions.size());
+   GCtab *c_functions = tabV(L->top - 1);
+   for (const auto &[address, count] : counters->native_c_functions) {
+      char name[2 + sizeof(uintptr_t) * 2 + 1];
+      snprintf(name, sizeof(name), "%p", (void *)address);
+      setcounterfield(L, c_functions, name, count);
+   }
+   lua_setfield(L, -2, "nativeCFunctions");
+   return 1;
+#else
+   setnilV(L->top++);
+   return 1;
+#endif
+}
+
+//********************************************************************************************************************
 
 #include "lj_libdef.h" // Includes the LJLIB_MODULE_jit_util table: lj_lib_cf_jit and lj_lib_init_jit_util
 
@@ -657,6 +725,8 @@ extern int luaopen_jit(lua_State* L)
    // Register jit.util as a subtable of jit (avoid lib_create_table's dotted name handling)
    lua_getglobal(L, "jit");  // Get the jit table we just created
    LJ_LIB_REG(L, nullptr, jit_util);  // Create util table without setting in globals
+   lua_pushcfunction(L, jit_util_contextStats);
+   lua_setfield(L, -2, "contextStats");
    lua_setfield(L, -2, "util");
    lua_pop(L, 1);
 
@@ -686,6 +756,7 @@ extern int luaopen_jit(lua_State* L)
    reg_iface_prototype("jit.util", "traceMC", { TiriType::Str, TiriType::Num, TiriType::Num }, { TiriType::Num });
    reg_iface_prototype("jit.util", "traceExitStub", { TiriType::Num }, { TiriType::Num, TiriType::Num });
    reg_iface_prototype("jit.util", "irCallAddr", { TiriType::Num }, { TiriType::Num });
+   reg_iface_prototype("jit.util", "contextStats", { TiriType::Table }, { TiriType::Bool });
 
    // Register jit.opt interface prototypes
    reg_iface_prototype("jit.opt", "start", {}, { TiriType::Str }, FProtoFlags::Variadic);

--- a/src/tiri/jit/src/lib/lib_range.cpp
+++ b/src/tiri/jit/src/lib/lib_range.cpp
@@ -1079,7 +1079,7 @@ extern "C" int luaopen_range(lua_State *L)
    reg_iface_method(L, "range", "map", TiriType::Range, builtin_callable_id(FastFunc::range_map),
       { TiriType::Array }, { TiriType::Range, TiriType::Func });
    reg_iface_method(L, "range", "take", TiriType::Range, builtin_callable_id(FastFunc::range_take),
-      { TiriType::Array }, { TiriType::Range, TiriType::Num });
+      { TiriType::Array }, { TiriType::Range, TiriType::Num }, FProtoFlags::ContextIndependent);
    reg_iface_method(L, "range", "any", TiriType::Range, builtin_callable_id(FastFunc::range_any),
       { TiriType::Bool }, { TiriType::Range, TiriType::Func });
    reg_iface_method(L, "range", "all", TiriType::Range, builtin_callable_id(FastFunc::range_all),
@@ -1087,9 +1087,9 @@ extern "C" int luaopen_range(lua_State *L)
    reg_iface_method(L, "range", "find", TiriType::Range, builtin_callable_id(FastFunc::range_find),
       { TiriType::Num }, { TiriType::Range, TiriType::Func });
    reg_iface_method(L, "range", "contains", TiriType::Range, builtin_callable_id(FastFunc::range_contains),
-      { TiriType::Bool }, { TiriType::Range, TiriType::Num });
+      { TiriType::Bool }, { TiriType::Range, TiriType::Num }, FProtoFlags::ContextIndependent);
    reg_iface_method(L, "range", "toArray", TiriType::Range, builtin_callable_id(FastFunc::range_toArray),
-      { TiriType::Array }, { TiriType::Range });
+      { TiriType::Array }, { TiriType::Range }, FProtoFlags::ContextIndependent);
 
    return 1;
 }

--- a/src/tiri/jit/src/lib/lib_string.cpp
+++ b/src/tiri/jit/src/lib/lib_string.cpp
@@ -882,7 +882,7 @@ extern int luaopen_string(lua_State *L)
       { TiriType::Str }, { TiriType::Str });
    reg_iface_prototype("string", "dump", { TiriType::Str }, { TiriType::Func });
    reg_iface_method(L, "string", "endsWith", TiriType::Str, builtin_callable_id(FastFunc::string_endsWith),
-      { TiriType::Bool }, { TiriType::Str, TiriType::Str });
+      { TiriType::Bool }, { TiriType::Str, TiriType::Str }, FProtoFlags::ContextIndependent);
    reg_iface_method(L, "string", "escXML", TiriType::Str, builtin_callable_id(FastFunc::string_escXML),
       { TiriType::Str }, { TiriType::Str });
    reg_iface_method(L, "string", "find", TiriType::Str, builtin_callable_id(FastFunc::string_find),
@@ -892,11 +892,11 @@ extern int luaopen_string(lua_State *L)
    reg_iface_method(L, "string", "hash", TiriType::Str, builtin_callable_id(FastFunc::string_hash),
       { TiriType::Num }, { TiriType::Str, TiriType::Bool });
    reg_iface_method(L, "string", "len", TiriType::Str, builtin_callable_id(FastFunc::string_len),
-      { TiriType::Num }, { TiriType::Str });
+      { TiriType::Num }, { TiriType::Str }, FProtoFlags::ContextIndependent);
    reg_iface_method(L, "string", "lower", TiriType::Str, builtin_callable_id(FastFunc::string_lower),
-      { TiriType::Str }, { TiriType::Str });
+      { TiriType::Str }, { TiriType::Str }, FProtoFlags::ContextIndependent);
    reg_iface_method(L, "string", "pop", TiriType::Str, builtin_callable_id(FastFunc::string_pop),
-      { TiriType::Str }, { TiriType::Str, TiriType::Num });
+      { TiriType::Str }, { TiriType::Str, TiriType::Num }, FProtoFlags::ContextIndependent);
    reg_iface_method(L, "string", "rep", TiriType::Str, builtin_callable_id(FastFunc::string_rep),
       { TiriType::Str }, { TiriType::Str, TiriType::Num });
    reg_iface_method(L, "string", "replace", TiriType::Str, builtin_callable_id(FastFunc::string_replace),
@@ -908,15 +908,15 @@ extern int luaopen_string(lua_State *L)
    reg_iface_method(L, "string", "split", TiriType::Str, builtin_callable_id(FastFunc::string_split),
       { TiriType::Array }, { TiriType::Str, TiriType::Str });
    reg_iface_method(L, "string", "startsWith", TiriType::Str, builtin_callable_id(FastFunc::string_startsWith),
-      { TiriType::Bool }, { TiriType::Str, TiriType::Str });
+      { TiriType::Bool }, { TiriType::Str, TiriType::Str }, FProtoFlags::ContextIndependent);
    reg_iface_method(L, "string", "sub", TiriType::Str, builtin_callable_id(FastFunc::string_sub),
       { TiriType::Str }, { TiriType::Str, TiriType::Num, TiriType::Num });
    reg_iface_method(L, "string", "trim", TiriType::Str, builtin_callable_id(FastFunc::string_trim),
-      { TiriType::Str }, { TiriType::Str });
+      { TiriType::Str }, { TiriType::Str }, FProtoFlags::ContextIndependent);
    reg_iface_method(L, "string", "unescapeXML", TiriType::Str,
       builtin_callable_id(FastFunc::string_unescapeXML), { TiriType::Str }, { TiriType::Str });
    reg_iface_method(L, "string", "upper", TiriType::Str, builtin_callable_id(FastFunc::string_upper),
-      { TiriType::Str }, { TiriType::Str }, FProtoFlags::NoNil);
+      { TiriType::Str }, { TiriType::Str }, FProtoFlags::NoNil | FProtoFlags::ContextIndependent);
 
    return 1;
 }

--- a/src/tiri/jit/src/lj_asm.cpp
+++ b/src/tiri/jit/src/lj_asm.cpp
@@ -967,7 +967,10 @@ static void asm_snap_alloc(ASMState* as, int snapno)
    SnapEntry* map = &as->T->snapmap[snap->mapofs];
    MSize n, nent = snap->nent;
    as->snapfilt1 = as->snapfilt2 = 0;
-   if (snap->context_ref and not irref_isk(snap->context_ref)) asm_snap_alloc1(as, snap->context_ref);
+   for (size_t context_index = 0; context_index < snap->context_count; context_index++) {
+      IRRef context_ref = snap->context_refs[context_index];
+      if (not irref_isk(context_ref)) asm_snap_alloc1(as, context_ref);
+   }
    for (n = 0; n < nent; n++) {
       SnapEntry sn = map[n];
       IRRef ref = snap_ref(sn);

--- a/src/tiri/jit/src/lj_dispatch.h
+++ b/src/tiri/jit/src/lj_dispatch.h
@@ -45,6 +45,7 @@ struct GG_State {
    BCIns bcff[GG_NUM_ASMFF];          // Bytecode for ASM fast functions.
    // VM-only roots live after JIT state so growth does not move fields encoded in the 10-bit FOLD key.
    GCRef builtin_callables[BUILTIN_CALLABLE_CAPACITY]; // Immutable canonical native closures, indexed by FastFunc.
+   uint8_t builtin_context_independent[BUILTIN_CALLABLE_CAPACITY]; // Explicitly safe while context remains virtual.
 };
 
 static_assert(sizeof(((GG_State *)nullptr)->builtin_callables) / sizeof(GCRef) IS BUILTIN_CALLABLE_CAPACITY);

--- a/src/tiri/jit/src/lj_opt_dce.cpp
+++ b/src/tiri/jit/src/lj_opt_dce.cpp
@@ -25,7 +25,10 @@ static void dce_marksnap(jit_State* J)
    SnapNo i, nsnap = J->cur.nsnap;
    for (i = 0; i < nsnap; i++) {
       SnapShot* snap = &J->cur.snap[i];
-      if (snap->context_ref >= REF_FIRST) irt_setmark(IR(snap->context_ref)->t);
+      for (size_t context_index = 0; context_index < snap->context_count; context_index++) {
+         IRRef context_ref = snap->context_refs[context_index];
+         if (context_ref >= REF_FIRST) irt_setmark(IR(context_ref)->t);
+      }
       SnapEntry* map = &J->cur.snapmap[snap->mapofs];
       MSize n, nent = snap->nent;
       for (n = 0; n < nent; n++) {

--- a/src/tiri/jit/src/lj_opt_loop.cpp
+++ b/src/tiri/jit/src/lj_opt_loop.cpp
@@ -227,16 +227,20 @@ static void loop_subst_snap(jit_State* J, SnapShot* osnap, SnapEntry* loopmap, I
    // Setup new snapshot.
    snap->mapofs = (uint32_t)nmapofs;
    snap->ref = (IRRef1)J->cur.nins;
-   snap->context_ref = osnap->context_ref;
-   if (snap->context_ref and not irref_isk(snap->context_ref)) {
-      lj_assertJ(subst[snap->context_ref] != REF_DROP, "virtual context dropped during loop substitution");
-      snap->context_ref = subst[snap->context_ref];
+   snap->context_count = osnap->context_count;
+   for (size_t context_index = 0; context_index < snap->context_count; context_index++) {
+      IRRef context_ref = osnap->context_refs[context_index];
+      if (context_ref and not irref_isk(context_ref)) {
+         lj_assertJ(subst[context_ref] != REF_DROP, "virtual context dropped during loop substitution");
+         context_ref = subst[context_ref];
+      }
+      snap->context_refs[context_index] = IRRef1(context_ref);
+      snap->context_owner_slots[context_index] = osnap->context_owner_slots[context_index];
    }
-   snap->context_owner_slot = osnap->context_owner_slot;
    snap->mcofs = 0;
    snap->nslots = nslots;
    snap->topslot = osnap->topslot;
-   snap->count = snap->context_ref ? SNAPCOUNT_DONE : 0;
+   snap->count = snap->context_count ? SNAPCOUNT_DONE : 0;
    nmap = &J->cur.snapmap[nmapofs];
    // Substitute snapshot slots.
    on = ln = nn = 0;

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1339,7 +1339,7 @@ static bool rec_context_is_tail_call(jit_State *J, BCREG CallBase)
 static TRef rec_context_current(jit_State *J)
 {
    for (int32_t slot = int32_t(J->baseslot) - 1; slot >= 0; slot--) {
-      if (J->context_call_receiver[slot]) return J->context_call_receiver[slot];
+      if (J->context_call_state[slot] IS CONTEXT_CALL_VIRTUAL) return J->context_call_receiver[slot];
    }
    return lj_ir_call(J, IRCALL_lj_context_current_jit);
 }
@@ -4645,6 +4645,9 @@ void lj_record_ins(jit_State *J)
 
    case BC_CTXBEGIN:
       if (not tref_istab(ra)) lj_trace_err_info(J, LJ_TRERR_NYIBC);
+      // Block activations are installed physically. Materialise any virtual call receivers first so current-context
+      // lookup observes the block before the enclosing receiver, matching interpreter stack order.
+      rec_context_materialise(J, ContextMaterialisationReason::UnsupportedBoundary);
       lj_ir_call(J, IRCALL_lj_context_begin_block_jit, ra, lj_ir_kint(J, int32_t(bc_d(*pc))),
          lj_ir_kint(J, int32_t(bc_a(*pc)) + 1));
       J->needsnap = 1;

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1344,28 +1344,32 @@ static TRef rec_context_current(jit_State *J)
    return lj_ir_call(J, IRCALL_lj_context_current_jit);
 }
 
-enum : uint8_t {
-   CONTEXT_CALL_NONE,
-   CONTEXT_CALL_VIRTUAL,
-   CONTEXT_CALL_MATERIALISED,
-   CONTEXT_CALL_EXEMPT
-};
-
-static void rec_context_materialise(jit_State *J)
+static uint32_t rec_context_virtual_count(const jit_State *J)
 {
-   int32_t function_slot = J->context_virtual_slot;
-   if (function_slot < 0) return;
+   uint32_t count = 0;
+   for (size_t slot = 0; slot < std::size(J->context_call_state); slot++) {
+      if (J->context_call_state[slot] IS CONTEXT_CALL_VIRTUAL) count++;
+   }
+   return count;
+}
 
-   TRef receiver = J->context_call_receiver[function_slot];
-   lj_assertJ(tref_istab(receiver), "virtual context receiver is not a table");
-   lj_assertJ(J->context_call_state[function_slot] IS CONTEXT_CALL_VIRTUAL,
-      "virtual context slot has inconsistent state");
+static void rec_context_materialise(
+   jit_State *J, ContextMaterialisationReason Reason, const GCfunc *Callable = nullptr)
+{
+   if (J->context_virtual_slot < 0) return;
 
+   lj_context_debug_materialise(J->L, Reason, Callable);
    IRBuilder ir(J);
-   int32_t owner_slot = function_slot + 1 + LJ_FR2;
-   TRef owner_base = rec_stack_slot_addr(J, ir, owner_slot);
-   lj_ir_call(J, IRCALL_lj_context_enter_jit, receiver, owner_base);
-   J->context_call_state[function_slot] = CONTEXT_CALL_MATERIALISED;
+   for (size_t function_slot = 0; function_slot < std::size(J->context_call_state); function_slot++) {
+      if (J->context_call_state[function_slot] != CONTEXT_CALL_VIRTUAL) continue;
+      TRef receiver = J->context_call_receiver[function_slot];
+      lj_assertJ(tref_istab(receiver), "virtual context receiver is not a table");
+      int32_t owner_slot = int32_t(function_slot) + 1 + LJ_FR2;
+      TRef owner_base = rec_stack_slot_addr(J, ir, owner_slot);
+      lj_ir_call(J, IRCALL_lj_context_enter_jit, receiver, owner_base);
+      lj_context_debug_virtual_leave(J->L);
+      J->context_call_state[function_slot] = CONTEXT_CALL_MATERIALISED;
+   }
    J->context_virtual_slot = -1;
    // Guards emitted later in the same bytecode must not reuse a snapshot that still describes virtual state.
    lj_snap_add(J);
@@ -1399,7 +1403,14 @@ static void rec_context_enter(jit_State *J, BCREG CallBase)
       ir.guard_ne_int(designated, ir.kint(0));
    }
 
-   if (tail_call or native_target) rec_context_materialise(J);
+   if (tail_call) {
+      rec_context_materialise(
+         J, ContextMaterialisationReason::TailCall, tvisfunc(callable) ? funcV(callable) : nullptr);
+   }
+   else if (native_target) {
+      rec_context_materialise(
+         J, ContextMaterialisationReason::NativeCall, tvisfunc(callable) ? funcV(callable) : nullptr);
+   }
 
    int32_t function_slot = int32_t(J->baseslot) + int32_t(CallBase);
    J->context_call_func[function_slot] = getslot(J, CallBase);
@@ -1407,16 +1418,17 @@ static void rec_context_enter(jit_State *J, BCREG CallBase)
 
    if (not tail_call) {
       J->context_call_receiver[function_slot] = receiver;
-      if (not J->L->context_active and not J->context_call_activation_count) {
-         J->context_call_state[function_slot] = CONTEXT_CALL_VIRTUAL;
-         J->context_call_activation_count++;
-         J->context_virtual_slot = function_slot;
-         J->needsnap = 1;
-         return;
+      uint32_t virtual_count = rec_context_virtual_count(J);
+      if (virtual_count >= LJ_MAX_VIRTUAL_CONTEXTS) {
+         rec_context_materialise(J, ContextMaterialisationReason::UnsupportedBoundary, funcV(callable));
+         virtual_count = 0;
       }
-      rec_context_materialise(J);
-      J->context_call_state[function_slot] = CONTEXT_CALL_MATERIALISED;
+      J->context_call_state[function_slot] = CONTEXT_CALL_VIRTUAL;
       J->context_call_activation_count++;
+      J->context_virtual_slot = function_slot;
+      lj_context_debug_virtual_enter(J->L, virtual_count + 1);
+      J->needsnap = 1;
+      return;
    }
    IRBuilder ir(J);
    int32_t owner_slot = int32_t(J->baseslot) + int32_t(CallBase) + 1 + LJ_FR2;
@@ -1441,6 +1453,13 @@ static void rec_context_leave(jit_State *J, BCREG CallBase, const BCIns *LeavePc
       if (context_state IS CONTEXT_CALL_VIRTUAL) {
          lj_assertJ(J->context_virtual_slot IS function_slot, "virtual context leave has inconsistent owner");
          J->context_virtual_slot = -1;
+         for (int32_t slot = function_slot - 1; slot >= 0; slot--) {
+            if (J->context_call_state[slot] IS CONTEXT_CALL_VIRTUAL) {
+               J->context_virtual_slot = slot;
+               break;
+            }
+         }
+         lj_context_debug_virtual_leave(J->L);
       }
       else {
          IRBuilder ir(J);
@@ -1485,7 +1504,19 @@ static void rec_context_leave(jit_State *J, BCREG CallBase, const BCIns *LeavePc
 void lj_record_call(jit_State *J, BCREG func, ptrdiff_t nargs)
 {
    cTValue *callable = &J->L->base[func];
-   if (not tvisfunc(callable) or not isluafunc(funcV(callable))) rec_context_materialise(J);
+   bool context_independent = tvisfunc(callable) and
+      lj_builtin_context_independent(J->L, funcV(callable));
+   if ((not tvisfunc(callable) or not isluafunc(funcV(callable))) and not context_independent) {
+      uint32_t virtual_count = rec_context_virtual_count(J);
+      rec_context_materialise(
+         J, ContextMaterialisationReason::NativeCall, tvisfunc(callable) ? funcV(callable) : nullptr);
+      // A context-observing native boundary can resume through a native frame whose stack top is not represented by
+      // a multi-context snapshot. Hand the call back to the interpreter after materialising the complete prefix.
+      if (virtual_count > 1) {
+         lj_record_stop(J, TraceLink::INTERP, 0);
+         return;
+      }
+   }
    rec_call_setup(J, func, nargs);
    FrameManager fm(J);
    // Bump frame.
@@ -1519,14 +1550,14 @@ static void rec_tailcall_compact(jit_State *J, BCREG Func)
 
 void lj_record_tailcall(jit_State *J, BCREG func, ptrdiff_t nargs)
 {
-   rec_context_materialise(J);
+   rec_context_materialise(J, ContextMaterialisationReason::TailCall);
    rec_call_setup(J, func, nargs);
    rec_tailcall_compact(J, func);
 }
 
 static void rec_context_tailcall(jit_State *J, BCREG CallBase, ptrdiff_t ArgumentCount)
 {
-   rec_context_materialise(J);
+   rec_context_materialise(J, ContextMaterialisationReason::TailCall);
    cTValue *callable = &J->L->base[CallBase];
    if (not tvisfunc(callable)) {
       lj_trace_err(J, LJ_TRERR_NYIBC);

--- a/src/tiri/jit/src/lj_snap.cpp
+++ b/src/tiri/jit/src/lj_snap.cpp
@@ -11,7 +11,7 @@
 **   - mapofs: Offset into snapmap where this snapshot's entries begin
 **   - nent:   Number of slot entries (NOT including frame links)
 **   - ref:    IR reference at which this snapshot was created
-**   - context_ref/context_owner_slot: Virtual contextual activation materialised on exit
+**   - context_refs/context_owner_slots: Virtual contextual activations materialised on exit
 **   - nslots: Total number of stack slots
 **   - topslot: Top slot for stack sizing
 **
@@ -171,19 +171,25 @@ static void snapshot_stack(jit_State* J, SnapShot* snap, MSize nsnapmap)
    nent += snapshot_framelinks(J, p + nent, &snap->topslot);
    snap->mapofs = (uint32_t)nsnapmap;
    snap->ref = (IRRef1)J->cur.nins;
-   snap->context_ref = 0;
-   snap->context_owner_slot = 0;
+   memset(snap->context_refs, 0, sizeof(snap->context_refs));
+   memset(snap->context_owner_slots, 0, sizeof(snap->context_owner_slots));
    snap->mcofs = 0;
    snap->nslots = (uint8_t)nslots;
+   snap->context_count = 0;
    snap->count = 0;
-   if (J->context_virtual_slot >= 0) {
-      int32_t function_slot = J->context_virtual_slot;
+   for (size_t function_slot = 0; function_slot < std::size(J->context_call_state); function_slot++) {
+      if (J->context_call_state[function_slot] != CONTEXT_CALL_VIRTUAL) continue;
+      lj_assertJ(snap->context_count < LJ_MAX_VIRTUAL_CONTEXTS, "too many virtual contexts for snapshot");
       TRef receiver = J->context_call_receiver[function_slot];
       lj_assertJ(tref_istab(receiver), "snapshot virtual context is not a table");
-      snap->context_ref = IRRef1(tref_ref(receiver));
-      snap->context_owner_slot = uint16_t(function_slot + 1 + LJ_FR2);
+      size_t context_index = snap->context_count++;
+      snap->context_refs[context_index] = IRRef1(tref_ref(receiver));
+      snap->context_owner_slots[context_index] = uint16_t(function_slot + 1 + LJ_FR2);
       // Side traces cannot inherit virtual VM state. A guard exit materialises it and resumes in the interpreter.
       snap->count = SNAPCOUNT_DONE;
+   }
+   if (snap->context_count) {
+      lj_context_debug_materialise(J->L, ContextMaterialisationReason::Snapshot);
    }
    J->cur.nsnapmap = (uint32_t)(nsnapmap + nent);
 }
@@ -943,19 +949,20 @@ const BCIns * lj_snap_restore(jit_State *J, void *exptr)
    L->base += base_adj;
    lj_assertJ(map + nent IS flinks, "inconsistent frames in snapshot");
 
-   if (snap->context_ref) {
+   for (size_t context_index = 0; context_index < snap->context_count; context_index++) {
       TValue context;
-      TValue *context_owner = frame + snap->context_owner_slot;
+      TValue *context_owner = frame + snap->context_owner_slots[context_index];
       // A root trace may be reused beneath an inherited context, and a deeper inlined activation may have been
       // materialised after this snapshot. Preserve owners below this activation and discard owners abandoned by the
       // restored frames before installing (or de-duplicating) the snapshot activation.
       lj_context_unwind(L, context_owner);
-      IRIns *context_ir = &T->ir[snap->context_ref];
+      IRRef context_ref = snap->context_refs[context_index];
+      IRIns *context_ir = &T->ir[context_ref];
       if (context_ir->r IS RID_SUNK) {
          bool restored_slot = false;
          for (n = 0; n < nent; n++) {
             SnapEntry sn = map[n];
-            if (snap_ref(sn) IS snap->context_ref and not (sn & SNAP_NORESTORE)) {
+            if (snap_ref(sn) IS context_ref and not (sn & SNAP_NORESTORE)) {
                copyTV(L, &context, &frame[snap_slot(sn)]);
                restored_slot = true;
                break;
@@ -964,10 +971,11 @@ const BCIns * lj_snap_restore(jit_State *J, void *exptr)
          if (not restored_slot) snap_unsink(J, T, ex, snapno, rfilt, context_ir, &context);
       }
       else {
-         snap_restoreval(J, T, ex, snapno, rfilt, snap->context_ref, &context);
+         snap_restoreval(J, T, ex, snapno, rfilt, context_ref, &context);
       }
       lj_assertJ(tvistab(&context), "virtual context snapshot did not restore a table");
       lj_context_enter_jit(L, tabV(&context), context_owner);
+      lj_context_debug_materialise(L, ContextMaterialisationReason::SideExit);
    }
 
    // Compute current stack top.

--- a/src/tiri/jit/src/lj_trace.cpp
+++ b/src/tiri/jit/src/lj_trace.cpp
@@ -574,6 +574,7 @@ static void trace_start(jit_State *J)
    setgcref(J->cur.startpt, obj2gco(J->pt));
 
    L = J->L;
+   lj_context_debug_trace_start(L);
    lj_vmevent_send(L, TRACE, setstrV(L, L->top++, lj_str_newlit(L, "start"));
    setintV(L->top++, traceno);
    setfuncV(L, L->top++, J->fn);
@@ -598,6 +599,7 @@ static void trace_start(jit_State *J)
 
 static void trace_stop(jit_State *J)
 {
+   lj_context_debug_trace_compiled(J->L);
    BCIns *pc = mref<BCIns>(J->cur.startpc);
    BCOp op = bc_op(J->cur.startins);
    GCproto* pt = &gcref(J->cur.startpt)->pt;
@@ -697,6 +699,7 @@ static int trace_downrec(jit_State *J)
 static int trace_abort(jit_State *J)
 {
    lua_State* L = J->L;
+   lj_context_debug_trace_abort(L);
    TraceError e = LJ_TRERR_RECERR;
    TraceNo traceno;
 
@@ -991,6 +994,7 @@ typedef struct ExitDataCP {
 
 static TValue* trace_exit_cp(lua_State* L, lua_CFunction dummy, void* ud)
 {
+   lj_context_debug_side_exit(L);
    ExitDataCP* exd = (ExitDataCP*)ud;
    // Always catch error here and don't call error function.
    cframe_errfunc(L->cframe) = 0;

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -580,6 +580,18 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          break;
       }
 
+      case TokenKind::CurrentContext: {
+         const Token following = this->ctx.tokens().peek(1);
+         if ((following.kind() IS TokenKind::Identifier or following.kind() IS TokenKind::Ampersand) and
+             following.span().offset IS current.span().offset + 2) {
+            return this->fail<ExprNodePtr>(ParserErrorCode::ExpectedToken, following,
+               "invalid token adjacent to '&&' current-context access");
+         }
+         node = make_current_context_expr(current.span());
+         this->ctx.tokens().advance();
+         break;
+      }
+
       case TokenKind::Dots:
          node = make_vararg_expr(current.span());
          this->ctx.tokens().advance();

--- a/src/tiri/jit/src/parser/lexer.cpp
+++ b/src/tiri/jit/src/parser/lexer.cpp
@@ -1417,6 +1417,12 @@ static LexToken lex_scan(LexState *State, TValue *tv)
             if (auto tok = check_compound(State, TK_cmod)) return tok;
             return '%';
 
+         case '&':
+            State->mark_token_start();
+            lex_next(State);
+            if (State->c IS '&') { lex_next(State); return TK_current_context; }
+            return '&';
+
          case '!':
             State->mark_token_start();
             lex_next(State);

--- a/src/tiri/jit/src/parser/lexer_types.h
+++ b/src/tiri/jit/src/parser/lexer_types.h
@@ -89,7 +89,7 @@ struct TokenDefinition {
    TOKEN_DEF(using,        "using",    TKF_RESERVED | TKF_STATEMENT_START) \
    TOKEN_DEF(where,        "where",    TKF_RESERVED) \
    TOKEN_DEF(case_arrow,   "->",       TKF_NONE) \
-   TOKEN_DEF(current_context, "&&",    TKF_NONE) \
+   TOKEN_DEF(current_context, "&&",    TKF_CAN_END_RANGE_EXPRESSION) \
    TOKEN_DEF(if_empty,     "??",       TKF_NONE) \
    TOKEN_DEF(guard,        "?!",       TKF_NONE) \
    TOKEN_DEF(safe_field,   "?.",       TKF_MEMBER_NAME_CONTEXT) \

--- a/src/tiri/jit/src/parser/lexer_types.h
+++ b/src/tiri/jit/src/parser/lexer_types.h
@@ -89,6 +89,7 @@ struct TokenDefinition {
    TOKEN_DEF(using,        "using",    TKF_RESERVED | TKF_STATEMENT_START) \
    TOKEN_DEF(where,        "where",    TKF_RESERVED) \
    TOKEN_DEF(case_arrow,   "->",       TKF_NONE) \
+   TOKEN_DEF(current_context, "&&",    TKF_NONE) \
    TOKEN_DEF(if_empty,     "??",       TKF_NONE) \
    TOKEN_DEF(guard,        "?!",       TKF_NONE) \
    TOKEN_DEF(safe_field,   "?.",       TKF_MEMBER_NAME_CONTEXT) \

--- a/src/tiri/jit/src/parser/parse_expr.cpp
+++ b/src/tiri/jit/src/parser/parse_expr.cpp
@@ -84,6 +84,7 @@ static int token_starts_expression(LexToken tok)
       case '~':
       case '#':
       case '&':
+      case TK_current_context:
          return 1;
       default:
          return 0;

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -3969,6 +3969,81 @@ static bool test_contextual_member_ast_foundations(kt::Log &Log)
       return false;
    }
 
+   constexpr std::string_view materialisation_source =
+      "local current = &&\n"
+      "consume(&&, &value)\n"
+      "local member = &&.value\n"
+      "local indexed = &&['value']\n"
+      "local optional = &&?.value\n";
+   auto materialisation = build_ast_from_source(materialisation_source, false, false);
+   if (not materialisation.chunk.ok() or materialisation.chunk.value_ref()->statements.size() != 5) {
+      Log.error("failed to parse standalone current-context expressions");
+      log_diagnostics(materialisation.diagnostics, Log);
+      return false;
+   }
+
+   const auto &current_decl =
+      std::get<LocalDeclStmtPayload>(materialisation.chunk.value_ref()->statements[0]->data);
+   if (current_decl.values.size() != 1 or current_decl.values[0]->kind != AstNodeKind::CurrentContextExpr or
+       infer_expression_type(*current_decl.values[0]) != TiriType::Table) {
+      Log.error("standalone current-context materialisation did not retain its table-valued AST node");
+      return false;
+   }
+
+   const auto &consume_statement =
+      std::get<ExpressionStmtPayload>(materialisation.chunk.value_ref()->statements[1]->data);
+   const auto *consume_call = consume_statement.expression ?
+      std::get_if<CallExprPayload>(&consume_statement.expression->data) : nullptr;
+   if (not consume_call or consume_call->arguments.size() != 2 or
+       consume_call->arguments[0]->kind != AstNodeKind::CurrentContextExpr) {
+      Log.error("a standalone current-context call argument was not preserved");
+      return false;
+   }
+
+   constexpr std::array<AstNodeKind, 3> suffix_kinds = {
+      AstNodeKind::MemberExpr,
+      AstNodeKind::IndexExpr,
+      AstNodeKind::SafeMemberExpr
+   };
+   for (size_t i = 0; i < suffix_kinds.size(); ++i) {
+      const auto &declaration =
+         std::get<LocalDeclStmtPayload>(materialisation.chunk.value_ref()->statements[i + 2]->data);
+      if (declaration.values.size() != 1 or declaration.values[0]->kind != suffix_kinds[i]) {
+         Log.error("current-context suffix fixture %" PRId64 " produced the wrong AST node", int64_t(i));
+         return false;
+      }
+   }
+
+   const auto &materialised_member = std::get<MemberExprPayload>(
+      std::get<LocalDeclStmtPayload>(materialisation.chunk.value_ref()->statements[2]->data).values[0]->data);
+   const auto &materialised_index = std::get<IndexExprPayload>(
+      std::get<LocalDeclStmtPayload>(materialisation.chunk.value_ref()->statements[3]->data).values[0]->data);
+   const auto &materialised_safe_member = std::get<SafeMemberExprPayload>(
+      std::get<LocalDeclStmtPayload>(materialisation.chunk.value_ref()->statements[4]->data).values[0]->data);
+   if (not materialised_member.table or
+       materialised_member.table->kind != AstNodeKind::CurrentContextExpr or
+       not materialised_index.table or materialised_index.table->kind != AstNodeKind::CurrentContextExpr or
+       not materialised_safe_member.table or
+       materialised_safe_member.table->kind != AstNodeKind::CurrentContextExpr) {
+      Log.error("a current-context suffix did not retain its standalone context receiver");
+      return false;
+   }
+
+   auto spaced_context_operand = build_ast_from_source("local value = 7 & &glProbe\n", false, false);
+   if (not spaced_context_operand.chunk.ok()) {
+      Log.error("spaced bitwise-AND with a context-prefixed right operand stopped parsing");
+      log_diagnostics(spaced_context_operand.diagnostics, Log);
+      return false;
+   }
+
+   for (std::string_view invalid_source : { "local value = &&name\n", "local value = &&&name\n" }) {
+      auto invalid = build_ast_from_source(invalid_source, false, false);
+      if (invalid.diagnostics.empty()) {
+         Log.error("an invalid adjacent current-context expression was accepted");
+         return false;
+      }
+   }
+
    const auto &alias_decl = std::get<LocalDeclStmtPayload>(block.statements[9]->data);
    if (alias_decl.values.empty() or alias_decl.values[0]->kind != AstNodeKind::MemberExpr) {
       Log.error("member extraction did not remain an unbound member expression");
@@ -4680,6 +4755,31 @@ static bool test_static_result_set_model(kt::Log &Log)
 
 static size_t count_opcode_tree(const BytecodeSnapshot &, BCOp);
 static size_t count_opcode(const BytecodeSnapshot &, BCOp);
+
+static bool test_current_context_materialisation_bytecode(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *L = state.get();
+   std::string error;
+
+   auto standalone = compile_snapshot(L, "return &&\n", true, error);
+   if (not standalone or count_opcode(*standalone, BC_CTXGET) != 1 or
+       count_opcode(*standalone, BC_TGETS) != 0 or count_opcode(*standalone, BC_TGETV) != 0) {
+      Log.error("standalone current-context materialisation emitted unexpected bytecode: %s", error.c_str());
+      return false;
+   }
+
+   auto prefixed = compile_snapshot(L, "return &value\n", true, error);
+   auto suffixed = compile_snapshot(L, "return &&.value\n", true, error);
+   if (not prefixed or not suffixed or count_opcode(*prefixed, BC_CTXGET) != 1 or
+       count_opcode(*suffixed, BC_CTXGET) != 1 or count_opcode(*prefixed, BC_TGETS) != 1 or
+       count_opcode(*suffixed, BC_TGETS) != 1) {
+      Log.error("equivalent current-context member spellings emitted different bytecode: %s", error.c_str());
+      return false;
+   }
+
+   return true;
+}
 
 static int envstore_protected_attempt(lua_State *L)
 {
@@ -8165,7 +8265,7 @@ static bool test_contextual_designation_ownership(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 72> tests = { {
+   constexpr std::array<TestCase, 73> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -8189,6 +8289,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "tail_call_eligibility", test_tail_call_eligibility },
       { "multres_save_unwind", test_multres_save_unwind },
       { "contextual_member_ast_foundations", test_contextual_member_ast_foundations },
+      { "current_context_materialisation_bytecode", test_current_context_materialisation_bytecode },
       { "ast_call_lowering", test_ast_call_lowering },
       { "bytecode_equivalence", test_bytecode_equivalence },
       { "signature_metadata_roundtrip", test_signature_metadata_roundtrip },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -806,6 +806,40 @@ return sum
 
 //********************************************************************************************************************
 
+static bool test_current_context_range_operands(kt::Log &Log)
+{
+   constexpr std::array<std::string_view, 2> sources = {
+      "local upper = 8\nlocal values = {&& to upper}",
+      "local step = 2\nlocal values = {0 to && by step}"
+   };
+
+   for (std::string_view source : sources) {
+      auto result = build_ast_from_source(source, true);
+      if (not result.chunk.ok() or not result.diagnostics.empty()) {
+         Log.error("failed to parse current-context range operand");
+         log_diagnostics(result.diagnostics, Log);
+         return false;
+      }
+
+      StatementListView statements = result.chunk.value_ref()->view();
+      if (statements.size() != 2 or statements[1].kind != AstNodeKind::LocalDeclStmt) {
+         Log.error("current-context range fixture did not produce the expected local declarations");
+         return false;
+      }
+
+      const auto *declaration = std::get_if<LocalDeclStmtPayload>(&statements[1].data);
+      if (not declaration or declaration->values.size() != 1 or
+          declaration->values[0]->kind != AstNodeKind::RangeExpr) {
+         Log.error("current-context operand was not classified as a range expression");
+         return false;
+      }
+   }
+
+   return true;
+}
+
+//********************************************************************************************************************
+
 static bool test_deprecated_numeric_for_rejected(kt::Log &Log)
 {
    struct DeprecatedForCase {
@@ -8265,7 +8299,7 @@ static bool test_contextual_designation_ownership(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 73> tests = { {
+   constexpr std::array<TestCase, 74> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -8278,6 +8312,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "local_function_table_ast", test_local_function_table_ast },
       { "ast_statement_matrix", test_ast_statement_matrix },
       { "range_for_ast", test_range_for_ast },
+      { "current_context_range_operands", test_current_context_range_operands },
       { "deprecated_numeric_for_rejected", test_deprecated_numeric_for_rejected },
       { "colon_method_syntax_rejected", test_colon_method_syntax_rejected },
       { "array_length_range_for_ast", test_array_length_range_for_ast },

--- a/src/tiri/jit/src/parser/token_types.h
+++ b/src/tiri/jit/src/parser/token_types.h
@@ -87,6 +87,7 @@ enum class TokenKind : uint16_t {
    From = TK_from,
    When = TK_when,
    CaseArrow = TK_case_arrow,
+   CurrentContext = TK_current_context,
    Annotate = TK_annotate,
    CompileIf = TK_compif,
    CompileEnd = TK_compend,

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -50,6 +50,7 @@ struct StrInternState;
 
 class TipEmitter;
 struct ParserSymbolCollection;
+struct ContextDebugCounters;
 
 // Debug objects
 
@@ -549,9 +550,10 @@ inline constexpr size_t PROTO_MAX_RETURN_TYPES = 8;
 // Prototype flags for function metadata
 
 enum class FProtoFlags : uint8_t {
-   None     = 0x00,
-   Variadic = 0x01,  // Function accepts variable arguments beyond listed params
-   NoNil    = 0x02   // All declared parameters are required (no nil values permitted)
+   None               = 0x00,
+   Variadic           = 0x01,  // Function accepts variable arguments beyond listed params
+   NoNil              = 0x02,  // All declared parameters are required (no nil values permitted)
+   ContextIndependent = 0x04   // Native callable cannot observe or re-enter dynamically scoped table context
 };
 
 inline constexpr FProtoFlags operator|(FProtoFlags a, FProtoFlags b) {
@@ -1666,6 +1668,7 @@ struct lua_State {
    // table-only overrides; direct and non-table calls do not need an entry.
    std::vector<ContextFrame> context_stack;
    uint8_t context_active = 0; // Fast VM return gate; indicates a visible override above the active root floor.
+   ContextDebugCounters *context_debug_counters = nullptr; // Lazily allocated in Debug builds only.
 
    // An asynchronous root boundary hides, but does not remove, suspended overrides. Keeping them in context_stack
    // ensures that the collector continues to trace their tables while a callback runs and performs collection.

--- a/src/tiri/jit/src/runtime/lj_proto_registry.cpp
+++ b/src/tiri/jit/src/runtime/lj_proto_registry.cpp
@@ -286,6 +286,9 @@ ERR reg_iface_method(lua_State *L, std::string_view Interface, std::string_view 
    if (limits != ERR::Okay) return limits;
    ERR state_validation = validate_method_state(L, Interface, Method, Callable);
    if (state_validation != ERR::Okay) return state_validation;
+   if ((Flags & FProtoFlags::ContextIndependent) != FProtoFlags::None) {
+      lj_builtin_set_context_independent(L, Callable);
+   }
 
    ProtoKey prototype_key{ kt::strhash(Interface), kt::strhash(Method) };
    MethodKey method_key{ ReceiverType, kt::strhash(Method) };

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -14,6 +14,7 @@
 #include "lj_str.h"
 #include "lj_tab.h"
 #include "lj_func.h"
+#include "lj_ff.h"
 #include "lj_meta.h"
 #include "lj_state.h"
 #include "lj_frame.h"
@@ -34,6 +35,81 @@
 
 // Type alias for the function names map (GCproto * -> function name string)
 using FuncNameMap = ankerl::unordered_dense::map<const GCproto *, std::string>;
+
+#ifdef LUA_USE_ASSERT
+ContextDebugCounters *lj_context_debug_get(lua_State *L, bool Create)
+{
+   if (not L->context_debug_counters and Create) L->context_debug_counters = new ContextDebugCounters();
+   return L->context_debug_counters;
+}
+
+void lj_context_debug_reset(lua_State *L)
+{
+   ContextDebugCounters *counters = lj_context_debug_get(L, true);
+   *counters = ContextDebugCounters();
+}
+
+void lj_context_debug_virtual_enter(lua_State *L, uint32_t Depth)
+{
+   if (ContextDebugCounters *counters = lj_context_debug_get(L, false)) {
+      counters->virtual_activations_created++;
+      if (Depth > counters->maximum_virtual_depth) counters->maximum_virtual_depth = Depth;
+   }
+}
+
+void lj_context_debug_virtual_leave(lua_State *L)
+{
+   if (ContextDebugCounters *counters = lj_context_debug_get(L, false)) counters->virtual_activations_retired++;
+}
+
+void lj_context_debug_materialise(
+   lua_State *L, ContextMaterialisationReason Reason, const GCfunc *Callable)
+{
+   ContextDebugCounters *counters = lj_context_debug_get(L, false);
+   if (not counters) return;
+   counters->materialisations[size_t(Reason)]++;
+   if (Reason != ContextMaterialisationReason::NativeCall or not Callable) return;
+   if (Callable->c.ffid < counters->native_fast_functions.size()) {
+      counters->native_fast_functions[Callable->c.ffid]++;
+   }
+   if (Callable->c.ffid IS FF_C) counters->native_c_functions[uintptr_t(Callable->c.f)]++;
+}
+
+void lj_context_debug_physical_enter(lua_State *L)
+{
+   ContextDebugCounters *counters = lj_context_debug_get(L, false);
+   if (not counters) return;
+   counters->physical_context_entries++;
+   size_t floor = L->context_root_floors.empty() ? 0 : L->context_root_floors.back();
+   uint32_t depth = uint32_t(L->context_stack.size() - floor);
+   if (depth > counters->maximum_physical_depth) counters->maximum_physical_depth = depth;
+}
+
+void lj_context_debug_physical_leave(lua_State *L, size_t Count)
+{
+   if (ContextDebugCounters *counters = lj_context_debug_get(L, false)) counters->physical_context_leaves += Count;
+}
+
+void lj_context_debug_trace_start(lua_State *L)
+{
+   if (ContextDebugCounters *counters = lj_context_debug_get(L, false)) counters->trace_starts++;
+}
+
+void lj_context_debug_trace_compiled(lua_State *L)
+{
+   if (ContextDebugCounters *counters = lj_context_debug_get(L, false)) counters->trace_compilations++;
+}
+
+void lj_context_debug_trace_abort(lua_State *L)
+{
+   if (ContextDebugCounters *counters = lj_context_debug_get(L, false)) counters->trace_aborts++;
+}
+
+void lj_context_debug_side_exit(lua_State *L)
+{
+   if (ContextDebugCounters *counters = lj_context_debug_get(L, false)) counters->side_exits++;
+}
+#endif
 
 //********************************************************************************************************************
 // Function name registry - maps GCproto pointers to their declared names for tostring() support.
@@ -202,11 +278,17 @@ extern "C" void lj_context_load(lua_State *L, TValue *Destination) noexcept
 
 extern "C" GCtab * lj_context_current_jit(lua_State *L) noexcept
 {
+#ifdef LUA_USE_ASSERT
+   if (ContextDebugCounters *counters = lj_context_debug_get(L, false)) counters->jit_current_calls++;
+#endif
    return lj_context_current(L);
 }
 
 extern "C" void lj_context_enter_jit(lua_State *L, GCtab *Table, TValue *OwnerBase)
 {
+#ifdef LUA_USE_ASSERT
+   if (ContextDebugCounters *counters = lj_context_debug_get(L, false)) counters->jit_enter_calls++;
+#endif
    lj_assertL(L and Table and OwnerBase, "invalid recorded contextual activation");
    ptrdiff_t owner_base = savestack(L, OwnerBase);
    if (not L->context_stack.empty() and
@@ -221,6 +303,9 @@ extern "C" void lj_context_enter_jit(lua_State *L, GCtab *Table, TValue *OwnerBa
 
 extern "C" void lj_context_leave_jit(lua_State *L, TValue *OwnerBase) noexcept
 {
+#ifdef LUA_USE_ASSERT
+   if (ContextDebugCounters *counters = lj_context_debug_get(L, false)) counters->jit_leave_calls++;
+#endif
    lj_assertL(L and OwnerBase, "invalid recorded contextual activation owner");
    ptrdiff_t owner_base = savestack(L, OwnerBase);
    if (not L->context_stack.empty() and
@@ -247,10 +332,12 @@ extern "C" void lj_context_tail_jit(
       "recorded tail context does not match the prepared activation");
 
    L->context_stack.pop_back();
+   lj_context_debug_physical_leave(L);
    if (not L->context_stack.empty() and
        L->context_stack.back().owner_kind IS lua_State::ContextFrame::OwnerKind::Call and
        L->context_stack.back().owner_base IS outgoing_owner) {
       L->context_stack.pop_back();
+      lj_context_debug_physical_leave(L);
    }
    lj_context_push(L, Table, OutgoingOwner);
    L->context_stack.back().tail_transfer = true;
@@ -305,6 +392,7 @@ extern "C" void lj_context_end_block(lua_State *L, uint32_t BlockIndex) noexcept
    if (frame.owner_kind IS lua_State::ContextFrame::OwnerKind::Block and
        frame.owner_base IS savestack(L, L->base) and frame.block_index IS BlockIndex) {
       L->context_stack.pop_back();
+      lj_context_debug_physical_leave(L);
       L->context_active = context_has_visible_override(L);
    }
 }
@@ -398,6 +486,7 @@ extern "C" void lj_context_leave_call(
        L->context_stack.back().owner_kind IS lua_State::ContextFrame::OwnerKind::Call and
        L->context_stack.back().owner_base IS owner_base) {
       L->context_stack.pop_back();
+      lj_context_debug_physical_leave(L);
       L->context_active = context_has_visible_override(L);
    }
 
@@ -431,12 +520,14 @@ extern "C" uint32_t lj_context_prepare_tail_call(lua_State *L, uint32_t CallBase
    GCtab *context = tabref(L->context_stack.back().table);
    lj_assertL(tabV(receiver) IS context, "tail context does not match its receiver");
    L->context_stack.pop_back();
+   lj_context_debug_physical_leave(L);
 
    ptrdiff_t outgoing_owner = savestack(L, L->base);
    if (not L->context_stack.empty() and
        L->context_stack.back().owner_kind IS lua_State::ContextFrame::OwnerKind::Call and
        L->context_stack.back().owner_base IS outgoing_owner) {
       L->context_stack.pop_back();
+      lj_context_debug_physical_leave(L);
    }
    lj_context_push(L, context, L->base);
    L->context_stack.back().tail_transfer = true;
@@ -459,6 +550,7 @@ void lj_context_push(lua_State *L, GCtab *Table, const TValue *OwnerBase)
    frame.owner_base = savestack(L, OwnerBase);
    L->context_stack.push_back(frame);
    L->context_active = 1;
+   lj_context_debug_physical_enter(L);
    lj_gc_barriercontext(L, Table);
 }
 
@@ -472,6 +564,7 @@ void lj_context_pop(lua_State *L, const TValue *OwnerBase) noexcept
    lj_assertL(L->context_stack.back().owner_base IS owner_base, "unbalanced contextual activation");
    if (L->context_stack.back().owner_base IS owner_base) {
       L->context_stack.pop_back();
+      lj_context_debug_physical_leave(L);
       L->context_active = context_has_visible_override(L);
    }
 }
@@ -485,6 +578,7 @@ extern "C" uint32_t lj_context_leave_frame(
        L->context_stack.back().owner_kind IS lua_State::ContextFrame::OwnerKind::Call and
        L->context_stack.back().owner_base IS frame_base) {
       L->context_stack.pop_back();
+      lj_context_debug_physical_leave(L);
       L->context_active = context_has_visible_override(L);
    }
    return ReturnState;
@@ -510,6 +604,7 @@ void lj_context_unwind(lua_State *L, const TValue *SurvivingBase) noexcept
    size_t floor = L->context_root_floors.empty() ? 0 : L->context_root_floors.back();
    while (L->context_stack.size() > floor and L->context_stack.back().owner_base > surviving_base) {
       L->context_stack.pop_back();
+      lj_context_debug_physical_leave(L);
    }
    for (auto state = L->close_frames.begin(); state != L->close_frames.end();) {
       if (state->owner_base > surviving_base) state = L->close_frames.erase(state);
@@ -523,7 +618,11 @@ void lj_context_restore_depth(lua_State *L, size_t Depth) noexcept
    size_t floor = L->context_root_floors.empty() ? 0 : L->context_root_floors.back();
    if (Depth < floor) Depth = floor;
    lj_assertL(Depth <= L->context_stack.size(), "context unwind depth exceeds the active stack");
-   if (Depth <= L->context_stack.size()) L->context_stack.resize(Depth);
+   if (Depth <= L->context_stack.size()) {
+      size_t removed = L->context_stack.size() - Depth;
+      L->context_stack.resize(Depth);
+      lj_context_debug_physical_leave(L, removed);
+   }
    L->context_active = context_has_visible_override(L);
 }
 
@@ -581,6 +680,10 @@ static void close_state(lua_State *L)
    L->context_stack.clear();
    L->context_active = 0;
    L->context_root_floors.clear();
+#ifdef LUA_USE_ASSERT
+   delete L->context_debug_counters;
+   L->context_debug_counters = nullptr;
+#endif
    if (L->parser_diagnostics) { delete (ParserDiagnostics*)L->parser_diagnostics; L->parser_diagnostics = nullptr; }
    if (L->parser_tips) { delete L->parser_tips; L->parser_tips = nullptr; }
    if (L->parser_symbols) { delete L->parser_symbols; L->parser_symbols = nullptr; }
@@ -733,6 +836,10 @@ void lj_state_free(global_State* g, lua_State *L)
    if (L->parser_diagnostics) { delete (ParserDiagnostics*)L->parser_diagnostics; L->parser_diagnostics = nullptr; }
    if (L->parser_tips) { delete L->parser_tips; L->parser_tips = nullptr; }
    if (L->parser_symbols) { delete L->parser_symbols; L->parser_symbols = nullptr; }
+#ifdef LUA_USE_ASSERT
+   delete L->context_debug_counters;
+   L->context_debug_counters = nullptr;
+#endif
 
    lj_func_closeuv(L, tvref(L->stack));
    lj_assertG(gcref(L->openupval) IS nullptr, "stale open upvalues");

--- a/src/tiri/jit/src/runtime/lj_state.h
+++ b/src/tiri/jit/src/runtime/lj_state.h
@@ -7,6 +7,11 @@
 
 #include "lj_obj.h"
 
+#ifdef LUA_USE_ASSERT
+#include <array>
+#include <unordered_map>
+#endif
+
 #define incr_top(L) (++L->top >= tvref(L->maxstack) and (lj_state_growstack1(L), 0))
 
 [[nodiscard]] inline ptrdiff_t savestack(lua_State* L, const TValue* p) noexcept
@@ -78,6 +83,60 @@ LJ_FUNC void lj_context_unwind(lua_State *L, const TValue *SurvivingBase) noexce
 LJ_FUNC void lj_context_restore_depth(lua_State *L, size_t Depth) noexcept;
 LJ_FUNC [[nodiscard]] size_t lj_context_depth(const lua_State *L) noexcept;
 
+enum class ContextMaterialisationReason : uint8_t {
+   NestedLuaCall,
+   NativeCall,
+   TailCall,
+   Snapshot,
+   SideExit,
+   UnsupportedBoundary,
+   Count
+};
+
+#ifdef LUA_USE_ASSERT
+struct ContextDebugCounters {
+   uint64_t virtual_activations_created = 0;
+   uint64_t virtual_activations_retired = 0;
+   uint64_t physical_context_entries = 0;
+   uint64_t physical_context_leaves = 0;
+   uint64_t jit_enter_calls = 0;
+   uint64_t jit_leave_calls = 0;
+   uint64_t jit_current_calls = 0;
+   uint64_t trace_starts = 0;
+   uint64_t trace_compilations = 0;
+   uint64_t trace_aborts = 0;
+   uint64_t side_exits = 0;
+   uint32_t maximum_virtual_depth = 0;
+   uint32_t maximum_physical_depth = 0;
+   std::array<uint64_t, size_t(ContextMaterialisationReason::Count)> materialisations{};
+   std::array<uint64_t, 256> native_fast_functions{};
+   std::unordered_map<uintptr_t, uint64_t> native_c_functions;
+};
+
+LJ_FUNC ContextDebugCounters *lj_context_debug_get(lua_State *L, bool Create);
+LJ_FUNC void lj_context_debug_reset(lua_State *L);
+LJ_FUNC void lj_context_debug_virtual_enter(lua_State *L, uint32_t Depth);
+LJ_FUNC void lj_context_debug_virtual_leave(lua_State *L);
+LJ_FUNC void lj_context_debug_materialise(
+   lua_State *L, ContextMaterialisationReason Reason, const GCfunc *Callable = nullptr);
+LJ_FUNC void lj_context_debug_physical_enter(lua_State *L);
+LJ_FUNC void lj_context_debug_physical_leave(lua_State *L, size_t Count = 1);
+LJ_FUNC void lj_context_debug_trace_start(lua_State *L);
+LJ_FUNC void lj_context_debug_trace_compiled(lua_State *L);
+LJ_FUNC void lj_context_debug_trace_abort(lua_State *L);
+LJ_FUNC void lj_context_debug_side_exit(lua_State *L);
+#else
+inline void lj_context_debug_virtual_enter(lua_State *, uint32_t) {}
+inline void lj_context_debug_virtual_leave(lua_State *) {}
+inline void lj_context_debug_materialise(lua_State *, ContextMaterialisationReason, const GCfunc * = nullptr) {}
+inline void lj_context_debug_physical_enter(lua_State *) {}
+inline void lj_context_debug_physical_leave(lua_State *, size_t = 1) {}
+inline void lj_context_debug_trace_start(lua_State *) {}
+inline void lj_context_debug_trace_compiled(lua_State *) {}
+inline void lj_context_debug_trace_abort(lua_State *) {}
+inline void lj_context_debug_side_exit(lua_State *) {}
+#endif
+
 // Asynchronous callbacks are deliberately unbound.  Temporarily expose the dynamic root while retaining suspended
 // activations owned by the interrupted synchronous call chain.
 
@@ -97,7 +156,9 @@ public:
       size_t floor = this->state_->context_root_floors.back();
       lj_assertG_(G(this->state_), this->state_->context_stack.size() IS floor,
          "asynchronous callback leaked a contextual activation");
+      size_t removed = this->state_->context_stack.size() - floor;
       this->state_->context_stack.resize(floor);
+      lj_context_debug_physical_leave(this->state_, removed);
       this->state_->context_root_floors.pop_back();
       size_t outer_floor = this->state_->context_root_floors.empty() ? 0 :
          this->state_->context_root_floors.back();

--- a/src/tiri/tests/test_context_access.tiri
+++ b/src/tiri/tests/test_context_access.tiri
@@ -6,6 +6,13 @@ function activate_context_statement(Statement:str):obj
    return script
 end
 
+@Test function CurrentContextMaterialisesRootEnvironment()
+   local current = &&
+   assert(current is _G, 'A root current-context expression should materialise the global environment')
+   assert(&&.tostring is &tostring,
+      'Standalone and field-prefixed context access should resolve through the same root table')
+end
+
 @Test function RootContextReadsAndWritesGlobalEnvironment()
    &glContextAccessValue = 11
    assert(&glContextAccessValue is 11, 'Context-prefixed reads should resolve through the root environment')

--- a/src/tiri/tests/test_context_materialisation.tiri
+++ b/src/tiri/tests/test_context_materialisation.tiri
@@ -8,6 +8,39 @@ function reset_context_counters():bool
    return counters != nil and counters.enabled is true
 end
 
+@Test function StandaloneCurrentContextSurvivesRecordedSideExit()
+   if not reset_context_counters() then return end
+   local worker = entity {
+      name = 'worker',
+      read = function(Exit:bool):str
+         local current = &&
+         if Exit then return current.name .. ':exit' end
+         return current.name
+      end
+   }
+
+   function workload():<str, str>
+      local result = ''
+      local exit_result = ''
+      for i in {0 to 300} do
+         local exit = i is 93
+         result = worker.read(exit)
+         if exit then exit_result = result end
+      end
+      return result, exit_result
+   end
+
+   local result, exit_result = workload()
+   assert(result is 'worker', 'The normal path should retain the current-context receiver identity')
+   assert(exit_result is 'worker:exit',
+      'A standalone context value should retain receiver identity across a recorded side exit')
+   local counters = jit.util.contextStats()
+   assert(counters.traceCompilations > 0 and counters.sideExits > 0,
+      'The standalone current-context fixture should compile and exercise a recorded side exit')
+   assert(counters.physicalContextEntries is counters.physicalContextLeaves,
+      'Standalone materialisation should leave physical context ownership balanced')
+end
+
 @Test function NestedLuaContextsRemainVirtual()
    if not reset_context_counters() then return end
    local inner = entity {

--- a/src/tiri/tests/test_context_materialisation.tiri
+++ b/src/tiri/tests/test_context_materialisation.tiri
@@ -1,0 +1,145 @@
+-- Structural regression tests for JIT table-context materialisation.
+
+function reset_context_counters():bool
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   local counters = jit.util.contextStats(true)
+   return counters != nil and counters.enabled is true
+end
+
+@Test function NestedLuaContextsRemainVirtual()
+   if not reset_context_counters() then return end
+   local inner = entity {
+      value = 1,
+      read = function():num
+         return &value
+      end
+   }
+   local middle = entity {
+      bias = 2,
+      read = function():num
+         local value = inner.read()
+         return value + &bias
+      end
+   }
+   local outer = entity {
+      bias = 3,
+      read = function():num
+         local value = middle.read()
+         return value + &bias
+      end
+   }
+
+   function workload():num
+      local checksum = 0
+      for i in {0 to 1000} do
+         checksum += outer.read()
+      end
+      return checksum
+   end
+
+   assert(workload() is 6000, 'Three nested contextual receivers should preserve their values')
+   local counters = jit.util.contextStats()
+   assert(counters.traceCompilations > 0 and counters.traceAborts is 0,
+      'The nested contextual workload should compile without recorder aborts')
+   assert(counters.maximumVirtualDepth >= 3,
+      f'The recorder should retain three virtual receivers, observed {counters.maximumVirtualDepth}')
+   assert(counters.jitEnterCalls <= 1 and counters.jitLeaveCalls <= 1,
+      f'Nested hot calls should avoid physical helper pairs, observed ' ..
+      f'{counters.jitEnterCalls} entries and {counters.jitLeaveCalls} leaves')
+   assert(counters.materialisations.nestedLuaCall is 0,
+      'Nested Lua calls should no longer force materialisation')
+end
+
+@Test function ContextIndependentBuiltinsDoNotMaterialise()
+   if not reset_context_counters() then return end
+   local values = array<int> { 1, 2, 3, 4 }
+   local span = {0 to 10}
+   local worker = entity {
+      read = function():num
+         return values.first() + values.last() + 'abc'.len() + (span.contains(4) ? 1 :> 0)
+      end
+   }
+
+   function workload():num
+      local checksum = 0
+      for i in {0 to 1000} do
+         checksum += worker.read()
+      end
+      return checksum
+   end
+
+   assert(workload() is 9000, 'Array, string and range helpers should preserve their results')
+   local counters = jit.util.contextStats()
+   assert(counters.maximumVirtualDepth >= 1 and counters.traceCompilations > 0,
+      'The built-in workload should execute under a compiled virtual context')
+   assert(counters.materialisations.nativeCall is 0 and counters.jitEnterCalls is 0,
+      'Explicitly context-independent built-ins should not materialise their inherited context')
+end
+
+@Test function ArbitraryNativeReentryRemainsConservative()
+   if not reset_context_counters() then return end
+   local worker = entity {
+      name = 'worker',
+      read = function():str
+         return exec([[return &name]])
+      end
+   }
+
+   function workload():str
+      local result = ''
+      for i in {0 to 100} do
+         result = worker.read()
+      end
+      return result
+   end
+
+   assert(workload() is 'worker', 'A native re-entry should observe the materialised receiver context')
+   local counters = jit.util.contextStats()
+   assert(counters.materialisations.nativeCall >= 1 and counters.jitEnterCalls > 0,
+      'An unclassified native callable should conservatively materialise a virtual context')
+end
+
+@Test function SideExitsReconstructEveryVirtualReceiver()
+   if not reset_context_counters() then return end
+   local inner = entity {
+      value = 1,
+      read = function(Exit:bool):num
+         if Exit then return &value + 10 end
+         return &value
+      end
+   }
+   local middle = entity {
+      bias = 2,
+      read = function(Exit:bool):num
+         local value = inner.read(Exit)
+         return value + &bias
+      end
+   }
+   local outer = entity {
+      bias = 3,
+      read = function(Exit:bool):num
+         local value = middle.read(Exit)
+         return value + &bias
+      end
+   }
+
+   function workload():num
+      local checksum = 0
+      for i in {0 to 300} do
+         checksum += outer.read(i is 93)
+      end
+      return checksum
+   end
+
+   assert(workload() is 1810,
+      'A side exit in the innermost call should restore inner, middle and outer receiver state')
+   local counters = jit.util.contextStats()
+   assert(counters.maximumVirtualDepth >= 3 and counters.sideExits > 0,
+      'The fixture should exercise a side exit with three virtual receivers')
+   assert(counters.materialisations.sideExit > 0,
+      'Side-exit reconstruction should report the materialised virtual prefix')
+   assert(counters.physicalContextEntries is counters.physicalContextLeaves,
+      'Side-exit reconstruction should leave physical context ownership balanced')
+end

--- a/src/tiri/tests/test_context_materialisation.tiri
+++ b/src/tiri/tests/test_context_materialisation.tiri
@@ -176,3 +176,43 @@ end
    assert(counters.physicalContextEntries is counters.physicalContextLeaves,
       'Side-exit reconstruction should leave physical context ownership balanced')
 end
+
+@Test function ContextBlocksOverrideNestedVirtualReceivers()
+   if not reset_context_counters() then return end
+   local block = { name = 'block' }
+   local inner = entity {
+      name = 'inner',
+      read = function():str
+         local block_name = ''
+         using block do
+            block_name = &name
+         end
+         return block_name .. ':' .. &name
+      end
+   }
+   local outer = entity {
+      name = 'outer',
+      read = function():str
+         return inner.read() .. ':' .. &name
+      end
+   }
+
+   function workload():str
+      local result = ''
+      for _ in {0 to 300} do
+         result = outer.read()
+      end
+      return result
+   end
+
+   local result = workload()
+   assert(result is 'block:inner:outer',
+      f'A context block should override nested receivers and restore them in stack order, observed {result}')
+   local counters = jit.util.contextStats()
+   assert(counters.traceCompilations > 0 and counters.maximumVirtualDepth >= 2,
+      'The nested context-block workload should compile with multiple virtual receivers')
+   assert(counters.materialisations.unsupportedBoundary > 0,
+      'A physical context block should materialise its virtual receiver prefix')
+   assert(counters.physicalContextEntries is counters.physicalContextLeaves,
+      'Context block materialisation should leave physical context ownership balanced')
+end

--- a/src/tiri/tests/test_contextual_member_calls.tiri
+++ b/src/tiri/tests/test_contextual_member_calls.tiri
@@ -3,6 +3,41 @@
 import 'json'
 module core as mCore
 
+@Test function StandaloneCurrentContextPreservesDynamicReceiverIdentity()
+   local inner = entity { name = 'inner', value = 0 }
+   local outer = entity { name = 'outer' }
+
+   function update_context(Context:table!, Value:num!)
+      Context.value = Value
+   end
+
+   function inner.update(Value:num!):table!
+      update_context(&&, Value)
+      assert(&&.name is &name,
+         'Standalone and suffixed current-context expressions should use the same receiver')
+      return &&
+   end
+
+   function inner.current():table!
+      return &&
+   end
+
+   function outer.observe():<table, table>
+      local inner_context = inner.update(17)
+      return inner_context, &&
+   end
+
+   local inner_context, restored_context = outer.observe()
+   assert(inner_context is inner and inner.value is 17,
+      'Passing the current context to a free helper should preserve the receiver identity')
+   assert(restored_context is outer,
+      'Returning from a nested contextual call should restore the outer materialised context')
+
+   local extracted = inner.current
+   assert(extracted() is _G,
+      'An extracted ordinary function should materialise its inherited context rather than capture its source entity')
+end
+
 @Test function NamedAndComputedTableCallsEstablishContext()
    local point = entity { name = 'point', value = 0 }
 

--- a/tools/benchmark/benchmark_func.tiri
+++ b/tools/benchmark/benchmark_func.tiri
@@ -291,38 +291,38 @@ end
    local Counter = entity {
       value = 0,
       increment = function():num
-         .value++
-         return .value
+         &value++
+         return &value
       end,
       decrement = function():num
-         .value -= 1
-         return .value
+         &value -= 1
+         return &value
       end,
-      add = function(n):num
-         .value += n
-         return .value
+      add = function(Value:num):num
+         &value += Value
+         return &value
       end,
       getValue = function():num
-         return .value
+         return &value
       end,
       reset = function()
-         .value = 0
+         &value = 0
       end
    }
 
    local Point = entity {
       x = 0,
       y = 0,
-      set = function(x, y)
-         .x = x
-         .y = y
+      set = function(X:num, Y:num)
+         &x = X
+         &y = Y
       end,
-      translate = function(dx, dy)
-         .x += dx
-         .y += dy
+      translate = function(Dx:num, Dy:num)
+         &x += Dx
+         &y += Dy
       end,
       distance = function()
-         return math.sqrt(.x * .x + .y * .y)
+         return math.sqrt(&x * &x + &y * &y)
       end
    }
 

--- a/tools/tiri_lsp/include/lsp_parsing.tiri
+++ b/tools/tiri_lsp/include/lsp_parsing.tiri
@@ -838,10 +838,16 @@ global function tokenizeTiri(Source:str, ModulePrefixes:table):array<table>
             pos++
             col++
          end
-      elseif c is '&' then -- & bitwise AND
-         addToken(line, col, 1, 1, 0)
-         pos++
-         col++
+      elseif c is '&' then
+         if pos + 1 < len and Source.sub(pos + 1, pos + 2) is '&' then
+            addToken(line, col, 2, 1, 0) -- && current context
+            pos += 2
+            col += 2
+         else
+            addToken(line, col, 1, 1, 0) -- & bitwise AND or context field prefix
+            pos++
+            col++
+         end
       elseif c is '~' then -- ~ bitwise NOT
          addToken(line, col, 1, 1, 0)
          pos++

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -42,6 +42,26 @@ function assertNoToken(Tokens:array<table>, Line:num, Char:num, Text:str, Messag
    assert(not token, Message)
 end
 
+@Test function CurrentContextReceivesOneSemanticToken()
+   source = 'local current = &&\n' ..
+      'local field = &name\n' ..
+      'local masked = flags & mask\n'
+   tokens = tokenizeTiri(source)
+
+   assertOperatorToken(tokens, 0, 16, '&&',
+      'Current-context syntax should be highlighted as one two-character operator.')
+   assertOperatorToken(tokens, 1, 14, '&',
+      'Context-prefixed field access should retain its single-character operator token.')
+   assertOperatorToken(tokens, 2, 21, '&',
+      'Bitwise AND should retain its single-character operator token.')
+   assertNoToken(tokens, 0, 16, '&',
+      'Current-context syntax should not be emitted as two unrelated ampersand tokens.')
+
+   doc = makeDoc('local current = &&\nreturn current\n')
+   result = computeDiagnostics(doc)
+   assert(#result.diagnostics is 0, 'LSP diagnostics should accept current-context materialisation.')
+end
+
 @Test function ParserAnnotationsReceiveSemanticTokens()
    source = 'value = @SourceFile\n' ..
       'line = @SourceLine\n' ..

--- a/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
+++ b/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
@@ -260,6 +260,10 @@
                "match": "(<<|>>)"
             },
             {
+               "name": "keyword.operator.context.tiri",
+               "match": "&&"
+            },
+            {
                "name": "keyword.operator.bitwise.tiri",
                "match": "[&|~]"
             },


### PR DESCRIPTION
## Summary

Optimises how Tiri handles contextual state in the JIT, and adds a standalone expression for materialising the active context.

### Virtualised stacked contextual calls in JIT traces

* Nested virtual contexts are now tracked through recording, snapshots and side exits, so stacked contextual calls no longer force materialisation on every level.
* Context-independent built-ins are marked as proven, whilst native calls retain conservative handling.
* Debug builds gain materialisation counters (`lj_state`, `lj_jit.h`) to make regressions measurable.

### Standalone current-context expressions

* Added `&&` syntax for materialising the active context, with support for ordinary member and index suffixes.
* Parser, bytecode, contextual-call and side-exit paths extended to cover standalone context values.
* LSP support: semantic highlighting and diagnostics for the current-context operator, plus VS Code grammar updates.

## Testing

* `src/tiri/tests/test_context_materialisation.tiri` — new Flute coverage for virtualisation and materialisation counters.
* `src/tiri/tests/test_contextual_member_calls.tiri` — new coverage for stacked contextual calls.
* `src/tiri/tests/test_context_access.tiri` — extended for standalone context expressions.
* `src/tiri/jit/src/parser/parser_unit_tests.cpp` — parser unit tests for the new syntax.
* `tools/tiri_lsp/tests/test_semantic_tokens.tiri` — LSP token coverage.
