### PR TITLE
[Tiri] Signature checking for forward-declared local functions

### DIFF
--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1522,6 +1522,54 @@ static bool test_forward_declaration_signature_validation(kt::Log &Log)
 
    lua_pop(L, 1);
 
+   constexpr std::string_view matching_local_source =
+      "function local_declared(Name:str, Options:table, ...):<str, num> end\n"
+      "function local_declared(Value:str, Settings:table, ...):<str, num>\n"
+      "   return Value, 1\n"
+      "end\n";
+
+   if (lua_load(L, matching_local_source, "matching-local-forward-signature")) {
+      Log.error("matching local forward declaration was rejected: %s", lua_tostring(L, -1));
+      return false;
+   }
+   lua_pop(L, 1);
+
+   constexpr std::string_view mismatched_local_source =
+      "function local_klass(Name:str, Options:table):str end\n"
+      "function local_klass(Name:num, Options:table):num\n"
+      "   return ''\n"
+      "end\n";
+
+   if (lua_load(L, mismatched_local_source, "mismatched-local-forward-signature") IS 0) {
+      Log.error("mismatched local forward declaration was accepted");
+      lua_pop(L, 1);
+      return false;
+   }
+
+   message = lua_tostring(L, -1);
+   if (message.find("signature for local function 'local_klass' does not match its forward declaration") IS
+       std::string_view::npos or message.find("parameter 1 has type 'num', expected 'str'") IS
+       std::string_view::npos) {
+      Log.error("mismatched local forward declaration produced the wrong diagnostic: %s", lua_tostring(L, -1));
+      lua_pop(L, 1);
+      return false;
+   }
+
+   lua_pop(L, 1);
+
+   constexpr std::string_view nested_local_source =
+      "function local_scoped(Value:num):num end\n"
+      "function outer()\n"
+      "   function local_scoped(Value:str):str return Value end\n"
+      "end\n"
+      "function local_scoped(Value:num):num return Value end\n";
+
+   if (lua_load(L, nested_local_source, "nested-local-forward-signature")) {
+      Log.error("nested local function inherited an outer forward declaration: %s", lua_tostring(L, -1));
+      return false;
+   }
+   lua_pop(L, 1);
+
    constexpr std::string_view conditional_mismatch_source =
       "global function routed(Value:num) end\n"
       "if true then\n"
@@ -3474,130 +3522,6 @@ static bool test_module_dependency_corruption_rejected(kt::Log &Log)
 }
 
 //********************************************************************************************************************
-// Executing a unit's dependency declaration must populate the prototype's resolved sidecar, and the callables bound
-// into the generated locals must be exactly the records the sidecar holds.
-//
-// BC_MODACT serves its bindings from the sidecar rather than repeating module and function lookups.  Comparing the
-// bound upvalue against the sidecar slot makes the descriptor path observable independently of call behaviour.
-
-static bool test_module_dependency_activation_uses_sidecar(kt::Log &Log)
-{
-   LuaStateHolder state;
-   lua_State *L = state.get();
-   luaL_openlibs(L);
-   register_module_class(L);
-   lua_protect_globals(L);
-
-   // Two distinct functions from one module, plus a declaration that references none.  The unreferenced module must
-   // still resolve, and the referenced functions must occupy consecutive sidecar slots in declaration order.
-
-   constexpr std::string_view source =
-      "module core as mC\n"
-      "module display as mD\n"
-      "local a = mC.PreciseTime\n"
-      "local b = mC.GetErrorMsg\n"
-      "return a, b\n";
-
-   if (lua_load(L, source, "dependency-activation")) {
-      Log.error("failed to compile the activation fixture: %s", lua_tostring(L, -1));
-      return false;
-   }
-
-   GCproto *proto = funcproto(funcV(L->top - 1));
-
-   if (proto->resolved_dependencies) {
-      Log.error("the sidecar was populated before the chunk executed");
-      return false;
-   }
-
-   // lua_pcall() consumes the chunk, so retain a copy for the re-activation check below.
-
-   lua_pushvalue(L, -1);
-
-   if (lua_pcall(L, 0, 2, 0)) {
-      Log.error("the activation fixture failed to execute: %s", lua_tostring(L, -1));
-      return false;
-   }
-
-   if (not proto->resolved_dependencies) {
-      Log.error("executing a dependency declaration left the sidecar unresolved");
-      return false;
-   }
-
-   auto table = proto_dependencies(proto);
-   if (not table or table->function_count != 2) {
-      Log.error("expected two resolved function slots, found %d", table ? int(table->function_count) : -1);
-      return false;
-   }
-
-   // Every referenced function slot must hold a record, and every declaration must be marked activated even when it
-   // references no function.
-
-   std::array<const void *, 2> resolved = { };
-   for (uint32_t slot = 0; slot < table->function_count; ++slot) {
-      resolved[slot] = proto_dependency_callable(proto, slot);
-      if (not resolved[slot]) {
-         Log.error("sidecar slot %d is empty after activation", int(slot));
-         return false;
-      }
-   }
-   if (not proto->resolved_dependency_states or proto->resolved_dependency_count != table->dependency_count) {
-      Log.error("dependency activation state does not match the descriptor table");
-      return false;
-   }
-   for (uint32_t dependency = 0; dependency < table->dependency_count; ++dependency) {
-      if (not proto->resolved_dependency_states[dependency]) {
-         Log.error("dependency %d was not marked activated", int(dependency));
-         return false;
-      }
-   }
-
-   // The returned values are the generated bindings.  Each is a C closure whose single upvalue is the light userdata
-   // pointing at the callable record, so it can be compared directly against the sidecar.
-
-   for (int index = 0; index < 2; ++index) {
-      int stack_slot = index - 2; // -2 is the first result, -1 the second
-
-      if (not lua_iscfunction(L, stack_slot)) {
-         Log.error("binding %d is not a C closure", index);
-         return false;
-      }
-
-      if (not lua_getupvalue(L, stack_slot, 1)) {
-         Log.error("binding %d exposes no callable upvalue", index);
-         return false;
-      }
-
-      const void *bound = lua_topointer(L, -1);
-      lua_pop(L, 1);
-
-      const void *expected = proto_dependency_callable(proto, uint32_t(index));
-      if (bound != expected) {
-         Log.error("binding %d holds %p but sidecar slot %d holds %p; the adapter is not serving from the sidecar",
-            index, bound, index, expected);
-         return false;
-      }
-   }
-
-   lua_pop(L, 2); // Discard the two bindings, leaving the retained chunk on top.
-
-   // Re-executing the chunk must preserve the resolved sidecar and simply rebuild closures from its stable records.
-
-   if (lua_pcall(L, 0, 2, 0)) {
-      Log.error("re-executing the activation fixture failed: %s", lua_tostring(L, -1));
-      return false;
-   }
-   lua_pop(L, 2);
-
-   for (uint32_t slot = 0; slot < table->function_count; ++slot) {
-      if (proto_dependency_callable(proto, slot) != resolved[slot]) {
-         Log.error("re-activation replaced resolved sidecar slot %d", int(slot));
-         return false;
-      }
-   }
-
-   return true;
-}
 
 static bool test_module_registry(kt::Log &Log)
 {
@@ -3605,7 +3529,6 @@ static bool test_module_registry(kt::Log &Log)
       test_module_registry_shared_ordinal(Log) and
       test_module_registry_concurrency(Log) and
       test_module_definition_ownership(Log) and
-      test_module_dependency_activation_uses_sidecar(Log) and
       test_module_dependency_corruption_rejected(Log);
 }
 

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -239,6 +239,7 @@ private:
    void discover_global_decl_policy(const GlobalDeclStmtPayload &, bool PublishStaticPolicy);
    void analyse_local_function(const LocalFunctionStmtPayload &);
    void analyse_function_stmt(const FunctionStmtPayload &);
+   void declare_local_function(GCstr *, const FunctionExprPayload *, SourceSpan);
    void analyse_function_payload(const FunctionExprPayload &, GCstr *Name = nullptr);
    void analyse_expression(const ExprNode &);
    void analyse_call_expr(const CallExprPayload &, SourceSpan);
@@ -1980,9 +1981,30 @@ void TypeAnalyser::analyse_local_function(const LocalFunctionStmtPayload &Payloa
    #endif
 
    const FunctionExprPayload* function = Payload.function.get();
-   this->current_scope().declare_function(Payload.name.symbol, function, Payload.name.span);
+   this->declare_local_function(Payload.name.symbol, function, Payload.name.span);
 
    if (function) this->analyse_function_payload(*function, Payload.name.symbol);
+}
+
+//********************************************************************************************************************
+// Local Function Declaration: Retains an empty declaration as a lexical-scope-local signature contract for the
+// next definition of the same simple name.
+
+void TypeAnalyser::declare_local_function(GCstr *Name, const FunctionExprPayload *Function, SourceSpan Location)
+{
+   const FunctionExprPayload *forward_declaration = this->current_scope().lookup_function(Name);
+   if (forward_declaration and Function and is_function_forward_declaration(*forward_declaration)) {
+      if (auto mismatch = function_signature_mismatch(*forward_declaration, *Function)) {
+         TypeDiagnostic diag;
+         diag.location = Location;
+         diag.code = ParserErrorCode::FunctionSignatureMismatch;
+         diag.message = std::format("signature for local function '{}' does not match its forward declaration: {}",
+            std::string_view(strdata(Name), Name->len), *mismatch);
+         this->record_diagnostic(std::move(diag));
+      }
+   }
+
+   this->current_scope().declare_function(Name, Function, Location);
 }
 
 //********************************************************************************************************************
@@ -2001,7 +2023,8 @@ void TypeAnalyser::analyse_function_stmt(const FunctionStmtPayload &Payload)
    if (not Payload.name.is_explicit_global) {
       if (not Payload.name.segments.empty()) {
          const Identifier& terminal = Payload.name.segments.back();
-         this->current_scope().declare_function(terminal.symbol, function, terminal.span);
+         if (Payload.name.segments.size() IS 1) this->declare_local_function(terminal.symbol, function, terminal.span);
+         else this->current_scope().declare_function(terminal.symbol, function, terminal.span);
          function_name = terminal.symbol;
          function_location = terminal.span;
       }

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -1060,6 +1060,67 @@ global function glContractForwardKind():num return 1 end
    end, 'global callable kind')
 end
 
+@Test function LocalCallableForwardSignatures()
+   local result = exec([[
+function local_contract_forward(Value:num):num end
+function local_contract_forward(Value:num):num return Value end
+return local_contract_forward(4)
+]])
+   assert(result is 4, 'A matching local function definition must satisfy its forward declaration')
+
+   local mismatch_failed = false
+   try
+      exec([[
+function local_contract_forward_mismatch(Value:num):num end
+function local_contract_forward_mismatch(Value:str):str return Value end
+]])
+   except e
+      mismatch_failed = true
+      assert(e.message.find("signature for local function 'local_contract_forward_mismatch'") != nil,
+         'The local-forward diagnostic must identify the function: ' .. e.message)
+      assert(e.message.find("parameter 1 has type 'str', expected 'num'") != nil,
+         'The local-forward diagnostic must identify the parameter mismatch: ' .. e.message)
+   end
+   assert(mismatch_failed, 'An incompatible local function definition must fail compilation')
+
+   local return_mismatch_failed = false
+   try
+      exec([[
+function local_contract_return(Value:num):num end
+function local_contract_return(Value:num):str return '' end
+]])
+   except e
+      return_mismatch_failed = true
+      assert(e.message.find("return 1 has type 'str', expected 'num'") != nil,
+         'The local-forward diagnostic must identify the return mismatch: ' .. e.message)
+   end
+   assert(return_mismatch_failed, 'An incompatible local function return declaration must fail compilation')
+
+   local explicit_result = exec([[
+local function explicit_local_contract(Value:num):num end
+local function explicit_local_contract(Value:num):num return Value end
+return explicit_local_contract(6)
+]])
+   assert(explicit_result is 6, 'An explicit local function definition must satisfy its forward declaration')
+
+   expect_contract_failure(function()
+      exec([[
+local function explicit_local_contract_mismatch(Value:num):num end
+local function explicit_local_contract_mismatch(Value:str):num return 0 end
+]])
+   end, 'explicit local function forward signature')
+
+   local scoped_result = exec([[
+function local_contract_scoped(Value:num):num end
+function outer()
+   function local_contract_scoped(Value:str):str return Value end
+end
+function local_contract_scoped(Value:num):num return Value end
+return local_contract_scoped(5)
+]])
+   assert(scoped_result is 5, 'A nested local function must not inherit an outer forward declaration')
+end
+
 @Test function CompiledGlobalWriterObservesVariantPolicy()
    global glContractWriter:num = 1
 


### PR DESCRIPTION
* Local functions now retain an empty forward declaration as a lexical-scope signature contract, so a subsequent definition of the same simple name is validated against it
* Mismatched parameter or return types between a local forward declaration and its definition are now reported as compile-time diagnostics identifying the function and the offending parameter/return
* Nested definitions of the same name do not inherit an outer forward declaration
* Removed the obsolete module dependency sidecar activation unit test