### PR TITLE
[Tiri] Rename struct 'string' field type to 'str' and consolidate struct.size()

### DIFF
--- a/src/tiri/jit/BYTECODE.md
+++ b/src/tiri/jit/BYTECODE.md
@@ -546,10 +546,10 @@ and replaces P, so a single polymorphic instruction site can safely alternate be
 
 ### 6.3 Interpreter Semantics
 
-| Bytecode | Operation | Fast-type failure | Cached value |
-|----------|-----------|-------------------|--------------|
-| `STGETF` | Load a named field or the bound `structSize` closure | `vmeta_tgets` | Field index |
-| `STSETF` | Store a named writable field | `vmeta_tsets` | Field index |
+| Bytecode | Operation                    | Fast-type failure | Cached value |
+|----------|------------------------------|-------------------|--------------|
+| `STGETF` | Load a declared named field  | `vmeta_tgets`     | Field index  |
+| `STSETF` | Store a named writable field | `vmeta_tsets`     | Field index  |
 
 The x64, ARM64 and PowerPC handlers call `bc_struct_getfield` and `bc_struct_setfield`. The helpers synchronise the Lua
 frame before any operation that may allocate, protect setter values from garbage collection and restore the
@@ -559,7 +559,7 @@ site falls back to the ordinary metamethod path.
 ### 6.4 Parser and Platform Status
 
 `ExpKind::IndexedStruct` lowers constant string member access to `STGETF`/`STSETF`. A struct member used as a callee is
-downgraded to normal indexed access so helpers such as `value.structSize()` still resolve through `__index`.
+downgraded to normal indexed access so method-style helpers still resolve through `__index`.
 
 The interpreter implementation covers x64, ARM64 and PowerPC. The JIT can record these opcodes: scalar numeric fields may lower to guarded XLOAD/XSTORE, while complex or lifecycle-bound fields fall back to the C helpers.
 

--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -46,10 +46,11 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // BC_TCTX contextual table designation and cuts over to opt-in table context, which changes the meaning of every
 // existing contextual call sequence.  Version 0x8d adds materialised temporary context blocks and consuming close
 // activation bytecodes.  Version 0x8e adds the canonical regex.new identity used by regex literals.  Version 0x8f
-// separates object.create, object.new and object._state callable identities.  Older chunks are rejected rather than
-// retaining compatibility shims.
+// separates object.create, object.new and object._state callable identities.  Version 0x90 accepts a struct reference
+// in struct.size, which shifts the generated fast-function ordering.  Older chunks are rejected rather than retaining
+// compatibility shims.
 
-constexpr uint8_t BCDUMP_VERSION = 0x8f;
+constexpr uint8_t BCDUMP_VERSION = 0x90;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/debug/lj_ff.h
+++ b/src/tiri/jit/src/debug/lj_ff.h
@@ -76,7 +76,7 @@ static_assert(FF__MAX <= BUILTIN_CALLABLE_CAPACITY);
 static_assert(FF__MAX - 1 <= std::numeric_limits<uint16_t>::max());
 static_assert(builtin_callable_index(BuiltinCallableID::Invalid) >= FF__MAX);
 #ifdef FFDEF_BFUNC_ABI
-static_assert(builtin_callable_abi_fingerprint() IS 0x556b1c6e45bcaa4eull,
+static_assert(builtin_callable_abi_fingerprint() IS 0x66758fa657ea7f24ull,
    "fast-function ordering changed: bump BCDUMP_VERSION and update the BC_BFUNC ABI fingerprint");
 #endif
 

--- a/src/tiri/jit/src/lib/lib_struct.cpp
+++ b/src/tiri/jit/src/lib/lib_struct.cpp
@@ -469,6 +469,10 @@ static GCstruct * push_external_struct(lua_State *L, APTR Address, std::string_v
 
 LJLIB_CF(struct_size)
 {
+   if (lua_isstruct(L, 1)) { // A struct reference reports the byte size of its own definition.
+      lua_pushnumber(L, lua_tostruct(L, 1)->structsize);
+      return 1;
+   }
    if (auto name = lua_tostring(L, 1)) {
       if (auto def = find_struct(L, name)) {
          lua_pushnumber(L, def->Size);
@@ -476,7 +480,7 @@ LJLIB_CF(struct_size)
       }
       luaL_argerror(L, 1, "The requested structure is not defined.");
    }
-   else luaL_argerror(L, 1, "Structure name required.");
+   else luaL_argerror(L, 1, "A structure name or reference is required.");
    return 0;
 }
 
@@ -527,31 +531,6 @@ LJLIB_CF(struct_def)
    lua_pushstring(L, name);
    lua_pushcclosure(L, struct_definition_call, 1);
    return 1;
-}
-
-static int struct_struct_size(lua_State *L)
-{
-   auto *value = lua_isstruct(L, lua_upvalueindex(1)) ? lua_tostruct(L, lua_upvalueindex(1)) : nullptr;
-   if (not value) {
-      luaL_argerror(L, 1, "Expected struct.");
-      return 0;
-   }
-   lua_pushnumber(L, value->structsize);
-   return 1;
-}
-
-LJLIB_CF(struct_structSize)
-{
-   auto *value = lj_lib_checkstruct(L, 1);
-   lua_pushnumber(L, value->structsize);
-   return 1;
-}
-
-void lj_struct_push_size_closure(lua_State *L, GCstruct *Struct)
-{
-   setstructV(L, L->top, Struct);
-   incr_top(L);
-   lua_pushcclosure(L, &struct_struct_size, 1);
 }
 
 static int struct_len(lua_State *L)
@@ -715,10 +694,7 @@ static int struct_get(lua_State *L)
 {
    auto *value = lj_lib_checkstruct(L, 1);
    auto field_name = luaL_checkstring(L, 2);
-   if (std::string_view("structSize") IS field_name) {
-      lj_struct_push_size_closure(L, value);
-      return 1;
-   }
+
    lj_struct_check_lifecycle(L, value, field_name);
    if (not value->data) {
       luaL_error(L, ERR::Failed, "Cannot reference field '%s' because struct address is NULL.", field_name);
@@ -819,9 +795,7 @@ extern "C" int luaopen_struct(lua_State *L)
 
    reg_iface_prototype("struct", "new", { TiriType::Struct }, { TiriType::Str, TiriType::Table });
    reg_iface_prototype("struct", "def", { TiriType::Func }, { TiriType::Str });
-   reg_iface_prototype("struct", "size", { TiriType::Num }, { TiriType::Str });
-   reg_iface_method(L, "struct", "structSize", TiriType::Struct,
-      builtin_callable_id(FastFunc::struct_structSize), { TiriType::Num }, { TiriType::Struct });
+   reg_iface_prototype("struct", "size", { TiriType::Num }, { TiriType::Any }); // Accepts a struct name or reference
    reg_iface_method(L, "struct", "copy", TiriType::Struct, builtin_callable_id(FastFunc::struct_copy),
       { TiriType::Struct }, { TiriType::Struct, TiriType::Struct });
    reg_iface_method(L, "struct", "clone", TiriType::Struct, builtin_callable_id(FastFunc::struct_clone),

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -519,7 +519,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
       }
       else if (type_name IS "float") { field.Type = FD_FLOAT; field.NativeType = NativeStructType::Float; }
       else if (type_name IS "double") { field.Type = FD_DOUBLE; field.NativeType = NativeStructType::Double; }
-      else if (type_name IS "string") {
+      else if (type_name IS "str") {
          field.Type = FD_STRING|FD_CPP; field.NativeType = NativeStructType::String;
       }
       else if (type_name IS "cstr") { field.Type = FD_STRING; field.NativeType = NativeStructType::CStr; }

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -5092,7 +5092,7 @@ static bool test_builtin_method_registry(kt::Log &Log)
    constexpr std::array<std::string_view, 10> range_methods = {
       "each", "filter", "reduce", "map", "take", "any", "all", "find", "contains", "toArray"
    };
-   constexpr std::array<std::string_view, 3> struct_methods = { "structSize", "copy", "clone" };
+   constexpr std::array<std::string_view, 2> struct_methods = { "copy", "clone" };
    constexpr std::array<std::string_view, 12> object_methods = {
       "class", "init", "free", "children", "detach", "get", "set", "getKey", "setKey", "exists", "subscribe",
       "unsubscribe"

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -32,6 +32,7 @@ static bool is_builtin_interface_namespace(uint32_t Hash)
       case kt::strhash("debug"):
       case kt::strhash("array"):
       case kt::strhash("range"):
+      case kt::strhash("struct"):
          return true;
       default:
          return false;

--- a/src/tiri/jit/src/runtime/lj_struct.cpp
+++ b/src/tiri/jit/src/runtime/lj_struct.cpp
@@ -227,15 +227,6 @@ extern "C" void bc_struct_getfield(lua_State *L, GCstruct *Struct, GCstr *Key, T
    if (curr_funcisL(L)) L->top = curr_topL(L);
 
    const auto field_name = strdata(Key);
-   if (std::string_view("structSize") IS field_name) {
-      lj_struct_push_size_closure(L, Struct);
-      const auto result_dest = Ins ? restorestack(L, dest_offset) : Dest;
-      copyTV(L, result_dest, L->top - 1);
-      L->base = restorestack(L, saved_base);
-      L->top = restorestack(L, saved_top);
-      return;
-   }
-
    lj_struct_check_lifecycle(L, Struct, field_name, true);
    if (not Struct->data) {
       luaL_error_current(L, ERR::Failed, "Cannot reference field '%s' because struct address is NULL.", field_name);

--- a/src/tiri/jit/src/runtime/lj_struct.h
+++ b/src/tiri/jit/src/runtime/lj_struct.h
@@ -17,7 +17,6 @@ extern bool lj_struct_stale(GCstruct *);
 extern void lj_struct_check_lifecycle(lua_State *, GCstruct *, const char *, bool CurrentFrame = false);
 extern void lj_struct_getfield_core(lua_State *, GCstruct *, struct_field &, void *, bool CurrentFrame = false);
 extern void lj_struct_setfield_core(lua_State *, GCstruct *, struct_field &, void *, bool CurrentFrame = false);
-extern void lj_struct_push_size_closure(lua_State *, GCstruct *);
 
 // Fast path bytecode handlers for BC_STGETF and BC_STSETF.
 // Ins points to the current instruction for inline caching (nullptr disables caching in JIT traces).

--- a/src/tiri/tests/test_builtin_methods.tiri
+++ b/src/tiri/tests/test_builtin_methods.tiri
@@ -208,8 +208,6 @@ end
 
 @Test function StructMethods()
    local source = struct<BuiltinMethodRecord> { Value=42 }
-   assert(source.structSize() > 0, 'Struct size should be available as a canonical method')
-
    local clone = source.clone()
    assert(clone.Value is 42, 'Struct clone should retain the payload')
    local destination = struct<BuiltinMethodRecord> { Value=1 }

--- a/src/tiri/tests/test_debug.tiri
+++ b/src/tiri/tests/test_debug.tiri
@@ -760,7 +760,7 @@ end
 
 -- Leading description.
 struct ValidateUser
-   Name: string -- The user name.
+   Name: str -- The user name.
    Age: int
    Sock: obj<NetSocket>
    Buf: char[16]
@@ -800,7 +800,7 @@ end
    fields = {}
    for f in values(user.fields) do fields[f.name] = f end
 
-   assert(fields.Name.type is 'string', "Name field type should be preserved")
+   assert(fields.Name.type is 'str', "Name field type should be preserved")
    assert(fields.Name.doc is 'The user name.', "Trailing field doc comment should be captured")
    assert(fields.Age.type is 'int', "Age field type should be preserved")
    assert(fields.Sock.type is 'obj<NetSocket>', "Object class constraints should be preserved")

--- a/src/tiri/tests/test_stack_growth.tiri
+++ b/src/tiri/tests/test_stack_growth.tiri
@@ -33,7 +33,7 @@
 end
 
 struct StackGrowthRecord
-   Name: string
+   Name: str
 end
 
 @Test(hotpath=80) function JitFallbackDestinationsRemainStable()

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -663,7 +663,7 @@ end
    palette = struct.new('TinyStridePalette', { marker=77 })
    assert(type(palette) is 'struct', 'Expected struct.new() to return the native struct type')
    assert(#palette is 2, 'Expected the structure to report its field count')
-   assert(palette.structSize() > 0, 'Expected the structure to report its byte size')
+   assert(struct.size(palette) > 0, 'Expected the structure to report its byte size')
    colours = palette.Col
 
    assert(#colours is 2, 'Expected the embedded struct array to expose two elements, got ' .. #colours)
@@ -962,7 +962,6 @@ end
       error('Invalid struct field assignment should raise through STSETF')
    end
 
-   assert(value.structSize() > 0, 'structSize() should continue to resolve through the struct metatable')
    assert(#value is 1, 'Struct length should remain the number of declared fields')
 end
 

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -5,7 +5,7 @@ end
 
 struct DeclaredUser
    -- User-facing name retained as parser tooling metadata.
-   Name: string -- Owned string storage.
+   Name: str -- Owned string storage.
    Borrowed: cstr
    Age: int
    Enabled: bool
@@ -22,7 +22,7 @@ struct DeclaredLayout
    Bool: bool, Char: char, Byte: byte, Int8: int8, UInt8: uint8,
    Int16: int16, UInt16: uint16, Int: int, UInt: uint,
    Int32: int, UInt32: uint, Int64: int64, UInt64: uint64,
-   Float: float, Double: double, String: string, CStr: cstr,
+   Float: float, Double: double, String: str, CStr: cstr,
    Pointer: ptr, IntPointer: ptr<int>, IntList: ptr<int[]>, Object: obj, Callback: func, Buffer: char[7],
    Fixed: int[3], Child: struct<DeclaredChild>, ChildPointer: ptr<DeclaredChild>
 end
@@ -42,7 +42,7 @@ struct DeclaredVectorFields
 end
 
 struct DeclaredNonTrivialVectorElement
-   Name: string
+   Name: str
 end
 
 struct DeclaredVectorOwner

--- a/src/tiri/tests/test_type_annotations.tiri
+++ b/src/tiri/tests/test_type_annotations.tiri
@@ -146,7 +146,7 @@ end
    end
 
    assert_rejected('function invalid(Value:array) end', 'element type')
-   assert_rejected('function invalid(Value:array<str>) end', 'Unknown array element type')
+   assert_rejected('function invalid(Value:array<string>) end', 'Unknown array element type')
    assert_rejected('function invalid(Value:array<missing>) end', 'Unknown array element type')
    assert_rejected('function invalid(Value:array<pointer>) end', 'Unknown array element type')
    assert_rejected('function invalid(Value:array<array<str>>) end', 'Nested array specialisation')

--- a/src/tiri/tests/test_type_annotations.tiri
+++ b/src/tiri/tests/test_type_annotations.tiri
@@ -146,7 +146,7 @@ end
    end
 
    assert_rejected('function invalid(Value:array) end', 'element type')
-   assert_rejected('function invalid(Value:array<string>) end', 'Unknown array element type')
+   assert_rejected('function invalid(Value:array<str>) end', 'Unknown array element type')
    assert_rejected('function invalid(Value:array<missing>) end', 'Unknown array element type')
    assert_rejected('function invalid(Value:array<pointer>) end', 'Unknown array element type')
    assert_rejected('function invalid(Value:array<array<str>>) end', 'Nested array specialisation')

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -3,8 +3,8 @@
 To create a struct from a registered definition:  xmltag = struct.new('XTag')
 To create a struct with pre-configured values:    xmltag = struct.new('XTag', { name='Hello' })
 To get the byte size of any structure definition: size = struct.size('XTag')
+To get the byte size of a created structure:      size = struct.size(xmltag)
 To get the total number of fields in a structure: #xmltag
-To get the byte size of a created structure:      xmltag.structSize()
 
 Acceptable short-hand field definitions, for MAKESTRUCT() and IDL usage only:
 

--- a/tools/tiri_lsp/tests/test_definition.tiri
+++ b/tools/tiri_lsp/tests/test_definition.tiri
@@ -180,13 +180,13 @@ end
 end
 
 @Test function StructAnnotationResolvesToDeclaration()
-   doc = makeDoc('struct User\n   Name: string\nend\n\nfunction describe(Person: struct<User>)\nend\n')
+   doc = makeDoc('struct User\n   Name: str\nend\n\nfunction describe(Person: struct<User>)\nend\n')
    locations = resolveDefinition(doc, { line = 4, character = 34 })
    assertLocationLine(locations, 0, 'struct<User> annotation should resolve to the struct declaration')
 end
 
 @Test function StructFieldAccessResolvesToFieldLine()
-   doc = makeDoc('struct User\n   Name: string\n   Age: int\nend\n\nu = struct.new(\'User\')\nprint(u.Age)\n')
+   doc = makeDoc('struct User\n   Name: str\n   Age: int\nend\n\nu = struct.new(\'User\')\nprint(u.Age)\n')
    locations = resolveDefinition(doc, { line = 6, character = 9 })
    assertLocationLine(locations, 2, 'Field access should resolve to the field declaration line')
 end
@@ -204,7 +204,7 @@ end
 end
 
 @Test function EndTerminatedStructDeclarationResolves()
-   doc = makeDoc('struct User\n   Name: string\nend\n\nfunction describe(Person: struct<User>)\nend\n')
+   doc = makeDoc('struct User\n   Name: str\nend\n\nfunction describe(Person: struct<User>)\nend\n')
    locations = resolveDefinition(doc, { line = 4, character = 34 })
    assertLocationLine(locations, 0, 'An end-terminated struct declaration should resolve')
 end

--- a/tools/tiri_lsp/tests/test_document_symbols.tiri
+++ b/tools/tiri_lsp/tests/test_document_symbols.tiri
@@ -214,7 +214,7 @@ end
 @Test function StructDeclarationWithFieldChildren()
    doc = makeDoc([[
 struct User
-   Name: string -- The user name
+   Name: str -- The user name
    Age: int
    Sock: obj<NetSocket>
    Buf: char[32]
@@ -237,7 +237,7 @@ end
 
    name_field = findChild(user, 'Name')
    assert(name_field and name_field.kind is SYMBOL_KIND.FIELD, 'Struct fields should use the field kind.')
-   assert(name_field.detail is 'string', 'Field detail should carry the declared type.')
+   assert(name_field.detail is 'str', 'Field detail should carry the declared type.')
 
    sock_field = findChild(user, 'Sock')
    assert(sock_field and sock_field.detail is 'obj<NetSocket>', 'Generic field types should be preserved.')

--- a/tools/tiri_lsp/tests/test_folding.tiri
+++ b/tools/tiri_lsp/tests/test_folding.tiri
@@ -34,13 +34,13 @@ end
 end
 
 @Test function StructBlockFolds()
-   doc = makeDoc('struct User\n   Name: string\n   Age: int\nend\n')
+   doc = makeDoc('struct User\n   Name: str\n   Age: int\nend\n')
    ranges = extractFoldingRanges(doc)
    assert(findRange(ranges, 0, 3), 'Struct declaration blocks should fold to the end keyword.')
 end
 
 @Test function StructFollowedByFunctionFoldsBoth()
-   doc = makeDoc('struct User\n   Name: string\nend\n\nfunction greet()\n   print(2)\nend\n')
+   doc = makeDoc('struct User\n   Name: str\nend\n\nfunction greet()\n   print(2)\nend\n')
    ranges = extractFoldingRanges(doc)
    assert(findRange(ranges, 0, 2), 'The struct block should fold.')
    assert(findRange(ranges, 4, 6), 'A function after the struct should fold normally.')
@@ -59,7 +59,7 @@ end
 end
 
 @Test function StructNameOnOpeningLineFolds()
-   doc = makeDoc('struct User\n   Name: string\n   Age: int\nend\n')
+   doc = makeDoc('struct User\n   Name: str\n   Age: int\nend\n')
    ranges = extractFoldingRanges(doc)
    assert(findRange(ranges, 0, 3), 'An end-terminated struct should fold from its declaration.')
 end

--- a/tools/tiri_lsp/tests/test_hover.tiri
+++ b/tools/tiri_lsp/tests/test_hover.tiri
@@ -188,7 +188,7 @@ end
 @Test function StructDeclarationHoverShowsFields()
    hover, token = hoverAt([[
 struct Us|er
-   Name: string -- The user name
+   Name: str -- The user name
    Age: int
 end
 ]])
@@ -196,14 +196,14 @@ end
    assert(token and token.text is 'User', 'Hover token extraction should identify the struct name.')
    assertContains(hover, 'struct User', 'Struct hover should lead with the declaration signature.')
    assertContains(hover, '**Fields**', 'Struct hover should include a Fields section.')
-   assertContains(hover, '`Name: string`', 'Struct hover should list field names and types.')
+   assertContains(hover, '`Name: str`', 'Struct hover should list field names and types.')
    assertContains(hover, 'The user name', 'Struct hover should include field doc comments.')
 end
 
 @Test function StructFieldHoverViaStructNew()
    hover, token = hoverAt([[
 struct User
-   Name: string -- The user name
+   Name: str -- The user name
    Age: int
 end
 u = struct.new('User')
@@ -212,14 +212,14 @@ print(u.Na|me)
 
    assert(token and token.text is 'Name' and token.object is 'u', 'Token extraction should identify field access.')
    assertContains(hover, 'User.Name', 'Field hover should be attributed to the struct.')
-   assertContains(hover, '`string`', 'Field hover should state the declared type.')
+   assertContains(hover, '`str`', 'Field hover should state the declared type.')
    assertContains(hover, 'The user name', 'Field hover should include the doc comment.')
 end
 
 @Test function StructFieldHoverViaAnnotatedParameter()
    hover, token = hoverAt([[
 struct User
-   Name: string
+   Name: str
    Age: int -- Age in years
 end
 function describe(Person: struct<User>)
@@ -235,7 +235,7 @@ end
 @Test function StructFieldHoverViaConstruction()
    hover, token = hoverAt([[
 struct User
-   Name: string -- The user name
+   Name: str -- The user name
 end
 user = struct<User> { Name = 'Paul' }
 print(user.Na|me)
@@ -248,7 +248,7 @@ end
 @Test function StructUnknownFieldHasNoHover()
    hover, token = hoverAt([[
 struct User
-   Name: string
+   Name: str
 end
 u = struct.new('User')
 print(u.Mis|sing)

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -372,7 +372,7 @@ end
 
 @Test function StructDeclarationReceivesKeywordToken()
    source = 'struct User\n' ..
-      '   Name: string\n' ..
+      '   Name: str\n' ..
       'end\n'
 
    tokens = tokenizeTiri(source)
@@ -408,7 +408,7 @@ end
 @Test function StructDeclarationNameOnNextLine()
    source = 'struct\n' ..
       'User\n' ..
-      '   Name: string\n' ..
+      '   Name: str\n' ..
       'end\n'
 
    tokens = tokenizeTiri(source)


### PR DESCRIPTION
## Summary

* Renamed the `string` struct field type-name to `str` for consistency with the rest of the Tiri type-name vocabulary.
* Consolidated struct byte-size querying into `struct.size()`, which now accepts a struct reference in addition to a definition name, and removed the redundant `struct.structSize()` method.

## Details

* `struct.size()` returns the byte size of a struct's definition whether passed a definition name or a live struct reference.
* Removed the `struct.structSize()` method and its size-closure machinery in favour of the unified `struct.size()` entry point.
* Bumped `BCDUMP_VERSION` to `0x90` and updated the BC_BFUNC ABI fingerprint to reflect the shifted fast-function ordering.
* Registered the `struct` namespace for static descriptor analysis.

## Testing

Not yet verified in this session — recommend a build and the struct/type-annotation Flute tests before merge.
