### PR TITLE
[Tiri] Improved 'using' block type diagnostics

### DIFF
--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -4808,6 +4808,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mov CARG1, L
     |  mov CARG2w, RAw
     |  mov CARG3w, RDw
+    |  str PC, SAVE_PC
     |  bl extern lj_context_begin_block
     |  ldr BASE, L->base
     |  ins_next

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -6858,6 +6858,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mr CARG1, L
     |  srwi CARG2, RA, 3
     |  mr CARG3, RD
+    |  stw PC, SAVE_PC
     |  bl extern lj_context_begin_block
     |  lp BASE, L->base
     |  ins_next

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -5811,6 +5811,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mov CARG2d, RAd
     |  mov CARG3d, RDd
     |  mov L:CARG1, L:RB
+    |  mov SAVE_PC, PC
     |  call extern lj_context_begin_block
     |  mov BASE, L:RB->base
     |  ins_next

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -366,7 +366,7 @@ extern "C" void lj_tab_mark_contextual_jit(GCtab *Table) noexcept
 extern "C" void lj_context_begin_block(lua_State *L, uint32_t Slot, uint32_t BlockIndex)
 {
    TValue *reference = L->base + Slot;
-   if (not tvistab(reference)) lj_err_argt(L, int(Slot) + 1, LUA_TTABLE);
+   if (not tvistab(reference)) lj_err_msgv(L, ErrMsg::BADTYPE, "table", lj_typename(reference));
 
    GCfunc *function = frame_func(L->base - 1);
    lj_assertL(isluafunc(function), "temporary context block has no Lua owner");

--- a/src/tiri/tests/test_context_blocks.tiri
+++ b/src/tiri/tests/test_context_blocks.tiri
@@ -8,6 +8,23 @@ function enforce_hotpath() end
    assert(value.using is 'member', 'The using keyword should remain available as a member name')
 end
 
+@Test function NonTableReferenceReportsItsActualType()
+   local value:any = 42
+   local failed = false
+
+   try
+      using value do end
+   except e
+      failed = true
+      assert(e.message.find('table expected, got number') != nil,
+         'A non-table using reference should report its actual type: ' .. e.message)
+      assert(e.message.find('Bad argument') is nil,
+         'A using diagnostic should not expose the VM helper register as a function argument: ' .. e.message)
+   end
+
+   assert(failed, 'A using block should reject a non-table reference')
+end
+
 @Test function TemporaryContextDoesNotDesignateAndEvaluatesReferenceOnce()
    local lookups = 0
    local values = { { name = 'temporary' } }


### PR DESCRIPTION
* Reported the actual non-table reference type without exposing internal VM argument details
* Preserved bytecode source locations when context entry raises across all VM backends