### PR TITLE
[Tiri] Isolated compiler syntax from mutable interfaces

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -192,6 +192,7 @@ set (LJLIB_C
    "${JIT_SRC}/lib/lib_struct.cpp"
    "${JIT_SRC}/lib/lib_debug.cpp"
    "${JIT_SRC}/lib/lib_jit.cpp"
+   "${JIT_SRC}/lib/lib_regex.cpp"
 )
 
 # Buildvm source files (used in both build paths)
@@ -774,6 +775,7 @@ set (TIRI_SOURCES "${MOD}.cpp" "tiri_module.cpp" "tiri_async.cpp" "tiri_struct.c
    "${JIT_SRC}/lib/lib_object.cpp"
    "${JIT_SRC}/lib/lib_struct.cpp"
    "${JIT_SRC}/lib/lib_range.cpp"
+   "${JIT_SRC}/lib/lib_regex.cpp"
    "${JIT_SRC}/lib/lib_string.cpp"
    "${JIT_SRC}/lib/lib_table.cpp"
    "${JIT_SRC}/bytecode/lj_bc.cpp"

--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -483,6 +483,7 @@ extern void register_input_class(lua_State *);
 extern void register_module_class(lua_State *);
 extern void register_processing_class(lua_State *);
 extern void register_regex_class(lua_State *);
+extern int luaopen_regex_intrinsic(lua_State *);
 extern void register_async_class(lua_State *);
 //static void register_widget_class(lua_State *);
 void release_object(GCobject *);

--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -45,9 +45,10 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // ordering part of the private bytecode ABI.  Version 0x8a adds BC_BMETH runtime method dispatch.  Version 0x8c adds
 // BC_TCTX contextual table designation and cuts over to opt-in table context, which changes the meaning of every
 // existing contextual call sequence.  Version 0x8d adds materialised temporary context blocks and consuming close
-// activation bytecodes.  Older chunks are rejected rather than retaining compatibility shims.
+// activation bytecodes.  Version 0x8e adds the canonical regex.new identity used by regex literals.  Older chunks are
+// rejected rather than retaining compatibility shims.
 
-constexpr uint8_t BCDUMP_VERSION = 0x8d;
+constexpr uint8_t BCDUMP_VERSION = 0x8e;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/debug/lj_ff.h
+++ b/src/tiri/jit/src/debug/lj_ff.h
@@ -76,7 +76,7 @@ static_assert(FF__MAX <= BUILTIN_CALLABLE_CAPACITY);
 static_assert(FF__MAX - 1 <= std::numeric_limits<uint16_t>::max());
 static_assert(builtin_callable_index(BuiltinCallableID::Invalid) >= FF__MAX);
 #ifdef FFDEF_BFUNC_ABI
-static_assert(builtin_callable_abi_fingerprint() IS 0xa354e0882106d06eull,
+static_assert(builtin_callable_abi_fingerprint() IS 0x421679bd9529514aull,
    "fast-function ordering changed: bump BCDUMP_VERSION and update the BC_BFUNC ABI fingerprint");
 #endif
 

--- a/src/tiri/jit/src/lib/lib_object.cpp
+++ b/src/tiri/jit/src/lib/lib_object.cpp
@@ -48,20 +48,10 @@ template<class... Args> void RMSG(Args...) {
    //log.trace(Args)  // Enable if you want to debug results returned from functions, actions etc
 }
 
-static constexpr uint32_t OJH_init      = simple_hash("init");
-static constexpr uint32_t OJH_free      = simple_hash("free");
-static constexpr uint32_t OJH_children  = simple_hash("children");
-static constexpr uint32_t OJH_detach    = simple_hash("detach");
-static constexpr uint32_t OJH_get       = simple_hash("get");
+// Only obj.new and obj._state retain a member-read closure; the remaining registered obj.* methods are dispatched
+// canonically through BC_BMETH and no longer need member-read hashes here.
 static constexpr uint32_t OJH_new       = simple_hash("new");
 static constexpr uint32_t OJH_state     = simple_hash("_state");
-static constexpr uint32_t OJH_getKey    = simple_hash("getKey");
-static constexpr uint32_t OJH_set       = simple_hash("set");
-static constexpr uint32_t OJH_setKey    = simple_hash("setKey");
-static constexpr uint32_t OJH_delayCall = simple_hash("delayCall");
-static constexpr uint32_t OJH_exists    = simple_hash("exists");
-static constexpr uint32_t OJH_subscribe = simple_hash("subscribe");
-static constexpr uint32_t OJH_unsubscribe = simple_hash("unsubscribe");
 
 // Forward declarations
 [[nodiscard]] static int object_action_call_args(lua_State *);
@@ -115,6 +105,11 @@ inline void SET_CONTEXT(lua_State *Lua, APTR Function) {
    lua_pushcclosure(Lua, (lua_CFunction)Function, 1); // C function to call, +1 value for the object reference
 }
 
+// Most registered obj.* methods are dispatched as canonical built-in methods (BC_BMETH) with the object supplied as
+// an explicit receiver at native argument one.  Two methods, obj.new (child creation) and obj._state, retain the
+// bound-closure dispatch path where the receiver is recovered from the closure upvalue via object_context(); these
+// helpers therefore continue to accept either ABI.
+
 [[nodiscard]] static GCobject * object_method_receiver(lua_State *Lua)
 {
    if (lua_isobject(Lua, 1)) return lj_get_object_fast(Lua, 1);
@@ -126,19 +121,12 @@ inline void SET_CONTEXT(lua_State *Lua, APTR Function) {
    return lua_isobject(Lua, 1) ? WrittenArgument + 1 : WrittenArgument;
 }
 
-[[nodiscard]] static int stack_object_children(lua_State *Lua, const obj_read &Handle, GCobject *def) { SET_CONTEXT(Lua, (APTR)object_children); return 1; }
-[[nodiscard]] static int stack_object_detach(lua_State *Lua, const obj_read &Handle, GCobject *def) { SET_CONTEXT(Lua, (APTR)object_detach); return 1; }
-[[nodiscard]] static int stack_object_exists(lua_State *Lua, const obj_read &Handle, GCobject *def) { SET_CONTEXT(Lua, (APTR)object_exists); return 1; }
-[[nodiscard]] static int stack_object_free(lua_State *Lua, const obj_read &Handle, GCobject *def) { SET_CONTEXT(Lua, (APTR)object_free); return 1; }
-[[nodiscard]] static int stack_object_get(lua_State *Lua, const obj_read &Handle, GCobject *def) { SET_CONTEXT(Lua, (APTR)object_get); return 1; }
-[[nodiscard]] static int stack_object_getKey(lua_State *Lua, const obj_read &Handle, GCobject *def) { SET_CONTEXT(Lua, (APTR)object_getkey); return 1; }
-[[nodiscard]] static int stack_object_init(lua_State *Lua, const obj_read &Handle, GCobject *def) { SET_CONTEXT(Lua, (APTR)object_init); return 1; }
+// obj.new (child creation) and obj._state retain the bound-closure dispatch path: they have no canonical BC_BMETH
+// identity, so a member read still yields a closure that carries the receiving object in its upvalue.  Every other
+// registered obj.* method is dispatched canonically with an explicit receiver and therefore no longer needs a
+// member-read closure factory here.
 [[nodiscard]] static int stack_object_newchild(lua_State *Lua, const obj_read &Handle, GCobject *def) { SET_CONTEXT(Lua, (APTR)object_newchild); return 1; }
-[[nodiscard]] static int stack_object_set(lua_State *Lua, const obj_read &Handle, GCobject *def) { SET_CONTEXT(Lua, (APTR)object_set); return 1; }
-[[nodiscard]] static int stack_object_setKey(lua_State *Lua, const obj_read &Handle, GCobject *def) { SET_CONTEXT(Lua, (APTR)object_setkey); return 1; }
 [[nodiscard]] static int stack_object_state(lua_State *Lua, const obj_read &Handle, GCobject *def) { SET_CONTEXT(Lua, (APTR)object_state); return 1; }
-[[nodiscard]] static int stack_object_subscribe(lua_State *Lua, const obj_read &Handle, GCobject *def) { SET_CONTEXT(Lua, (APTR)object_subscribe); return 1; }
-[[nodiscard]] static int stack_object_unsubscribe(lua_State *Lua, const obj_read &Handle, GCobject *def) { SET_CONTEXT(Lua, (APTR)object_unsubscribe); return 1; }
 
 //********************************************************************************************************************
 // Action jump table implementation
@@ -365,19 +353,11 @@ READ_TABLE * get_read_table(objMetaClass *Class)
       }
    }
 
-   jmp.emplace_back(OJH_init, stack_object_init);
-   jmp.emplace_back(OJH_free, stack_object_free);
-   jmp.emplace_back(OJH_children, stack_object_children);
-   jmp.emplace_back(OJH_detach, stack_object_detach);
-   jmp.emplace_back(OJH_get, stack_object_get);
+   // obj.new and obj._state are dispatched through bound-receiver closures at member-read time.  All other
+   // registered obj.* methods use canonical BC_BMETH dispatch with an explicit receiver and are intentionally
+   // absent from the member-read table.
    jmp.emplace_back(OJH_new, stack_object_newchild);
    jmp.emplace_back(OJH_state, stack_object_state);
-   jmp.emplace_back(OJH_getKey, stack_object_getKey);
-   jmp.emplace_back(OJH_set, stack_object_set);
-   jmp.emplace_back(OJH_setKey, stack_object_setKey);
-   jmp.emplace_back(OJH_exists, stack_object_exists);
-   jmp.emplace_back(OJH_subscribe, stack_object_subscribe);
-   jmp.emplace_back(OJH_unsubscribe, stack_object_unsubscribe);
 
    std::sort(jmp.begin(), jmp.end(), read_hash);
 

--- a/src/tiri/jit/src/lib/lib_range.cpp
+++ b/src/tiri/jit/src/lib/lib_range.cpp
@@ -545,10 +545,6 @@ static int fp_range_contains(lua_State *L)
 {
    auto range = check_range(L, 1);
    int argument = 2;
-   if (not range) {
-      range = (tiri_range *)lua_touserdata(L, lua_upvalueindex(1));
-      argument = 1;
-   }
    if (not range or lua_type(L, argument) != LUA_TNUMBER) {
       lua_pushboolean(L, 0);
       return 1;
@@ -579,7 +575,6 @@ static int fp_range_contains(lua_State *L)
 static int fp_range_toarray(lua_State *L)
 {
    auto range = check_range(L, 1);
-   if (not range) range = (tiri_range *)lua_touserdata(L, lua_upvalueindex(1));
    if (not range) lj_err_caller(L, ErrMsg::BADVAL);
    size_t count = fp_range_count(L, range, true);
    GCarray *array = fp_range_materialise(L, range, count);
@@ -657,8 +652,9 @@ LJLIB_CF(range_new)
 
 //********************************************************************************************************************
 // __index metamethod
-// Handles property access (.start, .stop, .step, .inclusive, .length)
-// and method calls (:contains, :toArray)
+// Handles property access (.start, .stop, .step, .inclusive, .length) and returns the functional helper fast
+// functions (.each, .filter, ...).  The .contains and .toArray methods are dispatched canonically through BC_BMETH
+// with an explicit receiver and are intentionally not exposed here as bound-receiver closures.
 
 constexpr auto HASH_start     = kt::strhash("start");
 constexpr auto HASH_stop      = kt::strhash("stop");
@@ -697,14 +693,10 @@ static int range_index(lua_State *Lua)
          case HASH_any:       lua_pushcfunction(Lua, fp_range_any); return 1;
          case HASH_all:       lua_pushcfunction(Lua, fp_range_all); return 1;
          case HASH_find:      lua_pushcfunction(Lua, fp_range_find); return 1;
-         case HASH_contains: // Methods - return closures with range as upvalue
-            lua_pushvalue(Lua, 1);  // Push the range userdata
-            lua_pushcclosure(Lua, fp_range_contains, 1);
-            return 1;
-         case HASH_toArray:
-            lua_pushvalue(Lua, 1);  // Push the range userdata
-            lua_pushcclosure(Lua, fp_range_toarray, 1);
-            return 1;
+         // range.contains and range.toArray are dispatched as canonical built-in methods with an explicit
+         // receiver (BC_BMETH); they are no longer exposed as bound-receiver closures through member lookup.
+         case HASH_contains:
+         case HASH_toArray:   break;
       }
    }
 

--- a/src/tiri/jit/src/lib/lib_regex.cpp
+++ b/src/tiri/jit/src/lib/lib_regex.cpp
@@ -1,0 +1,27 @@
+// Compiler-owned regex callable registration.
+// Copyright (C) 2026 Paul Manias
+
+#define lib_regex_c
+#define LUA_LIB
+
+#include "lua.h"
+#include "lauxlib.h"
+
+#include "lib.h"
+
+extern int tiri_regex_new(lua_State *Lua);
+
+#define LJLIB_MODULE_regex
+
+LJLIB_INTRINSIC LJLIB_CF(regex_new)
+{
+   return tiri_regex_new(L);
+}
+
+#include "lj_libdef.h"
+
+extern int luaopen_regex_intrinsic(lua_State *Lua)
+{
+   LJ_LIB_REG(Lua, nullptr, regex);
+   return 1;
+}

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -38,6 +38,7 @@ ExprNodePtr make_builtin_call(ParserContext &Context, SourceSpan Span, FastFunc 
       case FastFunc::array_of: interface_name = "array"; member_name = "of"; break;
       case FastFunc::array_resize: interface_name = "array"; member_name = "resize"; break;
       case FastFunc::struct_new: interface_name = "struct"; member_name = "new"; break;
+      case FastFunc::regex_new: interface_name = "regex"; member_name = "new"; break;
       default:
          assert_node(false, "unsupported compiler-owned callable");
          interface_name = "<invalid>";
@@ -498,17 +499,9 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          GCstr *pattern = current.payload().as_string();
          this->ctx.tokens().advance();
 
-         Identifier regex_id = Identifier::from_keepstr(this->ctx.lex().keepstr("regex"), span);
-         NameRef regex_ref;
-         regex_ref.identifier = regex_id;
-         ExprNodePtr regex_base = make_identifier_expr(span, regex_ref);
-
-         Identifier new_id = Identifier::from_keepstr(this->ctx.lex().keepstr("new"), span);
-         ExprNodePtr regex_new = make_member_expr(span, std::move(regex_base), new_id);
-
          ExprNodeList args;
          args.push_back(make_literal_expr(span, LiteralValue::string(pattern)));
-         node = make_call_expr(span, std::move(regex_new), std::move(args), false);
+         node = make_builtin_call(this->ctx, span, FastFunc::regex_new, std::move(args), TiriType::Userdata);
          break;
       }
 

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -777,7 +777,7 @@ ParserResult<AstBuilder::ResultFilterInfo> AstBuilder::parse_result_filter_patte
 }
 
 //********************************************************************************************************************
-// Parses result filter expressions: [_*]func(), [*_]obj:method(), etc.
+// Parses result filter expressions: [_*]func(), [*_]obj.method(), etc.
 // This syntax allows selective extraction of return values from multi-value function calls.
 
 ParserResult<ExprNodePtr> AstBuilder::parse_result_filter_expr(const Token &StartToken)

--- a/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
@@ -1201,7 +1201,7 @@ void IrEmitter::optimise_assert(ExprNodeList &Args)
 }
 
 //********************************************************************************************************************
-// Result filter expression: [_*]func(), [*_]obj:method(), etc.
+// Result filter expression: [_*]func(), [*_]obj.method(), etc.
 // Transforms to: __filter(mask, count, trailing_keep, func(...))
 // The __filter function is a built-in that selectively returns values based on the filter pattern.
 

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -5802,6 +5802,47 @@ static bool test_canonical_core_syntax_bytecode_emission(kt::Log &Log)
    return true;
 }
 
+static bool test_regex_literal_canonical_bytecode_emission(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *L = state.get();
+   luaL_openlibs(L);
+   luaopen_regex_intrinsic(L);
+   lua_pop(L, 1);
+   std::string error;
+
+   BuiltinCallableID constructor = builtin_callable_id(FastFunc::regex_new);
+   GCfunc *canonical_constructor = lj_builtin_callable(L, constructor);
+   if (not canonical_constructor or canonical_constructor->c.ffid != builtin_callable_index(constructor) or
+       std::string_view(builtin_callable_name(constructor)) != "regex.new") {
+      Log.error("canonical regex.new callable was not registered with its generated identity");
+      return false;
+   }
+   lua_gc(L, LUA_GCCOLLECT, 0);
+   if (lj_builtin_callable(L, constructor) != canonical_constructor) {
+      Log.error("canonical regex.new callable was not rooted independently of its public field");
+      return false;
+   }
+
+   auto literal = compile_snapshot(L, "local value = r'\\d+'\nreturn value\n", true, error);
+   if (not literal or not find_builtin_callable_opcode(*literal, constructor) or
+       count_opcode_tree(*literal, BC_BFUNC) != 1 or count_opcode_tree(*literal, BC_GGET) != 0 or
+       count_opcode_tree(*literal, BC_TGETS) != 0 or count_opcode_tree(*literal, BC_TGETV) != 0) {
+      Log.error("regex literal did not use the canonical regex.new callable: %s", error.c_str());
+      return false;
+   }
+
+   error.clear();
+   auto explicit_call = compile_snapshot(L, "extern regex\nreturn regex.new('\\\\d+')\n", true, error);
+   if (not explicit_call or find_builtin_callable_opcode(*explicit_call, constructor) or
+       count_opcode_tree(*explicit_call, BC_GGET) IS 0 or count_opcode_tree(*explicit_call, BC_BMETH) IS 0) {
+      Log.error("explicit regex.new call lost ordinary dynamic lookup bytecode: %s", error.c_str());
+      return false;
+   }
+
+   return true;
+}
+
 // Phase 4 of the opt-in table context plan: specialise member-call bytecode from positive table contextuality.
 
 static bool test_contextual_call_specialisation(kt::Log &Log)
@@ -8346,7 +8387,7 @@ static bool test_contextual_designation_ownership(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 76> tests = { {
+   constexpr std::array<TestCase, 77> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -8406,6 +8447,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "builtin_method_bytecode_emission", test_builtin_method_bytecode_emission },
       { "compiler_intrinsic_bytecode_emission", test_compiler_intrinsic_bytecode_emission },
       { "canonical_core_syntax_bytecode_emission", test_canonical_core_syntax_bytecode_emission },
+      { "regex_literal_canonical_bytecode_emission", test_regex_literal_canonical_bytecode_emission },
       { "contextual_call_specialisation", test_contextual_call_specialisation },
       { "contextual_tail_call_bytecode_emission", test_contextual_tail_call_bytecode_emission },
       { "builtin_method_runtime", test_builtin_method_runtime },

--- a/src/tiri/tests/test_compiler_intrinsics.tiri
+++ b/src/tiri/tests/test_compiler_intrinsics.tiri
@@ -16,6 +16,7 @@ function replacement_bnot(Value:num):num return 104 end
 function replacement_lshift(Left:num, Right:num):num return 105 end
 function replacement_rshift(Left:num, Right:num):num return 106 end
 function replacement_range(Start:num, Stop:num, Inclusive:bool):str return 'replacement range' end
+function replacement_regex_new(Pattern:str, Flags:num):str return 'replacement regex.new' end
 
 @BeforeEach(hotpath=true)
 function enforce_hotpath() end
@@ -26,6 +27,21 @@ function enforce_hotpath() end
    assert(rawget(_G, '__filter') is nil, 'The result-filter intrinsic must not be published in _G')
    assert(rawget(_G, '__create_thunk') is nil, 'The deferred-expression intrinsic must not be published in _G')
    assert(array.append is nil, 'The array append intrinsic must not be published in the array namespace')
+end
+
+@Test function CanonicalRegexLiteralIgnoresNamespaceRebinding()
+   local original_regex_new = regex.new
+
+   defer regex.new = original_regex_new end
+
+   regex.new = replacement_regex_new
+   processing.collect('full')
+
+   local literal = r'\d+'
+   assert(literal.pattern is [[\d+]] and literal.test('abc123'),
+      'Regex literal syntax should use the rooted canonical regex.new constructor')
+   assert(regex.new('dynamic', 0) is 'replacement regex.new',
+      'Explicit regex.new calls should retain dynamic field lookup semantics')
 end
 
 @Test function CanonicalCoreSyntaxIgnoresNamespaceRebinding()

--- a/src/tiri/tests/test_object.tiri
+++ b/src/tiri/tests/test_object.tiri
@@ -243,6 +243,29 @@ end
 end
 
 -----------------------------------------------------------------------------------------------------------------------
+-- Registered obj.* methods (get, set, exists, ...) are dispatched as canonical built-in methods with the object
+-- supplied as an explicit receiver.  The colon-era bound-receiver closures for these methods were removed, while
+-- obj.new (child creation) and obj._state retain their bound-closure dispatch path.
+
+@Test(hotpath=true) function RegisteredMethodsUseExplicitReceiver()
+   f = obj.new('file', { path='temp:' })
+   assert(f.exists(), "exists() should dispatch through the explicit receiver")
+   assert(f.get('path') is 'temp:', "get() should read a field through the explicit receiver")
+
+   scene = obj.new('VectorScene', { pageWidth=100, pageHeight=100 })
+   vp = scene.new('VectorViewport', { x=0, y=0, width=50, height=50 })
+
+   err = vp.set('opacity', 0.5)
+   assert(err is ERR_Okay, "set() should update a field through the explicit receiver")
+   assert(math.abs(vp.get('opacity') - 0.5) < 0.0001, "set() should have persisted the field value")
+
+   -- obj.new (used above for VectorViewport) and obj._state retain bound-closure dispatch.
+   state = f._state()
+   state.marker = 7
+   assert(f._state().marker is 7, "_state() should still bind the receiver and persist state")
+end
+
+-----------------------------------------------------------------------------------------------------------------------
 -- Test action calling on objects
 
 @Test function ActionCalling()

--- a/src/tiri/tests/test_ranges.tiri
+++ b/src/tiri/tests/test_ranges.tiri
@@ -1908,6 +1908,23 @@ end
    end
 end
 
+@Test function RangeMethodsUseExplicitReceiver()
+   -- Colon-era bound-receiver closures were removed: range.contains and range.toArray are dispatched as canonical
+   -- built-in methods with the range supplied as an explicit receiver.
+
+   r = {0 to 10}
+   assert(r.contains(5), "member call should confirm an in-range value")
+   assert(not r.contains(11), "member call should reject an out-of-range value")
+   assert(5 in r, "membership operator should resolve range.contains canonically")
+
+   arr = r.toArray()
+   assert(arr[0] is 0 and arr[9] is 9, "toArray should materialise the range through the explicit receiver")
+
+   -- A bare member read no longer yields a callable bound to the receiver upvalue.
+   assert(r.contains is nil, "range.contains must not be exposed as a bound-receiver closure")
+   assert(r.toArray is nil, "range.toArray must not be exposed as a bound-receiver closure")
+end
+
 @Test function FloatingRangeJitParity()
    jit.off()
    interpreter_sum = 0

--- a/src/tiri/tiri_regex.cpp
+++ b/src/tiri/tiri_regex.cpp
@@ -26,6 +26,7 @@ Examples:
 #include "lj_array.h"
 #include "lj_str.h"
 #include "lj_gc.h"
+#include "lj_ff.h"
 #include "lj_proto_registry.h"
 #include "defs.h"
 
@@ -187,7 +188,7 @@ static ERR match_none(int Index, std::vector<std::string_view> &Captures, size_t
 // Constructor: regex.new(pattern [, flags])
 // Will throw if compilation of the pattern fails.
 
-static int regex_new(lua_State *Lua)
+int tiri_regex_new(lua_State *Lua)
 {
    kt::Log log(__FUNCTION__);
 
@@ -607,7 +608,6 @@ static int regex_tostring(lua_State *Lua)
 void register_regex_class(lua_State *Lua)
 {
    static const struct luaL_Reg functions[] = {
-      { "new", regex_new },
       { "escape", regex_escape },
       { nullptr, nullptr }
    };
@@ -621,6 +621,9 @@ void register_regex_class(lua_State *Lua)
 
    kt::Log(__FUNCTION__).trace("Registering regex interface");
 
+   luaopen_regex_intrinsic(Lua);
+   lua_pop(Lua, 1);
+
    // Create metatable
    luaL_newmetatable(Lua, "Tiri.regex");
    lua_pushstring(Lua, "Tiri.regex");
@@ -632,6 +635,14 @@ void register_regex_class(lua_State *Lua)
 
    // Create regex module
    luaL_openlib(Lua, "regex", functions, 0);
+
+   GCfunc *constructor = lj_builtin_callable(Lua, builtin_callable_id(FastFunc::regex_new));
+   if (not constructor) {
+      luaL_error(Lua, ERR::Init, "Canonical regex.new constructor is unavailable");
+      return;
+   }
+   setfuncV(Lua, Lua->top++, constructor);
+   lua_setfield(Lua, -2, "new");
 
    // Add flag constants to regex module.  These match the REGEX_* flags but making them available
    // in this way means that scripts don't need to include the regex module.


### PR DESCRIPTION
* Added a canonical regex constructor identity and lowered regex literals through BC_BFUNC while preserving explicit lookup

* Removed colon-era bound receiver closures for registered range and object methods

* Added parser, GC, rebinding and hot-path regression coverage