### PR TITLE
[Tiri] Removed implicit string-to-number coercion from arithmetic ope…

### DIFF
--- a/examples/widgets.tiri
+++ b/examples/widgets.tiri
@@ -137,8 +137,9 @@ end
       x=win.margins.left, y=y, string='Kōtuku interfaces are drawn using real-time vector graphics',
       face='Noto Sans', fontSize=20, fill=win.theme.window.text, textFlags='!editable'
    })
-   text.y += text.fontSize
-   y += text.fontSize + 14
+   font_size = tonumber(text.fontSize)
+   text.y += font_size
+   y += font_size + 14
 
    msgButton = gui.button({
       target = viewport,

--- a/scripts/gui.tiri
+++ b/scripts/gui.tiri
@@ -694,14 +694,14 @@ gui.sizing = {
 }
 
 gui.fonts = {
-   -- Use percentages for scalable sizes, where 100% is equivalent to the value of gui.interface.fontSize
+   -- Percentages are scaled against gui.interface.fontSize
    default  = { face='Noto Sans,Source Sans Pro', size='100%' },
    window   = { face='Noto Sans,Source Sans Pro', style='medium', size='100%' }, -- For non-widget text
-   button   = { face='Noto Sans,Source Sans Pro', size='12' }, -- Text inside buttons
-   filesys  = { face='Inconsolata', size='12', style='medium' }, -- Text for files, folders
+   button   = { face='Noto Sans,Source Sans Pro', size=12 }, -- Text inside buttons
+   filesys  = { face='Inconsolata', size=12, style='medium' }, -- Text for files, folders
    icon     = { face='Noto Sans,Source Sans Pro', size='100%' }, -- Labeling for icons
-   menu     = { face='Noto Sans,Source Sans Pro', style='medium', size='12' }, -- Menu & dropdown item text
-   page     = { face='Noto Sans,Source Sans Pro', size='12' }, -- Multiple lines of text
+   menu     = { face='Noto Sans,Source Sans Pro', style='medium', size=12 }, -- Menu & dropdown item text
+   page     = { face='Noto Sans,Source Sans Pro', size=12 }, -- Multiple lines of text
    titlebar = { face='Noto Sans', size='100%' }, -- Window titlebar text
    small    = { face='Tiny', size='60%' }, -- Recommended text for small sizes
    large    = { face='Noto Sans,Source Sans Pro', size='130%' }, -- Recommended text for headers

--- a/scripts/gui/columnview.tiri
+++ b/scripts/gui/columnview.tiri
@@ -399,7 +399,7 @@ gui.columnView = function(Options):table
 
          col.x = x
          col.minWidth = x + MARGIN
-         col.px_width = col.width * View.fontSize * (4 / 3)
+         col.px_width = col.width * tonumber(View.fontSize) * (4 / 3)
 
          if not col.bannerVP then
             -- Each banner viewport hosts the title and sorting icon

--- a/scripts/gui/tooltip.tiri
+++ b/scripts/gui/tooltip.tiri
@@ -54,7 +54,7 @@ gui.tooltip = function(Options)
       textFlags = VTXF_RASTER
    })
 
-   self.surface.height = (gui.fonts.button.size*1.5) + self.text.fontSize
+   self.surface.height = (gui.fonts.button.size*1.5) + tonumber(self.text.fontSize)
    self.surface.y = ptr.y - self.surface.height
    self.text.y = math.floor((self.viewport.height * 0.5) + (self.text.displaySize * 0.5))
 

--- a/src/font/tests/font_metrics.tiri
+++ b/src/font/tests/font_metrics.tiri
@@ -61,7 +61,7 @@ function setFont(Face, Size)
 
    -- FONTSIZE MATCHES THE CAP HEIGHT WHEN * 0.75
    glSize.y = glText.y
-   glSize.height = -glText.fontSize * 0.75
+   glSize.height = -tonumber(glText.fontSize) * 0.75
 
    glNextLine.y = glText.y + metrics.lineSpacing
    glNextHeight.y = glText.y + metrics.lineSpacing - metrics.ascent

--- a/src/tiri/jit/src/lib/lib_struct.cpp
+++ b/src/tiri/jit/src/lib/lib_struct.cpp
@@ -569,7 +569,7 @@ static int struct_pairs(lua_State *L)
 static int struct_tostring(lua_State *L)
 {
    auto value = lj_lib_checkstruct(L, 1);
-   lua_pushfstring(L, "%s: %p", value->def->Name.c_str(), value->data);
+   lua_pushstring(L, value->def->Name.c_str());
    return 1;
 }
 

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -3148,7 +3148,9 @@ static TRef rec_arith_op(jit_State *J, RecordOps *ops)
 
    switch (op) {
       case BC_UNM:
-         if (tref_isnumber_str(rc)) return lj_opt_narrow_unm(J, rc, rcv);
+         // Arithmetic does not coerce strings; string operands route to the metamethod path
+         // (mirroring lj_meta_arith), where they raise an arithmetic type error.
+         if (tref_isnumber(rc)) return lj_opt_narrow_unm(J, rc, rcv);
          ix->tab = rc;
          copyTV(J->L, &ix->tabv, rcv);
          return rec_mm_arith(J, ix, MM_unm);
@@ -3160,7 +3162,7 @@ static TRef rec_arith_op(jit_State *J, RecordOps *ops)
          copyTV(J->L, rbv, rcv);
          copyTV(J->L, rcv, rav);
          if (op IS BC_MODNV) {
-            if (tref_isnumber_str(rb) and tref_isnumber_str(rc))
+            if (tref_isnumber(rb) and tref_isnumber(rc))
                return lj_opt_narrow_mod(J, rb, rc, rbv, rcv);
             return rec_mm_arith(J, ix, MM_mod);
          }
@@ -3169,18 +3171,18 @@ static TRef rec_arith_op(jit_State *J, RecordOps *ops)
       case BC_ADDVN: case BC_SUBVN: case BC_MULVN: case BC_DIVVN:
       case BC_ADDVV: case BC_SUBVV: case BC_MULVV: case BC_DIVVV: {
          MMS mm = bcmode_mm(op);
-         if (tref_isnumber_str(rb) and tref_isnumber_str(rc))
+         if (tref_isnumber(rb) and tref_isnumber(rc))
             return lj_opt_narrow_arith(J, rb, rc, rbv, rcv, (IROp)((int)mm - (int)MM_add + (int)IR_ADD));
          return rec_mm_arith(J, ix, mm);
       }
 
       case BC_MODVN: case BC_MODVV:
-         if (tref_isnumber_str(rb) and tref_isnumber_str(rc))
+         if (tref_isnumber(rb) and tref_isnumber(rc))
             return lj_opt_narrow_mod(J, rb, rc, rbv, rcv);
          return rec_mm_arith(J, ix, MM_mod);
 
       case BC_POW:
-         if (tref_isnumber_str(rb) and tref_isnumber_str(rc))
+         if (tref_isnumber(rb) and tref_isnumber(rc))
             return lj_opt_narrow_pow(J, rb, rc, rbv, rcv);
          return rec_mm_arith(J, ix, MM_pow);
 

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -346,7 +346,9 @@ static cTValue * str2num(cTValue *o, TValue *n)
 {
    if (tvisnum(o)) return o;
    else if (tvisint(o)) return (setnumV(n, (lua_Number)intV(o)), n);
-   else if (tvisstr(o) and lj_strscan_num(strV(o), n)) return n;
+   // String-to-number coercion is intentionally not performed for arithmetic; callers must use
+   // tonumber() explicitly, e.g. 1 + tonumber('2').  Non-numeric operands fall through to the
+   // metamethod path and, failing that, raise an arithmetic type error.
    else return nullptr;
 }
 

--- a/src/tiri/tests/test_numeric_limits.tiri
+++ b/src/tiri/tests/test_numeric_limits.tiri
@@ -408,14 +408,80 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- String-to-number arithmetic coercion
 
-@Test function StringToNumberCoercionInArithmetic()
-   -- Tiri may or may not coerce strings in arithmetic; test the actual behaviour
+function expect_string_arithmetic_error(Operation:func, Description:str)
+   local raised = false
    try
-      result = 3 + '4'
-      -- If we get here, coercion happened
-      assert(result is 7, 'If string coercion occurs, 3 + "4" should be 7')
+      Operation()
    except
-      -- If we get here, coercion is not supported (which is safer)
-      assert(true, 'String-to-number coercion in arithmetic correctly raises error')
+      raised = true
    end
+   assert(raised, Description .. ' must raise an arithmetic type error')
+end
+
+function string_arithmetic_metamethod_workload(Iterations:num):num
+   local text = '4'
+   local other_text = '5'
+   local total = 0
+
+   for _ in {0 to Iterations} do
+      total += 3 + text
+      total += text + 3
+      total += text + other_text
+      total += text % 3
+      total += 3 % text
+      total += 2 ** text
+      total += -text
+   end
+   return total
+end
+
+@Test function StringToNumberCoercionInArithmetic()
+   local text = '4'
+   local other_text = '5'
+
+   -- Arithmetic does not coerce strings; the operand must be converted explicitly with tonumber().
+   expect_string_arithmetic_error(function() return -text end, 'Unary minus on a string')
+   expect_string_arithmetic_error(function() return 3 + text end, 'Number plus string')
+   expect_string_arithmetic_error(function() return text + 3 end, 'String plus number')
+   expect_string_arithmetic_error(function() return text + other_text end, 'String plus string')
+   expect_string_arithmetic_error(function() return text % 3 end, 'String modulo number')
+   expect_string_arithmetic_error(function() return 3 % text end, 'Number modulo string')
+   expect_string_arithmetic_error(function() return 2 ** text end, 'Number to a string power')
+   assert(3 + tonumber('4') is 7, '3 + tonumber("4") should be 7')
+
+   -- A string arithmetic metamethod must run instead of implicit conversion in both the interpreter and JIT.
+   local original_metatable = debug.getMetatable('')
+   defer
+      debug.setMetatable('', original_metatable)
+      jit.on()
+      jit.flush()
+      jit.opt.start()
+   end
+
+   debug.setMetatable('', {
+      __unm = function(Value):num return 400 - tonumber(Value) end,
+      __add = function(Left, Right):num return 100 + tonumber(Left) + tonumber(Right) end,
+      __mod = function(Left, Right):num return 200 + (tonumber(Left) % tonumber(Right)) end,
+      __pow = function(Left, Right):num return 300 + (tonumber(Left) ** tonumber(Right)) end
+   })
+
+   jit.off()
+   jit.flush()
+   local expected = string_arithmetic_metamethod_workload(10)
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   local actual = 0
+   for _ in {0 into 50} do actual = string_arithmetic_metamethod_workload(10) end
+
+   assert(actual is expected, 'JIT string arithmetic must match the interpreter metamethod result')
+
+   jit.off()
+   local trace_count = 0
+   for trace_no in {1 into 30} do
+      if jit.util.traceInfo(trace_no) != nil then trace_count++ end
+   end
+   jit.on()
+   assert(trace_count > 0, 'String arithmetic metamethod workload must produce a JIT trace')
 end

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -779,7 +779,7 @@ end
 
    assert(fields is array<str> { 'count', 'name', 'enabled' }, 'pairs() should preserve declaration order')
    assert(values[0] is 7 and values[1] is 'sample' and values[2] is 1, 'pairs() should return live field values')
-   assert(tostring(value).startsWith('IterableRecord: 0x'), 'tostring() should include the struct definition name')
+   assert(tostring(value) is 'IterableRecord', 'tostring() should return the struct definition name')
 end
 
 -----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
…rations

* Arithmetic operands are no longer coerced from strings in the JIT recorder or interpreter; non-numeric operands now route to the metamethod path and raise an arithmetic type error unless converted with tonumber()
* [Script] Updated gui font sizing and widget scripts to apply tonumber() where string sizes were previously coerced
* struct_tostring now returns the struct definition name without the data pointer
* [Test] Expanded string arithmetic coercion tests to verify errors, tonumber() conversion and metamethod behaviour across the interpreter and JIT