### PR TITLE
[Tiri] Fixed Lua stack relocation pointer safety

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -871,6 +871,7 @@ set (TIRI_TESTS
    object_pinning import_type_analysis global_types type_contracts thunk_contract_argument type_signature_dumps
    type_guided_emission type_guided_jit_signatures
    context_access contextual_member_calls contextual_designation context_blocks
+   stack_growth
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -539,13 +539,17 @@ TValue * lj_meta_equal_thunk(lua_State *L, BCIns ins)
       o2 = &tv;
    }
 
-   // Resolve thunks if present
+   // Snapshot both operands before resolving either thunk.  Resolution can execute arbitrary Tiri code and relocate
+   // the Lua stack, while the original slots keep copied GC values rooted.
 
-   cTValue *resolved_o1 = o1;
-   cTValue *resolved_o2 = o2;
+   TValue o1_copy, o2_copy;
+   copyTV(L, &o1_copy, o1);
+   copyTV(L, &o2_copy, o2);
+   cTValue *resolved_o1 = &o1_copy;
+   cTValue *resolved_o2 = &o2_copy;
 
-   if (lj_is_thunk(o1)) resolved_o1 = lj_thunk_resolve(L, udataV(o1));
-   if (lj_is_thunk(o2)) resolved_o2 = lj_thunk_resolve(L, udataV(o2));
+   if (lj_is_thunk(resolved_o1)) resolved_o1 = lj_thunk_resolve(L, udataV(resolved_o1));
+   if (lj_is_thunk(resolved_o2)) resolved_o2 = lj_thunk_resolve(L, udataV(resolved_o2));
 
    // Now compare the resolved values using standard Lua equality semantics
    // Return semantics: 0 = don't branch, 1 = branch

--- a/src/tiri/jit/src/runtime/lj_object.cpp
+++ b/src/tiri/jit/src/runtime/lj_object.cpp
@@ -222,7 +222,9 @@ extern "C" void bc_object_getfield(lua_State *L, GCobject *Obj, GCstr *Key, TVal
 
    const auto saved_base = savestack(L, L->base);
    const auto saved_top = savestack(L, L->top);
-   const auto dest_offset = savestack(L, Dest);
+   // Interpreter destinations are stack slots and must follow relocation.  JIT recorders pass global_State::tmptv
+   // with no instruction pointer, so that external destination must remain a raw pointer.
+   const auto dest_offset = Ins ? savestack(L, Dest) : ptrdiff_t(0);
 
    if (not Ins) {
       auto jb = tvref(G(L)->jit_base);
@@ -269,14 +271,16 @@ extern "C" void bc_object_getfield(lua_State *L, GCobject *Obj, GCstr *Key, TVal
    }
 
    // Call the field handler - it pushes result onto the Lua stack
-   if (func->Call(L, *func, Obj) > 0) copyTV(L, restorestack(L, dest_offset), L->top - 1);
+   const auto result_count = func->Call(L, *func, Obj);
+   const auto result_dest = Ins ? restorestack(L, dest_offset) : Dest;
+   if (result_count > 0) copyTV(L, result_dest, L->top - 1);
    else { // An error occurred and is stored in L->CaughtError
       if (L->CaughtError > ERR::ExceptionThreshold) {
          luaL_error(L, L->CaughtError, "Read failure: %s.%s: %s", cl->ClassName.c_str(), strdata(Key),
             GetErrorMsg(L->CaughtError));
       }
 
-      setnilV(restorestack(L, dest_offset));
+      setnilV(result_dest);
    }
    L->base = restorestack(L, saved_base);
    L->top = restorestack(L, saved_top);

--- a/src/tiri/jit/src/runtime/lj_object.cpp
+++ b/src/tiri/jit/src/runtime/lj_object.cpp
@@ -220,8 +220,9 @@ extern "C" void bc_object_getfield(lua_State *L, GCobject *Obj, GCstr *Key, TVal
    //
    // For JIT traces (Ins == nullptr), L->base is also stale; sync from jit_base first.
 
-   const auto saved_base = L->base;
-   const auto saved_top = L->top;
+   const auto saved_base = savestack(L, L->base);
+   const auto saved_top = savestack(L, L->top);
+   const auto dest_offset = savestack(L, Dest);
 
    if (not Ins) {
       auto jb = tvref(G(L)->jit_base);
@@ -268,17 +269,17 @@ extern "C" void bc_object_getfield(lua_State *L, GCobject *Obj, GCstr *Key, TVal
    }
 
    // Call the field handler - it pushes result onto the Lua stack
-   if (func->Call(L, *func, Obj) > 0) copyTV(L, Dest, L->top - 1);
+   if (func->Call(L, *func, Obj) > 0) copyTV(L, restorestack(L, dest_offset), L->top - 1);
    else { // An error occurred and is stored in L->CaughtError
       if (L->CaughtError > ERR::ExceptionThreshold) {
          luaL_error(L, L->CaughtError, "Read failure: %s.%s: %s", cl->ClassName.c_str(), strdata(Key),
             GetErrorMsg(L->CaughtError));
       }
 
-      setnilV(Dest);
+      setnilV(restorestack(L, dest_offset));
    }
-   L->base = saved_base;
-   L->top = saved_top;
+   L->base = restorestack(L, saved_base);
+   L->top = restorestack(L, saved_top);
 }
 
 //********************************************************************************************************************
@@ -295,8 +296,8 @@ extern "C" void bc_object_setfield(lua_State *L, GCobject *Obj, GCstr *Key, TVal
    // L->top is not maintained by the VM assembly between bytecodes (see bc_object_getfield).
    // For JIT traces (Ins == nullptr), L->base is also stale; sync from jit_base first.
 
-   const auto saved_base = L->base;
-   const auto saved_top  = L->top;
+   const auto saved_base = savestack(L, L->base);
+   const auto saved_top = savestack(L, L->top);
    if (not Ins) {
       auto jb = tvref(G(L)->jit_base);
       if (jb) L->base = jb;
@@ -352,8 +353,8 @@ extern "C" void bc_object_setfield(lua_State *L, GCobject *Obj, GCstr *Key, TVal
    if (auto error = access_object(Obj, pobj); !error) {
       auto stack_idx = int(val_ptr - L->base) + 1;
       error = func->Call(L, pobj, func->Field, stack_idx);
-      L->base = saved_base;
-      L->top = saved_top;
+      L->base = restorestack(L, saved_base);
+      L->top = restorestack(L, saved_top);
       release_object(Obj);
 
       if (error >= ERR::ExceptionThreshold) luaL_error(L, error);

--- a/src/tiri/jit/src/runtime/lj_struct.cpp
+++ b/src/tiri/jit/src/runtime/lj_struct.cpp
@@ -216,7 +216,9 @@ extern "C" void bc_struct_getfield(lua_State *L, GCstruct *Struct, GCstr *Key, T
 {
    const auto saved_base = savestack(L, L->base);
    const auto saved_top = savestack(L, L->top);
-   const auto dest_offset = savestack(L, Dest);
+   // Interpreter destinations are stack slots and must follow relocation.  JIT recorders pass global_State::tmptv
+   // with no instruction pointer, so that external destination must remain a raw pointer.
+   const auto dest_offset = Ins ? savestack(L, Dest) : ptrdiff_t(0);
 
    if (not Ins) {
       auto jit_base = tvref(G(L)->jit_base);
@@ -227,7 +229,8 @@ extern "C" void bc_struct_getfield(lua_State *L, GCstruct *Struct, GCstr *Key, T
    const auto field_name = strdata(Key);
    if (std::string_view("structSize") IS field_name) {
       lj_struct_push_size_closure(L, Struct);
-      copyTV(L, restorestack(L, dest_offset), L->top - 1);
+      const auto result_dest = Ins ? restorestack(L, dest_offset) : Dest;
+      copyTV(L, result_dest, L->top - 1);
       L->base = restorestack(L, saved_base);
       L->top = restorestack(L, saved_top);
       return;
@@ -241,7 +244,8 @@ extern "C" void bc_struct_getfield(lua_State *L, GCstruct *Struct, GCstr *Key, T
    if (auto field = find_cached_field(Struct, Key, Ins)) {
       auto address = (int8_t *)Struct->data + field->Offset;
       lj_struct_getfield_core(L, Struct, *field, address, true);
-      copyTV(L, restorestack(L, dest_offset), L->top - 1);
+      const auto result_dest = Ins ? restorestack(L, dest_offset) : Dest;
+      copyTV(L, result_dest, L->top - 1);
       L->base = restorestack(L, saved_base);
       L->top = restorestack(L, saved_top);
       return;

--- a/src/tiri/jit/src/runtime/lj_struct.cpp
+++ b/src/tiri/jit/src/runtime/lj_struct.cpp
@@ -214,8 +214,9 @@ extern "C" int ir_struct_field_type(GCstruct *Struct, GCstr *Key, uint32_t Field
 
 extern "C" void bc_struct_getfield(lua_State *L, GCstruct *Struct, GCstr *Key, TValue *Dest, BCIns *Ins)
 {
-   const auto saved_base = L->base;
-   const auto saved_top = L->top;
+   const auto saved_base = savestack(L, L->base);
+   const auto saved_top = savestack(L, L->top);
+   const auto dest_offset = savestack(L, Dest);
 
    if (not Ins) {
       auto jit_base = tvref(G(L)->jit_base);
@@ -226,9 +227,9 @@ extern "C" void bc_struct_getfield(lua_State *L, GCstruct *Struct, GCstr *Key, T
    const auto field_name = strdata(Key);
    if (std::string_view("structSize") IS field_name) {
       lj_struct_push_size_closure(L, Struct);
-      copyTV(L, Dest, L->top - 1);
-      L->base = saved_base;
-      L->top = saved_top;
+      copyTV(L, restorestack(L, dest_offset), L->top - 1);
+      L->base = restorestack(L, saved_base);
+      L->top = restorestack(L, saved_top);
       return;
    }
 
@@ -240,9 +241,9 @@ extern "C" void bc_struct_getfield(lua_State *L, GCstruct *Struct, GCstr *Key, T
    if (auto field = find_cached_field(Struct, Key, Ins)) {
       auto address = (int8_t *)Struct->data + field->Offset;
       lj_struct_getfield_core(L, Struct, *field, address, true);
-      copyTV(L, Dest, L->top - 1);
-      L->base = saved_base;
-      L->top = saved_top;
+      copyTV(L, restorestack(L, dest_offset), L->top - 1);
+      L->base = restorestack(L, saved_base);
+      L->top = restorestack(L, saved_top);
       return;
    }
 
@@ -255,8 +256,8 @@ extern "C" void bc_struct_getfield(lua_State *L, GCstruct *Struct, GCstr *Key, T
 
 extern "C" void bc_struct_setfield(lua_State *L, GCstruct *Struct, GCstr *Key, TValue *Val, BCIns *Ins)
 {
-   const auto saved_base = L->base;
-   const auto saved_top = L->top;
+   const auto saved_base = savestack(L, L->base);
+   const auto saved_top = savestack(L, L->top);
 
    if (not Ins) {
       auto jit_base = tvref(G(L)->jit_base);
@@ -292,8 +293,8 @@ extern "C" void bc_struct_setfield(lua_State *L, GCstruct *Struct, GCstr *Key, T
    if (auto field = find_cached_field(Struct, Key, Ins)) {
       auto address = (int8_t *)Struct->data + field->Offset;
       lj_struct_setfield_core(L, Struct, *field, address, true);
-      L->base = saved_base;
-      L->top = saved_top;
+      L->base = restorestack(L, saved_base);
+      L->top = restorestack(L, saved_top);
       return;
    }
 

--- a/src/tiri/jit/src/runtime/lj_thunk.cpp
+++ b/src/tiri/jit/src/runtime/lj_thunk.cpp
@@ -192,10 +192,24 @@ static int thunk_tostring(lua_State *L);
 
 // Helper: Get number value from TValue, handling integer and number types
 
-inline lua_Number getnumvalue(TValue *o)
+inline lua_Number getnumvalue(cTValue *o)
 {
    if (tvisint(o)) return (lua_Number)intV(o);
    return numV(o);
+}
+
+// Resolve both operands without retaining pointers into the Lua stack across either deferred call.  The original
+// stack slots keep any copied GC values rooted while thunk resolution executes arbitrary Tiri code.
+
+static void resolve_binary_operands(lua_State *L, TValue &FirstCopy, TValue &SecondCopy,
+   cTValue *&First, cTValue *&Second)
+{
+   copyTV(L, &FirstCopy, L->base);
+   copyTV(L, &SecondCopy, L->base + 1);
+   First = &FirstCopy;
+   Second = &SecondCopy;
+   if (lj_is_thunk(First)) First = lj_thunk_resolve(L, udataV(First));
+   if (lj_is_thunk(Second)) Second = lj_thunk_resolve(L, udataV(Second));
 }
 
 //********************************************************************************************************************
@@ -203,8 +217,9 @@ inline lua_Number getnumvalue(TValue *o)
 
 static int thunk_add(lua_State *L)
 {
-   TValue *a = resolve_at(L, 0);
-   TValue *b = resolve_at(L, 1);
+   TValue a_copy, b_copy;
+   cTValue *a, *b;
+   resolve_binary_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number result = getnumvalue(a) + getnumvalue(b);
@@ -218,8 +233,9 @@ static int thunk_add(lua_State *L)
 
 static int thunk_sub(lua_State *L)
 {
-   TValue *a = resolve_at(L, 0);
-   TValue *b = resolve_at(L, 1);
+   TValue a_copy, b_copy;
+   cTValue *a, *b;
+   resolve_binary_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number result = getnumvalue(a) - getnumvalue(b);
@@ -233,8 +249,9 @@ static int thunk_sub(lua_State *L)
 
 static int thunk_mul(lua_State *L)
 {
-   TValue *a = resolve_at(L, 0);
-   TValue *b = resolve_at(L, 1);
+   TValue a_copy, b_copy;
+   cTValue *a, *b;
+   resolve_binary_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number result = getnumvalue(a) * getnumvalue(b);
@@ -248,8 +265,9 @@ static int thunk_mul(lua_State *L)
 
 static int thunk_div(lua_State *L)
 {
-   TValue *a = resolve_at(L, 0);
-   TValue *b = resolve_at(L, 1);
+   TValue a_copy, b_copy;
+   cTValue *a, *b;
+   resolve_binary_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number result = getnumvalue(a) / getnumvalue(b);
@@ -263,8 +281,9 @@ static int thunk_div(lua_State *L)
 
 static int thunk_mod(lua_State *L)
 {
-   TValue *a = resolve_at(L, 0);
-   TValue *b = resolve_at(L, 1);
+   TValue a_copy, b_copy;
+   cTValue *a, *b;
+   resolve_binary_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number na = getnumvalue(a);
@@ -280,8 +299,9 @@ static int thunk_mod(lua_State *L)
 
 static int thunk_pow(lua_State *L)
 {
-   TValue *a = resolve_at(L, 0);
-   TValue *b = resolve_at(L, 1);
+   TValue a_copy, b_copy;
+   cTValue *a, *b;
+   resolve_binary_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number result = pow(getnumvalue(a), getnumvalue(b));
@@ -313,8 +333,9 @@ static int thunk_unm(lua_State *L)
 
 static int thunk_concat(lua_State *L)
 {
-   TValue *a = resolve_at(L, 0);
-   TValue *b = resolve_at(L, 1);
+   TValue a_copy, b_copy;
+   cTValue *a, *b;
+   resolve_binary_operands(L, a_copy, b_copy, a, b);
    lj_assertL(a != nullptr, "Invalid LHS (null)");
    lj_assertL(b != nullptr, "Invalid RHS (null)");
    copyTV(L, L->top, a);
@@ -332,8 +353,9 @@ static int thunk_concat(lua_State *L)
 
 static int thunk_eq(lua_State *L)
 {
-   TValue *a = resolve_at(L, 0);
-   TValue *b = resolve_at(L, 1);
+   TValue a_copy, b_copy;
+   cTValue *a, *b;
+   resolve_binary_operands(L, a_copy, b_copy, a, b);
 
    // Same pointer means equal
 
@@ -387,8 +409,9 @@ static int thunk_eq(lua_State *L)
 
 static int thunk_lt(lua_State *L)
 {
-   TValue *a = resolve_at(L, 0);
-   TValue *b = resolve_at(L, 1);
+   TValue a_copy, b_copy;
+   cTValue *a, *b;
+   resolve_binary_operands(L, a_copy, b_copy, a, b);
 
    int result;
    if (tvisnumber(a) and tvisnumber(b)) {
@@ -415,8 +438,9 @@ static int thunk_lt(lua_State *L)
 // Less than or equal - compares resolved values
 static int thunk_le(lua_State *L)
 {
-   TValue *a = resolve_at(L, 0);
-   TValue *b = resolve_at(L, 1);
+   TValue a_copy, b_copy;
+   cTValue *a, *b;
+   resolve_binary_operands(L, a_copy, b_copy, a, b);
 
    int result;
    if (tvisnumber(a) and tvisnumber(b)) {

--- a/src/tiri/jit/src/runtime/stack_utils.h
+++ b/src/tiri/jit/src/runtime/stack_utils.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "lj_obj.h"
+#include "lj_state.h"
 
 //********************************************************************************************************************
 // StackFrame: RAII wrapper for automatic L->top restoration
@@ -60,26 +61,26 @@
 
 class StackFrame {
    lua_State *L_;
-   TValue *saved_top_;
+   ptrdiff_t saved_top_;
 
 public:
    explicit StackFrame(lua_State* L) noexcept
-      : L_(L), saved_top_(L->top) {}
+      : L_(L), saved_top_(savestack(L, L->top)) {}
 
    ~StackFrame() noexcept {
-      if (L_) L_->top = saved_top_;
+      if (L_) L_->top = restorestack(L_, saved_top_);
    }
 
    // Disarm the guard without restoring
    constexpr void disarm() noexcept { L_ = nullptr; }
 
    // Commit n results and disarm (keeps n values on stack)
-   constexpr void commit(int nresults) noexcept {
-      L_->top = saved_top_ + nresults;
+   void commit(int nresults) noexcept {
+      L_->top = restorestack(L_, saved_top_) + nresults;
       L_ = nullptr;
    }
 
-   [[nodiscard]] constexpr TValue * saved() const noexcept { return saved_top_; }
+   [[nodiscard]] TValue * saved() const noexcept { return restorestack(L_, saved_top_); }
 
    // Prevent copying
    StackFrame(const StackFrame&) = delete;
@@ -93,7 +94,7 @@ public:
 
    StackFrame& operator=(StackFrame&& other) noexcept {
       if (this != &other) {
-         if (L_) L_->top = saved_top_;
+         if (L_) L_->top = restorestack(L_, saved_top_);
          L_ = other.L_;
          saved_top_ = other.saved_top_;
          other.L_ = nullptr;

--- a/src/tiri/tests/test_contextual_member_calls.tiri
+++ b/src/tiri/tests/test_contextual_member_calls.tiri
@@ -79,6 +79,56 @@ end
       'A safe dynamic built-in fallback should use the runtime table gate on its non-nil path')
 end
 
+@Test function DynamicFallbackObjectReadsSurviveStackGrowth()
+   local holder:any = {
+      func = function()
+         local file = obj.new('file')
+         file.path = 'temp:contextual_stack_growth.txt'
+         local value_00, value_01, value_02, value_03, value_04, value_05, value_06, value_07 =
+            0, 1, 2, 3, 4, 5, 6, 7
+         local value_08, value_09, value_10, value_11, value_12, value_13, value_14, value_15 =
+            8, 9, 10, 11, 12, 13, 14, 15
+         local value_16, value_17, value_18, value_19, value_20, value_21, value_22, value_23 =
+            16, 17, 18, 19, 20, 21, 22, 23
+         local value_24, value_25, value_26, value_27, value_28, value_29, value_30, value_31 =
+            24, 25, 26, 27, 28, 29, 30, 31
+         local value_32, value_33, value_34, value_35, value_36, value_37, value_38, value_39 =
+            32, 33, 34, 35, 36, 37, 38, 39
+         local value_40, value_41, value_42, value_43, value_44, value_45, value_46, value_47 =
+            40, 41, 42, 43, 44, 45, 46, 47
+         local value_48, value_49, value_50, value_51, value_52, value_53, value_54, value_55 =
+            48, 49, 50, 51, 52, 53, 54, 55
+         local value_56, value_57, value_58, value_59, value_60, value_61, value_62, value_63 =
+            56, 57, 58, 59, 60, 61, 62, 63
+         local value_64, value_65, value_66, value_67, value_68, value_69, value_70, value_71 =
+            64, 65, 66, 67, 68, 69, 70, 71
+         local value_72, value_73, value_74, value_75, value_76, value_77, value_78, value_79 =
+            72, 73, 74, 75, 76, 77, 78, 79
+         local value_80, value_81, value_82, value_83, value_84, value_85, value_86, value_87 =
+            80, 81, 82, 83, 84, 85, 86, 87
+         local value_88, value_89, value_90, value_91, value_92, value_93, value_94, value_95 =
+            88, 89, 90, 91, 92, 93, 94, 95
+         local value_96, value_97, value_98, value_99, value_100, value_101, value_102, value_103 =
+            96, 97, 98, 99, 100, 101, 102, 103
+         local value_104, value_105, value_106, value_107, value_108, value_109, value_110, value_111 =
+            104, 105, 106, 107, 108, 109, 110, 111
+         local value_112, value_113, value_114, value_115, value_116, value_117, value_118, value_119 =
+            112, 113, 114, 115, 116, 117, 118, 119
+         local value_120, value_121, value_122, value_123, value_124, value_125, value_126, value_127 =
+            120, 121, 122, 123, 124, 125, 126, 127
+         local value_128, value_129, value_130, value_131, value_132, value_133 = 128, 129, 130, 131, 132, 133
+         local path = file.path
+
+         assert(value_00 is 0 and value_31 is 31 and value_63 is 63 and value_95 is 95 and value_133 is 133,
+            'The object field read should preserve every live register across stack growth')
+         return path
+      end
+   }
+
+   assert(holder.func() is 'temp:contextual_stack_growth.txt',
+      'A dynamic fallback should preserve a native object field result when its callee grows the stack')
+end
+
 @Test function CurrentContextMemberCallsUseOrdinaryCallBytecode()
    &glCurrentContextCallName = 'root'
    &glCurrentContextCallRead = function(Value:str):str

--- a/src/tiri/tests/test_stack_growth.tiri
+++ b/src/tiri/tests/test_stack_growth.tiri
@@ -1,0 +1,155 @@
+-- Regression coverage for Lua stack relocation across native and deferred calls.
+
+@Test function ObjectFunctionWritesSurviveStackGrowth()
+   local holder:any = {
+      func = function()
+         local thread = obj.new('thread')
+         local v00, v01, v02, v03, v04, v05, v06, v07 = 0, 1, 2, 3, 4, 5, 6, 7
+         local v08, v09, v10, v11, v12, v13, v14, v15 = 8, 9, 10, 11, 12, 13, 14, 15
+         local v16, v17, v18, v19, v20, v21, v22, v23 = 16, 17, 18, 19, 20, 21, 22, 23
+         local v24, v25, v26, v27, v28, v29, v30, v31 = 24, 25, 26, 27, 28, 29, 30, 31
+         local v32, v33, v34, v35, v36, v37, v38, v39 = 32, 33, 34, 35, 36, 37, 38, 39
+         local v40, v41, v42, v43, v44, v45, v46, v47 = 40, 41, 42, 43, 44, 45, 46, 47
+         local v48, v49, v50, v51, v52, v53, v54, v55 = 48, 49, 50, 51, 52, 53, 54, 55
+         local v56, v57, v58, v59, v60, v61, v62, v63 = 56, 57, 58, 59, 60, 61, 62, 63
+         local v64, v65, v66, v67, v68, v69, v70, v71 = 64, 65, 66, 67, 68, 69, 70, 71
+         local v72, v73, v74, v75, v76, v77, v78, v79 = 72, 73, 74, 75, 76, 77, 78, 79
+         local v80, v81, v82, v83, v84, v85, v86, v87 = 80, 81, 82, 83, 84, 85, 86, 87
+         local v88, v89, v90, v91, v92, v93, v94, v95 = 88, 89, 90, 91, 92, 93, 94, 95
+         local v96, v97, v98, v99, v100, v101, v102, v103 = 96, 97, 98, 99, 100, 101, 102, 103
+         local v104, v105, v106, v107, v108, v109, v110, v111 = 104, 105, 106, 107, 108, 109, 110, 111
+         local v112, v113, v114, v115, v116, v117, v118, v119 = 112, 113, 114, 115, 116, 117, 118, 119
+         local v120, v121, v122, v123, v124, v125, v126, v127 = 120, 121, 122, 123, 124, 125, 126, 127
+         local v128, v129, v130, v131, v132, v133 = 128, 129, 130, 131, 132, 133
+
+         thread.callback = function(Thread) end
+         assert(v00 is 0 and v31 is 31 and v63 is 63 and v95 is 95 and v133 is 133,
+            'A native function-field write should preserve the active frame across stack growth')
+         return true
+      end
+   }
+
+   assert(holder.func() is true, 'A contextual object function-field write should survive stack growth')
+end
+
+struct StackGrowthRecord
+   Name: string
+end
+
+@Test function StructStringReadsSurviveStackGrowth()
+   local holder:any = {
+      func = function()
+         local native_record = struct<StackGrowthRecord> { Name='relocated' }
+         local v00, v01, v02, v03, v04, v05, v06, v07 = 0, 1, 2, 3, 4, 5, 6, 7
+         local v08, v09, v10, v11, v12, v13, v14, v15 = 8, 9, 10, 11, 12, 13, 14, 15
+         local v16, v17, v18, v19, v20, v21, v22, v23 = 16, 17, 18, 19, 20, 21, 22, 23
+         local v24, v25, v26, v27, v28, v29, v30, v31 = 24, 25, 26, 27, 28, 29, 30, 31
+         local v32, v33, v34, v35, v36, v37, v38, v39 = 32, 33, 34, 35, 36, 37, 38, 39
+         local v40, v41, v42, v43, v44, v45, v46, v47 = 40, 41, 42, 43, 44, 45, 46, 47
+         local v48, v49, v50, v51, v52, v53, v54, v55 = 48, 49, 50, 51, 52, 53, 54, 55
+         local v56, v57, v58, v59, v60, v61, v62, v63 = 56, 57, 58, 59, 60, 61, 62, 63
+         local v64, v65, v66, v67, v68, v69, v70, v71 = 64, 65, 66, 67, 68, 69, 70, 71
+         local v72, v73, v74, v75, v76, v77, v78, v79 = 72, 73, 74, 75, 76, 77, 78, 79
+         local v80, v81, v82, v83, v84, v85, v86, v87 = 80, 81, 82, 83, 84, 85, 86, 87
+         local v88, v89, v90, v91, v92, v93, v94, v95 = 88, 89, 90, 91, 92, 93, 94, 95
+         local v96, v97, v98, v99, v100, v101, v102, v103 = 96, 97, 98, 99, 100, 101, 102, 103
+         local v104, v105, v106, v107, v108, v109, v110, v111 = 104, 105, 106, 107, 108, 109, 110, 111
+         local v112, v113, v114, v115, v116, v117, v118, v119 = 112, 113, 114, 115, 116, 117, 118, 119
+         local v120, v121, v122, v123, v124, v125, v126, v127 = 120, 121, 122, 123, 124, 125, 126, 127
+         local v128, v129, v130, v131, v132, v133 = 128, 129, 130, 131, 132, 133
+         local name = native_record.Name
+
+         assert(name is 'relocated', 'A native struct read should retain its result across stack growth')
+         assert(v00 is 0 and v31 is 31 and v63 is 63 and v95 is 95 and v133 is 133,
+            'A native struct read should preserve the active frame across stack growth')
+         return name
+      end
+   }
+
+   assert(holder.func() is 'relocated', 'A contextual native struct read should survive stack growth')
+end
+
+@Test function PrintRestoresTopAfterCustomTostringGrowsStack()
+   local rendered = false
+   local value = setmetatable({}, {
+      __tostring = function()
+         local v00, v01, v02, v03, v04, v05, v06, v07 = 0, 1, 2, 3, 4, 5, 6, 7
+         local v08, v09, v10, v11, v12, v13, v14, v15 = 8, 9, 10, 11, 12, 13, 14, 15
+         local v16, v17, v18, v19, v20, v21, v22, v23 = 16, 17, 18, 19, 20, 21, 22, 23
+         local v24, v25, v26, v27, v28, v29, v30, v31 = 24, 25, 26, 27, 28, 29, 30, 31
+         local v32, v33, v34, v35, v36, v37, v38, v39 = 32, 33, 34, 35, 36, 37, 38, 39
+         local v40, v41, v42, v43, v44, v45, v46, v47 = 40, 41, 42, 43, 44, 45, 46, 47
+         local v48, v49, v50, v51, v52, v53, v54, v55 = 48, 49, 50, 51, 52, 53, 54, 55
+         local v56, v57, v58, v59, v60, v61, v62, v63 = 56, 57, 58, 59, 60, 61, 62, 63
+         local v64, v65, v66, v67, v68, v69, v70, v71 = 64, 65, 66, 67, 68, 69, 70, 71
+         local v72, v73, v74, v75, v76, v77, v78, v79 = 72, 73, 74, 75, 76, 77, 78, 79
+         local v80, v81, v82, v83, v84, v85, v86, v87 = 80, 81, 82, 83, 84, 85, 86, 87
+         local v88, v89, v90, v91, v92, v93, v94, v95 = 88, 89, 90, 91, 92, 93, 94, 95
+         local v96, v97, v98, v99, v100, v101, v102, v103 = 96, 97, 98, 99, 100, 101, 102, 103
+         local v104, v105, v106, v107, v108, v109, v110, v111 = 104, 105, 106, 107, 108, 109, 110, 111
+         local v112, v113, v114, v115, v116, v117, v118, v119 = 112, 113, 114, 115, 116, 117, 118, 119
+         local v120, v121, v122, v123, v124, v125, v126, v127 = 120, 121, 122, 123, 124, 125, 126, 127
+         local v128, v129, v130, v131, v132, v133 = 128, 129, 130, 131, 132, 133
+         rendered = v00 is 0 and v63 is 63 and v133 is 133
+         return 'stack-growth-print'
+      end
+   })
+
+   print(value)
+   assert(rendered is true, 'print() should restore its stack top after custom tostring grows the stack')
+end
+
+@Test function BinaryThunkOperandsSurviveStackGrowth()
+   thunk deferred_rhs():num
+      local v00, v01, v02, v03, v04, v05, v06, v07 = 0, 1, 2, 3, 4, 5, 6, 7
+      local v08, v09, v10, v11, v12, v13, v14, v15 = 8, 9, 10, 11, 12, 13, 14, 15
+      local v16, v17, v18, v19, v20, v21, v22, v23 = 16, 17, 18, 19, 20, 21, 22, 23
+      local v24, v25, v26, v27, v28, v29, v30, v31 = 24, 25, 26, 27, 28, 29, 30, 31
+      local v32, v33, v34, v35, v36, v37, v38, v39 = 32, 33, 34, 35, 36, 37, 38, 39
+      local v40, v41, v42, v43, v44, v45, v46, v47 = 40, 41, 42, 43, 44, 45, 46, 47
+      local v48, v49, v50, v51, v52, v53, v54, v55 = 48, 49, 50, 51, 52, 53, 54, 55
+      local v56, v57, v58, v59, v60, v61, v62, v63 = 56, 57, 58, 59, 60, 61, 62, 63
+      local v64, v65, v66, v67, v68, v69, v70, v71 = 64, 65, 66, 67, 68, 69, 70, 71
+      local v72, v73, v74, v75, v76, v77, v78, v79 = 72, 73, 74, 75, 76, 77, 78, 79
+      local v80, v81, v82, v83, v84, v85, v86, v87 = 80, 81, 82, 83, 84, 85, 86, 87
+      local v88, v89, v90, v91, v92, v93, v94, v95 = 88, 89, 90, 91, 92, 93, 94, 95
+      local v96, v97, v98, v99, v100, v101, v102, v103 = 96, 97, 98, 99, 100, 101, 102, 103
+      local v104, v105, v106, v107, v108, v109, v110, v111 = 104, 105, 106, 107, 108, 109, 110, 111
+      local v112, v113, v114, v115, v116, v117, v118, v119 = 112, 113, 114, 115, 116, 117, 118, 119
+      local v120, v121, v122, v123, v124, v125, v126, v127 = 120, 121, 122, 123, 124, 125, 126, 127
+      local v128, v129, v130, v131, v132, v133 = 128, 129, 130, 131, 132, 133
+      assert(v00 is 0 and v63 is 63 and v133 is 133, 'Deferred operand frame should remain live')
+      return 7
+   end
+
+   local rhs:any = deferred_rhs()
+   assert(5 + rhs is 12, 'A binary thunk operation should retain its left operand across stack growth')
+end
+
+@Test function ThunkEqualityOperandsSurviveStackGrowth()
+   thunk deferred_rhs():num
+      local v00, v01, v02, v03, v04, v05, v06, v07 = 0, 1, 2, 3, 4, 5, 6, 7
+      local v08, v09, v10, v11, v12, v13, v14, v15 = 8, 9, 10, 11, 12, 13, 14, 15
+      local v16, v17, v18, v19, v20, v21, v22, v23 = 16, 17, 18, 19, 20, 21, 22, 23
+      local v24, v25, v26, v27, v28, v29, v30, v31 = 24, 25, 26, 27, 28, 29, 30, 31
+      local v32, v33, v34, v35, v36, v37, v38, v39 = 32, 33, 34, 35, 36, 37, 38, 39
+      local v40, v41, v42, v43, v44, v45, v46, v47 = 40, 41, 42, 43, 44, 45, 46, 47
+      local v48, v49, v50, v51, v52, v53, v54, v55 = 48, 49, 50, 51, 52, 53, 54, 55
+      local v56, v57, v58, v59, v60, v61, v62, v63 = 56, 57, 58, 59, 60, 61, 62, 63
+      local v64, v65, v66, v67, v68, v69, v70, v71 = 64, 65, 66, 67, 68, 69, 70, 71
+      local v72, v73, v74, v75, v76, v77, v78, v79 = 72, 73, 74, 75, 76, 77, 78, 79
+      local v80, v81, v82, v83, v84, v85, v86, v87 = 80, 81, 82, 83, 84, 85, 86, 87
+      local v88, v89, v90, v91, v92, v93, v94, v95 = 88, 89, 90, 91, 92, 93, 94, 95
+      local v96, v97, v98, v99, v100, v101, v102, v103 = 96, 97, 98, 99, 100, 101, 102, 103
+      local v104, v105, v106, v107, v108, v109, v110, v111 = 104, 105, 106, 107, 108, 109, 110, 111
+      local v112, v113, v114, v115, v116, v117, v118, v119 = 112, 113, 114, 115, 116, 117, 118, 119
+      local v120, v121, v122, v123, v124, v125, v126, v127 = 120, 121, 122, 123, 124, 125, 126, 127
+      local v128, v129, v130, v131, v132, v133 = 128, 129, 130, 131, 132, 133
+      assert(v00 is 0 and v63 is 63 and v133 is 133, 'Deferred equality frame should remain live')
+      return 5
+   end
+
+   local lhs:any = 5
+   local rhs:any = deferred_rhs()
+   assert(lhs is rhs, 'Thunk equality should retain its ordinary stack operand across stack growth')
+end

--- a/src/tiri/tests/test_stack_growth.tiri
+++ b/src/tiri/tests/test_stack_growth.tiri
@@ -36,6 +36,29 @@ struct StackGrowthRecord
    Name: string
 end
 
+@Test(hotpath=80) function JitFallbackDestinationsRemainStable()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   local file = obj.new('file')
+   file.path = 'temp:jit_stack_growth.txt'
+   local native_record = struct<StackGrowthRecord> { Name='jit-relocated' }
+   local path = ''
+   local name = ''
+
+   for index in {0 to 80} do
+      path = file.path
+      name = native_record.Name
+   end
+
+   assert(path is 'temp:jit_stack_growth.txt', 'A traced object fallback should retain its external result destination')
+   assert(name is 'jit-relocated', 'A traced struct fallback should retain its external result destination')
+
+   jit.flush()
+   jit.opt.start()
+end
+
 @Test function StructStringReadsSurviveStackGrowth()
    local holder:any = {
       func = function()


### PR DESCRIPTION
* Preserved VM stack positions with offsets across object, struct and nested callback operations
* Stabilised thunk operands while deferred resolution can grow the Lua stack
* Added consolidated stack growth regression coverage