### PR TITLE
[Tiri] Hoisted inherited context resolution into a per-region cache register

### DIFF
--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -32,7 +32,7 @@
 #include "ankerl/unordered_dense.h"
 #endif
 
-#define CORE_BUILD_DATE 20260811
+#define CORE_BUILD_DATE 20260814
 class objMetaClass;
 
 // Predefined cursor styles

--- a/src/tiri/jit/BYTECODE.md
+++ b/src/tiri/jit/BYTECODE.md
@@ -760,11 +760,16 @@ The process-wide ownership, publication and lock contract is documented in
 | `CTXCALLT` | AD | Transfer context ownership and invoke a fixed-argument tail call |
 
 `CTXGET` is appended to the opcode set so existing opcode numbers remain stable. An empty physical context stack is
-the permanent root sentinel and resolves dynamically through `L->env`; consequently a supported environment
-replacement is visible to the next `CTXGET`.  The standalone `&&` current-context expression lowers directly to
-`CTXGET`.  `&name` and the equivalent `&&.name` access lower to `CTXGET` followed by ordinary `TGET*` or `TSET*`
-operations. Root writes therefore cross the same marked-environment mutation boundary as `_G` writes and cannot
-bypass protected-global, const or sticky-type contracts.
+the permanent root sentinel and resolves dynamically through `L->env`.  A function or chunk that directly uses its
+inherited context emits one `CTXGET` into a hidden blank local at region entry; repeated `&&`, `&name` and
+`&&.name` expressions then read that register through ordinary `TGET*` or `TSET*` operations.  A `using` body reads
+its retained reference register, while contextual-call arguments read the retained receiver or one runtime-selected
+scratch register.  Regions without a context use retain neither a cache local nor a `CTXGET`.
+
+Root-environment replacement is supported between Lua activations and is observed when the next region acquires its
+inherited source.  Replacing `L->env` during an active Lua activation is unsupported; mutating the root table remains
+fully supported.  Root writes therefore cross the same marked-environment mutation boundary as `_G` writes and
+cannot bypass protected-global, const or sticky-type contracts.
 
 Phase 2 deliberately stops recording a trace at `CTXGET`; Phase 5 will model context in recorder state and snapshots.
 

--- a/src/tiri/jit/src/debug/lj_debug.cpp
+++ b/src/tiri/jit/src/debug/lj_debug.cpp
@@ -4,6 +4,8 @@
 #define lj_debug_c
 #define LUA_CORE
 
+#include <cstring>
+
 #include "lj_obj.h"
 #include "lj_ff.h"
 #include "lj_err.h"
@@ -522,6 +524,10 @@ extern CSTRING lua_setlocal(lua_State *L, const lua_Debug *ar, int n)
 {
    CSTRING name = nullptr;
    TValue *o = debug_localname(L, ar, &name, n);
+   if (name and strcmp(name, "(context cache)") IS 0) {
+      name = nullptr;
+      o = nullptr;
+   }
    if (name) copyTV(L, o, L->top - 1);
    L->top--;
    return name;

--- a/src/tiri/jit/src/debug/lj_debug.h
+++ b/src/tiri/jit/src/debug/lj_debug.h
@@ -54,7 +54,8 @@ extern int lj_debug_getinfo(lua_State* L, const char* what, lj_Debug* ar, int ex
   _(RANGE_ORDINAL, "(range ordinal)") \
   _(RANGE_START, "(range start)") \
   _(RANGE_STEP, "(range step)") \
-  _(RANGE_FLAGS, "(range flags)")
+  _(RANGE_FLAGS, "(range flags)") \
+  _(CONTEXT_CACHE, "(context cache)")
 
 enum {
    VARNAME_END,

--- a/src/tiri/jit/src/lj_api.cpp
+++ b/src/tiri/jit/src/lj_api.cpp
@@ -288,6 +288,8 @@ static void copy_slot(lua_State *L, TValue * f, int idx)
 {
    if (idx IS LUA_GLOBALSINDEX) {
       lj_checkapi(tvistab(f), "stack slot %d is not a table", idx);
+      // Root replacement is an embedding boundary operation.  Native runtime code mutates this table rather than
+      // replacing L->env while Lua bytecode is active, so inherited context caches remain valid for the activation.
       // NOBARRIER: A thread (i.e. L) is never black.
       setgcref(L->env, obj2gco(tabV(f)));
    }

--- a/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
@@ -53,23 +53,6 @@ static const ExprNode * builtin_method_receiver(const CallExprPayload &Payload)
    return nullptr;
 }
 
-// A known ordinary allocation needs no contextual frame.  A known contextual table and an unresolved receiver use
-// the contextual bytecode shape; the latter is gated by TAB_CONTEXTUAL at runtime.  Proved non-table receivers retain
-// their specialised ordinary ABI.
-
-static bool receiver_uses_contextual_call(
-   const ParserContext &Context, const ExprNode &Receiver)
-{
-   if (Receiver.kind IS AstNodeKind::CurrentContextExpr) return false;
-   if (not Receiver.static_value) return true;
-
-   const StaticValueDescriptor &descriptor = Context.descriptors().value(Receiver.static_value);
-   if (descriptor.contextuality IS StaticContextuality::Ordinary) return false;
-   if (descriptor.contextuality IS StaticContextuality::Contextual) return true;
-   return not (descriptor.proved() and descriptor.primary != TiriType::Unknown and
-      descriptor.primary != TiriType::Any and descriptor.primary != TiriType::Table);
-}
-
 static BCReg prepare_builtin_method_frame(
    FuncState *State, BuiltinCallableID Callable, BCReg Receiver, BCReg CallBase)
 {
@@ -199,6 +182,28 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_pipe(
       bcemit_INS(state, BCINS_AD(BC_CTXENTER, field_call_base.raw(), 0));
    }
 
+   ContextSourceScope argument_context_scope;
+   if (contextual_field) {
+      if (receiver_is_proven_contextual(this->ctx, *receiver_node)) {
+         argument_context_scope.activate(this,
+            ContextSource{ .slot = call_base, .kind = ContextSourceKind::ContextualArgument });
+      }
+      else {
+         bool arguments_use_context = this->expression_uses_context(*Payload.lhs);
+         for (const ExprNodePtr &argument : Call.arguments) {
+            if (argument and this->expression_uses_context(*argument)) {
+               arguments_use_context = true;
+               break;
+            }
+         }
+         if (arguments_use_context) {
+            bcemit_AD(state, BC_CTXGET, call_base.raw(), 0);
+            argument_context_scope.activate(this,
+               ContextSource{ .slot = call_base, .kind = ContextSourceKind::ContextualArgument });
+         }
+      }
+   }
+
    auto field_result = emit_branch(false);
    if (not field_result.ok()) return ParserResult<ExpDesc>::failure(field_result.error_ref());
    BCPos field_call = field_result.value_ref();
@@ -296,6 +301,150 @@ ParserResult<ExpDesc> IrEmitter::emit_pipe_expr(const PipeExprPayload &Payload)
    const CallExprPayload &call_payload = std::get<CallExprPayload>(Payload.rhs_call->data);
    if (call_payload.runtime_builtin_method) {
       return this->emit_runtime_builtin_method_pipe(Payload, call_payload);
+   }
+
+   const auto *direct = std::get_if<DirectCallTarget>(&call_payload.target);
+   const ExprNode *context_receiver_node = call_receiver(call_payload);
+   bool contextual_call = context_receiver_node and
+      receiver_uses_contextual_call(this->ctx, *context_receiver_node);
+   bool safe_callable = direct and direct->callable and
+      (direct->callable->kind IS AstNodeKind::SafeMemberExpr or
+       direct->callable->kind IS AstNodeKind::SafeIndexExpr);
+
+   if (contextual_call) {
+      if (not direct or not direct->callable) return this->unsupported_expr(AstNodeKind::PipeExpr, SourceSpan{});
+
+      BCReg context_result_base = fs->free_reg();
+      auto receiver_result = this->emit_expression(*context_receiver_node);
+      if (not receiver_result.ok()) return receiver_result;
+      ExpDesc receiver = receiver_result.value_ref();
+      this->materialise_to_next_reg(receiver, "contextual pipe receiver");
+      context_result_base = BCReg(receiver.u.s.info);
+
+      ControlFlowEdge receiver_nil_jump;
+      if (safe_callable) {
+         ExpDesc nil_value(ExpKind::Nil);
+         bcemit_INS(fs, BCINS_AD(BC_ISEQP, context_result_base, const_pri(&nil_value)));
+         receiver_nil_jump = this->control_flow.make_unconditional(BCPos(bcemit_jmp(fs)));
+      }
+
+      BCReg base = fs->free_reg();
+      if (direct->callable->kind IS AstNodeKind::MemberExpr or
+          direct->callable->kind IS AstNodeKind::SafeMemberExpr) {
+         GCstr *member = direct->callable->kind IS AstNodeKind::MemberExpr ?
+            std::get<MemberExprPayload>(direct->callable->data).member.symbol :
+            std::get<SafeMemberExprPayload>(direct->callable->data).member.symbol;
+         ExpDesc key(member);
+         bcreg_reserve(fs, 1);
+         bcemit_tgets(fs, base.raw(), context_result_base.raw(), const_str(fs, &key));
+      }
+      else {
+         const ExprNode *index_node = direct->callable->kind IS AstNodeKind::IndexExpr ?
+            std::get<IndexExprPayload>(direct->callable->data).index.get() :
+            std::get<SafeIndexExprPayload>(direct->callable->data).index.get();
+         if (not index_node) return this->unsupported_expr(AstNodeKind::PipeExpr, direct->callable->span);
+         BCReg retained_receiver_reg = fs->free_reg();
+         bcreg_reserve(fs, 1);
+         bcemit_AD(fs, BC_MOV, retained_receiver_reg, context_result_base.raw());
+         auto key_result = this->emit_expression(*index_node);
+         if (not key_result.ok()) return key_result;
+         ExpDesc key = key_result.value_ref();
+         ExpressionValue key_value(fs, key);
+         key_value.to_val();
+         key = key_value.legacy();
+         ExpDesc lookup(ExpKind::NonReloc, context_result_base.raw());
+         lookup.static_value = receiver.static_value;
+         expr_index(fs, &lookup, &key);
+         this->materialise_to_next_reg(lookup, "contextual pipe callee");
+         base = BCReg(lookup.u.s.info);
+      }
+      RegisterAllocator context_allocator(fs);
+      context_allocator.reserve(BCReg(1));
+
+      ControlFlowEdge nil_jump;
+      if (safe_callable) {
+         ExpDesc nil_value(ExpKind::Nil);
+         bcemit_INS(fs, BCINS_AD(BC_ISEQP, base, const_pri(&nil_value)));
+         nil_jump = this->control_flow.make_unconditional(BCPos(bcemit_jmp(fs)));
+      }
+
+      bcemit_INS(fs, BCINS_AD(BC_CTXENTER, base, 0));
+      ContextSourceScope context_scope;
+      if (receiver_is_proven_contextual(this->ctx, *context_receiver_node)) {
+         context_scope.activate(this,
+            ContextSource{ .slot = context_result_base, .kind = ContextSourceKind::ContextualArgument });
+      }
+      else {
+         bool arguments_use_context = this->expression_uses_context(*Payload.lhs);
+         for (const ExprNodePtr &argument : call_payload.arguments) {
+            if (argument and this->expression_uses_context(*argument)) {
+               arguments_use_context = true;
+               break;
+            }
+         }
+         if (arguments_use_context) {
+            bcemit_AD(fs, BC_CTXGET, context_result_base.raw(), 0);
+            context_scope.activate(this,
+               ContextSource{ .slot = context_result_base, .kind = ContextSourceKind::ContextualArgument });
+         }
+      }
+
+      auto lhs_result = this->emit_expression(*Payload.lhs);
+      if (not lhs_result.ok()) return lhs_result;
+      ExpDesc lhs = lhs_result.value_ref();
+      bool forward_multret = false;
+      if (lhs.k IS ExpKind::Call) {
+         if (Payload.limit > 0) {
+            set_call_result_count(fs, lhs, Payload.limit + 1);
+            fs->freereg = lhs.u.s.aux + Payload.limit;
+         }
+         else {
+            set_call_result_count(fs, lhs, 0);
+            forward_multret = true;
+         }
+      }
+      else this->materialise_to_next_reg(lhs, "contextual pipe operand");
+
+      BCReg arg_count(0);
+      ExpDesc args(ExpKind::Void);
+      if (not call_payload.arguments.empty()) {
+         auto args_result = this->emit_expression_list(call_payload.arguments, arg_count);
+         if (not args_result.ok()) return ParserResult<ExpDesc>::failure(args_result.error_ref());
+         args = args_result.value_ref();
+      }
+
+      BCIns instruction;
+      if (forward_multret and call_payload.arguments.empty()) {
+         instruction = BCINS_ABC(BC_CTXCALLM, base, 2, lhs.u.s.aux - base - 1 - 1);
+      }
+      else {
+         if (args.k != ExpKind::Void) this->materialise_to_next_reg(args, "contextual pipe arguments");
+         instruction = BCINS_ABC(BC_CTXCALL, base, 2, fs->freereg - base - 1);
+      }
+      this->lex_state.lastline = call_line;
+      BCPos call_pc = BCPos(bcemit_INS(fs, instruction));
+      bcemit_INS(fs, BCINS_AD(BC_CTXLEAVE, base, BCREG(base.raw() - context_result_base.raw())));
+
+      if (safe_callable) {
+         ControlFlowEdge skip_nil = this->control_flow.make_unconditional(BCPos(bcemit_jmp(fs)));
+         BCPos nil_path = BCPos(fs->pc);
+         if (not receiver_nil_jump.empty()) receiver_nil_jump.patch_to(nil_path);
+         nil_jump.patch_to(nil_path);
+         bcemit_nil(fs, context_result_base.raw(), 1);
+         skip_nil.patch_to(BCPos(fs->pc));
+      }
+
+      ExpDesc result(ExpKind::Call, call_pc);
+      result.u.s.aux = context_result_base.raw();
+      result.static_results = call_payload.results;
+      if (call_payload.results) {
+         const auto &descriptor = this->ctx.descriptors().results(call_payload.results).value_at(0);
+         result.result_type = descriptor.primary;
+         result.object_class_id = descriptor.object_class_id;
+         result.struct_def = descriptor.struct_def;
+      }
+      fs->freereg = base;
+      return ParserResult<ExpDesc>::success(result);
    }
 
    // Emit the callee (function) FIRST to establish base register
@@ -610,6 +759,28 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_call(const CallExpr
       bcemit_INS(state, BCINS_AD(BC_CTXENTER, field_call_base.raw(), 0));
    }
 
+   ContextSourceScope argument_context_scope;
+   if (contextual_field) {
+      if (receiver_is_proven_contextual(this->ctx, *receiver_node)) {
+         argument_context_scope.activate(this,
+            ContextSource{ .slot = call_base, .kind = ContextSourceKind::ContextualArgument });
+      }
+      else {
+         bool arguments_use_context = false;
+         for (const ExprNodePtr &argument : Payload.arguments) {
+            if (argument and this->expression_uses_context(*argument)) {
+               arguments_use_context = true;
+               break;
+            }
+         }
+         if (arguments_use_context) {
+            bcemit_AD(state, BC_CTXGET, call_base.raw(), 0);
+            argument_context_scope.activate(this,
+               ContextSource{ .slot = call_base, .kind = ContextSourceKind::ContextualArgument });
+         }
+      }
+   }
+
    auto field_call_result = emit_branch_call(false);
    if (not field_call_result.ok()) return ParserResult<ExpDesc>::failure(field_call_result.error_ref());
    BCPos field_call = field_call_result.value_ref();
@@ -681,6 +852,7 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
    bool is_safe_callable = false;
    bool is_contextual_call = false;
    bool uses_specialised_member_dispatch = false;
+   const ExprNode *context_receiver_node = nullptr;
    ControlFlowEdge receiver_nil_jump;
    TiriType callee_return_type = TiriType::Unknown;  // First return type of callee (if known)
    CLASSID callee_object_class_id = CLASSID::NIL;  // CLASSID if return type is Object
@@ -739,6 +911,7 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
       }
 
       is_contextual_call = receiver_node and receiver_uses_contextual_call(this->ctx, *receiver_node);
+      context_receiver_node = receiver_node;
 
       if (is_contextual_call) {
          auto receiver_result = this->emit_expression(*receiver_node);
@@ -873,7 +1046,28 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
       nil_jump = this->control_flow.make_unconditional(BCPos(bcemit_jmp(&this->func_state)));
    }
 
-   if (is_contextual_call) bcemit_INS(&this->func_state, BCINS_AD(BC_CTXENTER, base, 0));
+   ContextSourceScope argument_context_scope;
+   if (is_contextual_call) {
+      bcemit_INS(&this->func_state, BCINS_AD(BC_CTXENTER, base, 0));
+      if (context_receiver_node and receiver_is_proven_contextual(this->ctx, *context_receiver_node)) {
+         argument_context_scope.activate(this,
+            ContextSource{ .slot = context_result_base, .kind = ContextSourceKind::ContextualArgument });
+      }
+      else {
+         bool arguments_use_context = false;
+         for (const ExprNodePtr &argument : Payload.arguments) {
+            if (argument and this->expression_uses_context(*argument)) {
+               arguments_use_context = true;
+               break;
+            }
+         }
+         if (arguments_use_context) {
+            bcemit_AD(&this->func_state, BC_CTXGET, context_result_base.raw(), 0);
+            argument_context_scope.activate(this,
+               ContextSource{ .slot = context_result_base, .kind = ContextSourceKind::ContextualArgument });
+         }
+      }
+   }
 
    // Evaluate arguments only after the nil check, so if callable is nil we skip argument evaluation
    auto arg_count = BCReg(0);

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -300,6 +300,13 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
       }
    }
 
+   auto inherited_cache = child_emitter.allocate_inherited_context_cache(*Payload.body);
+   IrEmitter::ContextSourceScope child_context_scope;
+   if (inherited_cache) {
+      child_context_scope.activate(&child_emitter, ContextSource{ .slot = inherited_cache.value(),
+         .kind = ContextSourceKind::Inherited });
+   }
+
    // Save the parent's lastline - function body emission will update it, but we need
    // to restore it so the BC_FNEW instruction gets the correct line (start of function, not body).
    BCLine saved_lastline = this->lex_state.lastline;

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -41,6 +41,328 @@ inline const TiriConstant * lookup_constant(const GCstr *Name)
 static bool is_named_external_global(GCstr *Name);
 
 //********************************************************************************************************************
+// Contextual member calls select a dynamic context only for contextual tables or unresolved receivers.  A current
+// context expression is already the active receiver, so entering it again would add a redundant runtime frame.
+
+static bool receiver_uses_contextual_call(const ParserContext &Context, const ExprNode &Receiver)
+{
+   if (Receiver.kind IS AstNodeKind::CurrentContextExpr) return false;
+   if (not Receiver.static_value) return true;
+
+   const StaticValueDescriptor &descriptor = Context.descriptors().value(Receiver.static_value);
+   if (descriptor.contextuality IS StaticContextuality::Ordinary) return false;
+   if (descriptor.contextuality IS StaticContextuality::Contextual) return true;
+   return not (descriptor.proved() and descriptor.primary != TiriType::Unknown and
+      descriptor.primary != TiriType::Any and descriptor.primary != TiriType::Table);
+}
+
+static bool receiver_is_proven_contextual(const ParserContext &Context, const ExprNode &Receiver)
+{
+   if (not Receiver.static_value) return false;
+   return Context.descriptors().value(Receiver.static_value).contextuality IS StaticContextuality::Contextual;
+}
+
+static const ExprNode *call_receiver(const CallExprPayload &Payload)
+{
+   const auto *direct = std::get_if<DirectCallTarget>(&Payload.target);
+   if (not direct or not direct->callable) return nullptr;
+
+   switch (direct->callable->kind) {
+      case AstNodeKind::MemberExpr:
+         return std::get<MemberExprPayload>(direct->callable->data).table.get();
+      case AstNodeKind::SafeMemberExpr:
+         return std::get<SafeMemberExprPayload>(direct->callable->data).table.get();
+      case AstNodeKind::IndexExpr:
+         return std::get<IndexExprPayload>(direct->callable->data).table.get();
+      case AstNodeKind::SafeIndexExpr:
+         return std::get<SafeIndexExprPayload>(direct->callable->data).table.get();
+      default:
+         return nullptr;
+   }
+}
+
+//********************************************************************************************************************
+// Walk the AST for context reads that execute in the current emitter region.  Function bodies and using bodies are
+// separate regions: their child emitter or retained reference supplies their own context source.  Contextual call
+// arguments are likewise excluded when the runtime call will install a receiver before evaluating them.  Runtime
+// built-in dispatch is the exception because its ordinary built-in branch evaluates the same arguments without a
+// contextual activation.
+
+class ContextUseWalker {
+public:
+   explicit ContextUseWalker(const ParserContext &Context) : context(Context) { }
+
+   [[nodiscard]] bool block_uses_context(const BlockStmt &Block)
+   {
+      for (const StmtNode &statement : Block.view()) {
+         if (this->statement_uses_context(statement)) return true;
+      }
+      return false;
+   }
+
+   [[nodiscard]] bool expression_uses_context(const ExprNode &Expression)
+   {
+      return this->expression_uses_context_impl(Expression);
+   }
+
+private:
+   const ParserContext &context;
+
+   [[nodiscard]] bool expressions_use_context(const ExprNodeList &Expressions)
+   {
+      for (const ExprNodePtr &expression : Expressions) {
+         if (expression and this->expression_uses_context_impl(*expression)) return true;
+      }
+      return false;
+   }
+
+   [[nodiscard]] bool block_uses_context(const std::unique_ptr<BlockStmt> &Block)
+   {
+      return Block and this->block_uses_context(*Block);
+   }
+
+   [[nodiscard]] bool statement_uses_context(const StmtNode &Statement)
+   {
+      switch (Statement.kind) {
+         case AstNodeKind::AssignmentStmt: {
+            const auto &payload = std::get<AssignmentStmtPayload>(Statement.data);
+            return this->expressions_use_context(payload.targets) or this->expressions_use_context(payload.values);
+         }
+         case AstNodeKind::LocalDeclStmt: {
+            const auto &payload = std::get<LocalDeclStmtPayload>(Statement.data);
+            return this->expressions_use_context(payload.values);
+         }
+         case AstNodeKind::GlobalDeclStmt: {
+            const auto &payload = std::get<GlobalDeclStmtPayload>(Statement.data);
+            return this->expressions_use_context(payload.values);
+         }
+         case AstNodeKind::LocalFunctionStmt:
+         case AstNodeKind::FunctionStmt:
+            return false;
+         case AstNodeKind::IfStmt: {
+            const auto &payload = std::get<IfStmtPayload>(Statement.data);
+            for (const IfClause &clause : payload.clauses) {
+               if ((clause.condition and this->expression_uses_context_impl(*clause.condition)) or
+                   this->block_uses_context(clause.block)) return true;
+            }
+            return false;
+         }
+         case AstNodeKind::WhileStmt:
+         case AstNodeKind::RepeatStmt: {
+            const auto &payload = std::get<LoopStmtPayload>(Statement.data);
+            return (payload.condition and this->expression_uses_context_impl(*payload.condition)) or
+               this->block_uses_context(payload.body);
+         }
+         case AstNodeKind::NumericForStmt: {
+            const auto &payload = std::get<NumericForStmtPayload>(Statement.data);
+            return (payload.start and this->expression_uses_context_impl(*payload.start)) or
+               (payload.stop and this->expression_uses_context_impl(*payload.stop)) or
+               (payload.step and this->expression_uses_context_impl(*payload.step)) or
+               this->block_uses_context(payload.body);
+         }
+         case AstNodeKind::RangeForStmt: {
+            const auto &payload = std::get<RangeForStmtPayload>(Statement.data);
+            return (payload.start and this->expression_uses_context_impl(*payload.start)) or
+               (payload.stop and this->expression_uses_context_impl(*payload.stop)) or
+               (payload.step and this->expression_uses_context_impl(*payload.step)) or
+               this->block_uses_context(payload.body);
+         }
+         case AstNodeKind::GenericForStmt: {
+            const auto &payload = std::get<GenericForStmtPayload>(Statement.data);
+            return this->expressions_use_context(payload.iterators) or this->block_uses_context(payload.body);
+         }
+         case AstNodeKind::ReturnStmt:
+            return this->expressions_use_context(std::get<ReturnStmtPayload>(Statement.data).values);
+         case AstNodeKind::DeferStmt: {
+            const auto &payload = std::get<DeferStmtPayload>(Statement.data);
+            return this->expressions_use_context(payload.arguments);
+         }
+         case AstNodeKind::DoStmt:
+            return this->block_uses_context(std::get<DoStmtPayload>(Statement.data).block);
+         case AstNodeKind::ContextStmt: {
+            const auto &payload = std::get<ContextStmtPayload>(Statement.data);
+            // The reference is evaluated before the new context becomes visible.  The body is a separate source.
+            return payload.reference and this->expression_uses_context_impl(*payload.reference);
+         }
+         case AstNodeKind::ConditionalShorthandStmt: {
+            const auto &payload = std::get<ConditionalShorthandStmtPayload>(Statement.data);
+            return (payload.condition and this->expression_uses_context_impl(*payload.condition)) or
+               (payload.body and this->statement_uses_context(*payload.body));
+         }
+         case AstNodeKind::TryExceptStmt: {
+            const auto &payload = std::get<TryExceptPayload>(Statement.data);
+            if (this->block_uses_context(payload.try_block) or this->block_uses_context(payload.success_block)) {
+               return true;
+            }
+            for (const ExceptClause &clause : payload.except_clauses) {
+               if (this->expressions_use_context(clause.filter_codes) or this->block_uses_context(clause.block)) {
+                  return true;
+               }
+            }
+            return false;
+         }
+         case AstNodeKind::RaiseStmt: {
+            const auto &payload = std::get<RaiseStmtPayload>(Statement.data);
+            return (payload.error_code and this->expression_uses_context_impl(*payload.error_code)) or
+               (payload.message and this->expression_uses_context_impl(*payload.message));
+         }
+         case AstNodeKind::CheckStmt: {
+            const auto &payload = std::get<CheckStmtPayload>(Statement.data);
+            return payload.error_code and this->expression_uses_context_impl(*payload.error_code);
+         }
+         case AstNodeKind::ImportStmt: {
+            const auto &payload = std::get<ImportStmtPayload>(Statement.data);
+            for (const ImportEntryPayload &entry : payload.entries) {
+               if (this->block_uses_context(entry.inlined_body)) return true;
+            }
+            return false;
+         }
+         case AstNodeKind::WithStmt: {
+            const auto &payload = std::get<WithStmtPayload>(Statement.data);
+            return this->expressions_use_context(payload.objects) or this->block_uses_context(payload.block);
+         }
+         case AstNodeKind::ExpressionStmt:
+            return std::get<ExpressionStmtPayload>(Statement.data).expression and
+               this->expression_uses_context_impl(*std::get<ExpressionStmtPayload>(Statement.data).expression);
+         case AstNodeKind::BreakStmt:
+         case AstNodeKind::ContinueStmt:
+         case AstNodeKind::ExternStmt:
+            return false;
+         default:
+            return false;
+      }
+   }
+
+   [[nodiscard]] bool expression_uses_context_impl(const ExprNode &Expression)
+   {
+      switch (Expression.kind) {
+         case AstNodeKind::CurrentContextExpr:
+            return true;
+         case AstNodeKind::UnaryExpr:
+            return this->expression_uses_context_ptr(std::get<UnaryExprPayload>(Expression.data).operand);
+         case AstNodeKind::UpdateExpr:
+            return this->expression_uses_context_ptr(std::get<UpdateExprPayload>(Expression.data).target);
+         case AstNodeKind::BinaryExpr: {
+            const auto &payload = std::get<BinaryExprPayload>(Expression.data);
+            return this->expression_uses_context_ptr(payload.left) or this->expression_uses_context_ptr(payload.right);
+         }
+         case AstNodeKind::ComparisonChainExpr:
+            return this->expressions_use_context(std::get<ComparisonChainExprPayload>(Expression.data).operands);
+         case AstNodeKind::TernaryExpr: {
+            const auto &payload = std::get<TernaryExprPayload>(Expression.data);
+            return this->expression_uses_context_ptr(payload.condition) or
+               this->expression_uses_context_ptr(payload.if_true) or
+               this->expression_uses_context_ptr(payload.if_false);
+         }
+         case AstNodeKind::PresenceExpr:
+            return this->expression_uses_context_ptr(std::get<PresenceExprPayload>(Expression.data).value);
+         case AstNodeKind::PipeExpr: {
+            const auto &payload = std::get<PipeExprPayload>(Expression.data);
+            if (payload.rhs_call and
+                (payload.rhs_call->kind IS AstNodeKind::CallExpr or
+                 payload.rhs_call->kind IS AstNodeKind::SafeCallExpr)) {
+               const auto &call = std::get<CallExprPayload>(payload.rhs_call->data);
+               const ExprNode *receiver = call_receiver(call);
+               bool callable_uses_context = false;
+               if (const auto *direct = std::get_if<DirectCallTarget>(&call.target)) {
+                  callable_uses_context = direct->callable and this->expression_uses_context_impl(*direct->callable);
+               }
+               if (call.runtime_builtin_method) {
+                  return callable_uses_context or this->expression_uses_context_ptr(payload.lhs) or
+                     this->expressions_use_context(call.arguments);
+               }
+               if (receiver and receiver_uses_contextual_call(this->context, *receiver)) {
+                  // The contextual pipe path evaluates its piped value and written arguments after CTXENTER.  Only
+                  // the receiver, its key and the callable itself execute under the enclosing source.
+                  return callable_uses_context;
+               }
+            }
+            return this->expression_uses_context_ptr(payload.lhs) or
+               this->expression_uses_context_ptr(payload.rhs_call);
+         }
+         case AstNodeKind::CallExpr:
+         case AstNodeKind::SafeCallExpr: {
+            const auto &payload = std::get<CallExprPayload>(Expression.data);
+            bool result = false;
+            if (const auto *direct = std::get_if<DirectCallTarget>(&payload.target)) {
+               result = direct->callable and this->expression_uses_context_impl(*direct->callable);
+            }
+
+            // Runtime built-in dispatch emits an ordinary built-in branch and a contextual fallback branch.  Its
+            // arguments therefore need the enclosing source even when the receiver is unresolved.
+            if (payload.runtime_builtin_method or not call_receiver(payload)) {
+               return result or this->expressions_use_context(payload.arguments);
+            }
+
+            const ExprNode *receiver = call_receiver(payload);
+            if (receiver_uses_contextual_call(this->context, *receiver)) return result;
+            return result or this->expressions_use_context(payload.arguments);
+         }
+         case AstNodeKind::MemberExpr:
+            return this->expression_uses_context_ptr(std::get<MemberExprPayload>(Expression.data).table);
+         case AstNodeKind::IndexExpr: {
+            const auto &payload = std::get<IndexExprPayload>(Expression.data);
+            return this->expression_uses_context_ptr(payload.table) or
+               this->expression_uses_context_ptr(payload.index);
+         }
+         case AstNodeKind::SafeMemberExpr:
+            return this->expression_uses_context_ptr(std::get<SafeMemberExprPayload>(Expression.data).table);
+         case AstNodeKind::SafeIndexExpr: {
+            const auto &payload = std::get<SafeIndexExprPayload>(Expression.data);
+            return this->expression_uses_context_ptr(payload.table) or
+               this->expression_uses_context_ptr(payload.index);
+         }
+         case AstNodeKind::ResultFilterExpr:
+            return this->expression_uses_context_ptr(std::get<ResultFilterPayload>(Expression.data).expression);
+         case AstNodeKind::TableExpr: {
+            const auto &payload = std::get<TableExprPayload>(Expression.data);
+            for (const TableField &field : payload.fields) {
+               if (this->expression_uses_context_ptr(field.key) or this->expression_uses_context_ptr(field.value)) {
+                  return true;
+               }
+            }
+            return false;
+         }
+         case AstNodeKind::FunctionExpr:
+            return false;
+         case AstNodeKind::DeferredExpr:
+            return this->expression_uses_context_ptr(std::get<DeferredExprPayload>(Expression.data).inner);
+         case AstNodeKind::RangeExpr: {
+            const auto &payload = std::get<RangeExprPayload>(Expression.data);
+            return this->expression_uses_context_ptr(payload.start) or
+               this->expression_uses_context_ptr(payload.stop) or
+               this->expression_uses_context_ptr(payload.step);
+         }
+         case AstNodeKind::ChooseExpr: {
+            const auto &payload = std::get<ChooseExprPayload>(Expression.data);
+            if (this->expression_uses_context_ptr(payload.scrutinee) or
+                this->expressions_use_context(payload.scrutinee_tuple)) return true;
+            for (const ChooseCase &choice : payload.cases) {
+               if (this->expression_uses_context_ptr(choice.pattern) or
+                   this->expressions_use_context(choice.tuple_patterns) or
+                   this->expression_uses_context_ptr(choice.guard) or
+                   this->expression_uses_context_ptr(choice.result) or
+                   (choice.result_stmt and this->statement_uses_context(*choice.result_stmt))) return true;
+            }
+            return false;
+         }
+         case AstNodeKind::LiteralExpr:
+         case AstNodeKind::IdentifierExpr:
+         case AstNodeKind::VarArgExpr:
+         case AstNodeKind::ModuleFunctionExpr:
+            return false;
+         default:
+            return false;
+      }
+   }
+
+   [[nodiscard]] bool expression_uses_context_ptr(const ExprNodePtr &Expression)
+   {
+      return Expression and this->expression_uses_context_impl(*Expression);
+   }
+};
+
+//********************************************************************************************************************
 // Determine whether a constant integer range can use its visible value as the numeric loop induction variable.
 
 static bool range_direct_integer(
@@ -721,6 +1043,84 @@ IrEmitter::IrEmitter(ParserContext& context)
 {
 }
 
+IrEmitter::ContextSourceScope::ContextSourceScope(ContextSourceScope &&Other) noexcept
+   : emitter(Other.emitter), active(Other.active)
+{
+   Other.emitter = nullptr;
+   Other.active = false;
+}
+
+IrEmitter::ContextSourceScope& IrEmitter::ContextSourceScope::operator=(ContextSourceScope &&Other) noexcept
+{
+   if (this IS &Other) return *this;
+   this->release();
+   this->emitter = Other.emitter;
+   this->active = Other.active;
+   Other.emitter = nullptr;
+   Other.active = false;
+   return *this;
+}
+
+IrEmitter::ContextSourceScope::~ContextSourceScope()
+{
+   this->release();
+}
+
+void IrEmitter::ContextSourceScope::activate(IrEmitter *Owner, ContextSource Source)
+{
+   this->release();
+   if (not Owner) return;
+   Owner->push_context_source(Source);
+   this->emitter = Owner;
+   this->active = true;
+}
+
+void IrEmitter::ContextSourceScope::release()
+{
+   if (this->active and this->emitter) this->emitter->pop_context_source();
+   this->emitter = nullptr;
+   this->active = false;
+}
+
+bool IrEmitter::context_region_uses_context(const BlockStmt &Block) const
+{
+   ContextUseWalker walker(this->ctx);
+   return walker.block_uses_context(Block);
+}
+
+bool IrEmitter::expression_uses_context(const ExprNode &Expression) const
+{
+   ContextUseWalker walker(this->ctx);
+   return walker.expression_uses_context(Expression);
+}
+
+std::optional<BCReg> IrEmitter::allocate_inherited_context_cache(const BlockStmt &Block)
+{
+   if (not this->context_region_uses_context(Block)) return std::nullopt;
+
+   // The cache is an internal local, so it participates in frame sizing and GC stack marking but cannot be resolved by
+   // a source identifier, captured as an upvalue or modified through debug.setLocal().  It is allocated after
+   // parameter contracts and before body code.
+   this->func_state.reset_freereg();
+   this->lex_state.var_new_fixed(BCReg(0), VARNAME_CONTEXT_CACHE);
+   this->lex_state.var_add(BCReg(1));
+   this->func_state.reset_freereg();
+   BCReg slot = BCReg(this->func_state.varmap.size() - 1);
+   bcemit_AD(&this->func_state, BC_CTXGET, slot.raw(), 0);
+   return slot;
+}
+
+void IrEmitter::push_context_source(ContextSource Source)
+{
+   this->context_sources.push_back(Source);
+}
+
+void IrEmitter::pop_context_source()
+{
+   lj_assertX(not this->context_sources.empty(), "context source stack underflow");
+   this->context_sources.pop_back();
+}
+
 std::optional<CompileTimeValue> IrEmitter::resolve_compile_time_value(const NameRef &Reference) const
 {
    const LocalBindingEntry *entry = this->binding_table.resolve(Reference.identifier.symbol);
@@ -827,6 +1227,12 @@ ParserResult<IrEmitUnit> IrEmitter::emit_chunk(const BlockStmt& chunk)
    this->control_flow.reset(&this->func_state);
    FuncScope chunk_scope;
    ScopeGuard guard(&this->func_state, &chunk_scope, FuncScopeFlag::None);
+   auto inherited_cache = this->allocate_inherited_context_cache(chunk);
+   ContextSourceScope context_scope;
+   if (inherited_cache) {
+      context_scope.activate(this, ContextSource{ .slot = inherited_cache.value(),
+         .kind = ContextSourceKind::Inherited });
+   }
    auto result = this->emit_block(chunk, FuncScopeFlag::None);
    if (not result.ok()) return result;
    this->control_flow.finalize();
@@ -1001,7 +1407,9 @@ ParserResult<IrEmitUnit> IrEmitter::emit_context_stmt(const ContextStmtPayload &
    auto reference = this->emit_expression(*Payload.reference);
    if (not reference.ok()) return ParserResult<IrEmitUnit>::failure(reference.error_ref());
 
-   BCReg slot = fs->free_reg();
+   // Pending locals do not contribute to varmap.size(), and evaluating a complex reference may leave temporaries
+   // above the local floor.  The retained context must use the slot that var_add() will actually publish.
+   BCReg slot = BCReg(fs->varmap.size());
    ExpDesc value = reference.value_ref();
    this->materialise_to_reg(value, slot, "context block reference");
    RegisterAllocator allocator(fs);
@@ -1021,6 +1429,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_context_stmt(const ContextStmtPayload &
    });
    scope.context_block = block_index;
    bcemit_AD(fs, BC_CTXBEGIN, slot.raw(), block_index);
+   ContextSourceScope context_scope;
+   context_scope.activate(this, ContextSource{ .slot = slot, .kind = ContextSourceKind::UsingReference });
 
    for (const StmtNode &stmt : Payload.block->view()) {
       auto status = this->emit_statement(stmt);
@@ -2807,10 +3217,18 @@ ParserResult<ExpDesc> IrEmitter::emit_literal_expr(const LiteralValue& literal)
 }
 
 //********************************************************************************************************************
-// Load the state-local table context.  The runtime resolves an empty override stack through the current L->env.
+// Resolve the active table context.  Stable regions use their retained register; regions without a known source
+// materialise through BC_CTXGET, whose runtime resolution still follows the dynamic context stack and L->env root.
 
 ParserResult<ExpDesc> IrEmitter::emit_current_context_expr()
 {
+   if (not this->context_sources.empty()) {
+      const ContextSource &source = this->context_sources.back();
+      ExpDesc expr(ExpKind::NonReloc, source.slot.raw());
+      expr.result_type = TiriType::Table;
+      return ParserResult<ExpDesc>::success(expr);
+   }
+
    ExpDesc expr;
    expr.init(ExpKind::Relocable, bcemit_AD(&this->func_state, BC_CTXGET, 0, 0));
    expr.result_type = TiriType::Table;

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
@@ -36,6 +36,19 @@ struct BlockBinding {
 
 //********************************************************************************************************************
 
+enum class ContextSourceKind : uint8_t {
+   Inherited,
+   UsingReference,
+   ContextualArgument
+};
+
+struct ContextSource {
+   BCReg slot = BCReg(0);
+   ContextSourceKind kind = ContextSourceKind::Inherited;
+};
+
+//********************************************************************************************************************
+
 class LocalBindingTable {
 public:
    inline LocalBindingTable() = default;
@@ -150,6 +163,22 @@ private:
    friend struct LoopStackGuard;
    friend class NilShortCircuitGuard;
 
+   struct ContextSourceScope {
+      ContextSourceScope() = default;
+      ContextSourceScope(const ContextSourceScope &) = delete;
+      ContextSourceScope& operator=(const ContextSourceScope &) = delete;
+      ContextSourceScope(ContextSourceScope &&Other) noexcept;
+      ContextSourceScope& operator=(ContextSourceScope &&Other) noexcept;
+      ~ContextSourceScope();
+
+      void activate(IrEmitter *Owner, ContextSource Source);
+      void release();
+
+   private:
+      IrEmitter *emitter = nullptr;
+      bool active = false;
+   };
+
    ParserContext &ctx;
    FuncState &func_state;
    LexState &lex_state;
@@ -160,6 +189,7 @@ private:
    ConstantEvaluator constant_evaluator;
    StaticCallableHandle current_callable = 0;
    bool is_root_chunk = true;
+   std::vector<ContextSource> context_sources;
 
    ParserResult<IrEmitUnit> emit_block(const BlockStmt& block, FuncScopeFlag flags = FuncScopeFlag::None);
    ParserResult<IrEmitUnit> emit_block_with_bindings(const BlockStmt& block, FuncScopeFlag flags, std::span<const BlockBinding> bindings);
@@ -250,6 +280,11 @@ private:
    ParserResult<ExpDesc> unsupported_expr(AstNodeKind kind, const SourceSpan& span);
 
    [[nodiscard]] std::optional<CompileTimeValue> resolve_compile_time_value(const NameRef &Reference) const;
+   [[nodiscard]] bool context_region_uses_context(const BlockStmt &Block) const;
+   [[nodiscard]] bool expression_uses_context(const ExprNode &Expression) const;
+   [[nodiscard]] std::optional<BCReg> allocate_inherited_context_cache(const BlockStmt &Block);
+   void push_context_source(ContextSource Source);
+   void pop_context_source();
    inline std::optional<BCReg> resolve_local(GCstr *Symbol) const {
       const LocalBindingEntry *entry = this->binding_table.resolve(Symbol);
       return entry ? std::optional<BCReg>(entry->slot) : std::nullopt;

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -3330,187 +3330,6 @@ static bool test_module_definition_ownership(kt::Log &Log)
 }
 
 //********************************************************************************************************************
-// Phase 3: portable prototype dependency descriptors.
-//
-// Verifies that a compilation unit's module declarations are recorded as canonical names on its prototype, that the
-// names deduplicate across aliases, that a dependency with no referenced function is retained, and that the whole
-// block survives a bytecode round trip in a fresh state.
-
-static bool test_module_dependency_descriptors(kt::Log &Log)
-{
-   LuaStateHolder state;
-   lua_State *L = state.get();
-   luaL_openlibs(L);
-   register_module_class(L);
-   lua_protect_globals(L);
-
-   // 'core' is referenced through two aliases and 'display' is declared without being referenced, so the descriptors
-   // must contain exactly two modules, one carrying a single function and the other none.
-
-   constexpr std::string_view source =
-      "module core as mC\n"
-      "module core as mCore\n"
-      "module display as mD\n"
-      "local a = mC.PreciseTime()\n"
-      "local b = mCore.PreciseTime()\n"
-      "return a + b\n";
-
-   if (lua_load(L, source, "dependency-descriptors")) {
-      Log.error("failed to compile the descriptor fixture: %s", lua_tostring(L, -1));
-      return false;
-   }
-
-   GCproto *proto = funcproto(funcV(L->top - 1));
-   auto table = proto_dependencies(proto);
-   if (not table) {
-      Log.error("a unit declaring modules produced no dependency descriptors");
-      return false;
-   }
-
-   if (table->version != PROTO_DEPENDENCY_VERSION) {
-      Log.error("descriptor version is %d, expected %d", int(table->version), int(PROTO_DEPENDENCY_VERSION));
-      return false;
-   }
-
-   if (table->dependency_count != 2) {
-      Log.error("two aliases of one module produced %d dependencies, expected 2",
-         int(table->dependency_count));
-      return false;
-   }
-
-   if (table->function_count != 1) {
-      Log.error("one deduplicated function reference produced %d entries, expected 1",
-         int(table->function_count));
-      return false;
-   }
-
-   auto dependencies = proto_dependency_list(table);
-   auto functions = proto_dependency_functions(table);
-
-   bool saw_core = false, saw_display = false;
-   for (uint32_t i = 0; i < table->dependency_count; ++i) {
-      GCstr *name = gco_to_string(gcref(dependencies[i].name));
-      std::string_view view(strdata(name), name->len);
-
-      if (kt::iequals(view, "core")) {
-         saw_core = true;
-         if (dependencies[i].function_count != 1) {
-            Log.error("the core dependency records %d functions, expected 1",
-               int(dependencies[i].function_count));
-            return false;
-         }
-         GCstr *function = gco_to_string(gcref(functions[dependencies[i].first_function].name));
-         if (not kt::iequals(std::string_view(strdata(function), function->len), "PreciseTime")) {
-            Log.error("the recorded function name is '%.*s', expected PreciseTime",
-               int(function->len), strdata(function));
-            return false;
-         }
-      }
-      else if (kt::iequals(view, "display")) {
-         saw_display = true;
-         if (dependencies[i].function_count != 0) {
-            Log.error("an unreferenced declaration recorded %d functions, expected 0",
-               int(dependencies[i].function_count));
-            return false;
-         }
-      }
-      else {
-         Log.error("unexpected dependency '%.*s'", int(name->len), strdata(name));
-         return false;
-      }
-   }
-
-   if (not saw_core or not saw_display) {
-      Log.error("descriptors are missing core (%d) or display (%d)", int(saw_core), int(saw_display));
-      return false;
-   }
-
-   // Round trip through a dump.  The reload happens in a second state, so the rebuilt descriptors cannot be sharing
-   // anything with the originals; only the persisted names connect them.
-
-   std::string dump;
-   if (lua_dump(L, bytecode_writer, &dump) != 0) {
-      Log.error("failed to dump the descriptor fixture");
-      return false;
-   }
-   lua_pop(L, 1);
-
-   LuaStateHolder reload_state;
-   lua_State *R = reload_state.get();
-   luaL_openlibs(R);
-   register_module_class(R);
-   lua_protect_globals(R);
-   if (lua_load(R, std::string_view(dump.data(), dump.size()), "dependency-reload")) {
-      Log.error("failed to reload the descriptor fixture: %s", lua_tostring(R, -1));
-      return false;
-   }
-
-   auto reloaded = proto_dependencies(funcproto(funcV(R->top - 1)));
-   if (not reloaded) {
-      Log.error("the reloaded prototype lost its dependency descriptors");
-      return false;
-   }
-
-   if (reloaded->dependency_count != table->dependency_count or
-       reloaded->function_count != table->function_count) {
-      Log.error("the reloaded descriptors have %d/%d entries, expected %d/%d",
-         int(reloaded->dependency_count), int(reloaded->function_count),
-         int(table->dependency_count), int(table->function_count));
-      return false;
-   }
-
-   auto reloaded_dependencies = proto_dependency_list(reloaded);
-   for (uint32_t i = 0; i < reloaded->dependency_count; ++i) {
-      GCstr *original = gco_to_string(gcref(dependencies[i].name));
-      GCstr *restored = gco_to_string(gcref(reloaded_dependencies[i].name));
-      if (not kt::iequals(std::string_view(strdata(original), original->len),
-            std::string_view(strdata(restored), restored->len))) {
-         Log.error("dependency %d reloaded as '%.*s', expected '%.*s'", int(i),
-            int(restored->len), strdata(restored), int(original->len), strdata(original));
-         return false;
-      }
-      if (reloaded_dependencies[i].first_function != dependencies[i].first_function or
-          reloaded_dependencies[i].function_count != dependencies[i].function_count) {
-         Log.error("dependency %d reloaded with a different function range", int(i));
-         return false;
-      }
-   }
-
-   // The dumped chunk must still run in the fresh state, which exercises resolution of the reloaded names against
-   // the global registry rather than anything carried over from compilation.
-
-   if (lua_pcall(R, 0, 1, 0)) {
-      Log.error("the reloaded chunk failed to execute: %s", lua_tostring(R, -1));
-      return false;
-   }
-   if (not lua_isnumber(R, -1)) {
-      Log.error("the reloaded chunk did not produce a numeric result");
-      return false;
-   }
-   lua_pop(R, 1);
-
-   // A prototype without module declarations must carry no descriptor block at all, so that ordinary functions pay
-   // nothing for the feature.
-
-   LuaStateHolder plain_state;
-   lua_State *P = plain_state.get();
-   luaL_openlibs(P);
-   register_module_class(P);
-   lua_protect_globals(P);
-   if (lua_load(P, std::string_view("return 1"), "dependency-none")) {
-      Log.error("failed to compile the descriptor-free fixture: %s", lua_tostring(P, -1));
-      return false;
-   }
-   if (proto_dependencies(funcproto(funcV(P->top - 1)))) {
-      Log.error("a unit with no module declaration produced dependency descriptors");
-      return false;
-   }
-   lua_pop(P, 1);
-
-   return true;
-}
-
-//********************************************************************************************************************
 // Corrupt dependency metadata must be rejected rather than resolved.  The fixture mutates a valid dump, so every
 // rejection below is attributable to the dependency block and not to an unrelated inconsistency.
 
@@ -3785,7 +3604,6 @@ static bool test_module_registry(kt::Log &Log)
       test_module_registry_shared_ordinal(Log) and
       test_module_registry_concurrency(Log) and
       test_module_definition_ownership(Log) and
-      test_module_dependency_descriptors(Log) and
       test_module_dependency_activation_uses_sidecar(Log) and
       test_module_dependency_corruption_rejected(Log);
 }
@@ -4825,6 +4643,76 @@ static bool test_current_context_materialisation_bytecode(kt::Log &Log)
       return false;
    }
 
+   error.clear();
+   auto repeated = compile_snapshot(L,
+      "function repeated():num return &value + &value + &value end\n", true, error);
+   if (not repeated or count_opcode_tree(*repeated, BC_CTXGET) != 1 or
+       count_opcode_tree(*repeated, BC_TGETS) != 3) {
+      Log.error("repeated inherited context access did not reuse one cache register: %s", error.c_str());
+      return false;
+   }
+
+   error.clear();
+   auto context_free = compile_snapshot(L, "function plain():num return 1 end\n", true, error);
+   if (not context_free or count_opcode_tree(*context_free, BC_CTXGET) != 0) {
+      Log.error("a function without context access acquired an unnecessary cache: %s", error.c_str());
+      return false;
+   }
+
+   error.clear();
+   auto using_block = compile_snapshot(L,
+      "local receiver = { value = 1 }\n"
+      "using receiver do return &value + &value end\n", true, error);
+   if (not using_block or count_opcode_tree(*using_block, BC_CTXGET) != 0 or
+       count_opcode_tree(*using_block, BC_TGETS) != 2) {
+      Log.error("direct context access in a using block did not use its retained reference: %s", error.c_str());
+      return false;
+   }
+
+   error.clear();
+   auto using_closure = compile_snapshot(L,
+      "local receiver = { value = 1 }\n"
+      "using receiver do local read = function():num return &value end return read() end\n", true, error);
+   if (not using_closure or count_opcode_tree(*using_closure, BC_CTXGET) != 1 or
+       count_opcode_tree(*using_closure, BC_UGET) != 0) {
+      Log.error("a function declared in using did not acquire an isolated inherited cache: %s", error.c_str());
+      return false;
+   }
+
+   error.clear();
+   auto contextual_pipe = compile_snapshot(L,
+      "local receiver = entity { value = 1 }\n"
+      "function receiver.add(Value:num):num return &value + Value end\n"
+      "return 2 |> receiver.add()\n", true, error);
+   if (not contextual_pipe or count_opcode(*contextual_pipe, BC_CTXENTER) != 1 or
+       count_opcode(*contextual_pipe, BC_CTXCALL) != 1 or count_opcode(*contextual_pipe, BC_CTXLEAVE) != 1) {
+      Log.error("a contextual pipe destination did not use the contextual call frame: %s", error.c_str());
+      return false;
+   }
+
+   error.clear();
+   auto runtime_context_pipe = compile_snapshot(L,
+      "local function invoke(Target:any):num return &value |> Target['consume']() end\n", true, error);
+   if (not runtime_context_pipe or count_opcode_tree(*runtime_context_pipe, BC_CTXGET) != 1 or
+       count_opcode_tree(*runtime_context_pipe, BC_CTXENTER) != 1 or
+       count_opcode_tree(*runtime_context_pipe, BC_CTXCALL) != 1) {
+      Log.error("a runtime-dependent contextual pipe did not acquire its argument context: %s", error.c_str());
+      return false;
+   }
+
+   error.clear();
+   auto runtime_builtin_pipe = compile_snapshot(L,
+      "local function invoke(Target:any):num\n"
+      "   local inherited = &value\n"
+      "   return &value |> Target.add()\n"
+      "end\n", true, error);
+   if (not runtime_builtin_pipe or count_opcode_tree(*runtime_builtin_pipe, BC_CTXGET) != 2 or
+       count_opcode_tree(*runtime_builtin_pipe, BC_BMETH) != 1 or
+       count_opcode_tree(*runtime_builtin_pipe, BC_CTXENTER) != 1) {
+      Log.error("a runtime built-in pipe did not separate inherited and fallback contexts: %s", error.c_str());
+      return false;
+   }
+
    return true;
 }
 
@@ -5820,11 +5708,33 @@ static bool test_contextual_call_specialisation(kt::Log &Log)
    }
 
    error.clear();
+   auto contextual_arguments = compile_snapshot(L,
+      "local target = entity { value = 1 }\n"
+      "function target.read(Value:num):num return &value + Value end\n"
+      "return target.read(&value)\n", true, error);
+   if (not contextual_arguments or count_opcode(*contextual_arguments, BC_CTXGET) != 0 or
+       count_opcode(*contextual_arguments, BC_CTXENTER) != 1 or
+       count_opcode(*contextual_arguments, BC_CTXCALL) != 1) {
+      Log.error("a statically contextual argument region reacquired its retained receiver: %s", error.c_str());
+      return false;
+   }
+
+   error.clear();
    auto unknown = compile_snapshot(L,
       "local function invoke(Target:any) Target.run() end\n", true, error);
    if (not unknown or count_opcode_tree(*unknown, BC_CTXENTER) != 1 or
        count_opcode_tree(*unknown, BC_CTXCALL) != 1 or count_opcode_tree(*unknown, BC_CTXLEAVE) != 1) {
       Log.error("an unknown receiver lost its runtime contextual gate: %s", error.c_str());
+      return false;
+   }
+
+   error.clear();
+   auto runtime_arguments = compile_snapshot(L,
+      "local function invoke(Target:any):num return Target['run'](&value) end\n", true, error);
+   if (not runtime_arguments or count_opcode_tree(*runtime_arguments, BC_CTXGET) != 1 or
+       count_opcode_tree(*runtime_arguments, BC_CTXENTER) != 1 or
+       count_opcode_tree(*runtime_arguments, BC_CTXCALL) != 1) {
+      Log.error("a runtime contextual argument region did not acquire one scratch context: %s", error.c_str());
       return false;
    }
 

--- a/src/tiri/tests/test_context_access.tiri
+++ b/src/tiri/tests/test_context_access.tiri
@@ -42,6 +42,18 @@ end
    &glContextAccessInherited = nil
 end
 
+@Test function DebugSetLocalCannotModifyInheritedContextCache()
+   local receiver = entity { value = 7 }
+
+   function receiver.read():num
+      local cache_name = debug.setLocal(1, 0, { value = 99 })
+      assert(cache_name is nil, 'debug.setLocal should reject the internal context cache')
+      return &value
+   end
+
+   assert(receiver.read() is 7, 'Rejected debug mutation should leave the inherited context cache unchanged')
+end
+
 @Test function ContextStoreCannotOverrideProtectedGlobal()
    local script = activate_context_statement([[&tostring = 5]])
    assert(script.error != ERR_Okay, 'A root context store should reject a protected global')

--- a/src/tiri/tests/test_contextual_member_calls.tiri
+++ b/src/tiri/tests/test_contextual_member_calls.tiri
@@ -125,6 +125,62 @@ end
       'A safe dynamic built-in fallback should use the runtime table gate on its non-nil path')
 end
 
+@Test function ContextualPipeCallsPreserveReceiverContext()
+   local receiver = entity { value = 7 }
+
+   function receiver.add(Value:num):num
+      return &value + Value
+   end
+
+   function receiver.sum(First:num, Second:num):num
+      return &value + First + Second
+   end
+
+   function values():<num, num>
+      return 1, 2
+   end
+
+   assert(3 |> receiver.add() is 10,
+      'A statically contextual pipe destination should evaluate in its receiver context')
+   assert(3 |> receiver['add']() is 10,
+      'A computed contextual pipe destination should retain its receiver context')
+   assert(3 |> receiver?.add() is 10,
+      'A safe contextual pipe destination should establish context on its non-nil path')
+   assert(values() |> receiver.sum() is 10,
+      'A contextual pipe destination should preserve forwarded multiple results')
+end
+
+@Test function RuntimeDependentPipesSelectTheActiveArgumentContext()
+   local outer = entity { value = 100 }
+   local ordinary = {
+      value = 7,
+      consume = function(Value:num):num return Value end
+   }
+
+   function outer.pipe_to(Target:any):num
+      return &value + &value |> Target['consume']()
+   end
+
+   assert(outer.pipe_to(ordinary) is 200,
+      'A runtime ordinary pipe receiver should retain the caller context for its piped operand')
+end
+
+@Test function RuntimeBuiltinPipeFallbackUsesReceiverContext()
+   local outer = entity { value = 100, target = entity { value = 7 } }
+
+   function outer.target.add(Value:num):num
+      return &value + Value
+   end
+
+   function outer.pipe_to_target():num
+      local inherited = &value
+      return &value + &value |> &&.target.add()
+   end
+
+   assert(outer.pipe_to_target() is 21,
+      'A runtime built-in fallback should evaluate its piped operand in the contextual receiver')
+end
+
 @Test function DynamicFallbackObjectReadsSurviveStackGrowth()
    local holder:any = {
       func = function()

--- a/tools/idl/idl-c.tiri
+++ b/tools/idl/idl-c.tiri
@@ -105,7 +105,7 @@ global function extractFields(Def:str, Origin:str):table
             type = type.sub(1).trim()
          end
 
-         field = cType({ type=type, name=name.trim(), comment=comment.trim() }, Origin)
+         field = cType({ type=type, name=name?.trim(), comment=comment?.trim() }, Origin)
          if virtual then field.virtual = true end
          fields.insert(field)
       elseif not content.trim()?? then


### PR DESCRIPTION
* Functions and chunks that read their inherited context now emit a single CTXGET into a hidden local at region entry, with repeated `&&`, `&name` and `&&.name` accesses reading that register instead of re-resolving the context stack
* Added an AST walker that determines whether a region actually uses its context, so regions without context reads retain neither a cache local nor a CTXGET
* Introduced a context source stack with RAII scoping so using blocks read their retained reference register and contextual calls read the retained receiver
* Implemented the contextual pipe path in emit_pipe_expr(), giving `|>` destinations with contextual receivers a CTXENTER/CTXCALL/CTXLEAVE frame that supports member, computed, safe and multiple-result forms
* Contextual and runtime built-in call sites acquire a scratch context register only when their arguments read the enclosing context
* Fixed the using block retained slot to use the varmap publication slot rather than the free register, which could diverge when a complex reference left temporaries above the local floor
* Rejected debug.setLocal() writes to the internal context cache local
* [Doc] Documented the cache acquisition model and root environment replacement contract in BYTECODE.md
* [Tools] Guarded nil field type and comment values in the IDL field extractor