### PR TITLE
[Tiri] Isolate compiler intrinsics and close error state

### DIFF
--- a/src/tiri/jit/src/debug/lj_err.cpp
+++ b/src/tiri/jit/src/debug/lj_err.cpp
@@ -139,7 +139,8 @@ extern "C" void lj_err_prepare_foreign_exception(lua_State *L, const char *Messa
 
 //********************************************************************************************************************
 // Call __close handlers for to-be-closed locals during error unwinding.
-// Sets _G.__close_err so bytecode-based close handlers can access the error.
+// The active error is held in protected per-thread state while each handler runs. Normal bytecode scope exits use the
+// dedicated BC_CLOSE path, while error unwinding calls lj_meta_close() directly with this value.
 // Returns the error object to propagate (may be updated if a __close handler throws).
 // Per Lua 5.4: if a __close handler throws, that error replaces the original,
 // but all other pending __close handlers are still called.
@@ -191,19 +192,13 @@ static TValue* unwind_close_try_block(
    lj_assertL(MinimumSlotIndex <= LJ_MAX_SLOTS,
       "unwind_close_try_block: min_slot_index too large (%d)", MinimumSlotIndex);
 
-   // Set _G.__close_err for bytecode-based handlers
+   // A close handler can trigger and catch nested unwinding. Preserve the outer pending value so the enclosing close
+   // sequence remains isolated when the nested handler returns.
 
-   GCtab *env = tabref(L->env);
-   if (env) {
-      GCstr *key = lj_str_newlit(L, "__close_err");
-      TValue *slot = lj_tab_setstr(L, env, key);
-      if (ErrorObject) copyTV(L, slot, ErrorObject);
-      else setnilV(slot);
-      lj_gc_anybarriert(L, env);
-   }
-
-   if (ErrorObject) copyTV(L, &L->close_err, ErrorObject);
-   else setnilV(&L->close_err);
+   TValue saved_close_error;
+   copyTV(L, &saved_close_error, &L->pending_close_error);
+   if (ErrorObject) copyTV(L, &L->pending_close_error, ErrorObject);
+   else setnilV(&L->pending_close_error);
 
    // Call lj_meta_close for each slot with <close> attribute in LIFO order.
    // Only process slots >= min_slot_index (created inside the try block)
@@ -233,26 +228,12 @@ static TValue* unwind_close_try_block(
             has_current_err = true;
             current_err_offset = savestack(L, L->top - 1);
             current_err = restorestack(L, current_err_offset);
-            if (env) {
-               GCstr *key = lj_str_newlit(L, "__close_err");
-               TValue *slot_tv = lj_tab_setstr(L, env, key);
-               copyTV(L, slot_tv, current_err);
-               lj_gc_anybarriert(L, env);
-            }
-            copyTV(L, &L->close_err, current_err);
+            copyTV(L, &L->pending_close_error, current_err);
          }
       }
    }
 
-   // Clear __close_err after processing
-
-   if (env) {
-      GCstr *key = lj_str_newlit(L, "__close_err");
-      TValue *slot_tv = lj_tab_setstr(L, env, key);
-      setnilV(slot_tv);
-   }
-
-   setnilV(&L->close_err);
+   copyTV(L, &L->pending_close_error, &saved_close_error);
    return has_current_err ? restorestack(L, current_err_offset) : nullptr;
 }
 
@@ -315,14 +296,6 @@ static void unwind_close_all(lua_State *L, TValue *From, TValue *To)
 
    lj_assertL(count < LUAI_MAXCSTACK, "frame chain exceeded LUAI_MAXCSTACK during __close unwinding");
 
-   // Clear __close_err after all handlers run
-
-   if (GCtab *env = tabref(L->env)) {
-      GCstr *key = lj_str_newlit(L, "__close_err");
-      TValue *slot = lj_tab_setstr(L, env, key);
-      setnilV(slot);
-   }
-   setnilV(&L->close_err);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -28,6 +28,34 @@ ExprNodePtr make_direct_method_call(ParserContext &Context, SourceSpan Span, std
    return call;
 }
 
+ExprNodePtr make_builtin_call(ParserContext &Context, SourceSpan Span, FastFunc Callable,
+   ExprNodeList Arguments, TiriType ResultType)
+{
+   std::string_view interface_name;
+   std::string_view member_name;
+   switch (Callable) {
+      case FastFunc::array_new: interface_name = "array"; member_name = "new"; break;
+      case FastFunc::array_of: interface_name = "array"; member_name = "of"; break;
+      case FastFunc::array_resize: interface_name = "array"; member_name = "resize"; break;
+      case FastFunc::struct_new: interface_name = "struct"; member_name = "new"; break;
+      default:
+         assert_node(false, "unsupported compiler-owned callable");
+         interface_name = "<invalid>";
+         member_name = "<invalid>";
+         break;
+   }
+   NameRef interface_ref;
+   interface_ref.identifier = Identifier::from_keepstr(Context.lex().keepstr(interface_name), Span);
+   ExprNodePtr callable = make_member_expr(Span, make_identifier_expr(Span, interface_ref),
+      Identifier::from_keepstr(Context.lex().keepstr(member_name), Span));
+   ExprNodePtr call = make_call_expr(Span, std::move(callable), std::move(Arguments), false,
+      CallArgumentSyntax::Synthetic);
+   auto &payload = std::get<CallExprPayload>(call->data);
+   payload.compiler_callable = builtin_callable_id(Callable);
+   payload.result_type = ResultType;
+   return call;
+}
+
 } // namespace
 
 //********************************************************************************************************************
@@ -812,19 +840,9 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
 
          SourceSpan span = start.span();
 
-         // Build identifier for 'array' global
-         Identifier array_id = Identifier::from_keepstr(this->ctx.lex().keepstr("array"), span);
-         NameRef array_ref;
-         array_ref.identifier = array_id;
-         ExprNodePtr array_base = make_identifier_expr(span, array_ref);
-
          if (has_initialiser and not init_values.empty()) {
             // array<type> { values } -> array.of('type', v1, v2, ...)
             // Build: array.of('type', values...)
-
-            // Create member access for .of
-            Identifier of_id = Identifier::from_keepstr(this->ctx.lex().keepstr("of"), span);
-            ExprNodePtr array_of = make_member_expr(span, std::move(array_base), of_id);
 
             // Build argument list: ('type', v1, v2, ...)
             ExprNodeList args;
@@ -837,7 +855,8 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
                args.push_back(std::move(val));
             }
 
-            ExprNodePtr array_of_call = make_call_expr(span, std::move(array_of), std::move(args), false);
+            ExprNodePtr array_of_call = make_builtin_call(
+               this->ctx, span, FastFunc::array_of, std::move(args), TiriType::Array);
 
             // If size was specified (literal or expression) and may be larger than values count, wrap in IIFE to resize
             // For literal sizes, we only wrap if size > values count
@@ -861,14 +880,6 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
 
                // Build array.resize(_arr, size_expr_or_literal)
 
-               Identifier array_id2 = Identifier::from_keepstr(this->ctx.lex().keepstr("array"), span);
-               NameRef array_ref2;
-               array_ref2.identifier = array_id2;
-               ExprNodePtr array_base2 = make_identifier_expr(span, array_ref2);
-
-               Identifier resize_id = Identifier::from_keepstr(this->ctx.lex().keepstr("resize"), span);
-               ExprNodePtr array_resize = make_member_expr(span, std::move(array_base2), resize_id);
-
                // Arguments for resize: (_arr, size)
 
                ExprNodeList resize_args;
@@ -881,7 +892,8 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
                if (size_expr) resize_args.push_back(std::move(size_expr));
                else resize_args.push_back(make_literal_expr(span, LiteralValue::number(double(specified_size))));
 
-               ExprNodePtr resize_call = make_call_expr(span, std::move(array_resize), std::move(resize_args), false);
+               ExprNodePtr resize_call = make_builtin_call(
+                  this->ctx, span, FastFunc::array_resize, std::move(resize_args), TiriType::Array);
 
                // Statement 2: array.resize(_arr, size)
                StmtNodePtr resize_stmt = make_expression_stmt(span, std::move(resize_call));
@@ -913,10 +925,6 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
             // Empty braces {} or no initialiser: use array.new()
             // array<type> or array<type, size> -> array.new(size, 'type')
 
-            // Create member access for .new
-            Identifier new_id = Identifier::from_keepstr(this->ctx.lex().keepstr("new"), span);
-            ExprNodePtr array_new = make_member_expr(span, std::move(array_base), new_id);
-
             // Build argument list: (size, 'type')
 
             ExprNodeList args;
@@ -925,7 +933,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
 
             args.push_back(make_literal_expr(span, LiteralValue::string(type_str)));
 
-            node = make_call_expr(span, std::move(array_new), std::move(args), false);
+            node = make_builtin_call(this->ctx, span, FastFunc::array_new, std::move(args), TiriType::Array);
          }
 
          // Mark the result as TiriType::Array so downstream index expressions emit AGET/ASET opcodes
@@ -959,18 +967,10 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          }
          else initialiser = make_table_expr(span, {}, false);
 
-         // Build struct.new('Name', { fields })
-         Identifier struct_id = Identifier::from_keepstr(this->ctx.lex().keepstr("struct"), span);
-         NameRef struct_ref;
-         struct_ref.identifier = struct_id;
-         ExprNodePtr struct_base = make_identifier_expr(span, struct_ref);
-         Identifier new_id = Identifier::from_keepstr(this->ctx.lex().keepstr("new"), span);
-         ExprNodePtr struct_new = make_member_expr(span, std::move(struct_base), new_id);
-
          ExprNodeList args;
          args.push_back(make_literal_expr(span, LiteralValue::string(name_str)));
          args.push_back(std::move(initialiser));
-         node = make_call_expr(span, std::move(struct_new), std::move(args), false);
+         node = make_builtin_call(this->ctx, span, FastFunc::struct_new, std::move(args), TiriType::Struct);
          break;
       }
 

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -429,6 +429,7 @@ struct CallExprPayload {
    ExprNodeList arguments;
    CallArgumentSyntax argument_syntax = CallArgumentSyntax::Synthetic;
    bool forwards_multret = false;
+   BuiltinCallableID compiler_callable = BuiltinCallableID::Invalid;
    struct BuiltinMethodCall {
       const fprototype *prototype = nullptr;
       BuiltinCallableID callable = BuiltinCallableID::Invalid;

--- a/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
@@ -814,8 +814,10 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_call(const CallExpr
 
 ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
 {
-   if (Payload.builtin_method) return this->emit_builtin_method_call(Payload);
-   if (Payload.runtime_builtin_method) return this->emit_runtime_builtin_method_call(Payload);
+   if (Payload.compiler_callable IS BuiltinCallableID::Invalid) {
+      if (Payload.builtin_method) return this->emit_builtin_method_call(Payload);
+      if (Payload.runtime_builtin_method) return this->emit_runtime_builtin_method_call(Payload);
+   }
 
    kt::Log log(__FUNCTION__);
 
@@ -905,10 +907,16 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
          index_node = index->index.get();
       }
 
-      is_contextual_call = receiver_node and receiver_uses_contextual_call(this->ctx, *receiver_node);
+      is_contextual_call = Payload.compiler_callable IS BuiltinCallableID::Invalid and receiver_node and
+         receiver_uses_contextual_call(this->ctx, *receiver_node);
       context_receiver_node = receiver_node;
 
-      if (is_contextual_call) {
+      if (Payload.compiler_callable != BuiltinCallableID::Invalid) {
+         BCReg call_base = this->func_state.free_reg();
+         callee = bcemit_builtin_callable(&this->func_state, Payload.compiler_callable, call_base.raw());
+         bcreg_reserve(&this->func_state, 1);
+      }
+      else if (is_contextual_call) {
          auto receiver_result = this->emit_expression(*receiver_node);
          if (not receiver_result.ok()) return receiver_result;
          ExpDesc receiver = receiver_result.value_ref();

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1014,20 +1014,18 @@ static ControlFlowEdge emit_falsey_jumps(
 
 static void emit_bit_function_lookup(FuncState &State, RegisterAllocator &Allocator, std::string_view Name, BCReg Base)
 {
-   ExpDesc callee, key;
-   callee.init(ExpKind::Global, 0);
-   callee.u.sval = State.ls->keepstr("bit");
-
-   ExpressionValue callee_value(&State, callee);
-   callee_value.to_reg(Allocator, Base);
-   callee = callee_value.legacy();
-
-   key.init(ExpKind::Str, 0);
-   key.u.sval = State.ls->keepstr(Name);
-   expr_index(&State, &callee, &key);
-
-   ExpressionValue callee_indexed(&State, callee);
-   callee_indexed.to_reg(Allocator, Base);
+   (void)Allocator;
+   BuiltinCallableID callable = BuiltinCallableID::Invalid;
+   switch (kt::strhash(Name)) {
+      case kt::strhash("band"): callable = builtin_callable_id(FastFunc::bit_band); break;
+      case kt::strhash("bor"): callable = builtin_callable_id(FastFunc::bit_bor); break;
+      case kt::strhash("bxor"): callable = builtin_callable_id(FastFunc::bit_bxor); break;
+      case kt::strhash("bnot"): callable = builtin_callable_id(FastFunc::bit_bnot); break;
+      case kt::strhash("lshift"): callable = builtin_callable_id(FastFunc::bit_lshift); break;
+      case kt::strhash("rshift"): callable = builtin_callable_id(FastFunc::bit_rshift); break;
+      default: fs_check_assert(&State, false, "unknown compiler-generated bit operation"); break;
+   }
+   bcemit_builtin_callable(&State, callable, Base.raw());
 }
 
 IrEmitter::IrEmitter(ParserContext& context)
@@ -4163,30 +4161,11 @@ ParserResult<ExpDesc> IrEmitter::emit_index_expr(const IndexExprPayload &Payload
 ParserResult<ExpDesc> IrEmitter::emit_table_slice_call(const IndexExprPayload &Payload)
 {
    FuncState *fs = &this->func_state;
-   RegisterAllocator allocator(fs);
 
    // Capture the call base register before emitting anything
    BCReg call_base = fs->free_reg();
 
-   // Load range.slice function (range global, then access .slice field)
-   ExpDesc range_lib;
-   range_lib.init(ExpKind::Global, 0);
-   range_lib.u.sval = fs->ls->keepstr("range");
-
-   // Discharge range global to a register
-   ExpressionValue range_value(fs, range_lib);
-   range_value.discharge_to_any_reg(allocator);
-   range_lib = range_value.legacy();
-
-   // Access the .slice field
-   ExpDesc slice_key(fs->ls->keepstr("slice"));
-   expr_index(fs, &range_lib, &slice_key);
-
-   // Materialise the function to call base register
-   this->materialise_to_next_reg(range_lib, "range.slice function");
-
-   // Reserve register for frame link (LJ_FR2)
-   allocator.reserve(BCReg(1));
+   bcemit_builtin_call_frame(fs, builtin_callable_id(FastFunc::range_slice), call_base);
 
    // Emit base expression (table or string) as arg1
    auto base_result = this->emit_expression(*Payload.table);
@@ -4346,22 +4325,15 @@ ParserResult<ExpDesc> IrEmitter::emit_safe_index_expr(const SafeIndexExprPayload
 ParserResult<ExpDesc> IrEmitter::emit_range_expr(const RangeExprPayload &Payload)
 {
    FuncState* fs = &this->func_state;
-   RegisterAllocator allocator(fs);
 
    // Emit the start and stop expressions first
    if (not Payload.start or not Payload.stop) {
       return this->unsupported_expr(AstNodeKind::RangeExpr, SourceSpan{});
    }
 
-   // Load the 'range' global function first
+   // Load the canonical range constructor first.
    BCReg base = fs->free_reg();
-   ExpDesc callee;
-   callee.init(ExpKind::Global, 0);
-   callee.u.sval = fs->ls->keepstr("range");
-   this->materialise_to_next_reg(callee, "range function");
-
-   // Reserve register for frame link (LJ_FR2)
-   allocator.reserve(BCReg(1));
+   bcemit_builtin_call_frame(fs, builtin_callable_id(FastFunc::range_new), base);
 
    // Emit start expression as arg1
    auto start_result = this->emit_expression(*Payload.start);

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -2030,6 +2030,7 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
 {
    LuaStateHolder state;
    lua_State *L = state.get();
+   luaL_openlibs(L);
    constexpr std::string_view source =
       "extern obj\n"
       "extern array\n"
@@ -5673,7 +5674,7 @@ static bool test_builtin_method_bytecode_emission(kt::Log &Log)
    error.clear();
    auto range_pipe = compile_snapshot(L,
       "local total = 0\n{0 to 4} |> (Value => do total += Value end)\nreturn total\n", true, error);
-   if (not range_pipe or count_opcode_tree(*range_pipe, BC_BFUNC) != 1 or
+   if (not range_pipe or count_opcode_tree(*range_pipe, BC_BFUNC) != 2 or
        count_opcode_tree(*range_pipe, BC_TGETS) != 0) {
       Log.error("compiler-generated range iteration did not use canonical emission: %s", error.c_str());
       return false;
@@ -5682,8 +5683,9 @@ static bool test_builtin_method_bytecode_emission(kt::Log &Log)
    error.clear();
    auto append = compile_snapshot(L,
       "local values = array<byte>\nvalues ..= 'x' .. 'y'\nreturn values\n", true, error);
-   const BCIns *append_load = append ? find_opcode(*append, BC_BFUNC) : nullptr;
-   if (not append or not append_load or count_opcode(*append, BC_BFUNC) != 1 or
+   const BCIns *append_load = append ? find_builtin_callable_opcode(
+      *append, builtin_callable_id(FastFunc::array_append)) : nullptr;
+   if (not append or not append_load or count_opcode(*append, BC_BFUNC) != 2 or
        bc_d(*append_load) != builtin_callable_index(builtin_callable_id(FastFunc::array_append))) {
       Log.error("compiler-only array append did not use canonical emission: %s", error.c_str());
       return false;
@@ -5733,6 +5735,67 @@ static bool test_compiler_intrinsic_bytecode_emission(kt::Log &Log)
        count_opcode_tree(*thunk, BC_BFUNC) != 1 or count_opcode_tree(*thunk, BC_GGET) != 0 or
        count_opcode_tree(*thunk, BC_TGETS) != 0 or count_opcode_tree(*thunk, BC_TGETV) != 0) {
       Log.error("deferred expressions did not use the isolated thunk intrinsic: %s", error.c_str());
+      return false;
+   }
+
+   return true;
+}
+
+static bool test_canonical_core_syntax_bytecode_emission(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *L = state.get();
+   luaL_openlibs(L);
+   std::string error;
+
+   auto core = compile_snapshot(L,
+      "struct PhaseTwoRecord\n   Value: int\nend\n"
+      "local array:any = {}\nlocal struct:any = {}\n"
+      "local first = 1\nlocal last = 5\nlocal size = 4\nlocal source = { 10, 20, 30 }\n"
+      "local bounds = {first to last}\nlocal sliced = source[{0 to 2}]\nlocal present = first in bounds\n"
+      "local values = array<int, size> { 7, 8 }\n"
+      "local constructed = struct<PhaseTwoRecord> { Value=9 }\n"
+      "local bits = (first & last) | (first ^ last)\n"
+      "return sliced, present, values, constructed, bits\n", true, error);
+   constexpr std::array<FastFunc, 9> required = { {
+      FastFunc::range_new, FastFunc::range_slice, FastFunc::range_contains,
+      FastFunc::array_of, FastFunc::array_resize, FastFunc::struct_new,
+      FastFunc::bit_band, FastFunc::bit_bor, FastFunc::bit_bxor
+   } };
+   if (not core) {
+      Log.error("canonical core syntax fixture did not compile: %s", error.c_str());
+      return false;
+   }
+   for (FastFunc callable : required) {
+      if (find_builtin_callable_opcode(*core, builtin_callable_id(callable))) continue;
+      Log.error("canonical core syntax omitted built-in callable %u", unsigned(callable));
+      return false;
+   }
+   if (count_opcode_tree(*core, BC_GGET) != 0 or count_opcode_tree(*core, BC_TGETS) != 0 or
+       count_opcode_tree(*core, BC_TGETV) != 0) {
+      Log.error("compiler-owned core syntax retained namespace lookup bytecode");
+      return false;
+   }
+
+   error.clear();
+   auto shifts = compile_snapshot(L,
+      "local value = 5\nlocal amount = 1\nreturn ~value, value << amount, value >> amount\n", true, error);
+   if (not shifts or not find_builtin_callable_opcode(*shifts, builtin_callable_id(FastFunc::bit_bnot)) or
+       not find_builtin_callable_opcode(*shifts, builtin_callable_id(FastFunc::bit_lshift)) or
+       not find_builtin_callable_opcode(*shifts, builtin_callable_id(FastFunc::bit_rshift)) or
+       count_opcode_tree(*shifts, BC_GGET) != 0 or count_opcode_tree(*shifts, BC_TGETS) != 0) {
+      Log.error("unary and shifted bitwise syntax did not use canonical callables: %s", error.c_str());
+      return false;
+   }
+
+   error.clear();
+   auto explicit_calls = compile_snapshot(L,
+      "local values = array.new(2, 'int')\n"
+      "array.resize(values, 3)\n"
+      "return range(0, 2), range.slice({}, {0 to 1}), bit.band(1, 1)\n", true, error);
+   if (not explicit_calls or count_opcode_tree(*explicit_calls, BC_GGET) IS 0 or
+       count_opcode_tree(*explicit_calls, BC_TGETS) IS 0) {
+      Log.error("explicit namespace calls lost ordinary dynamic lookup bytecode: %s", error.c_str());
       return false;
    }
 
@@ -6668,7 +6731,9 @@ static bool test_tail_call_eligibility(kt::Log &Log)
    auto cleaned = compile_snapshot(L, cleanup_source, true, error);
    if (not cleaned or count_opcode_tree(*cleaned, BC_CALLT) != 0 or
        count_opcode_tree(*cleaned, BC_CALLMT) != 0 or count_opcode_tree(*cleaned, BC_MRSAVE) != 1 or
-       count_opcode_tree(*cleaned, BC_MRRESTORE) != 1 or count_opcode_tree(*cleaned, BC_RETM) IS 0) {
+       count_opcode_tree(*cleaned, BC_MRRESTORE) != 1 or count_opcode_tree(*cleaned, BC_RETM) IS 0 or
+       count_opcode_tree(*cleaned, BC_CLOSEARM) IS 0 or count_opcode_tree(*cleaned, BC_CLOSE) IS 0 or
+       count_opcode_tree(*cleaned, BC_GGET) != 0) {
       Log.error("user cleanup did not retain a protected multi-result return path: %s", error.c_str());
       return false;
    }
@@ -8281,7 +8346,7 @@ static bool test_contextual_designation_ownership(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 75> tests = { {
+   constexpr std::array<TestCase, 76> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -8340,6 +8405,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "unresolved_method_receiver_diagnostic", test_unresolved_method_receiver_diagnostic },
       { "builtin_method_bytecode_emission", test_builtin_method_bytecode_emission },
       { "compiler_intrinsic_bytecode_emission", test_compiler_intrinsic_bytecode_emission },
+      { "canonical_core_syntax_bytecode_emission", test_canonical_core_syntax_bytecode_emission },
       { "contextual_call_specialisation", test_contextual_call_specialisation },
       { "contextual_tail_call_bytecode_emission", test_contextual_tail_call_bytecode_emission },
       { "builtin_method_runtime", test_builtin_method_runtime },

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -866,6 +866,10 @@ private:
    void resolve_builtin_method(CallExprPayload &Call)
    {
       Call.runtime_builtin_method.reset();
+      if (Call.compiler_callable != BuiltinCallableID::Invalid) {
+         Call.builtin_method.reset();
+         return;
+      }
       const auto *direct = std::get_if<DirectCallTarget>(&Call.target);
       if (not direct or not direct->callable or
           (Call.argument_syntax != CallArgumentSyntax::Parenthesised and

--- a/src/tiri/jit/src/runtime/lj_gc.cpp
+++ b/src/tiri/jit/src/runtime/lj_gc.cpp
@@ -689,6 +689,7 @@ static void gc_traverse_thread(global_State *g, lua_State* th)
          setnilV(o);
    }
    gc_markobj(g, tabref(th->env));
+   gc_marktv(g, &th->pending_close_error);
    for (const lua_State::ContextFrame &context : th->context_stack) {
       GCtab *table = tabref(context.table);
       lj_assertG(table, "context stack contains a non-table root");

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -1642,7 +1642,9 @@ struct lua_State {
    ParserDiagnostics *parser_diagnostics; // Stores ParserDiagnostics* during parsing errors
    TipEmitter *parser_tips;               // Stores TipEmitter* during parsing for code hints
    ParserSymbolCollection *parser_symbols; // Stores parser symbol metadata for LSP/documentation tooling
-   TValue close_err;  // Current error for __close handlers (nil if no error)
+   // Protected error value for the __close handler currently being invoked. Nested unwinding saves and restores this
+   // field, and the collector treats it as a thread-local root. It is never mirrored through the public environment.
+   TValue pending_close_error;
    // Try-except exception handling runtime state (lazily allocated)
    TryFrameStack try_stack;      // Exception frame stack (nullptr until first BC_TRYENTER)
    const BCIns   *try_handler_pc; // Handler PC for error re-entry (set during unwind)

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -753,7 +753,7 @@ extern lua_State * lua_newstate(lua_Alloc allocf, void* allocd)
    L->gct = ~LJ_TSTRUCT;  // Tag shared with GCstruct; this is the only lua_State per interpreter.
    L->marked = LJ_GC_WHITE0 | LJ_GC_FIXED | LJ_GC_SFIXED;  //  Prevent free.
    L->dummy_ffid = FF_C;
-   setnilV(&L->close_err);  // Initialize __close error to nil
+   setnilV(&L->pending_close_error);
    L->try_handler_pc = nullptr;
    setmref(L->glref, g);
    g->gc.currentwhite = LJ_GC_WHITE0 | LJ_GC_FIXED;

--- a/src/tiri/jit/src/runtime/unit_tests_gc.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_gc.cpp
@@ -211,17 +211,47 @@ static bool test_active_context_survives_full_collection(kt::Log &Log)
    return passed;
 }
 
+static bool test_pending_close_error_is_thread_local_gc_root(kt::Log &Log)
+{
+   lua_State *first = luaL_newstate(nullptr);
+   lua_State *second = luaL_newstate(nullptr);
+   if (not first or not second) {
+      if (first) lua_close(first);
+      if (second) lua_close(second);
+      Log.error("failed to create Lua states");
+      return false;
+   }
+
+   GCtab *pending = lj_tab_new(first, 0, 1);
+   GCstr *key = lj_str_newlit(first, "pending_close_marker");
+   TValue *slot = lj_tab_setstr(first, pending, key);
+   setintV(slot, 91);
+   settabV(first, &first->pending_close_error, pending);
+   lj_gc_fullgc(first);
+
+   cTValue *retained = lj_tab_getstr(tabV(&first->pending_close_error), key);
+   bool passed = retained and tvisnumber(retained) and numberVnum(retained) IS 91 and
+      tvisnil(&second->pending_close_error);
+   if (not passed) Log.error("pending close-error state was not rooted and isolated per Lua state");
+
+   setnilV(&first->pending_close_error);
+   lua_close(second);
+   lua_close(first);
+   return passed;
+}
+
 } // namespace
 
 extern void gc_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 5> Tests = { {
+   constexpr std::array<TestCase, 6> Tests = { {
       { "shutdown_drains_pre_registered_finalisers_after_error",
          test_shutdown_drains_pre_registered_finalisers_after_error },
       { "shutdown_does_not_run_new_finalisers", test_shutdown_does_not_run_new_finalisers },
       { "context_root_tracks_environment_replacement", test_context_root_tracks_environment_replacement },
       { "nested_context_ownership_and_stack_relocation", test_nested_context_ownership_and_stack_relocation },
-      { "active_context_survives_full_collection", test_active_context_survives_full_collection }
+      { "active_context_survives_full_collection", test_active_context_survives_full_collection },
+      { "pending_close_error_is_thread_local_gc_root", test_pending_close_error_is_thread_local_gc_root }
    } };
 
    for (const TestCase& Test : Tests) {

--- a/src/tiri/tests/test_close.tiri
+++ b/src/tiri/tests/test_close.tiri
@@ -260,6 +260,87 @@ end
    assert(tostring(received_err).find('test error message'), 'Error message should contain "test error message": got ' .. tostring(received_err))
 end
 
+-- Error unwinding must never publish its private control state through the global environment.
+
+@Test function CloseErrorStateIsPrivate()
+   _G.__close_err = nil
+   received_message = nil
+   global_during_close = 'not_checked'
+
+   function inner()
+      local obj <close> = setmetatable({}, {
+         __close = function(Self, Error)
+            processing.collect('full')
+            received_message = tostring(Error)
+            global_during_close = _G.__close_err
+         end
+      })
+      error('private close error')
+   end
+
+   try
+      inner()
+   except err
+   end
+
+   assert(received_message.find('private close error'), 'The close handler must receive the active error')
+   assert(global_during_close is nil, 'The active close error must not be exposed through _G')
+   assert(_G.__close_err is nil, 'Error unwinding must not leave close state in _G')
+end
+
+-- Nested unwinding from a close handler must restore the enclosing error before the next outer handler runs.
+
+@Test function NestedCloseErrorIsolation()
+   inner_message = nil
+   outer_messages = {}
+
+   inner_mt = {
+      __close = function(Self, Error)
+         processing.collect('full')
+         inner_message = tostring(Error)
+      end
+   }
+
+   nesting_mt = {
+      __close = function(Self, Error)
+         outer_messages.insert(tostring(Error))
+
+         function nested_failure()
+            local nested <close> = setmetatable({}, inner_mt)
+            error('nested close error')
+         end
+
+         try
+            nested_failure()
+         except nested_err
+         end
+      end
+   }
+
+   trailing_mt = {
+      __close = function(Self, Error)
+         outer_messages.insert(tostring(Error))
+      end
+   }
+
+   function outer_failure()
+      local trailing <close> = setmetatable({}, trailing_mt)
+      local nesting <close> = setmetatable({}, nesting_mt)
+      error('outer close error')
+   end
+
+   try
+      outer_failure()
+   except outer_err
+   end
+
+   assert(inner_message.find('nested close error'), 'Nested cleanup must receive the nested error')
+   assert(#outer_messages is 2, 'Both outer close handlers must run')
+   assert(outer_messages[0].find('outer close error'), 'The nesting handler must receive the outer error')
+   assert(outer_messages[1].find('outer close error'), 'Nested unwinding must restore the outer error')
+   assert(_G.__close_err is nil, 'Nested unwinding must not expose close state through _G')
+end
+
 -- Close with string value - should not crash
 
 @Test function CloseWithString()

--- a/src/tiri/tests/test_compiler_intrinsics.tiri
+++ b/src/tiri/tests/test_compiler_intrinsics.tiri
@@ -1,5 +1,22 @@
 -- Regression coverage for compiler-only callables that must remain usable without public namespace bindings.
 
+struct CompilerIntrinsicRecord
+   Value: int
+end
+
+function replacement_range_slice(Value:any, Bounds:any):str return 'replacement slice' end
+function replacement_array_new(Size:num, Type:str):str return 'replacement array.new' end
+function replacement_array_of(Type:str, ...):str return 'replacement array.of' end
+function replacement_array_resize(Value:any, Size:num):str return 'replacement array.resize' end
+function replacement_struct_new(Name:str, Initialiser:table):str return 'replacement struct.new' end
+function replacement_band(Left:num, Right:num):num return 101 end
+function replacement_bor(Left:num, Right:num):num return 102 end
+function replacement_bxor(Left:num, Right:num):num return 103 end
+function replacement_bnot(Value:num):num return 104 end
+function replacement_lshift(Left:num, Right:num):num return 105 end
+function replacement_rshift(Left:num, Right:num):num return 106 end
+function replacement_range(Start:num, Stop:num, Inclusive:bool):str return 'replacement range' end
+
 @BeforeEach(hotpath=true)
 function enforce_hotpath() end
 
@@ -9,6 +26,101 @@ function enforce_hotpath() end
    assert(rawget(_G, '__filter') is nil, 'The result-filter intrinsic must not be published in _G')
    assert(rawget(_G, '__create_thunk') is nil, 'The deferred-expression intrinsic must not be published in _G')
    assert(array.append is nil, 'The array append intrinsic must not be published in the array namespace')
+end
+
+@Test function CanonicalCoreSyntaxIgnoresNamespaceRebinding()
+   local original_range_slice = range.slice
+   local original_array_new = array.new
+   local original_array_of = array.of
+   local original_array_resize = array.resize
+   local original_struct_new = struct.new
+   local original_band = bit.band
+   local original_bor = bit.bor
+   local original_bxor = bit.bxor
+   local original_bnot = bit.bnot
+   local original_lshift = bit.lshift
+   local original_rshift = bit.rshift
+
+   defer
+      range.slice = original_range_slice
+      array.new = original_array_new
+      array.of = original_array_of
+      array.resize = original_array_resize
+      struct.new = original_struct_new
+      bit.band = original_band
+      bit.bor = original_bor
+      bit.bxor = original_bxor
+      bit.bnot = original_bnot
+      bit.lshift = original_lshift
+      bit.rshift = original_rshift
+   end
+
+   range.slice = replacement_range_slice
+   array.new = replacement_array_new
+   array.of = replacement_array_of
+   array.resize = replacement_array_resize
+   struct.new = replacement_struct_new
+   bit.band = replacement_band
+   bit.bor = replacement_bor
+   bit.bxor = replacement_bxor
+   bit.bnot = replacement_bnot
+   bit.lshift = replacement_lshift
+   bit.rshift = replacement_rshift
+   local explicit_slice = range.slice({}, {0 to 1})
+   local range = replacement_range
+
+   local bounds = {1 to 5}
+   local sliced = { 10, 20, 30 }[{0 to 2}]
+   local initialised = array<int> { 7, 8 }
+   local resized = array<int, 4> { 7, 8 }
+   local empty = array<int, 2>
+   local constructed = struct<CompilerIntrinsicRecord> { Value=9 }
+   local value = 5
+   local amount = 1
+
+   assert(3 in bounds, 'Membership syntax should use canonical range.contains')
+   assert(#sliced is 2 and sliced[0] is 10 and sliced[1] is 20,
+      'Range slicing syntax should use canonical range.slice')
+   assert(#initialised is 2 and initialised[1] is 8, 'Initialised arrays should use canonical array.of')
+   assert(#resized is 4 and resized[0] is 7, 'Sized initialised arrays should use canonical array.resize')
+   assert(#empty is 2, 'Empty typed arrays should use canonical array.new')
+   assert(constructed.Value is 9, 'Declared struct syntax should use canonical struct.new')
+   assert((value & 3) is 1 and (value | 2) is 7 and (value ^ 1) is 4,
+      'Binary bitwise syntax should use canonical bit callables')
+   assert(~value is -6 and value << amount is 10 and value >> amount is 2,
+      'Unary and shifted bitwise syntax should use canonical bit callables')
+
+   assert(range(0, 2, false) is 'replacement range',
+      'Explicit range calls should retain dynamic lookup semantics')
+   assert(explicit_slice is 'replacement slice',
+      'Explicit range.slice calls should retain dynamic field lookup semantics')
+   assert(array.new(1, 'int') is 'replacement array.new' and array.of('int', 1) is 'replacement array.of',
+      'Explicit array constructor calls should retain dynamic field lookup semantics')
+   assert(struct.new('CompilerIntrinsicRecord', {}) is 'replacement struct.new',
+      'Explicit struct.new calls should retain dynamic field lookup semantics')
+   assert(bit.band(1, 1) is 101 and bit.bnot(1) is 104,
+      'Explicit bit calls should retain dynamic field lookup semantics')
+end
+
+@Test function CanonicalCoreSyntaxIgnoresVariantNamespaceShadows()
+   do
+      local array:any = {}
+      local initialised = array<int> { 7, 8 }
+      local resized = array<int, 4> { 7, 8 }
+      local empty = array<int, 2>
+
+      assert(#initialised is 2 and initialised[1] is 8,
+         'Initialised array syntax must ignore a variant array namespace shadow')
+      assert(#resized is 4 and resized[0] is 7,
+         'Sized array syntax must ignore a variant array namespace shadow')
+      assert(#empty is 2, 'Empty array syntax must ignore a variant array namespace shadow')
+   end
+
+   do
+      local struct:any = {}
+      local constructed = struct<CompilerIntrinsicRecord> { Value=9 }
+      assert(constructed.Value is 9, 'Struct syntax must ignore a variant struct namespace shadow')
+   end
 end
 
 @Test function IsolatedIntrinsicsRetainRuntimeBehaviour()


### PR DESCRIPTION
* Emit compiler-owned core syntax through canonical callables immune to namespace rebinding
* Keep pending close errors private per state and rooted during garbage collection
* Add parser, runtime and Flute regression coverage