### PR TITLE
[Tiri] Standardised string type naming across typed arrays

### DIFF
--- a/apps/find.tiri
+++ b/apps/find.tiri
@@ -166,11 +166,11 @@ Examples:
            comment = "A regex pattern to filter filenames; mutually exclusive with 'name'." },
          { name = 'name', type = 'str', excludes = 'filter', group = 'Search',
            comment = "An exact filename to match; mutually exclusive with 'filter'." },
-         { name = 'type', type = 'enum', default = 'file', choices = array<string> { 'file', 'dir', 'all' },
+         { name = 'type', type = 'enum', default = 'file', choices = array<str> { 'file', 'dir', 'all' },
            group = 'Search', comment = "Match type: 'file', 'dir', or 'all'." },
-         { names = array<string> { 'maxdepth', 'max-depth' }, type = 'int', default = 100, group = 'Search',
+         { names = array<str> { 'maxdepth', 'max-depth' }, type = 'int', default = 100, group = 'Search',
            comment = 'Maximum directory depth to recurse into.' },
-         { names = array<string> { 'mindepth', 'min-depth' }, type = 'int', default = 0, group = 'Search',
+         { names = array<str> { 'mindepth', 'min-depth' }, type = 'int', default = 0, group = 'Search',
            comment = 'Minimum depth before results are reported.' },
 
          { name = 'size', type = parseSizeOption, group = 'Filters',
@@ -184,7 +184,7 @@ Examples:
 
          { name = 'count', kind = 'flag', default = false, group = 'Output',
            comment = 'Print only the total match count.' },
-         { name = 'output', type = 'enum', default = 'path', choices = array<string> { 'path', 'name', 'detail' },
+         { name = 'output', type = 'enum', default = 'path', choices = array<str> { 'path', 'name', 'detail' },
            group = 'Output', comment = "Output format: 'path', 'name', or 'detail'." },
          { name = 'verbose', kind = 'flag', default = false, group = 'Output',
            comment = 'Print search parameters before searching.' },

--- a/apps/paintbox.tiri
+++ b/apps/paintbox.tiri
@@ -31,15 +31,15 @@ Examples:
 
       { name = 'output', type = 'csv', default = 'rgb,hex,hsl,xyz,oklab,oklch,p3,hsv,info', group = 'Output',
         comment = 'Comma-separated fields: rgb, hex, hsl, xyz, oklab, oklch, p3, hsv, info.' },
-      { name = 'format', type = lowercaseOption, default = 'text', choices = array<string> { 'text', 'json' },
+      { name = 'format', type = lowercaseOption, default = 'text', choices = array<str> { 'text', 'json' },
         group = 'Output', comment = 'Output format: text or json.' },
 
-      { names = array<string> { 'scheme', 'palette' }, type = lowercaseOption,
-        choices = array<string> { 'analogous', 'complementary', 'triadic', 'split', 'monochrome' },
+      { names = array<str> { 'scheme', 'palette' }, type = lowercaseOption,
+        choices = array<str> { 'analogous', 'complementary', 'triadic', 'split', 'monochrome' },
         group = 'Palette', comment = 'Palette scheme: analogous, complementary, triadic, split, monochrome.' },
       { name = 'palette-count', type = 'int', default = 5, group = 'Palette',
         comment = 'Number of colours for analogous/monochrome palettes.' },
-      { name = 'preview', type = lowercaseOption, choices = array<string> { 'true', 'ansi', 'svg' }, group = 'Palette',
+      { name = 'preview', type = lowercaseOption, choices = array<str> { 'true', 'ansi', 'svg' }, group = 'Palette',
         comment = 'Preview mode: true or ansi for text palettes, svg for JSON swatches.' },
       { name = 'save-to', type = 'file', group = 'Palette',
         comment = 'Save the SVG swatch preview when preview=svg.' }
@@ -217,7 +217,7 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function outputText(Report, Format:array<string>)
+function outputText(Report, Format:array<str>)
    if Format.find('rgb')   then print(f'RGB:     {Report.rgb}') end
    if Format.find('hex')   then print(f'RGB Hex: {Report.hex}') end
    if Format.find('hsl')   then print(f'HSL:     {Report.css.hsl}') end

--- a/apps/proximity.tiri
+++ b/apps/proximity.tiri
@@ -56,19 +56,19 @@ Examples:
            end
          },
          -- MITM Disabled until available in the proxyserver library
-         --{ names = array<string> { 'mitm', 'enableMITM', 'enable-mitm' }, kind = 'flag', default = false,
+         --{ names = array<str> { 'mitm', 'enableMITM', 'enable-mitm' }, kind = 'flag', default = false,
          --  group = 'HTTPS', comment = 'Enable MITM mode for HTTPS interception.' },
-         --{ names = array<string> { 'cacert', 'caCert', 'ca-cert' }, type = 'file', exists = true, group = 'HTTPS',
+         --{ names = array<str> { 'cacert', 'caCert', 'ca-cert' }, type = 'file', exists = true, group = 'HTTPS',
          --  comment = 'CA certificate file for MITM mode.' },
-         --{ names = array<string> { 'cakey', 'caKey', 'ca-key' }, type = 'file', exists = true, group = 'HTTPS',
+         --{ names = array<str> { 'cakey', 'caKey', 'ca-key' }, type = 'file', exists = true, group = 'HTTPS',
          --  comment = 'CA private key file for MITM mode.' },
-         --{ names = array<string> { 'capass', 'caPassword', 'ca-password' }, type = 'str', group = 'HTTPS',
+         --{ names = array<str> { 'capass', 'caPassword', 'ca-password' }, type = 'str', group = 'HTTPS',
          --  comment = 'Password for the CA private key.' },
-         { names = array<string> { 'upstream', 'upstreamProxy', 'upstream-proxy' }, type = 'str', group = 'Server',
+         { names = array<str> { 'upstream', 'upstreamProxy', 'upstream-proxy' }, type = 'str', group = 'Server',
            comment = 'Upstream proxy server in host:port form.' },
-         { names = array<string> { 'record', 'recordFlows', 'record-flows' }, kind = 'flag', default = true,
+         { names = array<str> { 'record', 'recordFlows', 'record-flows' }, kind = 'flag', default = true,
            group = 'Recording', comment = 'Enable flow recording.' },
-         { names = array<string> { 'maxflows', 'maxFlows', 'max-flows' }, type = 'int', default = 1000,
+         { names = array<str> { 'maxflows', 'maxFlows', 'max-flows' }, type = 'int', default = 1000,
            group = 'Recording', comment = 'Maximum number of flows to keep in memory.',
            exec = function(Parser:table, ArgName:str!, Value:any!, Param:table)
               if Value < 1 then
@@ -76,9 +76,9 @@ Examples:
               end
            end
          },
-         { names = array<string> { 'exportFile', 'export', 'export-file' }, type = 'path', group = 'Recording',
+         { names = array<str> { 'exportFile', 'export', 'export-file' }, type = 'path', group = 'Recording',
            comment = 'Export recorded flows to a JSON file on shutdown.' },
-         { names = array<string> { 'importFile', 'import', 'import-file' }, type = 'file', exists = true,
+         { names = array<str> { 'importFile', 'import', 'import-file' }, type = 'file', exists = true,
            group = 'Recording', comment = 'Import flows from a JSON file on startup.' }
       }
    })

--- a/apps/tests/test_find.tiri
+++ b/apps/tests/test_find.tiri
@@ -2,7 +2,7 @@
 
 glTask = mSys.CurrentTask()
 
-function resolveFirstPath(Candidates:array<string>):str
+function resolveFirstPath(Candidates:array<str>):str
    for candidate in values(Candidates) do
       err, resolved = mSys.ResolvePath(candidate, RSF_APPROXIMATE)
       if err is ERR_Okay then return resolved end
@@ -12,12 +12,12 @@ function resolveFirstPath(Candidates:array<string>):str
 end
 
 @BeforeAll function init(State)
-   global glOrigoPath = resolveFirstPath(array<string> {
+   global glOrigoPath = resolveFirstPath(array<str> {
       glTask.processPath .. 'origo',
       'sdk:build/agents-install/origo',
       'origo'
    })
-   global glFindPath = resolveFirstPath(array<string> {
+   global glFindPath = resolveFirstPath(array<str> {
       'sdk:apps/find.tiri',
    })
    global glAppsPath = [*_]io.splitPath(glFindPath)
@@ -35,10 +35,10 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function runFind(Parameters:array<string>):table
+function runFind(Parameters:array<str>):table
    local output = ''
    local errors = ''
-   local task_params = array<string> { quoteTaskParam(glFindPath.replace('\\', '/')) }
+   local task_params = array<str> { quoteTaskParam(glFindPath.replace('\\', '/')) }
 
    for param in values(Parameters) do
       task_params.push(quoteTaskParam(param))
@@ -72,7 +72,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function ContentOptionMatchesLiteralText()
-   result = runFind(array<string> {
+   result = runFind(array<str> {
       'path=' .. glAppsPath,
       'name=find.tiri',
       'content=Match files containing the specified literal text.',
@@ -86,7 +86,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function ContentOptionRejectsMissingText()
-   result = runFind(array<string> {
+   result = runFind(array<str> {
       'path=' .. glAppsPath,
       'name=find.tiri',
       'content=definitely_absent_find_fixture',
@@ -100,7 +100,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function HelpDocumentsContentOption()
-   result = runFind(array<string> { 'help' })
+   result = runFind(array<str> { 'help' })
 
    assert(result.returnCode is 0, 'Help should return 0: ' .. result.errors)
    assert(result.text.find('content=CONTENT'), 'Help should list the content option')

--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -10,7 +10,7 @@ glUploadFile <const> = 'temp:tuku-test-upload.txt'
 
 glTask = mSys.CurrentTask()
 
-function resolveFirstPath(Candidates:array<string>):str
+function resolveFirstPath(Candidates:array<str>):str
    for candidate in values(Candidates) do
       err, resolved = mSys.ResolvePath(candidate, RSF_APPROXIMATE)
       if err is ERR_Okay then return resolved end
@@ -20,12 +20,12 @@ function resolveFirstPath(Candidates:array<string>):str
 end
 
 @BeforeAll function init(State)
-   global glOrigoPath = resolveFirstPath(array<string> {
+   global glOrigoPath = resolveFirstPath(array<str> {
       glTask.processPath .. 'origo',
       'sdk:build/agents-install/origo',
       'origo'
    })
-   global glTukuPath = resolveFirstPath(array<string> {
+   global glTukuPath = resolveFirstPath(array<str> {
       'sdk:apps/tuku.tiri',
    })
    global glFollowNoRedirectHits = 0
@@ -278,10 +278,10 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function runTuku(Parameters:array<string>):table
+function runTuku(Parameters:array<str>):table
    local output = ''
    local errors = ''
-   local task_params = array<string> { quoteTaskParam(glTukuPath.replace('\\', '/')) }
+   local task_params = array<str> { quoteTaskParam(glTukuPath.replace('\\', '/')) }
 
    for param in values(Parameters) do
       task_params.push(quoteTaskParam(param))
@@ -315,7 +315,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineHelpListsFutureOptions()
-   result = runTuku(array<string> { 'help' })
+   result = runTuku(array<str> { 'help' })
 
    assert(result.returnCode is 0, 'Help should return 0, got ' .. result.returnCode)
    assert(result.text.find('headers'), 'Help should include response headers option')
@@ -331,7 +331,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineRejectsIncompatibleBodyOptions()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/echo',
       'data=plain',
       'json={}'
@@ -345,7 +345,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineParserErrorsFail()
-   result = runTuku(array<string> { 'timeout=abc' })
+   result = runTuku(array<str> { 'timeout=abc' })
 
    assert(result.returnCode != 0, 'Parser-level argument errors should fail')
    assert(result.text.find("Parameter 'timeout' requires a number."),
@@ -355,7 +355,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineFetchWritesOutputFile()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/hello',
       'output=' .. glOutputFile,
       'timeout=5',
@@ -370,7 +370,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineFollowsSingleRedirect()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/redirect-once',
       'follow',
       'timeout=5'
@@ -383,7 +383,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineFollowDoesNotReplayNonRedirectResponse()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/follow-counted',
       'follow',
       'timeout=5'
@@ -396,7 +396,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineFollowDoesNotReplayFinalRedirectHop()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/redirect-counted',
       'follow',
       'timeout=5'
@@ -411,7 +411,7 @@ end
 @Test function CommandLineFollowWritesFinalResponseToOutputFile()
    mSys.DeleteFile(glOutputFile)
 
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/redirect-once',
       'follow',
       'output=' .. glOutputFile,
@@ -425,7 +425,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineFollowsRedirectChain()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/chain-1',
       'follow',
       'timeout=5'
@@ -438,7 +438,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineRedirect303ChangesMethodToGet()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/redirect-303',
       'data=body',
       'follow',
@@ -452,7 +452,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineRedirect302PreservesPatchMethodAndBody()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/redirect-patch-302',
       'method=patch',
       'json=[7,8,9]',
@@ -472,7 +472,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineRedirect301PreservesPutMethodAndBody()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/redirect-put-301',
       'method=put',
       'data=put-body',
@@ -492,7 +492,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineRejectsRedirectLoopLimit()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/redirect-loop',
       'follow',
       'max-redirects=2',
@@ -509,7 +509,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineReturnsRedirectStatusWithoutFollow()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/redirect-once',
       'status',
       'timeout=5'
@@ -522,7 +522,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineReturnsPermanentRedirectStatusWithoutFollow()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/chain-1',
       'headers',
       'status',
@@ -538,7 +538,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLinePostsDataAndCustomHeaders()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/echo',
       'data=plain-body',
       'contenttype=text/plain',
@@ -561,7 +561,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLinePostsJsonAndFormBodies()
-   json_result = runTuku(array<string> {
+   json_result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/echo',
       'json=[1,2,3]',
       'timeout=5'
@@ -573,7 +573,7 @@ end
    assert(json_response.parsedBody[0] is 1, 'JSON array body should be parsed by the server')
    assert(json_response.parsedBody[2] is 3, 'JSON array body value mismatch')
 
-   form_result = runTuku(array<string> {
+   form_result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/echo',
       'form={name=Ada,email=ada@example.com}',
       'timeout=5'
@@ -592,7 +592,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLinePatchesJsonBody()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/echo',
       'method=patch',
       'json=[4,5,6]',
@@ -611,7 +611,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLinePostsMultipartTextFields()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/echo',
       'multipart={name=Ada,role=Engineer}',
       'timeout=5'
@@ -631,7 +631,7 @@ end
 @Test function CommandLinePostsMultipartFile()
    io.writeAll(glUploadFile, 'uploaded file body')
 
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/echo',
       'multipart={doc=@' .. glUploadFile .. '}',
       'timeout=5'
@@ -650,7 +650,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineRejectsMultipartWithOtherBodyOptions()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/echo',
       'data=plain',
       'multipart={name=Ada}',
@@ -667,7 +667,7 @@ end
 @Test function CommandLinePostsDataFile()
    io.writeAll(glBodyFile, 'file-body')
 
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/echo',
       'datafile=' .. glBodyFile,
       'contenttype=text/plain',
@@ -683,7 +683,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineAcceptsUserCredentials()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/hello',
       'user=tuku:pass',
       'timeout=5'
@@ -696,7 +696,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineHeadAndOptionsStatus()
-   head_result = runTuku(array<string> {
+   head_result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/head',
       'method=head',
       'status',
@@ -706,7 +706,7 @@ end
    assert(head_result.returnCode is 0, 'HEAD should return 0: ' .. head_result.errors)
    assert(head_result.text.trim() is '200', 'HEAD status should be 200, got ' .. head_result.text)
 
-   options_result = runTuku(array<string> {
+   options_result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/options',
       'method=options',
       'status',
@@ -721,7 +721,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineStatusOnlyUsesStdout()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/hello',
       'status',
       'timeout=5'
@@ -734,7 +734,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineFailTreatsHttpErrorStatusAsFailure()
-   normal_result = runTuku(array<string> {
+   normal_result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/missing',
       'status',
       'timeout=5'
@@ -743,7 +743,7 @@ end
    assert(normal_result.returnCode is 0, 'HTTP 404 should not fail without fail=true: ' .. normal_result.errors)
    assert(normal_result.output is '404\n', 'Non-failing 404 should still report status, got: ' .. normal_result.text)
 
-   fail_result = runTuku(array<string> {
+   fail_result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/missing',
       'fail',
       'status',
@@ -760,7 +760,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineVerbosePrintsSummaryAndSelectedHeaders()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/headers',
       'output=' .. glOutputFile,
       'verbose',
@@ -789,7 +789,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineHeadersPrintsFullResponseHeaderList()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/headers',
       'headers',
       'status',
@@ -809,7 +809,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineIncludePrintsHeadersBeforeBody()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/headers',
       'with-headers',
       'timeout=5'
@@ -834,7 +834,7 @@ end
 @Test function CommandLineIncludeWritesHeadersToStdoutAndBodyToFile()
    mSys.DeleteFile(glOutputFile)
 
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/headers',
       'with-headers',
       'output=' .. glOutputFile,
@@ -852,7 +852,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineSilentSuppressesNonBodyOutput()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/headers',
       'output=' .. glOutputFile,
       'silent',
@@ -872,7 +872,7 @@ end
 @Test function CommandLineResumesOutputDownload()
    io.writeAll(glOutputFile, 'hello ')
 
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/range',
       'output=' .. glOutputFile,
       'resume',
@@ -888,7 +888,7 @@ end
 @Test function CommandLineResumeRejectsFullResponse()
    io.writeAll(glOutputFile, 'hello ')
 
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/range-ignore',
       'output=' .. glOutputFile,
       'resume',
@@ -904,7 +904,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineValidatesResumeRequirements()
-   no_output = runTuku(array<string> {
+   no_output = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/range',
       'resume',
       'timeout=5'
@@ -914,7 +914,7 @@ end
    assert(no_output.text.find("Parameter 'resume' requires 'output'."),
       'Resume without output diagnostic mismatch: ' .. no_output.text)
 
-   post_resume = runTuku(array<string> {
+   post_resume = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/echo',
       'output=' .. glOutputFile,
       'resume',
@@ -930,7 +930,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineAcceptsTransferControlFlags()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/hello',
       'raw',
       'no-head',
@@ -947,7 +947,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineProxyParsesHostPort()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/proxy-target',
       f'proxy=127.0.0.1:{SERVER_PORT}',
       'timeout=5'
@@ -960,7 +960,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineRejectsInvalidProxy()
-   missing_port = runTuku(array<string> {
+   missing_port = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/hello',
       'proxy=127.0.0.1',
       'timeout=5'
@@ -970,7 +970,7 @@ end
    assert(missing_port.text.find("Parameter 'proxy' must use host:port syntax."),
       'Proxy missing port diagnostic mismatch: ' .. missing_port.text)
 
-   bad_port = runTuku(array<string> {
+   bad_port = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/hello',
       'proxy=127.0.0.1:70000',
       'timeout=5'
@@ -984,7 +984,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineRedirect303PreservesHeadMethod()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/redirect-head-303',
       'method=head',
       'follow',
@@ -1002,7 +1002,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineRedirectStripsCredentialsOnCrossOrigin()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/redirect-cross-origin',
       'user=secret:pass',
       'header={Authorization:Bearer token123}',
@@ -1019,7 +1019,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function CommandLineRedirectPreservesCredentialsOnSameOrigin()
-   result = runTuku(array<string> {
+   result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/redirect-same-origin',
       'header={Authorization:Bearer keep-me}',
       'follow',

--- a/apps/tuku.tiri
+++ b/apps/tuku.tiri
@@ -9,7 +9,7 @@ Tuku: A small HTTP/HTTPS client for Tiri command-line workflows.  Documented in 
 
 TUKU_VERSION <const> = '2026.5.7'
 TUKU_USER_AGENT <const> = 'Tuku/1.0 Kotuku'
-glResponseHeaderNames = array<string> { 'content-type', 'content-length', 'location' }
+glResponseHeaderNames = array<str> { 'content-type', 'content-length', 'location' }
 glReportedError = false
 glSilent = false
 
@@ -17,7 +17,7 @@ glOptionDefs = array<table> {
    { name = 'url', type = 'str', group = 'Core',
      comment = 'Target HTTP or HTTPS URL.' },
    { name = 'method', type = 'enum',
-     choices = array<string> { 'get', 'head', 'delete', 'options', 'post', 'put', 'patch' },
+     choices = array<str> { 'get', 'head', 'delete', 'options', 'post', 'put', 'patch' },
      group = 'Core', comment = 'HTTP method to use.' },
    { name = 'version', kind = 'flag', group = 'Core', comment = 'Print the Tuku version.' },
 
@@ -27,7 +27,7 @@ glOptionDefs = array<table> {
      comment = 'Print the numeric HTTP status.' },
    { name = 'headers', kind = 'flag', group = 'Output',
      comment = 'Print all response headers as key=value lines.' },
-   { name = 'include', names = array<string> { 'include', 'with-headers' }, kind = 'flag', group = 'Output',
+   { name = 'include', names = array<str> { 'include', 'with-headers' }, kind = 'flag', group = 'Output',
      comment = 'Print response headers before the response body.' },
    { name = 'silent', kind = 'flag', group = 'Output',
      comment = 'Suppress non-body output.' },
@@ -37,19 +37,19 @@ glOptionDefs = array<table> {
      comment = 'Treat HTTP 4xx and 5xx statuses as failures.' },
 
    { name = 'data', type = 'str', group = 'Request Body',
-     excludes = array<string> { 'datafile', 'json', 'form', 'multipart' },
+     excludes = array<str> { 'datafile', 'json', 'form', 'multipart' },
      comment = 'Send a string request body.' },
    { name = 'datafile', type = 'file', exists = true, group = 'Request Body',
-     excludes = array<string> { 'data', 'json', 'form', 'multipart' },
+     excludes = array<str> { 'data', 'json', 'form', 'multipart' },
      comment = 'Read the request body from a file.' },
    { name = 'json', type = 'str', group = 'Request Body',
-     excludes = array<string> { 'data', 'datafile', 'form', 'multipart' },
+     excludes = array<str> { 'data', 'datafile', 'form', 'multipart' },
      comment = 'Send a JSON request body.' },
    { name = 'form', type = 'array', group = 'Request Body',
-     excludes = array<string> { 'data', 'datafile', 'json', 'multipart' },
+     excludes = array<str> { 'data', 'datafile', 'json', 'multipart' },
      comment = 'Send form fields as name=value entries.' },
    { name = 'multipart', type = 'array', group = 'Request Body',
-     excludes = array<string> { 'data', 'datafile', 'json', 'form' },
+     excludes = array<str> { 'data', 'datafile', 'json', 'form' },
      comment = 'Send multipart/form-data fields as name=value or name=@path entries.' },
    { name = 'contenttype', type = 'str', group = 'Request Body',
      comment = 'Request Content-Type header.' },
@@ -103,7 +103,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Converts an array of name=value form arguments into application/x-www-form-urlencoded request content.
 
-function encodeFormBody(Form:array<string>!):str
+function encodeFormBody(Form:array<str>!):str
    params = array<table>
 
    for field in values(Form) do
@@ -132,7 +132,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Converts an array of name=value or name=@file arguments into multipart/form-data request content.
 
-function buildMultipartBody(Fields:array<string>!):<str, str>
+function buildMultipartBody(Fields:array<str>!):<str, str>
    boundary = '----TukuBoundary' .. tostring(math.floor(mSys.PreciseTime())) .. string.format('%08x', math.random(0, 0x7FFFFFFF))
    crlf <const> = '\r\n'
    body = ''
@@ -554,8 +554,8 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Returns available response header names, falling back to the phase 3 common keys on older HTTP builds.
 
-function readResponseHeaderNames(HTTP:obj!):array<string>
-   names = array<string>
+function readResponseHeaderNames(HTTP:obj!):array<str>
+   names = array<str>
    seen = {}
 
    if HTTP.responseKeys != nil then
@@ -627,8 +627,8 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Removes sensitive headers (Authorization, Cookie) from a custom header array.
 
-function filterSensitiveHeaders(Headers:array<string>!):array<string>
-   result = array<string>
+function filterSensitiveHeaders(Headers:array<str>!):array<str>
+   result = array<str>
    for header in values(Headers) do
       name = tostring(header)
       colon = name.find(':')

--- a/apps/tuku_server.tiri
+++ b/apps/tuku_server.tiri
@@ -48,9 +48,9 @@ Examples:
               end
            end
          },
-         { names = array<string> { 'autoIndex', 'autoindex' }, kind = 'flag', default = true, group = 'Behaviour',
+         { names = array<str> { 'autoIndex', 'autoindex' }, kind = 'flag', default = true, group = 'Behaviour',
            comment = 'Enable automatic directory listing.' },
-         { names = array<string> { 'rateLimit', 'ratelimit' }, type = 'int', group = 'Behaviour',
+         { names = array<str> { 'rateLimit', 'ratelimit' }, type = 'int', group = 'Behaviour',
            comment = 'Maximum requests per rate-limit window; 0 disables rate limiting.',
            exec = function(Parser:table, ArgName:str, Value:any!, Param:table)
               if Value < 0 or Value > 1000 then
@@ -58,7 +58,7 @@ Examples:
               end
            end
          },
-         { names = array<string> { 'rateLimitWindow', 'ratelimitwindow' }, type = 'int', group = 'Behaviour',
+         { names = array<str> { 'rateLimitWindow', 'ratelimitwindow' }, type = 'int', group = 'Behaviour',
            comment = 'Rate-limit window in seconds.' }
       }
    })

--- a/apps/vuepoint.tiri
+++ b/apps/vuepoint.tiri
@@ -74,7 +74,7 @@ glIntroduction = [[
 
    glOpenFilter = array<table> {
       { name='SVG Images', ext='.svg' },
-      { name='RIPL Documents', ext=array<string> { 'ripl', 'rpl' } }
+      { name='RIPL Documents', ext=array<str> { 'ripl', 'rpl' } }
    }
 
    glSaveFilter = array<table> { }

--- a/examples/benchmark_particles.tiri
+++ b/examples/benchmark_particles.tiri
@@ -34,14 +34,14 @@ Examples:
 ]],
       args        = array<table> {
          { name = 'mode', type = 'enum', default = 'vector',
-           choices = array<string> { 'primitive', 'directvector', 'vector' },
+           choices = array<str> { 'primitive', 'directvector', 'vector' },
            comment = 'Drawing mode to benchmark.' },
          { name = 'shape', type = 'enum', default = 'ellipse',
-           choices = array<string> { 'ellipse', 'star' },
+           choices = array<str> { 'ellipse', 'star' },
            comment = 'Particle shape for vector and direct vector modes.' },
          { name = 'scale', type = 'num', default = 1.0,
            comment = 'Particle radius scale; 1.0 leaves particles at their default size.' },
-         { names = array<string> { 'maxParticles', 'maxparticles' }, type = 'int', default = 500,
+         { names = array<str> { 'maxParticles', 'maxparticles' }, type = 'int', default = 500,
            comment = 'Number of particles to simulate; values below 100 are raised to 100.' }
       }
    })

--- a/scripts/benchmark.tiri
+++ b/scripts/benchmark.tiri
@@ -25,9 +25,9 @@ end
 
 -- Generate a text report from benchmark statistics
 
-bmark.textReport = function(Results:table!):array<string>
+bmark.textReport = function(Results:table!):array<str>
    assert(Results, "Results are required")
-   local msg = array<string>
+   local msg = array<str>
    msg.push('=== BENCHMARK RESULTS ===')
    msg.push(string.format('Total calls:    %d (%d warmup + %d benchmark)', Results.totalCalls, Results.warmupCount ?? 0, Results.benchmarkCalls))
    msg.push(string.format('Total time:     %.2f seconds', Results.totalTime))
@@ -603,10 +603,10 @@ end
 
 -- Generate an ASCII histogram representation for console output.
 
-bmark.histogramText = function(Histogram:table!, Width:num):array<string>
+bmark.histogramText = function(Histogram:table!, Width:num):array<str>
    Width ??= 40
 
-   local msg = array<string>
+   local msg = array<str>
    msg.push('=== DISTRIBUTION HISTOGRAM ===')
    msg.push(string.format('Total samples: %d', Histogram.total))
    msg.push(string.format('Range: %.3f - %.3f (bin width: %.3f)', Histogram.min, Histogram.max, Histogram.binWidth))
@@ -790,8 +790,8 @@ end
 
 -- Generate a text report from a comparison result
 
-bmark.comparisonReport = function(Comparison:table!):array<string>
-   local msg = array<string>
+bmark.comparisonReport = function(Comparison:table!):array<str>
+   local msg = array<str>
 
    local function formatChange(Change:num!, Improved:bool):str
       local sign = Change >= 0 and '+' or ''

--- a/scripts/config.tiri
+++ b/scripts/config.tiri
@@ -116,7 +116,7 @@ end
 @result Config text
 ]])
 config.encode = function(Value:table!):str
-   local output = array<string>
+   local output = array<str>
    local group_count = 0
 
    for group_name, group in Value.sortByKeys() do

--- a/scripts/gui.tiri
+++ b/scripts/gui.tiri
@@ -54,7 +54,7 @@ gui.fontList = thunk():table
       if entry.Styles then
          font.styles = entry.Styles.split(',')
       else
-         font.styles = array<string> { 'Regular' }
+         font.styles = array<str> { 'Regular' }
       end
 
       if entry.Points then

--- a/scripts/gui/colourdialog.tiri
+++ b/scripts/gui/colourdialog.tiri
@@ -20,7 +20,7 @@ BTNGAP     <const> = 3
 WIDGET_GAP <const> = 6
 COL_BORDER <const> = 'rgba(128,128,128,0.75)'
 
-COMMON <const> = array<string> {
+COMMON <const> = array<str> {
   '0,64,64', '0,128,128', '0,192,192', '0,255,255', '64,255,255',  '128,255,255', '192,255,255', '224,255,255', -- Aqua
   '0,64,0',  '0,128,0',   '0,192,0',   '0,255,0',   '64,255,64',   '128,255,128', '192,255,192', '224,255,224', -- Green
   '64,64,0', '128,128,0', '192,192,0', '255,255,0', '255,255,64',  '255,255,128', '255,255,192', '255,255,224', -- Yellow
@@ -37,7 +37,7 @@ local glRainbowBitmap
 function saveColours(self)
    self._paletteChanged ?! return
 
-   svgColours = array<string> {}
+   svgColours = array<str> {}
    for col in values(self._userColours) do
       svgColours.push(tostring(col))
    end

--- a/scripts/gui/fileview.tiri
+++ b/scripts/gui/fileview.tiri
@@ -22,7 +22,7 @@ glState <const> = mSys.GetSystemState()
 glCopyList <const> = [[
    import 'gui/file'
    source_size = arg('source:size')
-   glList = array<string>
+   glList = array<str>
    if source_size?? then
       source_size = tonumber(source_size)
       for i in {0 to source_size} do
@@ -242,9 +242,9 @@ end
 
 -- Return allowed file extensions as a string list, which is cached.
 
-function getFilters(self):array<string>
+function getFilters(self):array<str>
    if self._filters then return self._filters end
-   self._filters = array<string>
+   self._filters = array<str>
    if self.filterList then
       for filter in values(self.filterList) do
          if filter.selected then
@@ -419,7 +419,7 @@ function copyFromList(self, Folder:str!, List, Move:bool)
    try
       msg(f'copyFromList({Folder})')
 
-      params = array<string> { '--dest', Folder }
+      params = array<str> { '--dest', Folder }
       if Move then params.push('--move') end
       params.push('--source')
       params.push('{')

--- a/scripts/gui/icon.tiri
+++ b/scripts/gui/icon.tiri
@@ -35,7 +35,7 @@ gui.icon = function(Options)
    local lText, lTextGroup, lThemeColour
    lClick      = { held=false, x=0, y=0 }
    lWords      = array<table>
-   lLines      = array<string>
+   lLines      = array<str>
    lIconSize   = Options.size ?? 66
    lIconWidth  = lIconSize
    lFontSize   = FONT_HEIGHT
@@ -72,7 +72,7 @@ gui.icon = function(Options)
 
    function calcWords()
       lWords = array<table>
-      lLines = array<string>
+      lLines = array<str>
       lText ?! return
 
       lFontSize = choose lIconSize from

--- a/scripts/gui/libview.tiri
+++ b/scripts/gui/libview.tiri
@@ -629,7 +629,7 @@ gui.initView = function(Options:table!, BuildUI, NewItems)
       })
    end
 
-   for v in values(array<string> { 'x', 'y', 'xOffset', 'yOffset', 'width', 'height'}) do
+   for v in values(array<str> { 'x', 'y', 'xOffset', 'yOffset', 'width', 'height'}) do
       if Options[v] then vw.viewport[v] = Options[v] end
    end
 

--- a/scripts/json.tiri
+++ b/scripts/json.tiri
@@ -8,8 +8,8 @@
 
    json = _LIB[_NS]
 
-   in_char  = array<string> { '\\', '"', '/', '\b', '\f', '\n', '\r', '\t' }
-   out_char = array<string> { '\\', '"', '/',  'b',  'f',  'n',  'r',  't' }
+   in_char  = array<str> { '\\', '"', '/', '\b', '\f', '\n', '\r', '\t' }
+   out_char = array<str> { '\\', '"', '/',  'b',  'f',  'n',  'r',  't' }
 
 local num_regex = regex.new([[^-?[0-9]+\.?[0-9]*[eE]?[+\-]?[0-9]*]])
 local rx_whitespace = regex.new("[^ \\t\\n\\r\\f\\v]")
@@ -100,7 +100,7 @@ json.encode = function(Value:any, ErrorCallback:func, AsKey:bool):str
    local kind = type(Value)
    ErrorCallback ?= error
    if kind is 'array' then
-      s = array<string>
+      s = array<str>
       if AsKey then
          ErrorCallback('Can\'t encode array as key.')
       else
@@ -113,7 +113,7 @@ json.encode = function(Value:any, ErrorCallback:func, AsKey:bool):str
       end
       return s.concat()
    elseif kind is 'table' then
-      s = array<string>
+      s = array<str>
       if AsKey then
          ErrorCallback('Can\'t encode table as key.')
       else

--- a/scripts/net/httpserver.tiri
+++ b/scripts/net/httpserver.tiri
@@ -1621,7 +1621,7 @@ function serverIncoming(self, ClientSocket)
       end
 
       -- Check if method is supported
-      supportedMethods = array<string> { 'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS' }
+      supportedMethods = array<str> { 'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS' }
       methodSupported = false
       for method in values(supportedMethods) do
          if state.request.method is method then

--- a/scripts/net/url.tiri
+++ b/scripts/net/url.tiri
@@ -59,7 +59,7 @@ url.encode = function(String:str, ExtraChars:str):str
    if ExtraChars then chars_to_encode ..= ExtraChars end
 
    -- Simple character-by-character encoding to avoid pattern issues
-   result = array<string>
+   result = array<str>
    for i in {0 to #String} do
       c = String.sub(i, i+1)
       if chars_to_encode.find(c, 0, true) then
@@ -213,7 +213,7 @@ end
 url.buildQuery = function(Params:any):str
    Params ?! return ''
 
-   parts = array<string>
+   parts = array<str>
 
    if type(Params) is 'array' then
       for param in values(Params) do
@@ -358,7 +358,7 @@ end
 url.unparse = function(Components:table):str
    Components ?! return ''
 
-   parts = array<string>
+   parts = array<str>
 
    if Components.scheme then parts.push(Components.scheme .. ':') end
 
@@ -413,7 +413,7 @@ end
 ]])
 url.unsplit = function(Components:table):str
    Components ?! return ''
-   parts = array<string>
+   parts = array<str>
    if Components.scheme then parts.push(Components.scheme .. ':') end
    if Components.netloc then parts.push('//' .. Components.netloc) end
    if Components.path then parts.push(Components.path) end
@@ -431,7 +431,7 @@ end
 ]])
 url._buildNetloc = function(Components:table!):str
    Components.host ?! return nil
-   netloc = array<string>
+   netloc = array<str>
    if Components.auth then netloc.push(Components.auth .. '@') end
    if Components.host.find(':') then
       netloc.push('[' .. Components.host .. ']')
@@ -534,7 +534,7 @@ end
 url.normalize = function(Path:str):str
    Path ?! return ''
 
-   segments = array<string>
+   segments = array<str>
    isAbsolute = Path.sub(0, 1) is '/'
 
    for start, stop, cap in rxPathSegment.findAll(Path) do

--- a/scripts/options.tiri
+++ b/scripts/options.tiri
@@ -78,8 +78,8 @@ rx_css_colour <const> = regex.new(
 ----------------------------------------------------------------------------------------------------------------------
 -- Build the canonical name and alias list for a parameter definition.
 
-function normalise_names(Definition:table!):array<string>
-   names = array<string>
+function normalise_names(Definition:table!):array<str>
+   names = array<str>
    seen = {}
 
    if Definition.name then
@@ -221,8 +221,8 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Convert an existing array or table into an array of strings.
 
-function string_array(Value:any!):array<string>
-   result = array<string>
+function string_array(Value:any!):array<str>
+   result = array<str>
 
    for item in values(Value) do
       result.push(tostring(item))
@@ -234,7 +234,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Convert a comma-separated string into an array of trimmed strings.
 
-function convert_csv(Value:any!, Param:table!):array<string>
+function convert_csv(Value:any!, Param:table!):array<str>
    if type(Value) is 'array' or type(Value) is 'table' then
       return string_array(Value)
    end
@@ -243,7 +243,7 @@ function convert_csv(Value:any!, Param:table!):array<string>
       raise ERR_WrongType, f"Parameter '{Param.name}' requires a comma-separated string."
    end
 
-   result = array<string>
+   result = array<str>
    for item in values(string.split(Value, ',')) do
       result.push(item.trim())
    end
@@ -254,7 +254,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Convert a raw value into an array of strings.
 
-function convert_array(Value:any!, Param:table!):array<string>
+function convert_array(Value:any!, Param:table!):array<str>
    if type(Value) is 'array' or type(Value) is 'table' then
       return string_array(Value)
    end
@@ -723,8 +723,8 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Remove launcher options and the script path from ordered task parameters.
 
-function get_script_arguments(Parameters:array<string>!):array<string>
-   result = array<string>
+function get_script_arguments(Parameters:array<str>!):array<str>
+   result = array<str>
    index = 0
    script_seen = false
 
@@ -757,7 +757,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Read ordered arguments from the active task, or return nil if they are unavailable.
 
-function get_task_parameters(Options:table):array<string>
+function get_task_parameters(Options:table):array<str>
    if Options and Options.taskParameters != nil then
       assert(type(Options.taskParameters) is 'array', 'Options.taskParameters must be an array.')
       return Options.taskParameters
@@ -776,7 +776,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Parse ordered command-line tokens, preserving the order of named and positional input.
 
-function parse_ordered_input(Parser:table!, Result:table!, ArgNames:table!, Presence:table!, Input:array<string>!)
+function parse_ordered_input(Parser:table!, Result:table!, ArgNames:table!, Presence:table!, Input:array<str>!)
    -- Parse one ordered command-line token and apply it to the result table.
 
    function parse_ordered_token(Parser:table!, Result:table!, ArgNames:table!, Presence:table!, Token:str!,
@@ -935,7 +935,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Join prepared text lines into one help string.
 
-function append_help_line(Output:array<string>, Line:str!)
+function append_help_line(Output:array<str>, Line:str!)
    if Line.trim() is '' then
       if #Output > 0 and Output[#Output - 1] != '' then
          Output.push('')
@@ -947,8 +947,8 @@ function append_help_line(Output:array<string>, Line:str!)
    Output.push(Line.rtrim())
 end
 
-function line_list(Lines:array<string>!):str
-   output = array<string>
+function line_list(Lines:array<str>!):str
+   output = array<str>
 
    for line in values(Lines) do
       text = tostring(line)
@@ -1056,7 +1056,7 @@ end
 -- Format default and required annotations for normal help.
 
 function param_annotations(Param:table!):str
-   annotations = array<string>
+   annotations = array<str>
 
    if Param.required then
       annotations.push('required')
@@ -1073,7 +1073,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Append parser metadata fields to help output.
 
-function append_metadata(Lines:array<string>!, Parser:table!)
+function append_metadata(Lines:array<str>!, Parser:table!)
    if Parser.epilog then
       Lines.push('')
       Lines.push(Parser.epilog)
@@ -1172,7 +1172,7 @@ end
 -- Generate normal parser help.
 
 function build_normal_help(Parser:table!):str
-   lines = array<string>
+   lines = array<str>
 
    lines.push(Parser.name)
    if Parser.description then
@@ -1183,7 +1183,7 @@ function build_normal_help(Parser:table!):str
    lines.push('')
    lines.push(build_usage(Parser))
 
-   groups = array<string>
+   groups = array<str>
    seen_groups = {}
 
    for param in values(Parser._params) do
@@ -1210,7 +1210,7 @@ function build_normal_help(Parser:table!):str
       end
    end
 
-   command_groups = array<string>
+   command_groups = array<str>
    seen_command_groups = {}
 
    for command in values(Parser._commands) do
@@ -1250,7 +1250,7 @@ function build_param_help(Parser:table!, Topic:str!):str
       raise ERR_ParameterUnknown, f"Unknown help topic '{Topic}'."
    end
 
-   lines = array<string>
+   lines = array<str>
 
    lines.push(f"{param.name}:")
    if param.comment then
@@ -1305,7 +1305,7 @@ function build_command_help(Parser:table!, Topic:str!):str
       raise ERR_ParameterUnknown, f"Unknown help topic '{Topic}'."
    end
 
-   lines = array<string>
+   lines = array<str>
 
    lines.push(f"{command.name}:")
    if command.comment then
@@ -1330,7 +1330,7 @@ function build_command_help(Parser:table!, Topic:str!):str
    end
 
    if #command._params > 0 then
-      groups = array<string>
+      groups = array<str>
       seen_groups = {}
 
       for param in values(command._params) do
@@ -1527,8 +1527,8 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Normalise a relationship field to an array of canonical parameter names.
 
-function relationship_names(Parser:table!, Param:table!, Field:str!, Value:any!):array<string>
-   names = array<string>
+function relationship_names(Parser:table!, Param:table!, Field:str!, Value:any!):array<str>
+   names = array<str>
 
    if type(Value) is 'string' then
       item = Parser._lookup[Value]
@@ -1872,7 +1872,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Parse a non-command parser context from explicit ordered input.
 
-function parse_context_ordered_input(Parser:table!, Input:array<string>!):table
+function parse_context_ordered_input(Parser:table!, Input:array<str>!):table
    input_result = {}
    input_arg_names = {}
    input_presence = {}
@@ -1932,9 +1932,9 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Parse ordered input for a parser that defines subcommands.
 
-function parse_command_ordered_input(Parser:table, Input:array<string>!):table
-   global_input = array<string>
-   command_input = array<string>
+function parse_command_ordered_input(Parser:table, Input:array<str>!):table
+   global_input = array<str>
+   command_input = array<str>
    command = nil
    index = 0
 
@@ -2408,7 +2408,7 @@ create_parser = function(Config:table):table
    API intended for tests and advanced callers: parse failures are returned as standard exception tables instead of
    being raised through the default failure path.
 
-   Input may be an array of command-line tokens such as `array<string> { 'scene.svg', 'verbose' }`, a table of keyed
+   Input may be an array of command-line tokens such as `array<str> { 'scene.svg', 'verbose' }`, a table of keyed
    values, or `nil`.  When `Input` is `nil`, parsing reads ordered arguments from the active task parameters after the
    script path.  Explicit arrays
    and tables bypass task input.  Named options use `name=value` syntax unless a default allows a bare option token.
@@ -2455,7 +2455,7 @@ create_parser = function(Config:table):table
    normal scripts: successful parses return the typed argument table, while parse failures are raised as normal Tiri
    errors after any configured `onError` recovery has been applied.
 
-   Input may be an array of command-line tokens such as `array<string> { 'scene.svg', 'verbose' }`, a table of keyed
+   Input may be an array of command-line tokens such as `array<str> { 'scene.svg', 'verbose' }`, a table of keyed
    values, or `nil`.  When `Input` is `nil`, parsing reads ordered arguments from the active task parameters after the
    script path.  Explicit arrays
    and tables bypass task input.  Named options use `name=value` syntax unless a default allows a bare option token.

--- a/scripts/tempus.tiri
+++ b/scripts/tempus.tiri
@@ -18,7 +18,7 @@ MIN_ZONE_YEAR <const> = 1601
 MAX_ZONE_YEAR <const> = 9999
 ZONE_PROBE_YEAR <const> = 2024
 
-TYPE_NAMES = array<string> {
+TYPE_NAMES = array<str> {
    'Instant',
    'Duration',
    'Offset',

--- a/src/backstage/interface.tiri
+++ b/src/backstage/interface.tiri
@@ -370,7 +370,7 @@ function path_to_regex(Route:table):str
    param_name = ''
    in_param = false
 
-   Route.params = array<string> { }
+   Route.params = array<str> { }
 
    for i in {0 to #Route.path} do
       ch = Route.path.sub(i, i + 1)
@@ -441,8 +441,8 @@ function bool_literal(Value:any):str
    return Value ? 'true' :> 'false'
 end
 
-function sorted_field_names(Fields:table):array<string>
-   names = array<string> { }
+function sorted_field_names(Fields:table):array<str>
+   names = array<str> { }
    if not Fields then return names end
 
    for name, _ in pairs(Fields) do
@@ -453,7 +453,7 @@ function sorted_field_names(Fields:table):array<string>
    return names
 end
 
-function route_param_array(Name:str, Names:array<string>, Fields:table):str
+function route_param_array(Name:str, Names:array<str>, Fields:table):str
    out = f"static constexpr std::array<BackstageParam, {#Names}> {Name} = {{"
 
    if #Names > 0 then
@@ -562,7 +562,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
    glIncludes = {}
-   glIncludeList = array<string> { }
+   glIncludeList = array<str> { }
    meta = ''
 
    for _, route in glRoutes do

--- a/src/backstage/tests/test_backstage.tiri
+++ b/src/backstage/tests/test_backstage.tiri
@@ -114,7 +114,7 @@ function websocket_frame(Payload:str, Opcode:num):str
    return frame
 end
 
-function websocket_exchange(Frames:array<string>, ExpectedTokens:array<string>):str
+function websocket_exchange(Frames:array<str>, ExpectedTokens:array<str>):str
    response = ''
    frames_sent = false
 
@@ -502,7 +502,7 @@ end
 
 @Test; @Requires(network=true)
 function StreamingHandshakeReturnsSwitchingProtocols()
-   response = websocket_exchange(array<string> { }, array<string> {
+   response = websocket_exchange(array<str> { }, array<str> {
       'HTTP/1.1 101 Switching Protocols',
       'Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=',
       '"type":"event"',
@@ -576,7 +576,7 @@ end
 @Test; @Requires(network=true)
 function StreamingSubscribesToSystemTopic()
    frame = websocket_frame('{"id":"1","type":"subscribe","topics":["system"]}', 0x01)
-   response = websocket_exchange(array<string> { frame }, array<string> {
+   response = websocket_exchange(array<str> { frame }, array<str> {
       '"type":"ack"',
       '"id":"1"',
       '"command":"subscribe"',
@@ -590,7 +590,7 @@ end
 @Test; @Requires(network=true)
 function StreamingSubscribesToLogStub()
    frame = websocket_frame('{"id":"2","type":"subscribe","topics":["log"]}', 0x01)
-   response = websocket_exchange(array<string> { frame }, array<string> {
+   response = websocket_exchange(array<str> { frame }, array<str> {
       '"type":"ack"',
       '"id":"2"',
       '"topic":"log"',
@@ -603,7 +603,7 @@ end
 @Test; @Requires(network=true)
 function StreamingUnknownTopicReturnsError()
    frame = websocket_frame('{"id":"3","type":"subscribe","topics":["unknown"]}', 0x01)
-   response = websocket_exchange(array<string> { frame }, array<string> {
+   response = websocket_exchange(array<str> { frame }, array<str> {
       '"type":"error"',
       '"id":"3"',
       '"code":"unknown_topic"'
@@ -615,7 +615,7 @@ end
 @Test; @Requires(network=true)
 function StreamingPingReceivesPong()
    frame = websocket_frame('hello', 0x09)
-   response = websocket_exchange(array<string> { frame }, array<string> {
+   response = websocket_exchange(array<str> { frame }, array<str> {
       'HTTP/1.1 101 Switching Protocols',
       'hello'
    })

--- a/src/document/tests/test_stream.tiri
+++ b/src/document/tests/test_stream.tiri
@@ -81,7 +81,7 @@ end
 @Test function WellFormed()
    -- For several .rpl files the output must parse cleanly as an XML document, proving it is well formed
    -- and the escape helper is correct.
-   files = array<string> { 'paragraphs.rpl', 'tables.rpl', 'lists.rpl', 'fonts.rpl', 'links.rpl' }
+   files = array<str> { 'paragraphs.rpl', 'tables.rpl', 'lists.rpl', 'fonts.rpl', 'links.rpl' }
    for path in values(files) do
       err, xml_str = loadXML(path)
       assert(err is ERR_Okay, 'ReadContent(DATA_XML) failed for ' .. path .. ', err=' .. err)

--- a/src/http/tests/test_server_middleware.tiri
+++ b/src/http/tests/test_server_middleware.tiri
@@ -16,19 +16,19 @@ SERVER_PORT <const> = 18947
 
    -- Create middleware functions
    function loggingMiddleware(req, res, next)
-      if not req.middlewareOrder then req.middlewareOrder = array<string> {} end
+      if not req.middlewareOrder then req.middlewareOrder = array<str> {} end
       req.middlewareOrder.push('logging')
       next()
    end
 
    function authMiddleware(req, res, next)
-      if not req.middlewareOrder then req.middlewareOrder = array<string> {} end
+      if not req.middlewareOrder then req.middlewareOrder = array<str> {} end
       req.middlewareOrder.push('auth')
       next()
    end
 
    function timingMiddleware(req, res, next)
-      if not req.middlewareOrder then req.middlewareOrder = array<string> {} end
+      if not req.middlewareOrder then req.middlewareOrder = array<str> {} end
       req.middlewareOrder.push('timing')
       next()
    end

--- a/src/image/tests/test_png.tiri
+++ b/src/image/tests/test_png.tiri
@@ -222,7 +222,7 @@ glValidPNG = array<table> {
    { src='data/z09n2c08.png', crc=0x33610a6e }
 }
 
-glInvalidPNG = array<string> {
+glInvalidPNG = array<str> {
    'data/xc1n0g08.png',
    'data/xc9n2c08.png',
    'data/xcrn0g04.png',
@@ -265,8 +265,8 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test global function ValidPNGHashes()
-   missing = array<string> { }
-   mismatches = array<string> { }
+   missing = array<str> { }
+   mismatches = array<str> { }
 
    for entry in values(glValidPNG) do
       local hash, bmp, pic
@@ -318,7 +318,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test global function InvalidPNGsFailToLoad()
-   failures = array<string> { }
+   failures = array<str> { }
 
    for entry in values(glInvalidPNG) do
       try

--- a/src/network/tests/test_client_server.tiri
+++ b/src/network/tests/test_client_server.tiri
@@ -28,7 +28,7 @@ end
 -- Test address validation and error handling
 
 @Test function StrToAddress()
-   invalidAddresses = array<string> {
+   invalidAddresses = array<str> {
       'gggg::1',           -- Invalid hex digits
       '1::2::3',           -- Double double-colon
       '1:2:3:4:5:6:7:8:9', -- Too many groups
@@ -40,7 +40,7 @@ end
       assert(mNet.StrToAddress(addr, dest) != ERR_Okay, 'StrToAddress should fail for invalid IPv6 address: ' .. addr)
    end
 
-   validAddresses = array<string> {
+   validAddresses = array<str> {
       '::1',                   -- Loopback
       '::',                    -- Any address
       '2001:db8::1',           -- Documentation prefix
@@ -272,7 +272,7 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test function ConnectionStates()
-   stateChanges = array<string> {}
+   stateChanges = array<str> {}
 
    glPort++
 

--- a/src/network/tests/test_concurrency.tiri
+++ b/src/network/tests/test_concurrency.tiri
@@ -21,8 +21,8 @@ unique messages to verify proper isolation and delivery.
    glActiveClients = 0
    glMaxSockets = 5
    glMessagesPerClient = 3
-   glClientResponses = array<string>
-   glServerReceived = array<string>
+   glClientResponses = array<str>
+   glServerReceived = array<str>
 
 @AfterAll function cleanup()
    glActiveClients = 0
@@ -217,13 +217,13 @@ end
 
 @Test function ConnectionIsolation()
    clientCount = 3
-   clientMessages = array<array<string>>
+   clientMessages = array<array<str>>
    messagesPerClient = 2
    glPort++
 
    -- Initialize expected messages
    for i in {0 to clientCount} do
-      clientMessages.push(array<string>)
+      clientMessages.push(array<str>)
       for j in {0 to messagesPerClient} do
          clientMessages[i].push(f'ISOLATED_CLIENT_{i}_MESSAGE_{j}')
       end

--- a/src/network/tests/test_dns_parallel.tiri
+++ b/src/network/tests/test_dns_parallel.tiri
@@ -5,7 +5,7 @@ Tests for resolving server names in parallel.
    include 'network'
    module network as mNet
 
-glDomains = array<string> { 'google.com', 'kotuku.dev', 'amazon.co.uk', 'stackoverflow.com', 'theguardian.com', 'www.bbc.co.uk' }
+glDomains = array<str> { 'google.com', 'kotuku.dev', 'amazon.co.uk', 'stackoverflow.com', 'theguardian.com', 'www.bbc.co.uk' }
 glTotalResolved = 0
 local proc, signal
 
@@ -68,7 +68,7 @@ end
 @Test; @Requires(network=true) function Duplication()
    resolved = 0
 
-   domains = array<string> { 'google.com', 'reddit.com' }
+   domains = array<str> { 'google.com', 'reddit.com' }
    function duplicate_resolved(NetLookup, Error)
       assert(Error is ERR_Okay, 'Failed to resolve ' .. NetLookup.hostName .. ', error ' ..mSys.GetErrorMsg(Error))
       logOutput('Resolved: ' .. NetLookup.hostName)

--- a/src/network/tests/test_error_handling.tiri
+++ b/src/network/tests/test_error_handling.tiri
@@ -34,7 +34,7 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test function ConnectionFailures()
-   results = array<string> {}
+   results = array<str> {}
    glPort++
 
    -- Test 1: Invalid IP address
@@ -101,7 +101,7 @@ end
    processing.halt(1.0) -- Allow time for async operations
 
    -- Verify error handling results
-   expected_results = array<string> { 'invalid_ip_rejected', 'closed_port_rejected', 'port_conflict_detected' }
+   expected_results = array<str> { 'invalid_ip_rejected', 'closed_port_rejected', 'port_conflict_detected' }
    for expected in values(expected_results) do
       found = false
       for result in values(results) do

--- a/src/network/tests/test_ssl.tiri
+++ b/src/network/tests/test_ssl.tiri
@@ -262,7 +262,7 @@ end
 
 @Test(priority=30); @Requires(ssl=true)
 function SSLDataIntegrity()
-   test_messages = array<string> {
+   test_messages = array<str> {
       'Binary data: ' .. string.char(0, 1, 2, 3, 255, 254, 253),
       'Large SSL message '.rep(500), -- ~9KB message
       'Special chars: àáâãäåæçèéêë',

--- a/src/svg/tests/test_defs_export.tiri
+++ b/src/svg/tests/test_defs_export.tiri
@@ -4,7 +4,7 @@
    include 'vector'
 
 local glSVGFolder
-glFiles = array<string>
+glFiles = array<str>
 
 @BeforeAll function setup(State:table)
    glSVGFolder = State.folder

--- a/src/svg/tests/test_diffusiongradient_roundtrip.tiri
+++ b/src/svg/tests/test_diffusiongradient_roundtrip.tiri
@@ -4,7 +4,7 @@
    include 'vector'
 
 local glSVGFolder
-local glFiles = array<string>
+local glFiles = array<str>
 
 @BeforeAll function setup(State: table)
    glSVGFolder = State.folder

--- a/src/svg/tests/test_meshgradient_roundtrip.tiri
+++ b/src/svg/tests/test_meshgradient_roundtrip.tiri
@@ -4,7 +4,7 @@
    include 'vector'
 
 local glSVGFolder
-local glFiles = array<string>
+local glFiles = array<str>
 
 @BeforeAll function setup(State:table)
    glSVGFolder = State.folder

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -47,7 +47,7 @@ constexpr auto HASH_INT16   = kt::strhash("int16");
 constexpr auto HASH_INT64   = kt::strhash("int64");
 constexpr auto HASH_FLOAT   = kt::strhash("float");
 constexpr auto HASH_DOUBLE  = kt::strhash("double");
-constexpr auto HASH_STRING  = kt::strhash("string");
+constexpr auto HASH_STR     = kt::strhash("str");
 constexpr auto HASH_STRUCT  = kt::strhash("struct");
 constexpr auto HASH_POINTER = kt::strhash("pointer");
 constexpr auto HASH_OBJECT  = kt::strhash("object");
@@ -150,7 +150,7 @@ static CSTRING elemtype_name(AET Type)
       case AET::OBJECT:     return "object";
       case AET::CSTR:
       case AET::STR_GC:
-      case AET::STR_CPP:    return "string";
+      case AET::STR_CPP:    return "str";
       case AET::ANY:        return "any";
       default: return "unknown";
    }
@@ -234,12 +234,12 @@ static void append_integer(std::string &Result, int64_t Value)
 }
 
 //********************************************************************************************************************
-// Usage: array.new(size, type) or array.new('string')
+// Usage: array.new(size, type) or array.new('str')
 //
 // Creates a new array of the specified size and element type.
 //
 //   size: number of elements (must be non-negative)
-//   type: element type string ("char", "int16", "int", "int64", "float", "double", "string", "StructName")
+//   type: element type string ("char", "int16", "int", "int64", "float", "double", "str", "StructName")
 
 LJLIB_CF(array_new)      LJLIB_REC(.)
 {
@@ -283,10 +283,10 @@ LJLIB_CF(array_new)      LJLIB_REC(.)
 //
 // Creates a new array populated with the given values.
 //
-//   type: element type string ("char", "int16", "int", "int64", "float", "double", "string")
+//   type: element type string ("char", "int16", "int", "int64", "float", "double", "str")
 //   value1, value2, ...: values to populate the array with
 //
-// Example: array.of('string', 'google.com', 'kotuku.dev', 'amazon.co.uk')
+// Example: array.of('str', 'google.com', 'kotuku.dev', 'amazon.co.uk')
 // Example: array.of('int', 1, 2, 3, 4, 5)
 
 LJLIB_CF(array_of)

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -569,7 +569,8 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          this->ctx.tokens().advance();
          Token member_token = this->ctx.tokens().current();
          auto name_token = this->ctx.expect_name(ParserErrorCode::ExpectedIdentifier);
-         if (not name_token.ok() or name_token.value_ref().span().offset != context_token.span().offset + 1) {
+         if (not name_token.ok() or name_token.value_ref().span().line != context_token.span().line or
+             name_token.value_ref().span().column != context_token.span().column + 1) {
             return this->fail<ExprNodePtr>(ParserErrorCode::ExpectedIdentifier, member_token,
                "expected a member name immediately after '&' context access");
          }

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -441,7 +441,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
          }
          else if (element_name IS "float") { field.Type = FD_FLOAT; field.NativeType = NativeStructType::Float; }
          else if (element_name IS "double") { field.Type = FD_DOUBLE; field.NativeType = NativeStructType::Double; }
-         else if (element_name IS "string") {
+         else if (element_name IS "str") {
             field.Type = FD_STRING; field.NativeType = NativeStructType::String;
          }
          else if (element_name.starts_with("struct<") and element_name.ends_with(">")) {

--- a/src/tiri/jit/src/parser/lexer.cpp
+++ b/src/tiri/jit/src/parser/lexer.cpp
@@ -739,9 +739,9 @@ bool fstring_scan_expression(LexState *State, size_t Offset, bool &NeedConcat) {
       LexState::BufferedToken bt;
       bt.token = tok;
       copyTV(State->L, &bt.value, &expr_tv);
-      bt.line = State->current_token_line;
-      bt.column = State->current_token_column;
-      bt.offset = State->current_token_offset;
+      bt.line = State->pending_token_line;
+      bt.column = State->pending_token_column;
+      bt.offset = State->pending_token_offset;
       State->buffered_tokens.push_back(bt);
    }
 

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -4727,7 +4727,7 @@ static bool test_static_descriptor_model(kt::Log &Log)
       { "int64", AET::INT64, TiriType::Num },
       { "float", AET::FLOAT, TiriType::Num },
       { "double", AET::DOUBLE, TiriType::Num },
-      { "string", AET::STR_GC, TiriType::Str },
+      { "str", AET::STR_GC, TiriType::Str },
       { "table", AET::TABLE, TiriType::Table },
       { "array", AET::ARRAY, TiriType::Array },
       { "object", AET::OBJECT, TiriType::Object },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -4104,6 +4104,19 @@ static bool test_contextual_member_ast_foundations(kt::Log &Log)
       }
    }
 
+   auto interpolated_context = build_ast_from_source("local value = f'{&name}'\n", false, false);
+   if (not interpolated_context.chunk.ok()) {
+      Log.error("ampersand-prefixed context access failed inside f-string interpolation");
+      log_diagnostics(interpolated_context.diagnostics, Log);
+      return false;
+   }
+
+   auto spaced_interpolated_context = build_ast_from_source("local value = f'{& name}'\n", false, false);
+   if (spaced_interpolated_context.diagnostics.empty()) {
+      Log.error("spaced ampersand-prefixed context access was accepted inside f-string interpolation");
+      return false;
+   }
+
    auto legacy_context = build_ast_from_source(".value = 1\n", false, false);
    if (legacy_context.diagnostics.empty()) {
       Log.error("leading-dot context access remained accepted after the prefix change");

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -87,7 +87,7 @@ std::string array_element_name(const ArrayElementDescriptor &Element)
       case AET::INT64:  name = "int64"; break;
       case AET::FLOAT:  name = "float"; break;
       case AET::DOUBLE: name = "double"; break;
-      case AET::STR_GC: name = "string"; break;
+      case AET::STR_GC: name = "str"; break;
       case AET::TABLE:  name = "table"; break;
       case AET::ARRAY:  name = "array"; break;
       case AET::OBJECT: name = "object"; break;
@@ -616,7 +616,7 @@ std::optional<ArrayElementDescriptor> describe_array_element(std::string_view Na
    else if (Name IS "int64") result = { AET::INT64, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "float") result = { AET::FLOAT, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "double") result = { AET::DOUBLE, TiriType::Num, CLASSID::NIL, nullptr, true };
-   else if (Name IS "string") result = { AET::STR_GC, TiriType::Str, CLASSID::NIL, nullptr, true };
+   else if (Name IS "str") result = { AET::STR_GC, TiriType::Str, CLASSID::NIL, nullptr, true };
    else if (Name IS "table") result = { AET::TABLE, TiriType::Table, CLASSID::NIL, nullptr, true };
    else if (Name IS "array") result = { AET::ARRAY, TiriType::Array, CLASSID::NIL, nullptr, true };
    else if (Name IS "object") result = { AET::OBJECT, TiriType::Object, CLASSID::NIL, nullptr, true };

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -782,7 +782,7 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
          case AET::DOUBLE: member = "double"; break;
          case AET::CSTR:
          case AET::STR_CPP:
-         case AET::STR_GC: member = "string"; break;
+         case AET::STR_GC: member = "str"; break;
          case AET::TABLE:  member = "table"; break;
          case AET::ARRAY:  member = "array"; break;
          case AET::PTR:    member = "pointer"; break;

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -14,7 +14,7 @@ end
    function identity_int64(Value:array<int64>):array<int64> return Value end
    function identity_float(Value:array<float>):array<float> return Value end
    function identity_double(Value:array<double>):array<double> return Value end
-   function identity_string(Value:array<string>):array<string> return Value end
+   function identity_string(Value:array<str>):array<str> return Value end
    function identity_table(Value:array<table>):array<table> return Value end
    function identity_array(Value:array<array>):array<array> return Value end
    function identity_object(Value:array<obj>):array<obj> return Value end
@@ -27,7 +27,7 @@ end
    assert(identity_int64(array<int64> {}) != nil, 'int64 binding identity should be accepted')
    assert(identity_float(array<float> {}) != nil, 'float binding identity should be accepted')
    assert(identity_double(array<double> {}) != nil, 'double binding identity should be accepted')
-   assert(identity_string(array<string> {}) != nil, 'string binding identity should be accepted')
+   assert(identity_string(array<str> {}) != nil, 'string binding identity should be accepted')
    assert(identity_table(array<table> {}) != nil, 'table binding identity should be accepted')
    assert(identity_array(array<array> {}) != nil, 'immediate nested-array identity should be accepted')
    assert(identity_object(array<obj> {}) != nil, 'object binding identity should be accepted')
@@ -162,7 +162,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function StringArray()
-   string_array = array<string, 3>
+   string_array = array<str, 3>
    string_array[0] = 'hello'
    string_array[1] = 'world'
    string_array[2] = '!'
@@ -583,8 +583,8 @@ end
    int_array = array<int> { 1, 2, 3 }
    assert(tostring(int_array) is 'array<int, 3>', "Integer array tostring() failed, got '" .. tostring(int_array) .. "'")
 
-   string_array = array<string> { 'hello', 'world' }
-   assert(tostring(string_array) is 'array<string, 2>', "String array tostring() failed, got '" .. tostring(string_array) .. "'")
+   string_array = array<str> { 'hello', 'world' }
+   assert(tostring(string_array) is 'array<str, 2>', "String array tostring() failed, got '" .. tostring(string_array) .. "'")
 
    empty_double_array = array<double, 0>
    assert(tostring(empty_double_array) is 'array<double, 0>',
@@ -637,10 +637,10 @@ end
    assert(byte_a is byte_b, 'Byte arrays with embedded NUL bytes should compare equal by raw memory')
    assert(byte_a != byte_c, 'Byte arrays with different raw bytes should not compare equal')
 
-   string_a = array<string> { 'hello', 'world' }
-   string_b = array<string> { 'hello', 'world' }
-   string_c = array<string> { 'hello', 'there' }
-   string_short = array<string> { 'hello' }
+   string_a = array<str> { 'hello', 'world' }
+   string_b = array<str> { 'hello', 'world' }
+   string_c = array<str> { 'hello', 'there' }
+   string_short = array<str> { 'hello' }
 
    assert(string_a is string_b, 'String arrays with identical contents should be equal')
    assert(string_a != string_c, 'String arrays with different contents should not be equal')
@@ -1306,10 +1306,10 @@ end
 -- Test array.of() functionality
 
 @Test function ArrayOfString()
-   arr = array<string> { 'google.com', 'kotuku.dev', 'amazon.co.uk' }
+   arr = array<str> { 'google.com', 'kotuku.dev', 'amazon.co.uk' }
 
    assert(#arr is 3, "array.of string should have length 3")
-   assert(arr.type() is 'string', "array.of string type should be 'string'")
+   assert(arr.type() is 'str', "array.of string type should be 'string'")
    assert(arr[0] is 'google.com', "arr[0] should be 'google.com'")
    assert(arr[1] is 'kotuku.dev', "arr[1] should be 'kotuku.dev'")
    assert(arr[2] is 'amazon.co.uk', "arr[2] should be 'amazon.co.uk'")
@@ -1394,7 +1394,7 @@ end
 end
 
 @Test function ArrayOfStringConcat()
-   arr = array<string> { 'hello', 'world', '!' }
+   arr = array<str> { 'hello', 'world', '!' }
 
    result = arr.concat(' ', '%s')
    assert(result is 'hello world !', "concat should produce 'hello world !', got '" .. result .. "'")
@@ -1487,9 +1487,9 @@ end
 @Test function ArrayOfStringWithTable()
    -- Tables cannot be converted to strings and should fail
    try
-      t = array<string> { 'hello', {}, 'world' }
+      t = array<str> { 'hello', {}, 'world' }
    success
-      error("array.of('string') with table value should fail")
+      error("array.of('str') with table value should fail")
    end
 end
 
@@ -1535,7 +1535,7 @@ end
 end
 
 @Test function ArrayIterationString()
-   arr = array<string> { 'a', 'b', 'c' }
+   arr = array<str> { 'a', 'b', 'c' }
    concat = ''
    for _, s in arr do
       concat ..= s
@@ -1649,32 +1649,32 @@ end
 -- Test array.concat() functionality
 
 @Test function ArrayConcatString()
-   arr = array<string> { 'hello', 'world', '!' }
+   arr = array<str> { 'hello', 'world', '!' }
    result = arr.concat(' ')
    assert(result is 'hello world !', "concat(' ') should produce 'hello world !', got '" .. result .. "'")
 end
 
 @Test function ArrayConcatStringComma()
-   arr = array<string> { 'apple', 'banana', 'cherry' }
+   arr = array<str> { 'apple', 'banana', 'cherry' }
    result = arr.concat(', ')
    assert(result is 'apple, banana, cherry', "concat(', ') failed, got '" .. result .. "'")
 end
 
 @Test function ArrayConcatStringEmpty()
-   arr = array<string> { 'a', 'b', 'c' }
+   arr = array<str> { 'a', 'b', 'c' }
    result = arr.concat('')
    assert(result is 'abc', "concat('') should concatenate without separator, got '" .. result .. "'")
 end
 
 @Test function ArrayConcatStringDefault()
-   arr = array<string> { 'one', 'two', 'three' }
+   arr = array<str> { 'one', 'two', 'three' }
    result = arr.concat()
    assert(result is 'onetwothree', "concat() with no separator should concatenate directly, got '" .. result .. "'")
 end
 
 @Test function ArrayConcatStringEmbeddedNul()
    nul = string.char(0)
-   arr = array<string> { 'a' .. nul .. 'b', 'c' }
+   arr = array<str> { 'a' .. nul .. 'b', 'c' }
    result = arr.concat('|')
    expected = 'a' .. nul .. 'b|c'
 
@@ -1684,7 +1684,7 @@ end
 
 @Test function ArrayConcatStringEmbeddedNulFormat()
    nul = string.char(0)
-   arr = array<string> { 'a' .. nul .. 'b', 'c' }
+   arr = array<str> { 'a' .. nul .. 'b', 'c' }
    result = arr.concat('|', '%s')
    expected = 'a' .. nul .. 'b|c'
 
@@ -1694,7 +1694,7 @@ end
 
 @Test function ArrayConcatStringNulSeparator()
    nul = string.char(0)
-   arr = array<string> { 'a', 'b' }
+   arr = array<str> { 'a', 'b' }
    result = arr.concat(nul)
    expected = 'a' .. nul .. 'b'
 
@@ -1715,7 +1715,7 @@ end
 end
 
 @Test function ArrayConcatRangeString()
-   arr = array<string> { 'a', 'b', 'c', 'd' }
+   arr = array<str> { 'a', 'b', 'c', 'd' }
    result = arr.concat(',', nil, 1, 2)
    assert(result is 'b,c', "concat with indexes 1 to 2 should return 'b,c', got '" .. result .. "'")
 end
@@ -1733,25 +1733,25 @@ end
 end
 
 @Test function ArrayConcatRangeSingleElement()
-   arr = array<string> { 'zero', 'one', 'two' }
+   arr = array<str> { 'zero', 'one', 'two' }
    result = arr.concat(', ', nil, 1, 1)
    assert(result is 'one', "single-element concat range should return only that element, got '" .. result .. "'")
 end
 
 @Test function ArrayConcatRangeEmptySpan()
-   arr = array<string> { 'zero', 'one', 'two' }
+   arr = array<str> { 'zero', 'one', 'two' }
    result = arr.concat(', ', nil, 2, 1)
    assert(result is '', "concat range with End before Start should return an empty string, got '" .. result .. "'")
 end
 
 @Test function ArrayConcatRangeOmittedIndexes()
-   arr = array<string> { 'a', 'b', 'c' }
+   arr = array<str> { 'a', 'b', 'c' }
    result = arr.concat(',')
    assert(result is 'a,b,c', "concat with omitted range should preserve full-array behaviour, got '" .. result .. "'")
 end
 
 @Test function ArrayConcatRangeInvalidIndexes()
-   arr = array<string> { 'a', 'b', 'c' }
+   arr = array<str> { 'a', 'b', 'c' }
 
    try
       arr.concat(',', nil, -1, 1)
@@ -1777,7 +1777,7 @@ end
       error('concat should reject End indexes beyond the array length')
    end
 
-   empty = array<string>
+   empty = array<str>
    try
       empty.concat(',', nil, 0, 0)
    success
@@ -1822,13 +1822,13 @@ end
 end
 
 @Test function ArrayConcatEmpty()
-   arr = array<string>
+   arr = array<str>
    result = arr.concat(', ')
    assert(result is '', "concat on empty array should return empty string, got '" .. result .. "'")
 end
 
 @Test function ArrayConcatSingle()
-   arr = array<string> { 'only' }
+   arr = array<str> { 'only' }
    result = arr.concat(', ')
    assert(result is 'only', "concat on single element should return just that element, got '" .. result .. "'")
 end
@@ -1848,7 +1848,7 @@ end
 end
 
 @Test function ArrayJoinRemoved()
-   arr = array<string> { 'a', 'b' }
+   arr = array<str> { 'a', 'b' }
    try
       arr.join(',')
    success
@@ -1887,7 +1887,7 @@ end
 end
 
 @Test function ArrayContainsString()
-   arr = array<string> { 'apple', 'banana', 'cherry' }
+   arr = array<str> { 'apple', 'banana', 'cherry' }
 
    assert(arr.contains('apple') is true, "contains('apple') should return true")
    assert(arr.contains('banana') is true, "contains('banana') should return true")
@@ -1898,7 +1898,7 @@ end
 end
 
 @Test function ArrayContainsStringEmpty()
-   arr = array<string> { '', 'nonempty' }
+   arr = array<str> { '', 'nonempty' }
 
    assert(arr.contains('') is true, "contains('') should find empty string if present")
    assert(arr.contains('nonempty') is true, "contains('nonempty') should return true")
@@ -1987,7 +1987,7 @@ end
 end
 
 @Test function ArrayInOperatorString()
-   arr = array<string> { 'apple', 'banana', 'cherry' }
+   arr = array<str> { 'apple', 'banana', 'cherry' }
    assert('banana' in arr, "'banana' should be in array")
    assert(not ('grape' in arr), "'grape' should not be in array")
    assert(not ('APPLE' in arr), "'APPLE' should not be in array (case-sensitive)")
@@ -1999,7 +1999,7 @@ end
 end
 
 @Test function ArrayInOperatorInCondition()
-   arr = array<string> { 'red', 'green', 'blue' }
+   arr = array<str> { 'red', 'green', 'blue' }
    found = false
    if 'green' in arr then
       found = true
@@ -2016,7 +2016,7 @@ end
 end
 
 @Test function ArrayFirstString()
-   arr = array<string> { 'alpha', 'beta', 'gamma' }
+   arr = array<str> { 'alpha', 'beta', 'gamma' }
    assert(arr.first() is 'alpha', "first() should return 'alpha'")
 end
 
@@ -2077,7 +2077,7 @@ end
 end
 
 @Test function ArrayLastString()
-   arr = array<string> { 'alpha', 'beta', 'gamma' }
+   arr = array<str> { 'alpha', 'beta', 'gamma' }
    assert(arr.last() is 'gamma', "last() should return 'gamma'")
 end
 
@@ -2131,7 +2131,7 @@ end
 
 @Test function ArrayFirstLastConsistency()
    -- For single element array, first() and last() should return same value
-   arr = array<string> { 'only' }
+   arr = array<str> { 'only' }
    assert(arr.first() is arr.last(), "first() and last() should be same for single element")
 end
 
@@ -2206,7 +2206,7 @@ end
 end
 
 @Test function ArrayPairsStrings()
-   str_arr = array<string> { 'a', 'b', 'c' }
+   str_arr = array<str> { 'a', 'b', 'c' }
    concat = ''
    for i, s in ipairs(str_arr) do
       concat ..= s
@@ -2222,7 +2222,7 @@ end
 @Test function JITStringArrayGCBarrier()
    -- Store freshly-allocated strings into an array in a hot loop, interleaving
    -- GC collection to trigger the write barrier while traces are active.
-   arr = array<string, 200>
+   arr = array<str, 200>
    for i in {0 to 200} do
       arr[i] = f"item-{i}"
    end
@@ -2271,7 +2271,7 @@ end
 @Test function JITStringArrayGCInterleaved()
    -- Interleave GC steps with stores in a hot loop to maximise the chance of
    -- the write barrier firing during incremental marking.
-   arr = array<string, 300>
+   arr = array<str, 300>
    for i in {0 to 300} do
       arr[i] = f"val-{i}"
       if i % 50 is 0 then
@@ -2303,7 +2303,7 @@ end
 
 @Test function JITStringArrayNilStoreGC()
    -- Verify nil stores (clearing slots) work correctly under GC pressure
-   arr = array<string, 100>
+   arr = array<str, 100>
    for i in {0 to 100} do
       arr[i] = f"temp-{i}"
    end
@@ -2347,7 +2347,7 @@ end
 @Test function JITStringArrayReadGCStress()
    -- Verify JIT-compiled reads of string arrays survive GC cycles.
    -- The read loop should compile to inline XLOAD with null-guard.
-   arr = array<string> { 'alpha', 'bravo', 'charlie', 'delta', 'echo' }
+   arr = array<str> { 'alpha', 'bravo', 'charlie', 'delta', 'echo' }
    for round in {0 to 100} do
       for i in {0 to 5} do
          s = arr[i]

--- a/src/tiri/tests/test_array_element_validation.tiri
+++ b/src/tiri/tests/test_array_element_validation.tiri
@@ -22,7 +22,7 @@ function expect_failure(Action:func, Description:str)
 end
 
 @Test function NumericStringsAreNeverElements()
-   local element_types = array<string> { 'byte', 'int16', 'int', 'int64', 'float', 'double' }
+   local element_types = array<str> { 'byte', 'int16', 'int', 'int64', 'float', 'double' }
 
    for _, element_type in element_types do
       local indexed = array.new(1, element_type)
@@ -49,14 +49,15 @@ end
 end
 
 @Test function StringArraysRejectNumbers()
-   local indexed = array<string, 1>
+   local indexed = array<str, 1>
    expect_failure(() => do indexed[0] = 12 end, 'String indexed store accepted a number')
    expect_failure(() => do indexed.push(12) end, 'String push accepted a number')
    expect_failure(() => do indexed.insert(0, 12) end, 'String insert accepted a number')
    expect_failure(() => do indexed.fill(12) end, 'String fill accepted a number')
-   expect_failure(() => do array.of('string', 12) end, 'String constructor accepted a number')
+   expect_failure(() => do array.of('str', 12) end, 'String constructor accepted a number')
    expect_failure(() => do indexed.copy({ [0]=12 }) end, 'String table copy accepted a number')
    expect_failure(() => do indexed.map(Value => num: 12) end, 'String map accepted a number')
+   expect_failure(() => do array.new(0, 'string') end, "Legacy 'string' element name was accepted")
 end
 
 @Test function ReferenceCategoriesAreExact()
@@ -81,7 +82,7 @@ end
 end
 
 @Test function NilUsesTheTypedEmptyValue()
-   local numeric_types = array<string> { 'byte', 'int16', 'int', 'int64', 'float', 'double' }
+   local numeric_types = array<str> { 'byte', 'int16', 'int', 'int64', 'float', 'double' }
    for _, element_type in numeric_types do
       local values = array.new(1, element_type)
       values[0] = 9
@@ -89,7 +90,7 @@ end
       assert(values[0] is 0, element_type .. ' nil store did not produce zero')
    end
 
-   local strings = array<string> { 'value' }
+   local strings = array<str> { 'value' }
    local tables = array<table> { {} }
    local arrays = array<array> { array<int> { 1 } }
    strings.fill(nil)

--- a/src/tiri/tests/test_array_functional.tiri
+++ b/src/tiri/tests/test_array_functional.tiri
@@ -22,7 +22,7 @@ end
 end
 
 @Test function EachReceivesIndexAsSecondArg()
-   arr = array<string> { 'a', 'b', 'c' }
+   arr = array<str> { 'a', 'b', 'c' }
    indexes = {}
    arr.each(function(v, i)
       indexes[#indexes] = i
@@ -40,7 +40,7 @@ end
 end
 
 @Test function EachWithStringArray()
-   arr = array<string> { 'hello', 'world' }
+   arr = array<str> { 'hello', 'world' }
    local values = {}
    arr.each(function(v, i)
       values[i] = v
@@ -107,7 +107,7 @@ end
 end
 
 @Test function MapStringArray()
-   arr = array<string> { 'hello', 'world' }
+   arr = array<str> { 'hello', 'world' }
    upper = arr.map(v => str: v.upper())
    assert(upper[0] is 'HELLO' and upper[1] is 'WORLD', "map() should work with string arrays")
 end
@@ -184,7 +184,7 @@ end
 end
 
 @Test function FilterStringArray()
-   arr = array<string> { 'apple', 'banana', 'apricot', 'cherry' }
+   arr = array<str> { 'apple', 'banana', 'apricot', 'cherry' }
    aWords = arr.filter(v => v.startsWith('a'))
    assert(#aWords is 2, "filter() should work with string arrays")
    assert(aWords[0] is 'apple' and aWords[1] is 'apricot', "filter() should return correct string matches")
@@ -232,7 +232,7 @@ end
 end
 
 @Test function ReduceWithInitialString()
-   arr = array<string> { 'a', 'b', 'c' }
+   arr = array<str> { 'a', 'b', 'c' }
    result = arr.reduce('', (acc, v) => acc .. v)
    assert(result is 'abc', "reduce() should work with string accumulator")
 end
@@ -303,7 +303,7 @@ end
 end
 
 @Test function AnyStringArray()
-   arr = array<string> { 'apple', 'banana', 'cherry' }
+   arr = array<str> { 'apple', 'banana', 'cherry' }
    hasLong = arr.any(v => #v > 5)
    assert(hasLong, "any() should work with string arrays")
 end
@@ -350,7 +350,7 @@ end
 end
 
 @Test function AllStringArray()
-   arr = array<string> { 'abc', 'def', 'ghi' }
+   arr = array<str> { 'abc', 'def', 'ghi' }
    allShort = arr.all(v => #v is 3)
    assert(allShort, "all() should work with string arrays")
 end

--- a/src/tiri/tests/test_array_manip.tiri
+++ b/src/tiri/tests/test_array_manip.tiri
@@ -123,7 +123,7 @@ end
 end
 
 @Test function ArrayPushString()
-   arr = array<string>
+   arr = array<str>
    arr.push('hello')
    arr.push('world')
    arr.push('!')
@@ -234,7 +234,7 @@ end
 end
 
 @Test function ArrayPopString()
-   arr = array<string> { 'hello', 'world', '!' }
+   arr = array<str> { 'hello', 'world', '!' }
    val = arr.pop()
    assert(val is '!', 'pop() should return !')
    assert(#arr is 2, 'Array length should be 2')
@@ -292,7 +292,7 @@ end
 end
 
 @Test function ArrayClearString()
-   arr = array<string> { 'hello', 'world' }
+   arr = array<str> { 'hello', 'world' }
    arr.clear()
    assert(#arr is 0, 'String array should be empty after clear')
 
@@ -449,7 +449,7 @@ end
 end
 
 @Test function ArrayInsertString()
-   arr = array<string> { 'a', 'c', 'd' }
+   arr = array<str> { 'a', 'c', 'd' }
    arr.insert(1, 'b')
    assert(#arr is 4, "String array length should be 4")
    assert(arr[0] is 'a', "arr[0] should be 'a'")
@@ -603,7 +603,7 @@ end
 end
 
 @Test function ArrayRemoveString()
-   arr = array<string> { 'a', 'b', 'c', 'd' }
+   arr = array<str> { 'a', 'b', 'c', 'd' }
    len = arr.remove(1)
    assert(len is 3, "remove(1) should return new length 3")
    assert(#arr is 3, "Array length should be 3")
@@ -670,7 +670,7 @@ end
 
 @Test function ArrayRemoveStringGC()
    -- Verify that removed strings can be garbage collected
-   arr = array<string> { 'alpha', 'beta', 'gamma', 'delta' }
+   arr = array<str> { 'alpha', 'beta', 'gamma', 'delta' }
    arr.remove(1, 2)  -- Remove 'beta' and 'gamma'
    assert(#arr is 2, "Array should have 2 elements")
    assert(arr[0] is 'alpha', "arr[0] should be 'alpha'")
@@ -725,7 +725,7 @@ end
 
 @Test function ArrayRemoveAllStringsGC()
    -- Remove all elements from a string array
-   arr = array<string> { 'one', 'two', 'three' }
+   arr = array<str> { 'one', 'two', 'three' }
    arr.remove(0, 3)
    assert(#arr is 0, "Array should be empty")
 
@@ -838,7 +838,7 @@ end
 end
 
 @Test function ArrayCloneString()
-   original = array<string> { 'hello', 'world', '!' }
+   original = array<str> { 'hello', 'world', '!' }
    copy = original.clone()
 
    assert(#copy is 3, "Clone should have same length")
@@ -977,9 +977,9 @@ end
    float_clone = float_arr.clone()
    assert(float_clone.type() is 'float', "Clone should preserve float type")
 
-   string_arr = array<string> { 'a', 'b' }
+   string_arr = array<str> { 'a', 'b' }
    string_clone = string_arr.clone()
-   assert(string_clone.type() is 'string', "Clone should preserve string type")
+   assert(string_clone.type() is 'str', "Clone should preserve string type")
 end
 
 @Test function ArrayCloneIndependence()
@@ -1225,7 +1225,7 @@ end
 end
 
 @Test function ArraySortComparatorString()
-   arr = array<string> { 'cherry', 'apple', 'banana' }
+   arr = array<str> { 'cherry', 'apple', 'banana' }
    arr.sort((a, b) => a < b)
 
    assert(arr[0] is 'apple', "comparator string arr[0] should be 'apple'")
@@ -1234,7 +1234,7 @@ end
 end
 
 @Test function ArraySortComparatorStringDescending()
-   arr = array<string> { 'cherry', 'apple', 'banana' }
+   arr = array<str> { 'cherry', 'apple', 'banana' }
    arr.sort((a, b) => a > b)
 
    assert(arr[0] is 'cherry', "comparator string desc arr[0] should be 'cherry'")
@@ -1343,7 +1343,7 @@ end
 
 @Test function ArraySortComparatorStringLength()
    -- Sort strings by length rather than lexicographic order
-   arr = array<string> { 'hi', 'hello', 'hey', 'h' }
+   arr = array<str> { 'hi', 'hello', 'hey', 'h' }
    arr.sort((a, b) => #a < #b)
 
    assert(arr[0] is 'h', "length sort arr[0] should be 'h'")

--- a/src/tiri/tests/test_array_typed_syntax.tiri
+++ b/src/tiri/tests/test_array_typed_syntax.tiri
@@ -19,9 +19,9 @@ end
 end
 
 @Test function ArrayTypedBasicString()
-   arr = array<string>
-   assert(#arr is 0, "Empty array<string> should have length 0")
-   assert(arr.type() is 'string', "Type should be 'string'")
+   arr = array<str>
+   assert(#arr is 0, "Empty array<str> should have length 0")
+   assert(arr.type() is 'str', "Type should be 'str'")
 end
 
 @Test function ArrayTypedBasicTable()
@@ -62,9 +62,9 @@ end
 end
 
 @Test function ArrayTypedWithSizeString()
-   arr = array<string, 10>
+   arr = array<str, 10>
    assert(#arr is 10, "Pre-allocated string array should have length 10")
-   assert(arr.type() is 'string', "Type should be 'string'")
+   assert(arr.type() is 'str', "Type should be 'str'")
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -87,7 +87,7 @@ end
 end
 
 @Test function ArrayTypedWithStringValues()
-   arr = array<string> { 'hello', 'world', 'test' }
+   arr = array<str> { 'hello', 'world', 'test' }
    assert(#arr is 3, "String array should have 3 elements")
    assert(arr[0] is 'hello', "First element should be 'hello'")
    assert(arr[1] is 'world', "Second element should be 'world'")
@@ -127,8 +127,8 @@ end
    double_arr = array<double>
    assert(double_arr.type() is 'double', "double should be 'double'")
 
-   string_arr = array<string>
-   assert(string_arr.type() is 'string', "string should be 'string'")
+   string_arr = array<str>
+   assert(string_arr.type() is 'str', "string should be 'string'")
 
    table_arr = array<table>
    assert(table_arr.type() is 'table', "table should be 'table'")
@@ -146,7 +146,7 @@ end
 
 @Test function ArrayTypedWhitespaceWithValues()
    -- Whitespace with initialiser
-   arr = array< string > { 'a', 'b', 'c' }
+   arr = array< str > { 'a', 'b', 'c' }
    assert(#arr is 3, "Whitespace with values should work")
    assert(arr[0] is 'a', "First element should be 'a'")
 end
@@ -400,7 +400,7 @@ end
    -- Array as table field
    data = {
       numbers = array<int> { 1, 2, 3 },
-      names = array<string> { 'a', 'b', 'c' }
+      names = array<str> { 'a', 'b', 'c' }
    }
    assert(#data.numbers is 3, "Nested int array should have 3 elements")
    assert(#data.names is 3, "Nested string array should have 3 elements")
@@ -460,7 +460,7 @@ end
    -- Multiple array declarations (separate statements)
    a = array<int, 3>
    b = array<double, 2>
-   c = array<string> { 'x' }
+   c = array<str> { 'x' }
 
    assert(#a is 3, "First array should have 3 elements")
    assert(#b is 2, "Second array should have 2 elements")
@@ -510,7 +510,7 @@ end
 
 @Test function ArrayTypedSizeLargerThanValuesString()
    -- Test with string type - padded elements should be nil
-   arr = array<string, 5> { 'hello', 'world' }
+   arr = array<str, 5> { 'hello', 'world' }
    assert(#arr is 5, "Array should have length 5, got " .. #arr)
    assert(arr[0] is 'hello', "First element should be 'hello'")
    assert(arr[1] is 'world', "Second element should be 'world'")
@@ -604,7 +604,7 @@ end
 
 @Test function ArrayResizeStringArray()
    -- Test array.resize() with string array
-   arr = array<string> { 'a', 'b' }
+   arr = array<str> { 'a', 'b' }
    array.resize(arr, 5)
    assert(#arr is 5, "Length should be 5")
    assert(arr[0] is 'a', "First element preserved")
@@ -685,7 +685,7 @@ end
 @Test function ArrayInitialiserConsecutiveFormattedStrings()
    -- Separator handling must not peek into the buffered tokens produced by an interpolated string.
    local port = 18952
-   local args = array<string> { f'url=http://127.0.0.1:{port}/echo', f'proxy=127.0.0.1:{port}', 'timeout=5' }
+   local args = array<str> { f'url=http://127.0.0.1:{port}/echo', f'proxy=127.0.0.1:{port}', 'timeout=5' }
    assert(#args is 3, "Formatted string values should yield 3 elements, got " .. #args)
    assert(args[0] is 'url=http://127.0.0.1:18952/echo', "First formatted string should parse intact")
    assert(args[1] is 'proxy=127.0.0.1:18952', "Second formatted string should parse intact")

--- a/src/tiri/tests/test_async.tiri
+++ b/src/tiri/tests/test_async.tiri
@@ -138,7 +138,7 @@ end
 -- Verify that async.pool supports reading and writing scalar values (number, string, boolean).
 
 @Test(priority=5) function PoolScalarReadWrite()
-   async.pool.reset()
+   async.pool.clear()
 
    async.pool.count = 42
    async.pool.name  = 'hello'
@@ -155,14 +155,14 @@ end
    -- Non-existent key returns nil
    assert(async.pool.nonexistent is nil, 'Expected nil for missing key')
 
-   async.pool.reset()
+   async.pool.clear()
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 -- Verify that storing an object in the pool stores its ID and reads back as a live object.
 
 @Test(priority=6) function PoolObjectStorage()
-   async.pool.reset()
+   async.pool.clear()
 
    signal = obj.new('time', { })
    expected_id = signal.id
@@ -173,14 +173,14 @@ end
    assert(result != nil, 'Expected object, got nil')
    assert(result.id is expected_id, f'Expected object ID {expected_id}, got {result.id}')
 
-   async.pool.reset()
+   async.pool.clear()
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 -- Verify that assigning nil to a pool key deletes it.
 
 @Test(priority=7) function PoolNilDeletion()
-   async.pool.reset()
+   async.pool.clear()
 
    async.pool.temp = 99
    assert(async.pool.temp is 99, 'Expected 99')
@@ -188,26 +188,25 @@ end
    async.pool.temp = nil
    assert(async.pool.temp is nil, 'Expected nil after deletion')
 
-   async.pool.reset()
+   async.pool.clear()
 end
 
 -----------------------------------------------------------------------------------------------------------------------
--- Verify that async.pool.reset() removes all entries.
+-- Verify that async.pool.clear() removes all entries through the __clear metamethod.
 
-@Test(priority=8) function PoolResetAndClear()
-   async.pool.reset()
+@Test(priority=8) function PoolClear()
+   async.pool.clear()
 
    async.pool.a = 1
    async.pool.b = 2
    async.pool.c = 3
 
-   async.pool.reset()
+   async.pool.clear()
 
-   assert(async.pool.a is nil, 'Expected nil after reset')
-   assert(async.pool.b is nil, 'Expected nil after reset')
-   assert(async.pool.c is nil, 'Expected nil after reset')
+   assert(async.pool.a is nil, 'Expected nil after clear')
+   assert(async.pool.b is nil, 'Expected nil after clear')
+   assert(async.pool.c is nil, 'Expected nil after clear')
 
-   local reset = async.pool.reset
    async.pool.a = 1
    async.pool.b = 2
 
@@ -215,14 +214,14 @@ end
 
    assert(async.pool.a is nil, 'Expected nil after clear')
    assert(async.pool.b is nil, 'Expected nil after clear')
-   assert(async.pool.reset is reset, 'async.pool.clear() should preserve async.pool.reset()')
+   assert(async.pool.reset is nil, 'async.pool.reset should no longer be exposed')
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 -- Verify that a worker thread can read and write the pool, and the main thread sees the results.
 
 @Test(priority=9) function PoolCrossThread()
-   async.pool.reset()
+   async.pool.clear()
    async.pool.input = 'from main'
 
    script = obj.new('tiri', { statement=[[
@@ -240,14 +239,14 @@ end
    assert(async.pool.output is 'from thread: from main',
       f'Expected "from thread: from main", got "{async.pool.output}"')
 
-   async.pool.reset()
+   async.pool.clear()
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 -- In this test the signals are sent from the threaded script rather than being managed by the main thread's callback.
 
 @Test(priority=10) function PoolBinaryValues()
-   async.pool.reset()
+   async.pool.clear()
 
    -- Store and retrieve a string value containing embedded NUL bytes
 
@@ -258,7 +257,7 @@ end
    assert(#result is #binary_val, f'Length mismatch: expected {#binary_val}, got {#result}')
    assert(result is binary_val, 'Binary value round-trip failed')
 
-   async.pool.reset()
+   async.pool.clear()
 end
 
 -----------------------------------------------------------------------------------------------------------------------
@@ -266,7 +265,7 @@ end
 -- This guards against a failed write permanently locking the shared mutex.
 
 @Test(priority=11) function PoolErrorRecovery()
-   async.pool.reset()
+   async.pool.clear()
    async.pool.before = 'ok'
 
    -- Run a script that attempts an invalid pool write (function value), which should raise an error.
@@ -291,7 +290,7 @@ end
    async.pool.after = 'still works'
    assert(async.pool.after is 'still works', f'Expected "still works", got "{async.pool.after}"')
 
-   async.pool.reset()
+   async.pool.clear()
 end
 
 -----------------------------------------------------------------------------------------------------------------------
@@ -391,7 +390,7 @@ end
 -- async.pool must reject unsupported value types (table, function) from the same thread.
 
 @Test(priority=18) function PoolRejectsUnsupportedTypes()
-   async.pool.reset()
+   async.pool.clear()
 
    for val in values({ { 1, 2, 3 }, function() end }) do
       rejected = false
@@ -407,14 +406,14 @@ end
    async.pool.ok = 'yes'
    assert(async.pool.ok is 'yes', 'Pool should still work after rejected writes')
 
-   async.pool.reset()
+   async.pool.clear()
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 -- Rapid overwrite of the same pool key from multiple threads to stress the locking.
 
 @Test(priority=19) function PoolConcurrentOverwrite()
-   async.pool.reset()
+   async.pool.clear()
 
    total = 20
    completed = 0
@@ -439,7 +438,7 @@ end
    assert(type(result) is 'number', f'Expected number, got {type(result)}')
    print(f'Concurrent overwrite completed. Final counter value: {result}')
 
-   async.pool.reset()
+   async.pool.clear()
 end
 
 -----------------------------------------------------------------------------------------------------------------------
@@ -577,7 +576,7 @@ end
 -- async.cancel() must not leave stale cancellation state after the worker finishes but before its message is processed.
 
 @Test(priority=26) function CancelCompletedWorkerAllowsNextAction()
-   async.pool.reset()
+   async.pool.clear()
    async.pool.completed_cancel_race = 0
 
    script = obj.new('tiri', {
@@ -600,7 +599,7 @@ end
    assert(count is 2, f'Expected second action to run after stale cancellation window, got {count}')
    assert(pending is 0, f'Expected 0 pending after stale cancellation window, got {pending}')
 
-   async.pool.reset()
+   async.pool.clear()
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_compound.tiri
+++ b/src/tiri/tests/test_compound.tiri
@@ -544,7 +544,7 @@ end
 end
 
 @Test function ArrayConcatAssignmentNonByteArrayPushesSingleConcatResult()
-   result = array<string>
+   result = array<str>
 
    result ..= 'a' .. 'b'
 

--- a/src/tiri/tests/test_contextual_member_calls.tiri
+++ b/src/tiri/tests/test_contextual_member_calls.tiri
@@ -38,6 +38,17 @@ module core as mCore
       'An extracted ordinary function should materialise its inherited context rather than capture its source entity')
 end
 
+@Test function FStringInterpolationSupportsContextAccess()
+   local receiver = entity { name = 'interpolated' }
+
+   function receiver.describe():str
+      return f'context: {&name}; explicit: {&&.name}'
+   end
+
+   assert(receiver.describe() is 'context: interpolated; explicit: interpolated',
+      'F-string interpolation should support shorthand and explicit current-context access')
+end
+
 @Test function NamedAndComputedTableCallsEstablishContext()
    local point = entity { name = 'point', value = 0 }
 

--- a/src/tiri/tests/test_contextual_member_calls.tiri
+++ b/src/tiri/tests/test_contextual_member_calls.tiri
@@ -661,7 +661,7 @@ end
    end
 
    local text:str = 'needle stack'
-   local values:array<any> = array<string> { 'needle' }
+   local values:array<any> = array<str> { 'needle' }
    local indexes:range = {0 to 3}
    assert(text.startsWith(context_argument('needle')) is true,
       'String member dispatch should retain its existing behaviour')

--- a/src/tiri/tests/test_global_types.tiri
+++ b/src/tiri/tests/test_global_types.tiri
@@ -46,7 +46,7 @@ end
    try
       exec([[
 if false then global glGTBootstrapArray:array<int> = array<int> { 1 } end
-local dynamic:any = array<string> { 'wrong' }
+local dynamic:any = array<str> { 'wrong' }
 glGTBootstrapArray = dynamic
 ]])
    except e
@@ -125,7 +125,7 @@ end
    end
 
    function redeclare_variant()
-      global glGTJitVariantOverride:array<any> = array<string> { 'open' }
+      global glGTJitVariantOverride:array<any> = array<str> { 'open' }
    end
 
    jit.on()
@@ -432,16 +432,16 @@ end
    writer(array<int> { 9 })
    assert(glGTMemberArray[0] is 9, 'A matching member identity should cross an environment alias')
    try
-      writer(array<string> { 'wrong' })
+      writer(array<str> { 'wrong' })
       error('A different array member identity should be rejected')
    except e
-      assert(e.message.find('expected array<int>') != nil and e.message.find('got array<string>') != nil,
+      assert(e.message.find('expected array<int>') != nil and e.message.find('got array<str>') != nil,
          'The global member diagnostic should include both array identities: ' .. e.message)
    end
    assert(glGTMemberArray[0] is 9, 'A rejected cross-chunk array store should preserve the previous value')
 
    exec([[global glGTWildcardArray:array<any> = array<int> { 1 }]])
-   exec([[global glGTWildcardArray:array<any> = array<string> { 'open' }]])
+   exec([[global glGTWildcardArray:array<any> = array<str> { 'open' }]])
    assert(glGTWildcardArray[0] is 'open', 'array<any> should remain an explicit global member wildcard')
 end
 

--- a/src/tiri/tests/test_if_empty_guard.tiri
+++ b/src/tiri/tests/test_if_empty_guard.tiri
@@ -42,7 +42,7 @@ end
    assert(describeString('') is 'empty', "Empty string should trigger shorthand return")
    assert(describeString('hello') is 'value:hello', "Non-empty string should pass the shorthand guard")
 
-   parts = array<string>
+   parts = array<str>
    runtime_empty = parts.concat()
    assert(describeString(runtime_empty) is 'empty', "Runtime empty string should trigger shorthand return")
 end
@@ -138,11 +138,11 @@ end
       visited = true
    end
 
-   empty = array<string>
+   empty = array<str>
    visitArray(empty)
    assert(visited is false, "Empty array should trigger bare shorthand return")
 
-   filled = array<string> { '' }
+   filled = array<str> { '' }
    visitArray(filled)
    assert(visited is true, "Array containing an empty string should not trigger shorthand return")
 end

--- a/src/tiri/tests/test_io.tiri
+++ b/src/tiri/tests/test_io.tiri
@@ -2,7 +2,7 @@
 -- Flute tests for the Lua IO library
 
 glTestFolder = 'temp:'
-glTestFiles = array<string>
+glTestFiles = array<str>
 
 @AfterAll function cleanup()
    for path in values(glTestFiles) do
@@ -337,7 +337,7 @@ end
 
    -- Test io.lines with filename
    line_count = 0
-   collected_lines = array<string>
+   collected_lines = array<str>
    for line in io.lines(test_path) do
       line_count++
       collected_lines.push(line)
@@ -367,7 +367,7 @@ end
    assert(file, 'Failed to open file for line iteration')
 
    line_count = 0
-   collected_lines = array<string>
+   collected_lines = array<str>
    for line in file.lines() do
       line_count++
       collected_lines.push(line)
@@ -612,7 +612,7 @@ end
    glTestFiles.push(test_path)
 
    -- Read it back and verify
-   lines_read = array<string>
+   lines_read = array<str>
    for line in io.lines(test_path) do
       lines_read.push(line)
    end

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -660,7 +660,7 @@ end
    jit.flush()
    jit.opt.start('hotloop=3', 'hotexit=1', 'minstitch=0')
 
-   local keys = array<string> { 'alpha', 'missing', 'bravo', 'missing' }
+   local keys = array<str> { 'alpha', 'missing', 'bravo', 'missing' }
    local mismatch = ''
    for iteration in {0 to 500} do
       local key = keys[iteration % #keys]
@@ -2775,17 +2775,17 @@ end
 
    local failed = false
    try
-      checked_member(array<string> { 'wrong' })
+      checked_member(array<str> { 'wrong' })
    except e
       failed = true
-      assert(e.message.find('expected array<int>') != nil and e.message.find('got array<string>') != nil,
+      assert(e.message.find('expected array<int>') != nil and e.message.find('got array<str>') != nil,
          'A hot member mismatch should report both array identities: ' .. e.message)
    end
    assert(failed, 'Changing only the array member type at a hot contract site should raise')
 end
 
 @Test(hotpath=50) function JITStringArrayBindingMemberContract()
-   function checked_string_member(Value:array<string>):str
+   function checked_string_member(Value:array<str>):str
       return Value[0]
    end
 
@@ -2793,7 +2793,7 @@ end
    jit.flush()
    jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
 
-   local strings = array<string> { 'kept' }
+   local strings = array<str> { 'kept' }
    for _ in {1 into 100} do
       assert(checked_string_member(strings) is 'kept', 'The hot string-array contract should pass')
    end
@@ -2804,7 +2804,7 @@ end
       checked_string_member(array<int> { 7 })
    except e
       failed = true
-      assert(e.message.find('expected array<string>') != nil and e.message.find('got array<int>') != nil,
+      assert(e.message.find('expected array<str>') != nil and e.message.find('got array<int>') != nil,
          'A hot string member mismatch should report both array identities: ' .. e.message)
    end
    assert(failed, 'A hot string-array contract should reject a numeric member type')

--- a/src/tiri/tests/test_options.tiri
+++ b/src/tiri/tests/test_options.tiri
@@ -76,7 +76,7 @@ end
 
 @Test function ConstructEmptyParser()
    parser = options({})
-   local args = parser.process(array<string> { })
+   local args = parser.process(array<str> { })
    assert(type(args) is 'table', 'Empty parser should process to a table')
 end
 
@@ -89,11 +89,11 @@ end
       license     = 'MIT',
       args = array<table> {
          { name = 'file', kind = 'option', type = 'file' },
-         { names = array<string> { 'verbose', 'v' }, kind = 'flag', type = 'bool' }
+         { names = array<str> { 'verbose', 'v' }, kind = 'flag', type = 'bool' }
       }
    })
 
-   local args = parser.process(array<string> { 'file=scene.svg', 'v' })
+   local args = parser.process(array<str> { 'file=scene.svg', 'v' })
    assert(args.file is 'scene.svg', 'Named option should parse')
    assert(args.verbose is true, 'Flag alias should parse')
    assert(parser.getParam('verbose').name is 'verbose', 'Canonical parameter lookup should work')
@@ -136,8 +136,8 @@ end
    try
       options({
          args = array<table> {
-            { names = array<string> { 'file', 'f' } },
-            { names = array<string> { 'folder', 'f' } }
+            { names = array<str> { 'file', 'f' } },
+            { names = array<str> { 'folder', 'f' } }
          }
       })
    except e
@@ -151,7 +151,7 @@ end
 
 @Test function DuplicateAliasesWithinDefinitionFail()
    try
-      options({ args = array<table> { { names = array<string> { 'file', 'file' } } } })
+      options({ args = array<table> { { names = array<str> { 'file', 'file' } } } })
    except e
       assert(tostring(e.message).find("Duplicate parameter name or alias 'file'"),
          'Duplicate aliases inside one definition should be reported')
@@ -165,7 +165,7 @@ end
    parser = options({ args = array<table> { { name = 'file' } } })
 
    try
-      parser.addParam({ names = array<string> { 'folder', 'file' } })
+      parser.addParam({ names = array<str> { 'folder', 'file' } })
    except e
       assert(tostring(e.message).find("Duplicate parameter name or alias 'file'"),
          'Duplicate addParam() diagnostic should be reported')
@@ -183,9 +183,9 @@ end
       }
    })
 
-   expect_error(parser, array<string> { }, ERR_ParameterRequired, "Required parameter 'output' is missing.")
+   expect_error(parser, array<str> { }, ERR_ParameterRequired, "Required parameter 'output' is missing.")
 
-   local args = parser.process(array<string> { 'output=build/result.txt' })
+   local args = parser.process(array<str> { 'output=build/result.txt' })
    assert(args.count is 7, 'String defaults should be converted')
    assert(args.output is 'build/result.txt', 'Required option should parse')
 end
@@ -199,12 +199,12 @@ end
       }
    })
 
-   local args:table = parser.process(array<string> { })
+   local args:table = parser.process(array<str> { })
    assert(args.enabled is false, 'False default should be applied')
    assert(args.count is 0, 'Zero default should be applied')
    assert(args.label is '', 'Empty string default should be applied')
 
-   args = parser.process(array<string> { 'enabled' })
+   args = parser.process(array<str> { 'enabled' })
    assert(args.enabled is false, 'Bare option should use a false default when one exists')
 end
 
@@ -216,9 +216,9 @@ end
       }
    })
 
-   expect_error(parser, array<string> { 'enabled' }, ERR_Syntax, "Parameter 'enabled' requires name=value syntax.")
+   expect_error(parser, array<str> { 'enabled' }, ERR_Syntax, "Parameter 'enabled' requires name=value syntax.")
 
-   local args = parser.process(array<string> { 'enabled=true', 'mode' })
+   local args = parser.process(array<str> { 'enabled=true', 'mode' })
    assert(args.enabled is true, 'Boolean option should accept explicit values')
    assert(args.mode is 'auto', 'Bare option should use its default when one exists')
 end
@@ -226,38 +226,38 @@ end
 @Test function FlagSyntax()
    parser = options({
       args = array<table> {
-         { names = array<string> { 'verbose', 'v' }, kind = 'flag', type = 'bool', default = false },
+         { names = array<str> { 'verbose', 'v' }, kind = 'flag', type = 'bool', default = false },
          { name = 'dry-run', kind = 'flag', type = 'bool' },
          { name = 'browser', kind = 'flag', default = true }
       }
    })
 
-   local args:table = parser.process(array<string> { 'verbose', 'no-dry-run' })
+   local args:table = parser.process(array<str> { 'verbose', 'no-dry-run' })
    assert(args.verbose is true, 'Bare flag should parse as true')
    assert(args['dry-run'] is false, 'no- flag should parse as false')
    assert(args.browser is true, 'Flag default should convert to a boolean when type is omitted')
 
-   args = parser.process(array<string> { 'v=0' })
+   args = parser.process(array<str> { 'v=0' })
    assert(args.verbose is false, 'Explicit flag values should use boolean conversion')
 
-   args = parser.process(array<string> { 'no-browser' })
+   args = parser.process(array<str> { 'no-browser' })
    assert(args.browser is false, 'no- flag should parse as false when type is omitted')
 end
 
 @Test function NegationOnlyAppliesToFlags()
    parser = options({ args = array<table> { { name = 'feature' } } })
-   expect_error(parser, array<string> { 'no-feature' }, ERR_Args,
+   expect_error(parser, array<str> { 'no-feature' }, ERR_Args,
       "Parameter 'feature' is not a flag and cannot use no- negation.")
 end
 
 @Test function UnknownParametersRespectStrictMode()
    strict_parser = options({ args = array<table> { { name = 'file' } } })
-   err = expect_error(strict_parser, array<string> { 'extra=value' }, ERR_ParameterUnknown,
+   err = expect_error(strict_parser, array<str> { 'extra=value' }, ERR_ParameterUnknown,
       "Unknown parameter 'extra'.")
    assert(err.message.find('stack traceback') is nil, 'Unknown named parameters should not include a stack trace')
 
    loose_parser = options({ strict = false, args = array<table> { { name = 'file', default = 'fallback.txt' } } })
-   args = loose_parser.process(array<string> { 'extra=value' })
+   args = loose_parser.process(array<str> { 'extra=value' })
    assert(args.file is 'fallback.txt', 'strict=false should ignore unknown named input')
 end
 
@@ -274,7 +274,7 @@ end
       }
    })
 
-   args = parser.process(array<string> {
+   args = parser.process(array<str> {
       'title=hello',
       'ratio=2.5',
       'count=4',
@@ -292,8 +292,8 @@ end
    assert(args.file is 'scene.svg', 'File converter failed')
    assert(args.folder is 'examples', 'Folder converter failed')
 
-   expect_error(parser, array<string> { 'count=4.5' }, ERR_WrongType, "Parameter 'count' requires an integer.")
-   expect_error(parser, array<string> { 'enabled=maybe' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'count=4.5' }, ERR_WrongType, "Parameter 'count' requires an integer.")
+   expect_error(parser, array<str> { 'enabled=maybe' }, ERR_WrongType,
       "Parameter 'enabled' requires a boolean value.")
 end
 
@@ -317,10 +317,10 @@ end
       }
    })
 
-   args = parser.process(array<string> { 'label=value' })
+   args = parser.process(array<str> { 'label=value' })
    assert(args.label is 'custom:value', 'Custom converter should transform values')
 
-   err = expect_error(parser, array<string> { 'fail=value' }, ERR_Exception, 'custom failure')
+   err = expect_error(parser, array<str> { 'fail=value' }, ERR_Exception, 'custom failure')
    assert(err.message.find('custom failure'), 'Thrown converter errors should be returned by tryProcess()')
 end
 
@@ -332,7 +332,7 @@ end
       error(Error)
    end
 
-   args, err = parser.tryProcess(array<string> { 'unknown=value' })
+   args, err = parser.tryProcess(array<str> { 'unknown=value' })
    assert(args is nil, 'tryProcess() should return nil on parse failure')
    assert(err.code is ERR_ParameterUnknown, 'tryProcess() should return the parse error')
    assert(called is false, 'tryProcess() must not invoke parser.error()')
@@ -346,7 +346,7 @@ end
       error(Error)
    end
 
-   args = parser.process(array<string> { 'file=scene.svg' })
+   args = parser.process(array<str> { 'file=scene.svg' })
    assert(args.file is 'scene.svg', 'process() should return parsed arguments')
    assert(called is false, 'process() should not call parser.error() on success')
 end
@@ -372,7 +372,7 @@ end
       }
    })
 
-   args = parser.process(array<string> { 'scene.svg', 'output=preview.png' })
+   args = parser.process(array<str> { 'scene.svg', 'output=preview.png' })
    assert(args.input is 'scene.svg', 'First positional should parse in declaration order')
    assert(args.output is 'preview.png', 'Named option should parse alongside positional input')
 end
@@ -384,8 +384,8 @@ end
       }
    })
 
-   args = parser.process(array<string> { 'explicit.svg' }, {
-      taskParameters = array<string> { 'tools/flute.tiri', 'task.svg' }
+   args = parser.process(array<str> { 'explicit.svg' }, {
+      taskParameters = array<str> { 'tools/flute.tiri', 'task.svg' }
    })
 
    assert(args.input is 'explicit.svg', 'Explicit input should take precedence over task parameters')
@@ -401,7 +401,7 @@ end
    })
 
    args = parser.process(nil, {
-      taskParameters = array<string> {
+      taskParameters = array<str> {
          '--log-warning',
          '--set-volume',
          'scripts=E:/kotuku/scripts',
@@ -432,7 +432,7 @@ end
       }
    })
 
-   local args = parser.process(array<string> { 'tag=1', 'tag=2' })
+   local args = parser.process(array<str> { 'tag=1', 'tag=2' })
    assert(type(args.tag) is 'array', 'Repeated values should produce an array')
    assert(#args.tag is 2, 'Repeated values should preserve every occurrence')
    assert(args.tag[0] is 1, 'First repeated value should be converted')
@@ -443,11 +443,11 @@ end
    parser = options({
       args = array<table> {
          { name = 'single', type = 'int', multiple = true, default = '5' },
-         { name = 'many', type = 'int', multiple = true, default = array<string> { '1', '2' } }
+         { name = 'many', type = 'int', multiple = true, default = array<str> { '1', '2' } }
       }
    })
 
-   local args = parser.process(array<string> { })
+   local args = parser.process(array<str> { })
    assert(type(args.single) is 'array', 'Scalar multiple default should be wrapped in an array')
    assert(#args.single is 1, 'Scalar multiple default should produce one value')
    assert(args.single[0] is 5, 'Scalar multiple default should be converted')
@@ -462,7 +462,7 @@ end
       }
    })
 
-   local args = parser.process({ tag = array<string> { '3', '4' } })
+   local args = parser.process({ tag = array<str> { '3', '4' } })
    assert(#args.tag is 2, 'Programmatic array input should be treated as repeated values')
    assert(args.tag[0] is 3 and args.tag[1] is 4, 'Programmatic repeated values should be converted')
 end
@@ -475,7 +475,7 @@ end
       }
    })
 
-   args = parser.process(array<string> { 'scene.svg', 'one', 'two' })
+   args = parser.process(array<str> { 'scene.svg', 'one', 'two' })
    assert(args.input is 'scene.svg', 'Leading positional should receive the first value')
    assert(type(args.rest) is 'array', 'Variadic positional should produce an array')
    assert(#args.rest is 2, 'Variadic positional should consume remaining values')
@@ -507,7 +507,7 @@ end
       }
    })
 
-   err = expect_error(strict_parser, array<string> { 'scene.svg', 'extra.svg' }, ERR_ParameterUnknown,
+   err = expect_error(strict_parser, array<str> { 'scene.svg', 'extra.svg' }, ERR_ParameterUnknown,
       "Unknown parameter 'extra.svg'.")
    assert(err.message.find('stack traceback') is nil, 'Unknown positional parameters should not include a stack trace')
 
@@ -518,7 +518,7 @@ end
       }
    })
 
-   args = loose_parser.process(array<string> { 'scene.svg', 'extra.svg' })
+   args = loose_parser.process(array<str> { 'scene.svg', 'extra.svg' })
    assert(args.input is 'scene.svg', 'strict=false should ignore extra ordered tokens')
 end
 
@@ -531,18 +531,18 @@ end
       }
    })
 
-   args = parser.process(array<string> { })
+   args = parser.process(array<str> { })
    assert(args.count is 2, 'Parser defaults should override parameter defaults')
    assert(args.mode is 'parser', 'Parser string defaults should apply')
 
    returned = parser.setDefaults({ count = '3' })
    assert(returned is parser, 'setDefaults() should return the parser')
 
-   args = parser.process(array<string> { })
+   args = parser.process(array<str> { })
    assert(args.count is 3, 'setDefaults() should override parser defaults')
    assert(args.mode is 'parser', 'Parser defaults should remain below the setDefaults layer')
 
-   args = parser.process(array<string> { 'count=4' })
+   args = parser.process(array<str> { 'count=4' })
    assert(args.count is 4, 'Explicit input should override every default layer')
 end
 
@@ -556,12 +556,12 @@ end
       envPrefix = 'KOTUKU_OPTIONS_STAGE3',
       args = array<table> {
          { name = 'file', type = 'file', required = true },
-         { names = array<string> { 'verbose', 'v' }, kind = 'flag', type = 'bool' },
+         { names = array<str> { 'verbose', 'v' }, kind = 'flag', type = 'bool' },
          { name = 'dryRun', kind = 'flag', type = 'bool' }
       }
    })
 
-   args = parser.process(array<string> { })
+   args = parser.process(array<str> { })
    assert(args.file is 'scene.svg', 'Environment values should satisfy required parameters')
    assert(args.verbose is true, 'Environment values should be converted')
    assert(args.dryRun is true, 'Camel-case names should be converted to upper snake-case environment names')
@@ -584,10 +584,10 @@ end
    })
    parser.setDefaults({ count = '3' })
 
-   args = parser.process(array<string> { })
+   args = parser.process(array<str> { })
    assert(args.count is 4, 'Environment values should override all default layers')
 
-   args = parser.process(array<string> { 'count=5' })
+   args = parser.process(array<str> { 'count=5' })
    assert(args.count is 5, 'Input values should override environment values')
 
    set_test_env('KOTUKU_OPTIONS_PRECEDENCE_COUNT', nil)
@@ -607,14 +607,14 @@ end
       }
    })
 
-   args = parser.process(array<string> { })
+   args = parser.process(array<str> { })
    assert(args.config is config_path, 'Injected config parameter should report the selected path')
    assert(args.count is 12, 'JSON config should satisfy required parameters')
    assert(args.mode is 'json', 'JSON config should supply string defaults')
    assert(args.verbose is true, 'JSON config defaults should be converted')
 
    args, err = parser.tryProcess(nil, {
-      taskParameters = array<string> { '--log-warning', 'demo.tiri' }
+      taskParameters = array<str> { '--log-warning', 'demo.tiri' }
    })
    assert(err is nil, 'Empty task parameters should use a loaded user config instead of failing')
    assert(args.help is nil, 'Loaded user config should suppress automatic help')
@@ -641,7 +641,7 @@ end
       }
    })
 
-   args = parser.process(array<string> { 'config=' .. override_path })
+   args = parser.process(array<str> { 'config=' .. override_path })
    assert(args.config is override_path, 'Explicit config path should override userConfig')
    assert(args.count is 2, 'Explicit config path should load the selected JSON file')
 
@@ -652,7 +652,7 @@ end
       }
    })
 
-   args = missing_parser.process(array<string> { })
+   args = missing_parser.process(array<str> { })
    assert(args.config is missing_path, 'Missing config path should remain visible as the selected config value')
    assert(args.count is 7, 'Missing user config files should be skipped without changing defaults')
 
@@ -678,12 +678,12 @@ end
    })
    parser.setDefaults({ config = set_path, count = '4' })
 
-   args = parser.process(array<string> { })
+   args = parser.process(array<str> { })
    assert(args.config is set_path, 'setDefaults() should be able to select the user config path')
    assert(args.count is 4, 'setDefaults() should override JSON config defaults')
    assert(args.mode is 'set-config', 'JSON selected by setDefaults().config should still provide lower defaults')
 
-   args = parser.process(array<string> { 'count=5' })
+   args = parser.process(array<str> { 'count=5' })
    assert(args.count is 5, 'Explicit input should override JSON and setDefaults() values')
    assert(args.mode is 'set-config', 'Explicit input should not discard unrelated JSON defaults')
 
@@ -716,9 +716,9 @@ end
          { name = 'count', type = 'int' }
       }
    })
-   expect_error(bad_json_parser, array<string> { }, ERR_WrongType, 'requires valid JSON')
+   expect_error(bad_json_parser, array<str> { }, ERR_WrongType, 'requires valid JSON')
    result, err = bad_json_parser.tryProcess(nil, {
-      taskParameters = array<string> { '--log-warning', 'demo.tiri' }
+      taskParameters = array<str> { '--log-warning', 'demo.tiri' }
    })
    assert(result is nil, 'Invalid selected user config should not return automatic help')
    assert(err.code is ERR_WrongType, 'Invalid selected user config should report the config parse error')
@@ -729,7 +729,7 @@ end
          { name = 'count', type = 'int' }
       }
    })
-   expect_error(array_json_parser, array<string> { }, ERR_WrongType, 'requires a JSON object')
+   expect_error(array_json_parser, array<str> { }, ERR_WrongType, 'requires a JSON object')
 
    folder_parser = options({
       userConfig = 'temp:',
@@ -737,7 +737,7 @@ end
          { name = 'count', type = 'int' }
       }
    })
-   expect_error(folder_parser, array<string> { }, ERR_ExpectedFile, "User config path 'temp:' is not a file.")
+   expect_error(folder_parser, array<str> { }, ERR_ExpectedFile, "User config path 'temp:' is not a file.")
 
    help_parser = options({
       name = 'user-config-help',
@@ -747,7 +747,7 @@ end
       }
    })
 
-   result, err = help_parser.tryProcess(array<string> { 'help' })
+   result, err = help_parser.tryProcess(array<str> { 'help' })
    assert(err is nil, 'Help requests should not load invalid user config files')
    assert(result.help is true, 'Help should still be returned for parsers with userConfig')
    assert(result.text.find('Usage: user-config-help'), 'Help should include the parser usage text')
@@ -762,7 +762,7 @@ end
    })
 
    result, err = missing_required_parser.tryProcess(nil, {
-      taskParameters = array<string> { '--log-warning', 'demo.tiri' }
+      taskParameters = array<str> { '--log-warning', 'demo.tiri' }
    })
    assert(err is nil, 'Empty task parameters with incomplete user config should still return help')
    assert(result.help is true, 'Incomplete user config should not suppress automatic help')
@@ -783,9 +783,9 @@ end
       }
    })
 
-   args = env_parser.process(array<string> { 'count=3' })
+   args = env_parser.process(array<str> { 'count=3' })
    assert(args.count is 3, 'Explicit input should override an invalid environment value before conversion')
-   expect_error(env_parser, array<string> { }, ERR_WrongType, "Parameter 'count' requires an integer.")
+   expect_error(env_parser, array<str> { }, ERR_WrongType, "Parameter 'count' requires an integer.")
 
    default_parser = options({
       defaults = { count = 'bad' },
@@ -794,9 +794,9 @@ end
       }
    })
 
-   args = default_parser.process(array<string> { 'count=4' })
+   args = default_parser.process(array<str> { 'count=4' })
    assert(args.count is 4, 'Explicit input should override an invalid default before conversion')
-   expect_error(default_parser, array<string> { }, ERR_WrongType, "Parameter 'count' requires an integer.")
+   expect_error(default_parser, array<str> { }, ERR_WrongType, "Parameter 'count' requires an integer.")
 
    set_test_env('KOTUKU_OPTIONS_BAD_COUNT', nil)
 end
@@ -804,17 +804,17 @@ end
 @Test function ChoicesEnumAndPatternValidation()
    parser = options({
       args = array<table> {
-         { name = 'mode', type = 'enum', choices = array<string> { 'fast', 'slow' } },
+         { name = 'mode', type = 'enum', choices = array<str> { 'fast', 'slow' } },
          { name = 'tag', type = 'str', pattern = regex.new('^[a-z][a-z0-9_]+$') }
       }
    })
 
-   args = parser.process(array<string> { 'mode=fast', 'tag=build_1' })
+   args = parser.process(array<str> { 'mode=fast', 'tag=build_1' })
    assert(args.mode is 'fast', 'Enum values should parse as strings')
    assert(args.tag is 'build_1', 'Pattern-matching values should parse')
 
-   expect_error(parser, array<string> { 'mode=medium' }, ERR_Args, "Parameter 'mode' must be one of: fast, slow.")
-   expect_error(parser, array<string> { 'tag=1_bad' }, ERR_Args, "Parameter 'tag' does not match the required pattern.")
+   expect_error(parser, array<str> { 'mode=medium' }, ERR_Args, "Parameter 'mode' must be one of: fast, slow.")
+   expect_error(parser, array<str> { 'tag=1_bad' }, ERR_Args, "Parameter 'tag' does not match the required pattern.")
 
    try
       options({ args = array<table> { { name = 'bad', type = 'enum' } } })
@@ -835,7 +835,7 @@ end
       }
    })
 
-   args = parser.process(array<string> {
+   args = parser.process(array<str> {
       'path=sdk:scripts/options.tiri',
       'file=sdk:scripts/options.tiri',
       'folder=sdk:scripts'
@@ -844,9 +844,9 @@ end
    assert(args.file is 'sdk:scripts/options.tiri', 'Existing file should parse')
    assert(args.folder is 'sdk:scripts', 'Existing folder should parse')
 
-   expect_error(parser, array<string> { 'path=does-not-exist' }, ERR_FileNotFound, "does not exist")
-   expect_error(parser, array<string> { 'file=sdk:scripts' }, ERR_ExpectedFile, "is not a file")
-   expect_error(parser, array<string> { 'folder=sdk:scripts/options.tiri' }, ERR_ExpectedFolder, "is not a folder")
+   expect_error(parser, array<str> { 'path=does-not-exist' }, ERR_FileNotFound, "does not exist")
+   expect_error(parser, array<str> { 'file=sdk:scripts' }, ERR_ExpectedFile, "is not a file")
+   expect_error(parser, array<str> { 'folder=sdk:scripts/options.tiri' }, ERR_ExpectedFolder, "is not a folder")
 end
 
 @Test function MultipleValuesUseValidationRules()
@@ -856,11 +856,11 @@ end
       }
    })
 
-   args = parser.process(array<string> { 'level=1', 'level=3' })
+   args = parser.process(array<str> { 'level=1', 'level=3' })
    assert(#args.level is 2, 'Repeated validated values should be preserved')
    assert(args.level[0] is 1 and args.level[1] is 3, 'Repeated values should be converted before validation')
 
-   expect_error(parser, array<string> { 'level=4' }, ERR_Args, "Parameter 'level' must be one of: 1, 2, 3.")
+   expect_error(parser, array<str> { 'level=4' }, ERR_Args, "Parameter 'level' must be one of: 1, 2, 3.")
 end
 
 @Test function RelationshipValidation()
@@ -868,7 +868,7 @@ end
       args = array<table> {
          { name = 'output', requires = 'input' },
          { name = 'input' },
-         { name = 'credentials', requiresAny = array<string> { 'user', 'token' } },
+         { name = 'credentials', requiresAny = array<str> { 'user', 'token' } },
          { name = 'user' },
          { name = 'token' },
          { name = 'dry-run', kind = 'flag', excludes = 'write' },
@@ -876,14 +876,14 @@ end
       }
    })
 
-   args = parser.process(array<string> { 'input=scene.svg', 'output=preview.png', 'credentials=x', 'token=abc' })
+   args = parser.process(array<str> { 'input=scene.svg', 'output=preview.png', 'credentials=x', 'token=abc' })
    assert(args.output is 'preview.png', 'requires should pass when the dependency is present')
 
-   expect_error(parser, array<string> { 'output=preview.png' }, ERR_ParameterRequired,
+   expect_error(parser, array<str> { 'output=preview.png' }, ERR_ParameterRequired,
       "Parameter 'output' requires 'input'.")
-   expect_error(parser, array<string> { 'credentials=x' }, ERR_ParameterRequired,
+   expect_error(parser, array<str> { 'credentials=x' }, ERR_ParameterRequired,
       "Parameter 'credentials' requires one of: user, token.")
-   expect_error(parser, array<string> { 'dry-run', 'write' }, ERR_Args, "Parameter 'dry-run' excludes 'write'.")
+   expect_error(parser, array<str> { 'dry-run', 'write' }, ERR_Args, "Parameter 'dry-run' excludes 'write'.")
 end
 
 @Test function RelationshipValidationUsesExplicitPresence()
@@ -896,14 +896,14 @@ end
       }
    })
 
-   args = parser.process(array<string> { 'write' })
+   args = parser.process(array<str> { 'write' })
    assert(args.output is 'preview.png', 'Defaulted options should still be applied')
    assert(args['dry-run'] is false, 'Defaulted flags should still be applied')
    assert(args.write is true, 'Explicit flags should parse when excluded only by an unsupplied defaulted flag')
 
-   expect_error(parser, array<string> { 'output=final.png' }, ERR_ParameterRequired,
+   expect_error(parser, array<str> { 'output=final.png' }, ERR_ParameterRequired,
       "Parameter 'output' requires 'input'.")
-   expect_error(parser, array<string> { 'dry-run', 'write' }, ERR_Args, "Parameter 'dry-run' excludes 'write'.")
+   expect_error(parser, array<str> { 'dry-run', 'write' }, ERR_Args, "Parameter 'dry-run' excludes 'write'.")
 end
 
 @Test function ExecReceivesParserArgValueAndDefinition()
@@ -915,7 +915,7 @@ end
    parser = options({
       args = array<table> {
          {
-            names = array<string> { 'level', 'l' },
+            names = array<str> { 'level', 'l' },
             type = 'int',
             exec = function(Parser:table, Arg:str, Value:any, Definition:table):any
                assert(Parser.getParam('level') is Definition, 'exec should receive the parser and definition')
@@ -928,7 +928,7 @@ end
       }
    })
 
-   args = parser.process(array<string> { 'l=3' })
+   args = parser.process(array<str> { 'l=3' })
    assert(args.level is 3, 'exec should run after conversion')
    assert(called is true, 'exec should be called during validation')
    assert(seen_arg is 'l', 'exec should receive the original input argument name')
@@ -940,7 +940,7 @@ end
    parser = options({
       args = array<table> {
          { name = 'count', type = 'int', required = true },
-         { name = 'mode', type = 'enum', choices = array<string> { 'fast', 'slow' } },
+         { name = 'mode', type = 'enum', choices = array<str> { 'fast', 'slow' } },
          { name = 'output', requires = 'mode' }
       }
    })
@@ -958,14 +958,14 @@ end
    parser = options({
       defaults = { mode = 'invalid' },
       args = array<table> {
-         { name = 'mode', type = 'enum', choices = array<string> { 'fast', 'slow' } }
+         { name = 'mode', type = 'enum', choices = array<str> { 'fast', 'slow' } }
       }
    })
 
-   args = parser.process(array<string> { 'mode=fast' })
+   args = parser.process(array<str> { 'mode=fast' })
    assert(args.mode is 'fast', 'Higher-precedence input should be the value that validation sees')
 
-   expect_error(parser, array<string> { }, ERR_Args, "Parameter 'mode' must be one of: fast, slow.")
+   expect_error(parser, array<str> { }, ERR_Args, "Parameter 'mode' must be one of: fast, slow.")
 end
 
 @Test function UsageAndNormalHelp()
@@ -974,10 +974,10 @@ end
       description = 'View vector documents',
       epilog      = 'End of help.',
       args = array<table> {
-         { names = array<string> { 'output', 'o' }, type = 'file', metavar = 'PATH', default = 'preview.png',
+         { names = array<str> { 'output', 'o' }, type = 'file', metavar = 'PATH', default = 'preview.png',
             comment = 'Output preview' },
          { name = 'input', kind = 'positional', type = 'file', required = true, comment = 'Input document' },
-         { names = array<string> { 'verbose', 'v' }, kind = 'flag', type = 'bool', comment = 'Enable logs' }
+         { names = array<str> { 'verbose', 'v' }, kind = 'flag', type = 'bool', comment = 'Enable logs' }
       }
    })
 
@@ -1043,9 +1043,9 @@ end
       name = 'tool',
       args = array<table> {
          {
-            names = array<string> { 'mode', 'm' },
+            names = array<str> { 'mode', 'm' },
             type = 'enum',
-            choices = array<string> { 'fast', 'slow' },
+            choices = array<str> { 'fast', 'slow' },
             required = true,
             comment = 'Execution mode',
             description = 'Controls how much validation the tool performs.'
@@ -1094,17 +1094,17 @@ end
       }
    })
 
-   result, err = parser.tryProcess(array<string> { 'help' })
+   result, err = parser.tryProcess(array<str> { 'help' })
    assert(err is nil, f'tryProcess() should not treat help as a parse failure, got {err}')
    assert(result.help is true, 'tryProcess() should return a structured help result')
    assert(result.text.find('Usage: demo'), 'Structured help result should include normal help text')
 
-   result, err = parser.tryProcess(array<string> { 'help=file' })
+   result, err = parser.tryProcess(array<str> { 'help=file' })
    assert(err is nil, 'tryProcess() should return detailed help without failing')
    assert(result.topic is 'file', 'Detailed help result should report the requested topic')
    assert(result.text.find('File to read'), 'Detailed help should be generated for help=argname')
 
-   result, err = parser.tryProcess(array<string> { 'help', 'ignored' })
+   result, err = parser.tryProcess(array<str> { 'help', 'ignored' })
    assert(err is nil, 'Automatic help should ignore trailing ordered tokens')
    assert(result.help is true, 'Automatic help with trailing tokens should return a structured help result')
    assert(result.topic is nil, 'Bare automatic help with trailing tokens should request normal help')
@@ -1125,7 +1125,7 @@ end
       }
    })
 
-   result, err = caller_help_parser.tryProcess(array<string> { 'help' })
+   result, err = caller_help_parser.tryProcess(array<str> { 'help' })
    assert(result is nil, 'Caller-owned help should not bypass required parameters')
    assert(err.code is ERR_ParameterRequired, 'Caller-owned help should still validate required parameters')
 
@@ -1138,14 +1138,14 @@ end
    })
 
    result, err = cli_parser.tryProcess(nil, {
-      taskParameters = array<string> { '--log-warning', 'test.tiri', 'help' }
+      taskParameters = array<str> { '--log-warning', 'test.tiri', 'help' }
    })
    assert(err is nil, 'Default task-parameter help should not validate required arguments')
    assert(result.help is true, 'Default task-parameter help should return a structured help result')
    assert(result.text.find('Usage: convert'), 'Default task-parameter help should include normal help text')
 
    result, err = cli_parser.tryProcess(nil, {
-      taskParameters = array<string> { '--log-warning', 'test.tiri' }
+      taskParameters = array<str> { '--log-warning', 'test.tiri' }
    })
    assert(err is nil, 'Empty default task parameters should print help instead of validating required arguments')
    assert(result.help is true, 'Empty default task parameters should return a structured help result')
@@ -1159,7 +1159,7 @@ end
    })
 
    result, err = invalid_default_parser.tryProcess(nil, {
-      taskParameters = array<string> { '--log-warning', 'test.tiri' }
+      taskParameters = array<str> { '--log-warning', 'test.tiri' }
    })
    assert(err is nil, 'Empty task parameters should still prefer help over unrelated invalid defaults')
    assert(result.help is true, 'Unrelated invalid defaults should not suppress automatic help')
@@ -1178,7 +1178,7 @@ end
       }
    })
 
-   returned = help_parser.process(array<string> { 'help=file' })
+   returned = help_parser.process(array<str> { 'help=file' })
    assert(returned is nil, 'process() should not return normal args for help requests')
    assert(seen_topic is 'file', 'process() should pass the help topic to onHelp')
    assert(seen_text.find('File to read'), 'process() should pass generated help text to onHelp')
@@ -1201,7 +1201,7 @@ end
    end
    assert(failed is true, 'Unsupported help formats should fail')
 
-   args, err = parser.tryProcess(array<string> { 'help=missing' })
+   args, err = parser.tryProcess(array<str> { 'help=missing' })
    assert(args is nil, 'Unknown help topics should fail as structured errors')
    assert(err.code is ERR_ParameterUnknown, 'Unknown help topics should report parameter-unknown')
 end
@@ -1223,7 +1223,7 @@ end
       }
    })
 
-   args = ignore_parser.process(array<string> { 'count=bad' })
+   args = ignore_parser.process(array<str> { 'count=bad' })
    assert(args.count is 7, 'onError ignore should fall back to the parameter default')
    assert(seen_arg is 'count', 'onError should receive the original argument name')
    assert(seen_raw is 'bad', 'onError should receive the rejected raw value')
@@ -1237,7 +1237,7 @@ end
       }
    })
 
-   args = skip_parser.process(array<string> { 'count=bad' })
+   args = skip_parser.process(array<str> { 'count=bad' })
    assert(args.count is nil, 'onError skip should leave the parameter unset even when a default exists')
 
    fail_parser = options({
@@ -1249,7 +1249,7 @@ end
       }
    })
 
-   expect_error(fail_parser, array<string> { 'count=bad' }, ERR_WrongType,
+   expect_error(fail_parser, array<str> { 'count=bad' }, ERR_WrongType,
       "Parameter 'count' requires an integer.")
 end
 
@@ -1263,13 +1263,13 @@ end
             name     = 'tag',
             type     = 'array',
             multiple = true,
-            default  = array<string> { 'fallback' },
-            choices  = array<string> { 'fallback' }
+            default  = array<str> { 'fallback' },
+            choices  = array<str> { 'fallback' }
          }
       }
    })
 
-   args = parser.process(array<string> { 'tag=bad' })
+   args = parser.process(array<str> { 'tag=bad' })
    assert(type(args.tag) is 'array', 'Recovered array default should remain an array')
    assert(#args.tag is 1, 'Recovered array default should not be nested')
    assert(args.tag[0] is 'fallback', 'Recovered array default should keep the declared item')
@@ -1279,7 +1279,7 @@ end
    parser = options({
       commands = array<table> {
          {
-            names = array<string> { 'build', 'b' },
+            names = array<str> { 'build', 'b' },
             comment = 'Build the project',
             args = array<table> {
                { name = 'input', type = 'folder' }
@@ -1294,7 +1294,7 @@ end
       'Command parameters should be normalised and searchable')
 
    added = parser.addCommand({
-      names = array<string> { 'test', 't' },
+      names = array<str> { 'test', 't' },
       args = array<table> {
          { name = 'filter' }
       }
@@ -1309,8 +1309,8 @@ end
    try
       options({
          commands = array<table> {
-            { names = array<string> { 'build', 'b' } },
-            { names = array<string> { 'bundle', 'b' } }
+            { names = array<str> { 'build', 'b' } },
+            { names = array<str> { 'bundle', 'b' } }
          }
       })
    except e
@@ -1335,10 +1335,10 @@ end
 
    expect_options_error({
       args = array<table> {
-         { names = array<string> { 'verbose', 'v' }, kind = 'flag', type = 'bool' }
+         { names = array<str> { 'verbose', 'v' }, kind = 'flag', type = 'bool' }
       },
       commands = array<table> {
-         { names = array<string> { 'build', 'v' } }
+         { names = array<str> { 'build', 'v' } }
       }
    }, ERR_DuplicateValue, "Command name or alias 'v' conflicts with global parameter 'v'.")
 
@@ -1387,11 +1387,11 @@ end
 @Test function CommandDispatchAndResultShape()
    parser = options({
       args = array<table> {
-         { names = array<string> { 'verbose', 'v' }, kind = 'flag', type = 'bool' }
+         { names = array<str> { 'verbose', 'v' }, kind = 'flag', type = 'bool' }
       },
       commands = array<table> {
          {
-            names = array<string> { 'build', 'b' },
+            names = array<str> { 'build', 'b' },
             args = array<table> {
                { name = 'input', type = 'folder' },
                { name = 'release', kind = 'flag', type = 'bool' }
@@ -1406,7 +1406,7 @@ end
       }
    })
 
-   result = parser.process(array<string> { 'v', 'b', 'input=src', 'release' })
+   result = parser.process(array<str> { 'v', 'b', 'input=src', 'release' })
    assert(result.command is 'build', 'Command aliases should dispatch to the canonical name')
    assert(type(result.globals) is 'table', 'Command results should include global arguments')
    assert(type(result.args) is 'table', 'Command results should include command arguments')
@@ -1433,13 +1433,13 @@ end
       }
    })
 
-   result = parser.process(array<string> { 'test', 'filter=svg' })
+   result = parser.process(array<str> { 'test', 'filter=svg' })
    assert(result.command is 'test', 'Selected command should be returned')
    assert(result.args.filter is 'svg', 'Selected command arguments should parse')
    assert(result.args.input is nil, 'Arguments from other commands should not leak into the selected command')
 
-   expect_error(parser, array<string> { 'build', 'filter=svg' }, ERR_ParameterUnknown, "Unknown parameter 'filter'.")
-   expect_error(parser, array<string> { 'input=src', 'build' }, ERR_ParameterUnknown, "Unknown parameter 'input'.")
+   expect_error(parser, array<str> { 'build', 'filter=svg' }, ERR_ParameterUnknown, "Unknown parameter 'filter'.")
+   expect_error(parser, array<str> { 'input=src', 'build' }, ERR_ParameterUnknown, "Unknown parameter 'input'.")
 end
 
 @Test function MissingAndUnknownCommandsFail()
@@ -1449,8 +1449,8 @@ end
       }
    })
 
-   expect_error(parser, array<string> { }, ERR_ParameterRequired, 'Command is required.')
-   expect_error(parser, array<string> { 'unknown' }, ERR_ParameterUnknown, "Unknown parameter 'unknown'.")
+   expect_error(parser, array<str> { }, ERR_ParameterRequired, 'Command is required.')
+   expect_error(parser, array<str> { 'unknown' }, ERR_ParameterUnknown, "Unknown parameter 'unknown'.")
    expect_error(parser, { command = 'unknown' }, ERR_ParameterUnknown, "Unknown command 'unknown'.")
 end
 
@@ -1505,7 +1505,7 @@ end
       }
    })
 
-   result = parser.process(array<string> { 'build' })
+   result = parser.process(array<str> { 'build' })
    assert(result.globals.verbose is true, 'Global environment values should apply during command parsing')
    assert(result.args.input is 'src', 'Selected command environment values should apply')
 
@@ -1518,7 +1518,7 @@ end
       name = 'tool',
       commands = array<table> {
          {
-            names = array<string> { 'build', 'b' },
+            names = array<str> { 'build', 'b' },
             comment = 'Build the project',
             description = 'Compiles project assets.',
             args = array<table> {
@@ -1548,11 +1548,11 @@ end
    assert(detail.find('Aliases: b'), 'Command help should include command aliases')
    assert(detail.find('input=INPUT'), 'Command help should include command parameters')
 
-   result, err = parser.tryProcess(array<string> { 'help=build' })
+   result, err = parser.tryProcess(array<str> { 'help=build' })
    assert(err is nil, 'help=command should produce command help')
    assert(result.text.find('Build the project'), 'Structured command help should include command detail')
 
-   result = parser.process(array<string> { 'secret', 'token=abc' })
+   result = parser.process(array<str> { 'secret', 'token=abc' })
    assert(result.command is 'secret', 'Hidden commands should remain callable')
    assert(result.args.token is 'abc', 'Hidden command arguments should parse')
 end
@@ -1571,7 +1571,7 @@ end
       }
    })
 
-   args = parser.process(array<string> {
+   args = parser.process(array<str> {
       'columns=alpha, beta ,gamma',
       'items={one, two, 3}',
       'delay=250ms',
@@ -1628,7 +1628,7 @@ end
       }
    })
 
-   result = parser.process(array<string> { 'mode=120s', 'tag=alpha', 'tag=beta', 'build',
+   result = parser.process(array<str> { 'mode=120s', 'tag=alpha', 'tag=beta', 'build',
       'delay=2d', 'payload=[1,2,3]' })
    assert(result.globals.timeout is 300, 'Environment duration values should override parameter defaults')
    assert(result.globals.limit is 2097152, 'String size defaults should convert')
@@ -1657,19 +1657,19 @@ end
       }
    })
 
-   expect_error(parser, array<string> { 'delay=10' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'delay=10' }, ERR_WrongType,
       "Parameter 'delay' requires a duration with an ms, s, m, h, or d suffix.")
-   expect_error(parser, array<string> { 'delay=1w' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'delay=1w' }, ERR_WrongType,
       "Parameter 'delay' requires a duration with an ms, s, m, h, or d suffix.")
-   expect_error(parser, array<string> { 'limit=4pb' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'limit=4pb' }, ERR_WrongType,
       "Parameter 'limit' requires a size with a b, kb, mb, gb, or tb suffix.")
-   expect_error(parser, array<string> { 'scale=half' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'scale=half' }, ERR_WrongType,
       "Parameter 'scale' requires a percent value.")
-   expect_error(parser, array<string> { 'pattern=(' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'pattern=(' }, ERR_WrongType,
       "Parameter 'pattern' requires a valid regex pattern.")
-   expect_error(parser, array<string> { 'config={bad}' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'config={bad}' }, ERR_WrongType,
       "Parameter 'config' requires valid JSON.")
-   expect_error(parser, array<string> { 'config=1 2' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'config=1 2' }, ERR_WrongType,
       "Parameter 'config' requires valid JSON.")
 end
 
@@ -1696,7 +1696,7 @@ end
       }
    })
 
-   result = parser.process(array<string> { 'day=2025-12-31', 'start=23:59:59.123', 'build',
+   result = parser.process(array<str> { 'day=2025-12-31', 'start=23:59:59.123', 'build',
       'at=2024-02-29T00:00Z' })
    assert(result.globals.day is '2025-12-31', 'Date values should be returned unchanged when already normalised')
    assert(result.globals.leap is '2024-02-29', 'Leap-year default dates should validate')
@@ -1719,27 +1719,27 @@ end
       }
    })
 
-   expect_error(parser, array<string> { 'day=2023-02-29' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'day=2023-02-29' }, ERR_WrongType,
       "Parameter 'day' requires an ISO date in YYYY-MM-DD form.")
-   expect_error(parser, array<string> { 'day=1900-02-29' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'day=1900-02-29' }, ERR_WrongType,
       "Parameter 'day' requires an ISO date in YYYY-MM-DD form.")
-   expect_error(parser, array<string> { 'day=2100-02-29' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'day=2100-02-29' }, ERR_WrongType,
       "Parameter 'day' requires an ISO date in YYYY-MM-DD form.")
-   expect_error(parser, array<string> { 'day=2025-13-01' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'day=2025-13-01' }, ERR_WrongType,
       "Parameter 'day' requires an ISO date in YYYY-MM-DD form.")
-   expect_error(parser, array<string> { 'start=24:00' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'start=24:00' }, ERR_WrongType,
       "Parameter 'start' requires an ISO time value.")
-   expect_error(parser, array<string> { 'start=12:60' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'start=12:60' }, ERR_WrongType,
       "Parameter 'start' requires an ISO time value.")
-   expect_error(parser, array<string> { 'release=2023-02-29T12:00Z' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'release=2023-02-29T12:00Z' }, ERR_WrongType,
       "Parameter 'release' requires an ISO date-time value.")
-   expect_error(parser, array<string> { 'release=1900-02-29T12:00Z' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'release=1900-02-29T12:00Z' }, ERR_WrongType,
       "Parameter 'release' requires an ISO date-time value.")
-   expect_error(parser, array<string> { 'release=2100-02-29T12:00Z' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'release=2100-02-29T12:00Z' }, ERR_WrongType,
       "Parameter 'release' requires an ISO date-time value.")
-   expect_error(parser, array<string> { 'release=2025-01-01 12:00Z' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'release=2025-01-01 12:00Z' }, ERR_WrongType,
       "Parameter 'release' requires an ISO date-time value.")
-   expect_error(parser, array<string> { 'release=2025-01-01T12:00+24:00' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'release=2025-01-01T12:00+24:00' }, ERR_WrongType,
       "Parameter 'release' requires an ISO date-time value.")
 end
 
@@ -1764,7 +1764,7 @@ end
       }
    })
 
-   result = parser.process(array<string> { 'fill=rgb(255 0 128 / 50%)', 'paint', 'mark=hsv(120 40% 90%)' })
+   result = parser.process(array<str> { 'fill=rgb(255 0 128 / 50%)', 'paint', 'mark=hsv(120 40% 90%)' })
    assert(result.globals.fill is 'rgb(255 0 128 / 50%)', 'Modern rgb() colour values should validate')
    assert(result.globals.accent is 'hsl(270deg 80% 50% / 0.75)', 'Environment hsl() values should validate')
    assert(result.globals.stroke is 'rgb(12, 34, 56, 0.5)', 'Legacy rgb() defaults should validate')
@@ -1781,18 +1781,18 @@ end
       }
    })
 
-   expect_error(parser, array<string> { 'fill=lab(50% 0 0)' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'fill=lab(50% 0 0)' }, ERR_WrongType,
       "Parameter 'fill' requires a supported CSS colour value.")
-   expect_error(parser, array<string> { 'fill=rgb(256 0 0)' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'fill=rgb(256 0 0)' }, ERR_WrongType,
       "Parameter 'fill' requires a supported CSS colour value.")
-   expect_error(parser, array<string> { 'fill=rgb(10 20)' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'fill=rgb(10 20)' }, ERR_WrongType,
       "Parameter 'fill' requires a supported CSS colour value.")
-   expect_error(parser, array<string> { 'fill=rgb(10, 20, 30 / 0.5)' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'fill=rgb(10, 20, 30 / 0.5)' }, ERR_WrongType,
       "Parameter 'fill' requires a supported CSS colour value.")
-   expect_error(parser, array<string> { 'fill=hsl(10 50 50%)' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'fill=hsl(10 50 50%)' }, ERR_WrongType,
       "Parameter 'fill' requires a supported CSS colour value.")
-   expect_error(parser, array<string> { 'fill=hsv(10 50% 120%)' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'fill=hsv(10 50% 120%)' }, ERR_WrongType,
       "Parameter 'fill' requires a supported CSS colour value.")
-   expect_error(parser, array<string> { 'fill=oklch(50% -0.2 20)' }, ERR_WrongType,
+   expect_error(parser, array<str> { 'fill=oklch(50% -0.2 20)' }, ERR_WrongType,
       "Parameter 'fill' requires a supported CSS colour value.")
 end

--- a/src/tiri/tests/test_overflow.tiri
+++ b/src/tiri/tests/test_overflow.tiri
@@ -266,7 +266,7 @@ constant_pool[255] = 'constant_255'
 end
 
 function source_after_large_constant_pool(Tail):str
-   local lines = array<string> { 'local constant_pool = {}' }
+   local lines = array<str> { 'local constant_pool = {}' }
 
    for i in {0 to 256} do
       lines.push("constant_pool[" .. i .. "] = 'constant_" .. i .. "'")

--- a/src/tiri/tests/test_pipe_iteration.tiri
+++ b/src/tiri/tests/test_pipe_iteration.tiri
@@ -226,7 +226,7 @@ end
 
 @Test function ArrayVarPipeIterationWithIndex()
    -- Variable array pipe should pass (value, index) to callback
-   arr = array<string> { 'a', 'b', 'c' }
+   arr = array<str> { 'a', 'b', 'c' }
    captured = {}
    arr |> function(v, i) captured[i] = v end
    assert(captured[0] is 'a', "index 0 should be 'a'")

--- a/src/tiri/tests/test_ranges.tiri
+++ b/src/tiri/tests/test_ranges.tiri
@@ -41,7 +41,7 @@ end
 
    script = obj.new('tiri', { statement=[[
    port = 8080
-   args = array<string> {
+   args = array<str> {
       f'url=http://127.0.0.1:{port}/echo',
       'data=plain',
       'json={}'

--- a/src/tiri/tests/test_reserved_keywords.tiri
+++ b/src/tiri/tests/test_reserved_keywords.tiri
@@ -3,7 +3,7 @@
 @BeforeEach(hotpath=false)
 function enforce_hotpath() end
 
-reserved_keywords = array<string> {
+reserved_keywords = array<str> {
    'class',
    'interface',
    'record',
@@ -15,9 +15,9 @@ reserved_keywords = array<string> {
    'where',
 }
 
-assignment_operators = array<string> { '=', '?=', '??=' }
+assignment_operators = array<str> { '=', '?=', '??=' }
 
-primary_forms = array<string> {
+primary_forms = array<str> {
    '',
    '()',
 }

--- a/src/tiri/tests/test_safe_nav.tiri
+++ b/src/tiri/tests/test_safe_nav.tiri
@@ -38,7 +38,7 @@ end
    assert(value is "Second", "Safe index should return stored element when present, got " .. tostring(value))
 
    -- Test with native Tiri array (use separate variable since array != table)
-   arr_container = array<string> { "First", "Second" }
+   arr_container = array<str> { "First", "Second" }
    value = arr_container?[1]
    assert(value is "Second", "Safe index should return stored element when present, got " .. tostring(value))
 
@@ -410,7 +410,7 @@ end
 
 @Test function testTiriArraySafeIndexVariable()
    -- Test safe navigation with variable indices
-   arr = array<string> { "zero", "one", "two", "three" }
+   arr = array<str> { "zero", "one", "two", "three" }
 
    idx = 0
    assert(arr?[idx] is "zero", "Safe index with variable index 0 should work")
@@ -479,7 +479,7 @@ end
 
 @Test function testTiriArraySafeIndexWithFallback()
    -- Test safe array navigation combined with ?? operator
-   arr = array<string> { "first", "second" }
+   arr = array<str> { "first", "second" }
 
    v = arr?[0] ?? "default"
    assert(v is "first", "Safe index with fallback should return value when present")
@@ -518,7 +518,7 @@ end
    emptyInt = array.new(0, 'int')
    assert(emptyInt?[0] is nil, "Safe index on empty array should return nil")
 
-   emptyStr = array.new(0, 'string')
+   emptyStr = array.new(0, 'str')
    assert(emptyStr?[0] is nil, "Safe index on empty string array should return nil")
 end
 

--- a/src/tiri/tests/test_strings.tiri
+++ b/src/tiri/tests/test_strings.tiri
@@ -80,7 +80,7 @@ end
    assert(type(parts) is "array", "Expected type 'array', got '" .. type(parts) .. "'")
 
    -- Verify array methods are available
-   assert(parts.type() is "string", "Expected array element type 'string', got '" .. tostring(parts.type()) .. "'")
+   assert(parts.type() is "str", "Expected array element type 'str', got '" .. tostring(parts.type()) .. "'")
 
    -- Verify index-based iteration works
    assert(parts[0] is "a", "parts[0] should be 'a'")

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -37,7 +37,7 @@ struct DeclaredVectorFields
    Bool: array<bool>, Char: array<char>, Byte: array<byte>, Int8: array<int8>, UInt8: array<uint8>,
    Int16: array<int16>, UInt16: array<uint16>, Int: array<int>, UInt: array<uint>,
    Int32: array<int>, UInt32: array<uint>, Int64: array<int64>, UInt64: array<uint64>,
-   Float: array<float>, Double: array<double>, String: array<string>,
+   Float: array<float>, Double: array<double>, String: array<str>,
    Points: array<struct<DeclaredVectorElement>>
 end
 
@@ -365,7 +365,7 @@ end
 @Test function NativeStructVectorRoundTrips()
    local value = struct<DeclaredVectorFields> {
       Int=array<int> { 1, 2, 3 },
-      String=array<string> { 'alpha', 'beta' }
+      String=array<str> { 'alpha', 'beta' }
    }
 
    value.Bool = array<byte> { 0, 1 }
@@ -402,7 +402,7 @@ end
    local copy = struct<DeclaredVectorFields> { }
    struct.copy(copy, value)
    value.Int = array<int> { 99 }
-   value.String = array<string> { 'changed' }
+   value.String = array<str> { 'changed' }
    assert(clone.Int is array<int> { 8, 9, 10, 11, 12 } and copy.Int is array<int> { 8, 9, 10, 11, 12 },
       'copy() and clone() should deep-copy scalar vectors')
    local clone_strings = clone.String
@@ -443,7 +443,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function NativeStructVectorDeclarationErrors()
-   for statement in values(array<string> {
+   for statement in values(array<str> {
       'struct BadCStrVector Values: array<cstr> end',
       'struct BadObjectVector Values: array<obj> end',
       'struct BadPointerVector Values: array<ptr> end',
@@ -769,7 +769,7 @@ end
 @Test function StructPairsAndToString()
    MAKESTRUCT('IterableRecord', 'lCount,zsName,bEnabled')
    local value = struct.new('IterableRecord', { count=7, name='sample', enabled=1 })
-   local fields = array<string>
+   local fields = array<str>
    local values = array<any>
 
    for name, field_value in pairs(value) do
@@ -777,7 +777,7 @@ end
       values.push(field_value)
    end
 
-   assert(fields is array<string> { 'count', 'name', 'enabled' }, 'pairs() should preserve declaration order')
+   assert(fields is array<str> { 'count', 'name', 'enabled' }, 'pairs() should preserve declaration order')
    assert(values[0] is 7 and values[1] is 'sample' and values[2] is 1, 'pairs() should return live field values')
    assert(tostring(value).startsWith('IterableRecord: 0x'), 'tostring() should include the struct definition name')
 end
@@ -800,14 +800,14 @@ end
    value.dynamic = array<int> { 8, 9, 10, 11 }
    assert(value.dynamic is array<int> { 8, 9, 10, 11 }, 'C++ vector assignment should resize and copy elements')
 
-   value.names = array<string> { 'alpha', 'beta' }
+   value.names = array<str> { 'alpha', 'beta' }
    local names = value.names
    assert(#names is 2 and names[0] is 'alpha' and names[1] is 'beta',
       'C++ string vector assignment should copy strings')
 
    local clone = struct.clone(value)
    value.dynamic = array<int> { 99 }
-   value.names = array<string> { 'changed' }
+   value.names = array<str> { 'changed' }
    assert(clone.dynamic is array<int> { 8, 9, 10, 11 }, 'clone() should deep-copy C++ primitive vectors')
    local clone_names = clone.names
    assert(#clone_names is 2 and clone_names[0] is 'alpha' and clone_names[1] is 'beta',

--- a/src/tiri/tests/test_try_except.tiri
+++ b/src/tiri/tests/test_try_except.tiri
@@ -775,7 +775,7 @@ end
 -- Only locals created inside a try block should be closed when that try handles an exception.
 
 @Test(priority=33) function CloseInNestedTry()
-   order = array<string>
+   order = array<str>
    mt_outer = { __close = function() order.push('outer') end }
    mt_inner = { __close = function() order.push('inner') end }
 
@@ -801,7 +801,7 @@ end
 -- <close> cleanup when no exception occurs in try block, runs before success
 
 @Test(priority=34) function CloseInTryNoException()
-   order = array<string>
+   order = array<str>
    mt = {
       __close = function(self, err)
          order.push('close')
@@ -1015,7 +1015,7 @@ end
 -- Defer runs when try block exits normally (no exception), before success block
 
 @Test(priority=40) function DeferInTryBlockNormal()
-   order = array<string>
+   order = array<str>
 
    function subject()
       try
@@ -1038,7 +1038,7 @@ end
 -- Test defer behavior when exception is caught by try-except
 
 @Test(priority=40) function DeferInTryWithException()
-   order = array<string>
+   order = array<str>
 
    function subject()
       try
@@ -1063,7 +1063,7 @@ end
 -- Test multiple defers when exception is caught
 
 @Test(priority=40) function MultipleDeferInTryWithException()
-   order = array<string>
+   order = array<str>
 
    function subject()
       try
@@ -1093,7 +1093,7 @@ end
 -- Defer in except block runs correctly when except exits
 
 @Test(priority=40) function DeferInExceptBlock()
-   order = array<string>
+   order = array<str>
 
    function subject()
       try
@@ -1117,7 +1117,7 @@ end
 -- Test defer behavior with nested try blocks
 
 @Test(priority=40) function DeferInNestedTry()
-   order = array<string>
+   order = array<str>
 
    function subject()
       try
@@ -1152,7 +1152,7 @@ end
 -- Defer runs when returning from try block (no exception)
 
 @Test(priority=40) function DeferWithReturnFromTry()
-   order = array<string>
+   order = array<str>
 
    function subject()
       try
@@ -1178,7 +1178,7 @@ end
 -- Defer runs when breaking from try block in loop (no exception)
 
 @Test(priority=45) function DeferWithBreakInTryLoop()
-   order = array<string>
+   order = array<str>
 
    function subject()
       for i in {1 to 5} do
@@ -1203,7 +1203,7 @@ end
 -- Test defer behavior with continue in try loop
 
 @Test(priority=45) function DeferWithContinueInTryLoop()
-   order = array<string>
+   order = array<str>
 
    function subject()
       for i in {1 to 4} do
@@ -1231,7 +1231,7 @@ end
 -- Test interaction between defer and <close> in try block with exception
 
 @Test(priority=45) function DeferAndCloseInTry()
-   order = array<string>
+   order = array<str>
    mt = { __close = function() order.push('close') end }
 
    function subject()

--- a/src/tiri/tests/test_type_annotations.tiri
+++ b/src/tiri/tests/test_type_annotations.tiri
@@ -133,7 +133,7 @@ end
    end
 
    local values:array<int> = array<int> { 3, 5 }
-   global glAnnotatedWords:array<string> = array<string> { 'one' }
+   global glAnnotatedWords:array<str> = array<str> { 'one' }
    assert(accept_ints(values)[1] is 5, 'Concrete array annotations should work in parameters, locals and results')
    assert(glAnnotatedWords[0] is 'one', 'Concrete array annotations should work for globals')
 
@@ -147,9 +147,10 @@ end
    end
 
    assert_rejected('function invalid(Value:array) end', 'element type')
+   assert_rejected('function invalid(Value:array<string>) end', 'Unknown array element type')
    assert_rejected('function invalid(Value:array<missing>) end', 'Unknown array element type')
    assert_rejected('function invalid(Value:array<pointer>) end', 'Unknown array element type')
-   assert_rejected('function invalid(Value:array<array<string>>) end', 'Nested array specialisation')
+   assert_rejected('function invalid(Value:array<array<str>>) end', 'Nested array specialisation')
    assert_rejected('function invalid(Value:array<int, 4>) end', 'cannot declare a size')
 end
 

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -102,11 +102,11 @@ end
    local ints = array<int> { 1 }
    local words = array<str> { 'text' }
    assert(accept_ints(dynamic_value(ints)) is ints, 'A matching dynamic array should satisfy the member contract')
-   expect_array_contract_failure(function() accept_ints(dynamic_value(words)) end, 'int', 'string')
-   expect_array_contract_failure(function() checked_ints(words) end, 'int', 'string')
+   expect_array_contract_failure(function() accept_ints(dynamic_value(words)) end, 'int', 'str')
+   expect_array_contract_failure(function() checked_ints(words) end, 'int', 'str')
 
    local inferred = array<int> { 2 }
-   expect_array_contract_failure(function() inferred = dynamic_value(words) end, 'int', 'string')
+   expect_array_contract_failure(function() inferred = dynamic_value(words) end, 'int', 'str')
    assert(inferred[0] is 2, 'A rejected inferred-array store should preserve the previous value')
    inferred = nil
    inferred = dynamic_value(ints)

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -100,7 +100,7 @@ end
    function checked_ints(Value:any):array<int> return dynamic_value(Value) end
 
    local ints = array<int> { 1 }
-   local words = array<string> { 'text' }
+   local words = array<str> { 'text' }
    assert(accept_ints(dynamic_value(ints)) is ints, 'A matching dynamic array should satisfy the member contract')
    expect_array_contract_failure(function() accept_ints(dynamic_value(words)) end, 'int', 'string')
    expect_array_contract_failure(function() checked_ints(words) end, 'int', 'string')

--- a/src/tiri/tests/test_type_guided_emission.tiri
+++ b/src/tiri/tests/test_type_guided_emission.tiri
@@ -85,7 +85,7 @@ end
 
 @Test function ArrayLogicalElementTypes()
    local numbers = array<int> { 3, 7 }
-   local strings = array<string> { 'a', 'b' }
+   local strings = array<str> { 'a', 'b' }
    local tables = array<table> { { value=11 } }
    local nested = array<array> { array<int> { 19 } }
    local points = array<struct<EmissionPoint>> { struct<EmissionPoint> { Value=29 } }
@@ -93,7 +93,7 @@ end
    local objects = array<obj> { clock }
 
    assert(numbers[1] is 7, 'array<int> indexing should return a number')
-   assert(strings[0] is 'a', 'array<string> indexing should return a string')
+   assert(strings[0] is 'a', 'array<str> indexing should return a string')
    assert(tables[0].value is 11, 'array<table> indexing should retain table behaviour')
    assert(nested[0][0] is 19, 'array<array> indexing should retain nested array behaviour')
    assert(points[0].Value is 29, 'named struct-array indexing should retain its layout')
@@ -144,7 +144,7 @@ end
 
 @Test function ArrayDescriptorInvalidation()
    local values:array<any> = array<int> { 1 }
-   values = array<string> { 'changed' }
+   values = array<str> { 'changed' }
    assert(values[0] is 'changed', 'Conflicting array reassignment must not retain a stale numeric descriptor')
 
    local branch_values:array<any> = array<int> { 2 }

--- a/src/tiri/tiri_async.cpp
+++ b/src/tiri/tiri_async.cpp
@@ -549,9 +549,9 @@ static int pool_set(lua_State *Lua)
 }
 
 //********************************************************************************************************************
-// async.pool.reset() — Remove all entries from the shared pool.
+// async.pool.clear() — Remove all entries from the shared pool through the table __clear metamethod.
 
-static int pool_reset(lua_State *Lua)
+static int pool_clear(lua_State *Lua)
 {
    auto pool = get_pool(Lua);
    std::unique_lock lock(pool->mutex);
@@ -584,18 +584,13 @@ void register_async_class(lua_State *Lua)
    lua_setfield(Lua, -2, "__index");
    lua_pushcfunction(Lua, pool_set);
    lua_setfield(Lua, -2, "__newindex");
-   lua_pushcfunction(Lua, pool_reset);
+   lua_pushcfunction(Lua, pool_clear);
    lua_setfield(Lua, -2, "__clear");
    lua_pop(Lua, 1);
 
    lua_newtable(Lua);                          // Create the pool table
    luaL_getmetatable(Lua, "Tiri.async.pool");
    lua_setmetatable(Lua, -2);                  // Assign the metatable
-
-   // Store pool.reset() as a raw key so it takes precedence over __index.
-   lua_pushstring(Lua, "reset");
-   lua_pushcfunction(Lua, pool_reset);
-   lua_rawset(Lua, -3);
 
    lua_getglobal(Lua, "async");                // Push the async table
    lua_pushvalue(Lua, -2);                     // Push the pool table

--- a/tools/benchmark/benchmark_array.tiri
+++ b/tools/benchmark/benchmark_array.tiri
@@ -12,8 +12,8 @@
       local dbl_arr1 = array<double> { 1.1, 2.2, 3.3, 4.4, 5.5 }
       local dbl_arr2 = array<double> { 3.14159, 2.71828, 1.41421, 1.73205 }
 
-      local str_arr1 = array<string> { "apple", "banana", "cherry" }
-      local str_arr2 = array<string> { "one", "two", "three", "four", "five" }
+      local str_arr1 = array<str> { "apple", "banana", "cherry" }
+      local str_arr2 = array<str> { "one", "two", "three", "four", "five" }
       checksum += #int_arr1 + #int_arr2 + #dbl_arr1 + #dbl_arr2 + #str_arr1 + #str_arr2
    end
    return checksum
@@ -43,7 +43,7 @@ end
 -- Initialise arrays
 
 local glIntArray = array<int, 1000>
-local glStrArray = array<string, 100>
+local glStrArray = array<str, 100>
 local glIntTable = { }
 local glStrTable = { }
 
@@ -113,7 +113,7 @@ end
          dbl_arr.push(j * 1.5)
       end
 
-      local str_arr = array<string>
+      local str_arr = array<str>
       for j in {0 to 50} do
          str_arr.push(f"item_{j}")
       end
@@ -165,7 +165,7 @@ end
       end
 
       -- Pop strings
-      local str_arr = array<string> { "a", "b", "c", "d", "e" }
+      local str_arr = array<str> { "a", "b", "c", "d", "e" }
       for j in {0 to 5} do
          local val = str_arr.pop()
          checksum += #val
@@ -180,7 +180,7 @@ end
 @Test function ArrayFindValue()
    local int_arr = array<int, 1000>
    local dbl_arr = array<double, 1000>
-   local str_arr = array<string> { "apple", "banana", "cherry", "date", "elderberry",
+   local str_arr = array<str> { "apple", "banana", "cherry", "date", "elderberry",
       "fig", "grape", "honeydew", "kiwi", "lemon" }
 
    for i in {0 to 1000} do
@@ -220,7 +220,7 @@ end
 @Test function ArrayContainsValue()
    local int_arr = array<int> { 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
    local dbl_arr = array<double> { 1.5, 2.5, 3.5, 4.5, 5.5 }
-   local str_arr = array<string> { "red", "green", "blue", "yellow", "purple" }
+   local str_arr = array<str> { "red", "green", "blue", "yellow", "purple" }
 
    local checksum = 0
    for i in {0 to 15000} do
@@ -261,7 +261,7 @@ end
       dbl_arr.sort()
 
       -- Sort strings alphabetically
-      local str_arr = array<string> { "cherry", "apple", "banana", "date", "elderberry" }
+      local str_arr = array<str> { "cherry", "apple", "banana", "date", "elderberry" }
       str_arr.sort()
       checksum += int_arr[0] + int_arr2[0] + dbl_arr[0] + #str_arr[0]
    end
@@ -283,7 +283,7 @@ end
       dbl_arr.reverse()
 
       -- Reverse string array
-      local str_arr = array<string> { "first", "second", "third", "fourth", "fifth" }
+      local str_arr = array<str> { "first", "second", "third", "fourth", "fifth" }
       str_arr.reverse()
       checksum += int_arr[0] + dbl_arr[0] + #str_arr[0]
    end
@@ -296,7 +296,7 @@ end
 @Test function ArraySliceRange()
    local int_arr = array<int> { 0, 10, 20, 30, 40, 50, 60, 70, 80, 90 }
    local dbl_arr = array<double> { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 }
-   local str_arr = array<string> { "a", "b", "c", "d", "e", "f", "g", "h" }
+   local str_arr = array<str> { "a", "b", "c", "d", "e", "f", "g", "h" }
 
    local checksum = 0
    for i in {0 to 1000} do
@@ -591,7 +591,7 @@ end
 @Test function ArrayConvertToTable()
    local int_arr = array<int> { 10, 20, 30, 40, 50 }
    local dbl_arr = array<double> { 1.5, 2.5, 3.5, 4.5, 5.5 }
-   local str_arr = array<string> { "one", "two", "three" }
+   local str_arr = array<str> { "one", "two", "three" }
    local checksum = 0.0
 
    for i in {0 to 15000} do
@@ -662,7 +662,7 @@ end
       checksum += sum
 
       -- Mixed push/pop operations
-      local mixed = array<string>
+      local mixed = array<str>
       mixed.push("first")
       mixed.push("second")
       local top:str = mixed.pop()

--- a/tools/benchmark/benchmark_memory.tiri
+++ b/tools/benchmark/benchmark_memory.tiri
@@ -125,7 +125,7 @@ end
       -- Create typed string arrays
       local str_arrays = {}
       for j in {0 to 50} do
-         str_arrays[j] = array<string, 50>
+         str_arrays[j] = array<str, 50>
       end
       checksum += #int_arrays + #dbl_arrays + #str_arrays
    end

--- a/tools/benchmark/benchmark_string.tiri
+++ b/tools/benchmark/benchmark_string.tiri
@@ -605,7 +605,7 @@ end
    local filename = "document.txt"
    local path = "/home/user/documents/file.pdf"
    local url = "https://www.example.com/page"
-   local extensions = array<string> {".txt", ".pdf", ".doc", ".csv"}
+   local extensions = array<str> {".txt", ".pdf", ".doc", ".csv"}
    local checksum = 0
 
    for i in {0 to 20000} do

--- a/tools/docgen.tiri
+++ b/tools/docgen.tiri
@@ -19,7 +19,7 @@ rx_sdk_path = <{ regex.new([[(.+)CMakeLists\.txt]]) }>
 function resolveSDKPath(Path:str)
    local sdk_path
    err = ERR_Failed
-   search_list = array<string>
+   search_list = array<str>
    if not Path then
       search_path = 'CMakeLists.txt'
       limit = 5

--- a/tools/flute.tiri
+++ b/tools/flute.tiri
@@ -39,7 +39,7 @@ end
 global function resolveSDKPath()
    script_path = glSelf.workingPath
    err = ERR_Failed
-   search_list = array<string>
+   search_list = array<str>
    search_path = 'CMakeLists.txt'
    limit = 5
    local sdk_path

--- a/tools/idl/idl-c.tiri
+++ b/tools/idl/idl-c.tiri
@@ -7,8 +7,8 @@
 
    import 'json', 'options'
 
-   global glHeader = array<string>
-   global glOutput = array<string>
+   global glHeader = array<str>
+   global glOutput = array<str>
    global glConstants = { }
 
    global glSelf = obj.find('self')
@@ -50,9 +50,9 @@ Examples:
          { name = 'output-proto', type = 'file', group = 'Output',
            comment = 'Target file for generated C++ function prototypes.' },
 
-         { name = 'feedback', type = 'enum', choices = array<string> { 'verbose' }, group = 'Diagnostics',
+         { name = 'feedback', type = 'enum', choices = array<str> { 'verbose' }, group = 'Diagnostics',
            comment = 'Set to verbose to print debug messages.' },
-         { name = 'prototypes', type = 'enum', choices = array<string> { 'static' }, group = 'Generation',
+         { name = 'prototypes', type = 'enum', choices = array<str> { 'static' }, group = 'Generation',
            comment = 'Set to static to output static prototype functions.' }
       }
    })
@@ -260,7 +260,7 @@ global function idlFunction(Name:str, Category:str, Comment:str, Status:str, Des
       response = { type='void' }
    end
 
-   func.tags = Def.tags ? Def.tags :> array<string>
+   func.tags = Def.tags ? Def.tags :> array<str>
    func.tags = getTagsFromField(func.result, func.tags) -- User defined tags
    func.tags = getTagsFromCollection(func.tags, func.input) -- IDL defined tags
 

--- a/tools/idl/idl-compile.tiri
+++ b/tools/idl/idl-compile.tiri
@@ -8,8 +8,8 @@
 
 global glSelf = obj.find('self')
 global glPath = glSelf.workingPath
-global glOutput = array<string>
-global glHeader = array<string>
+global glOutput = array<str>
+global glHeader = array<str>
 
 global glProgram    = 'idl-compile'
 global glSource     = arg('src')

--- a/tools/idl/include/client_functions.tiri
+++ b/tools/idl/include/client_functions.tiri
@@ -162,7 +162,7 @@ global function module(Options:table, Function:func)
       if type(glModule.src) is 'string' then
          glModule.src = { glTDLFolder .. glModule.src }
       else
-         fixed_path = array<string>
+         fixed_path = array<str>
          for path in values(glModule.src) do
             fixed_path.push(glTDLFolder .. path)
          end
@@ -254,7 +254,7 @@ global function flags(Prefix, Options:table, ...)
 
    Options ?= {}
 
-   out = array<string>
+   out = array<str>
    sortedFlags = { }
    if Options.comment?? then
       out.push('// ' .. Options.comment)
@@ -471,7 +471,7 @@ global function constants(Prefix:str, Options:table, ...)
 
    Options ?= {}
 
-   out = array<string>
+   out = array<str>
    if Options.comment?? then
       out.push(f'// {Options.comment}')
       out.push('')
@@ -559,7 +559,7 @@ global function enums(Prefix:str, Options:table, ...)
 
    Options ?= {}
 
-   out = array<string>
+   out = array<str>
    if Options.comment?? then
       out.push(f'// {Options.comment}')
       out.push('')
@@ -644,8 +644,8 @@ end
 global function platform(Platform:str, Function:func)
    saveHeader = glHeader
    saveOutput = glOutput
-   global glHeader = array<string>
-   global glOutput = array<string>
+   global glHeader = array<str>
+   global glOutput = array<str>
 
    local define
    if (Platform.lower() is 'windows') then
@@ -708,7 +708,7 @@ global function structdef(Name:str, Options:table, Def:str, Append:str)
    try
       Options ?= {}
 
-      out = array<string>
+      out = array<str>
       full_name = Name
       if Options.version then
          out.push(f'#define VER_{Name.upper()} {string.format("%f", Options.version)}')

--- a/tools/idl/include/utils.tiri
+++ b/tools/idl/include/utils.tiri
@@ -83,7 +83,7 @@ end
 global function priority(Input:any)
    if type(Input) is 'function' then
       saveOutput = glOutput
-      glOutput = array<string>
+      glOutput = array<str>
       Input()
       for v in values(glOutput) do
          glHeader.push(v)
@@ -247,7 +247,7 @@ end
 global function resolveSDKPath(Path:str)
    local sdk_path
    err = ERR_Failed
-   search_list = array<string>
+   search_list = array<str>
    if not Path then
       search_path = 'CMakeLists.txt'
       limit = 5

--- a/tools/tiri_lsp/include/lsp_cache.tiri
+++ b/tools/tiri_lsp/include/lsp_cache.tiri
@@ -384,7 +384,7 @@ function serializeTable(Tbl:any, Indent):str
       end
    end
 
-   parts = array<string>
+   parts = array<str>
    for k, v in pairs(Tbl) do
       keyStr = type(k) is 'string' and "['" .. k .. "']" or '[' .. tostring(k) .. ']'
       valStr = serializeTable(v, nextIndent)

--- a/tools/tiri_lsp/include/lsp_definition.tiri
+++ b/tools/tiri_lsp/include/lsp_definition.tiri
@@ -539,7 +539,7 @@ function normaliseModuleName(Name:str):str
 end
 
 function resolveScriptImport(Doc:table, Name:str):table
-   candidates = array<string>
+   candidates = array<str>
    doc_path = lspUriToPath(Doc.uri)
    base_path = getParentPath(doc_path)
    script_name = Name.endsWith('.tiri') and Name or (Name .. '.tiri')

--- a/tools/tiri_lsp/include/lsp_handlers.tiri
+++ b/tools/tiri_lsp/include/lsp_handlers.tiri
@@ -227,12 +227,12 @@ global function registerCoreHandlers(Self)
                hoverProvider = true,
                -- Go to Definition
                definitionProvider = true,
-               completionProvider = { triggerCharacters = array<string> { '.' } },
+               completionProvider = { triggerCharacters = array<str> { '.' } },
                renameProvider = true,
                -- Signature Help
                signatureHelpProvider = {
-                  triggerCharacters = array<string> { '(', ',' },
-                  retriggerCharacters = array<string> { ',' }
+                  triggerCharacters = array<str> { '(', ',' },
+                  retriggerCharacters = array<str> { ',' }
                }
             },
             serverInfo = {

--- a/tools/tiri_lsp/include/lsp_hover.tiri
+++ b/tools/tiri_lsp/include/lsp_hover.tiri
@@ -272,7 +272,7 @@ function hoverSymbolMatches(Symbol:table, TokenInfo:table):bool
 end
 
 function hoverAppendParamSection(Markdown:str, Params:any):str
-   lines = array<string>
+   lines = array<str>
 
    for param in values(Params or array<table>) do
       if hoverTextHasContent(param.doc) then
@@ -293,7 +293,7 @@ function hoverAppendParamSection(Markdown:str, Params:any):str
 end
 
 function hoverAppendResultSection(Markdown:str, Results:any):str
-   lines = array<string>
+   lines = array<str>
 
    for result in values(Results or array<table>) do
       if hoverTextHasContent(result.type) or hoverTextHasContent(result.doc) then
@@ -312,7 +312,7 @@ function hoverAppendResultSection(Markdown:str, Results:any):str
 end
 
 function hoverAppendErrorSection(Markdown:str, Errors:any):str
-   lines = array<string>
+   lines = array<str>
 
    for err in values(Errors or array<table>) do
       if hoverTextHasContent(err.code) or hoverTextHasContent(err.doc) then
@@ -331,7 +331,7 @@ function hoverAppendErrorSection(Markdown:str, Errors:any):str
 end
 
 function hoverAppendFieldSection(Markdown:str, Fields:any):str
-   lines = array<string>
+   lines = array<str>
 
    for field in values(Fields or array<table>) do
       label = field.name or ''

--- a/tools/tiri_lsp/include/lsp_lib.tiri
+++ b/tools/tiri_lsp/include/lsp_lib.tiri
@@ -220,7 +220,7 @@ global LSP_ERROR = {
 
 -- Token types - order matters, index is used in the protocol
 
-global TOKEN_TYPES = array<string> {
+global TOKEN_TYPES = array<str> {
    'keyword',        -- 0: if, while, for, etc.
    'operator',       -- 1: and, or, not, is
    'variable',       -- 2: regular variables
@@ -237,7 +237,7 @@ global TOKEN_TYPES = array<string> {
 }
 
 -- Token modifiers (bitfield)
-global TOKEN_MODIFIERS = array<string> {
+global TOKEN_MODIFIERS = array<str> {
    'declaration',    -- 0: variable/function declaration
    'definition',     -- 1: definition site
    'readonly',       -- 2: constants

--- a/tools/tiri_lsp/include/lsp_signature.tiri
+++ b/tools/tiri_lsp/include/lsp_signature.tiri
@@ -581,7 +581,7 @@ end
 -- Build the display label for a signature sourced from XML API metadata.
 
 function signatureXmlLabel(DisplayName:str, Params:array<table>):str
-   labels = array<string>
+   labels = array<str>
    for param in values(Params or array<table>) do
       labels.push(signatureParamLabel(param))
    end

--- a/tools/tiri_lsp/include/lsp_symbols.tiri
+++ b/tools/tiri_lsp/include/lsp_symbols.tiri
@@ -92,8 +92,8 @@ function symbolMakeRange(LineNo:num, StartChar:num, EndChar:num):table
    }
 end
 
-function symbolAnnotationLabels(Annotations:array<table>):array<string>
-   labels = array<string>
+function symbolAnnotationLabels(Annotations:array<table>):array<str>
+   labels = array<str>
    for anno in values(Annotations or array<table>) do
       labels.push('@' .. anno.name)
    end
@@ -108,7 +108,7 @@ function symbolHasAnnotation(Annotations:array<table>, Name:str):bool
 end
 
 function symbolBuildDetail(Base:str, Annotations:array<table>):str
-   parts = array<string>
+   parts = array<str>
    if Base and Base != '' then parts.push(Base) end
    for label in values(symbolAnnotationLabels(Annotations)) do
       parts.push(label)

--- a/tools/tiri_lsp/server.tiri
+++ b/tools/tiri_lsp/server.tiri
@@ -18,7 +18,7 @@ rx_sdk_path <const> = <{ regex.new([[(.+)CMakeLists\.txt]]) }>
 function resolveSDKPath(Path:str)
    local sdk_path
    err = ERR_Failed
-   search_list = array<string>
+   search_list = array<str>
    if not Path then
       search_path = 'CMakeLists.txt'
       limit = 5
@@ -99,7 +99,7 @@ IDE Integration:
            comment = 'Path to generated XML documentation for hover support.' },
          { name = 'sdk', type = 'path', group = 'Paths',
            comment = 'Path to the Kotuku SDK folder; otherwise searched from the current directory.' },
-         { names = array<string> { 'requestLog', 'request-log' }, type = 'path', group = 'Diagnostics',
+         { names = array<str> { 'requestLog', 'request-log' }, type = 'path', group = 'Diagnostics',
            comment = 'Path to a log file for request/response debugging.' },
          { name = 'help', kind = 'flag', hidden = true,
            exec = function(Parser:table)


### PR DESCRIPTION
* Replaced the legacy string array element name with str across the parser, runtime, scripts and tests
* Reworked async pool clearing to use the standard clear metamethod and removed the reset API