### PR TITLE
[Tiri] Renamed the context-first 'method' keyword to 'metamethod'

### DIFF
--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -654,18 +654,18 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          break;
       }
 
-      case TokenKind::Method: {
-         Token method_token = this->ctx.tokens().current();
+      case TokenKind::Metamethod: {
+         Token metamethod_token = this->ctx.tokens().current();
          if (this->ctx.tokens().peek(1).kind() != TokenKind::LeftParen) {
-            Identifier id = make_identifier(method_token);
+            Identifier id = make_identifier(metamethod_token);
             NameRef name;
             name.identifier = id;
             this->ctx.tokens().advance();
-            node = make_identifier_expr(method_token.span(), name);
+            node = make_identifier_expr(metamethod_token.span(), name);
             break;
          }
          this->ctx.tokens().advance();
-         auto fn = this->parse_function_literal(method_token, false, nullptr,
+         auto fn = this->parse_function_literal(metamethod_token, false, nullptr,
             FunctionCallableKind::ContextFirstArgument);
          if (not fn.ok()) return fn;
          node = std::move(fn.value_ref());

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -100,7 +100,7 @@ ParserResult<ExprNodeList> AstBuilder::parse_array_initialiser()
       // Reject keyed syntax at the offending field rather than at the array type token.  Lookahead is limited to the
       // start of the field so that buffered interpolation tokens are never disturbed.
 
-      const bool record_key = (current.is_identifier_or_future_reserved() or current.kind() IS TokenKind::Method) and
+      const bool record_key = (current.is_identifier_or_future_reserved() or current.kind() IS TokenKind::Metamethod) and
          this->ctx.tokens().peek(1).kind() IS TokenKind::Equals;
 
       if (record_key or current.kind() IS TokenKind::LeftBracket) {
@@ -595,7 +595,7 @@ ParserResult<std::vector<TableField>> AstBuilder::parse_table_fields(bool *has_a
          field.key = std::move(key.value_ref());
          field.value = std::move(value.value_ref());
       }
-      else if ((current.is_identifier_or_future_reserved() or current.kind() IS TokenKind::Method) and
+      else if ((current.is_identifier_or_future_reserved() or current.kind() IS TokenKind::Metamethod) and
          this->ctx.tokens().peek(1).kind() IS TokenKind::Equals) {
          this->ctx.tokens().advance();
          this->ctx.tokens().advance();

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -39,9 +39,9 @@ ParserResult<StmtNodePtr> AstBuilder::parse_local()
          Token function_token = local_token;  // Use local_token as span start
          auto name_token = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
          if (not name_token.ok()) return ParserResult<StmtNodePtr>::failure(name_token.error_ref());
-         if (name_token.value_ref().kind() IS TokenKind::Method) {
+         if (name_token.value_ref().kind() IS TokenKind::Metamethod) {
             return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, name_token.value_ref(),
-               "'method' is reserved for context-first function literals and cannot name a function");
+               "'metamethod' is reserved for context-first function literals and cannot name a function");
          }
          if (this->is_module_namespace_name(name_token.value_ref().identifier())) {
             return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, name_token.value_ref(),
@@ -144,9 +144,9 @@ ParserResult<StmtNodePtr> AstBuilder::parse_global()
       Token function_token = global_token;
       auto name_token = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
       if (not name_token.ok()) return ParserResult<StmtNodePtr>::failure(name_token.error_ref());
-      if (name_token.value_ref().kind() IS TokenKind::Method) {
+      if (name_token.value_ref().kind() IS TokenKind::Metamethod) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, name_token.value_ref(),
-            "'method' is reserved for context-first function literals and cannot name a function");
+            "'metamethod' is reserved for context-first function literals and cannot name a function");
       }
       if (this->is_module_namespace_name(name_token.value_ref().identifier())) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, name_token.value_ref(),
@@ -877,9 +877,9 @@ ParserResult<StmtNodePtr> AstBuilder::parse_function_stmt()
       callable_name_token = seg.value_ref();
    }
 
-   if (callable_name_token.kind() IS TokenKind::Method) {
+   if (callable_name_token.kind() IS TokenKind::Metamethod) {
       return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, callable_name_token,
-         "'method' is reserved for context-first function literals and cannot name a function");
+         "'metamethod' is reserved for context-first function literals and cannot name a function");
    }
 
    GCstr *funcname = nullptr;

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -14,7 +14,7 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
    const bool context_first = Payload.callable_kind IS FunctionCallableKind::ContextFirstArgument;
    if (context_first and Payload.is_thunk) {
       return ParserResult<ExpDesc>::failure(this->make_error(ParserErrorCode::UnexpectedToken,
-         "context-first method literals cannot be thunks"));
+         "context-first metamethod literals cannot be thunks"));
    }
 
    // Handle thunk functions via AST transformation

--- a/src/tiri/jit/src/parser/lexer_types.h
+++ b/src/tiri/jit/src/parser/lexer_types.h
@@ -60,7 +60,7 @@ struct TokenDefinition {
    TOKEN_DEF(in,           "in",       TKF_RESERVED) \
    TOKEN_DEF(is,           "is",       TKF_RESERVED) \
    TOKEN_DEF(local,        "local",    TKF_RESERVED | TKF_STATEMENT_START) \
-   TOKEN_DEF(method,       "method",   TKF_RESERVED) \
+   TOKEN_DEF(metamethod,   "metamethod", TKF_RESERVED) \
    TOKEN_DEF(namespace,    "namespace", TKF_RESERVED | TKF_STATEMENT_START) \
    TOKEN_DEF(nil,          "nil",      TKF_RESERVED | TKF_CAN_END_RANGE_EXPRESSION | TKF_LITERAL) \
    TOKEN_DEF(not,          "not",      TKF_RESERVED) \

--- a/src/tiri/jit/src/parser/parser_context.cpp
+++ b/src/tiri/jit/src/parser/parser_context.cpp
@@ -88,7 +88,7 @@ ParserResult<Token> ParserContext::consume(TokenKind kind, ParserErrorCode code)
 ParserResult<Token> ParserContext::expect_identifier(ParserErrorCode code)
 {
    Token current = this->tokens().current();
-   if (current.is_identifier() or current.kind() IS TokenKind::Method) {
+   if (current.is_identifier() or current.kind() IS TokenKind::Metamethod) {
       this->token_stream.advance();
       return ParserResult<Token>::success(current);
    }

--- a/src/tiri/jit/src/parser/parser_symbols.cpp
+++ b/src/tiri/jit/src/parser/parser_symbols.cpp
@@ -641,7 +641,7 @@ static ParserSymbolMetadata make_function_symbol(const std::string &Name, const 
    ParserSymbolMetadata symbol;
    symbol.name = Name;
    symbol.kind = Function.is_thunk ? "thunk" :
-      (Function.callable_kind IS FunctionCallableKind::ContextFirstArgument ? "method" : "function");
+      (Function.callable_kind IS FunctionCallableKind::ContextFirstArgument ? "metamethod" : "function");
    symbol.span = Span;
    symbol.end_span = end_span_for(Function);
    symbol.signature = build_signature(Name, Function);

--- a/src/tiri/jit/src/parser/token_types.h
+++ b/src/tiri/jit/src/parser/token_types.h
@@ -26,7 +26,7 @@ enum class TokenKind : uint16_t {
    Function = TK_function,
    Global = TK_global,
    Local = TK_local,
-   Method = TK_method,
+   Metamethod = TK_metamethod,
    EndToken = TK_end,
    ReturnToken = TK_return,
    If = TK_if,
@@ -169,7 +169,7 @@ enum class TokenKind : uint16_t {
       case TokenKind::Function: return "function";
       case TokenKind::Global: return "global";
       case TokenKind::Local: return "local";
-      case TokenKind::Method: return "method";
+      case TokenKind::Metamethod: return "metamethod";
       case TokenKind::EndToken: return "end";
       case TokenKind::ReturnToken: return "return";
       case TokenKind::If: return "if";

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -83,8 +83,8 @@
 
    if (Expected.callable_kind != Actual.callable_kind) {
       return std::format("callable kind differs (expected {}, got {})",
-         Expected.callable_kind IS FunctionCallableKind::ContextFirstArgument ? "method" : "function",
-         Actual.callable_kind IS FunctionCallableKind::ContextFirstArgument ? "method" : "function");
+         Expected.callable_kind IS FunctionCallableKind::ContextFirstArgument ? "metamethod" : "function",
+         Actual.callable_kind IS FunctionCallableKind::ContextFirstArgument ? "metamethod" : "function");
    }
 
    if (Expected.parameters.size() != Actual.parameters.size()) {

--- a/src/tiri/tests/test_method_functions.tiri
+++ b/src/tiri/tests/test_method_functions.tiri
@@ -1,17 +1,17 @@
--- Flute coverage for context-first `method` function literals.
+-- Flute coverage for context-first `metamethod` function literals.
 
 @BeforeEach(hotpath=40)
 function enforce_hotpath() end
 
 @Test function MetamethodBodiesUseTheirFirstRuntimeTableArgument()
    local colour_mt = {
-      __tostring = method():str
+      __tostring = metamethod():str
          return f'colour:{&name}'
       end,
-      __eq = method(Other:table!):bool
+      __eq = metamethod(Other:table!):bool
          return &id is Other.id
       end,
-      __newindex = method(Key, Value)
+      __newindex = metamethod(Key, Value)
          error(f'Colour tables are immutable: {Key}')
       end
    }
@@ -32,17 +32,17 @@ function enforce_hotpath() end
    assert(failed, 'The context-first __newindex handler should run')
 end
 
-@Test function ExtractedMethodsRetainContextFirstBehaviour()
+@Test function ExtractedMetamethodsRetainContextFirstBehaviour()
    local receiver = setmetatable({ name = 'stored' }, {
-      __tostring = method():str
+      __tostring = metamethod():str
          return &name
       end
    })
    local render = getmetatable(receiver).__tostring
    local storage = { render = render }
 
-   assert(render(receiver) is 'stored', 'A directly-called extracted method should enter its first table argument')
-   assert(storage.render(receiver) is 'stored', 'Storing a method in another table must not remove its calling convention')
+   assert(render(receiver) is 'stored', 'A directly-called extracted metamethod should enter its first table argument')
+   assert(storage.render(receiver) is 'stored', 'Storing a metamethod in another table must not remove its calling convention')
 
    local failed = false
    try
@@ -50,13 +50,13 @@ end
    except e
       failed = true
       assert(e.message.find('table expected, got number') != nil,
-         'The hidden context argument should be validated at method entry')
+         'The hidden context argument should be validated at metamethod entry')
    end
    assert(failed, 'A non-table context argument must fail')
-   assert(&name is nil, 'A failed method entry must not leak a context activation')
+   assert(&name is nil, 'A failed metamethod entry must not leak a context activation')
 
    function renderer_factory():func
-      return method():str
+      return metamethod():str
          return &name
       end
    end
@@ -67,10 +67,10 @@ end
 
 @Test function ReceiverStableAndBinaryMetamethodsFollowTheirDocumentedRules()
    local indexed = setmetatable({ name = 'indexed' }, {
-      __index = method(Key):str
+      __index = metamethod(Key):str
          return f'{&name}:{Key}'
       end,
-      __len = method():num
+      __len = metamethod():num
          return &size
       end
    })
@@ -79,7 +79,7 @@ end
    assert(#indexed is 13, 'A context-first __len should enter its operand')
 
    local arithmetic_mt = {
-      __add = method(Other:table!):num
+      __add = metamethod(Other:table!):num
          return &value + Other.value
       end
    }
@@ -100,16 +100,16 @@ end
 
 @Test function ReceiverStableHandlersAndVarargsKeepTheirRuntimeLayout()
    local callable = setmetatable({ value = 8 }, {
-      __call = method(Amount:num):num
+      __call = metamethod(Amount:num):num
          return &value + Amount
       end
    })
    local negatable = setmetatable({ value = 6 }, {
-      __unm = method():num
+      __unm = metamethod():num
          return -&value
       end
    })
-   local collect = method(...):str
+   local collect = metamethod(...):str
       return f'{&prefix}:{...}'
    end
 
@@ -121,12 +121,12 @@ end
 
 @Test function BinaryConcatAndComparisonRejectRightProviders()
    local concat_mt = {
-      __concat = method(Other):str
+      __concat = metamethod(Other):str
          return &value .. Other
       end
    }
    local ordered_mt = {
-      __lt = method(Other:table!):bool
+      __lt = metamethod(Other:table!):bool
          return &value < Other.value
       end
    }
@@ -158,16 +158,16 @@ end
    assert(comparison_failed, 'A right-provider context-first ordering handler must fail')
 end
 
-@Test function MethodReturnsAndErrorsRestoreTheCallerContext()
-   local receiver = { name = 'method' }
+@Test function MetamethodReturnsAndErrorsRestoreTheCallerContext()
+   local receiver = { name = 'metamethod' }
    local caller = { name = 'caller' }
-   local read_or_fail = method(Fail:bool):str
+   local read_or_fail = metamethod(Fail:bool):str
       if Fail then error('expected method failure') end
       return &name
    end
 
    using caller do
-      assert(read_or_fail(receiver, false) is 'method', 'A normal return should run under the method context')
+      assert(read_or_fail(receiver, false) is 'metamethod', 'A normal return should run under the metamethod context')
       assert(&name is 'caller', 'A normal return should restore the caller context')
 
       local failed = false
@@ -182,11 +182,11 @@ end
    end
 end
 
-@Test function MethodCleanupRunsBeforeItsContextIsRestored()
+@Test function MetamethodCleanupRunsBeforeItsContextIsRestored()
    local events = {}
    local caller = { name = 'caller' }
    local receiver = { name = 'receiver' }
-   local read_with_cleanup = method():str
+   local read_with_cleanup = metamethod():str
       defer
          events.insert(&name)
       end
@@ -194,21 +194,21 @@ end
    end
 
    using caller do
-      assert(read_with_cleanup(receiver) is 'receiver', 'The method body should use its hidden table context')
-      assert(&name is 'caller', 'Method cleanup should restore the caller context before returning')
+      assert(read_with_cleanup(receiver) is 'receiver', 'The metamethod body should use its hidden table context')
+      assert(&name is 'caller', 'Metamethod cleanup should restore the caller context before returning')
    end
-   assert(events[0] is 'receiver', 'Deferred cleanup owned by a method should execute under its table context')
+   assert(events[0] is 'receiver', 'Deferred cleanup owned by a metamethod should execute under its table context')
 end
 
-@Test function MethodCannotNameDeclaredFunctions()
+@Test function MetamethodCannotNameDeclaredFunctions()
    local declarations = {
-      'function method() end',
-      'local function method() end',
-      'global function method() end',
-      'thunk method():num return 1 end',
-      'local thunk method():num return 1 end',
-      'global thunk method():num return 1 end',
-      'local receiver = {}; function receiver.method() end'
+      'function metamethod() end',
+      'local function metamethod() end',
+      'global function metamethod() end',
+      'thunk metamethod():num return 1 end',
+      'local thunk metamethod():num return 1 end',
+      'global thunk metamethod():num return 1 end',
+      'local receiver = {}; function receiver.metamethod() end'
    }
 
    for declaration in values(declarations) do
@@ -217,9 +217,17 @@ end
          exec(declaration)
       except e
          failed = true
-         assert(e.message.find("'method' is reserved") != nil,
-            'Rejected callable names should explain that method is reserved')
+         assert(e.message.find("'metamethod' is reserved") != nil,
+            'Rejected callable names should explain that metamethod is reserved')
       end
-      assert(failed, 'A declared function or method cannot be named method')
+      assert(failed, 'A declared function or metamethod cannot be named metamethod')
    end
+end
+
+@Test function MethodIsAnOrdinaryIdentifier()
+   local function method(Value:num):num
+      return Value + 1
+   end
+
+   assert(method(4) is 5, 'method should be available as an ordinary identifier')
 end

--- a/tools/tiri_lsp/include/lsp_defs.tiri
+++ b/tools/tiri_lsp/include/lsp_defs.tiri
@@ -196,6 +196,10 @@ glKeywords = {
 
    -- Functions
    ['function'] = { comment = 'Defines a function.' },
+   ['metamethod'] = { comment = 'Creates an anonymous context-first callable that treats its first runtime argument ' ..
+      'as the current table context. The visible parameter list starts at the second argument; use `&field` for ' ..
+      'fields and `&&` for the table itself. Intended for receiver-stable handlers such as `__index`, `__tostring` ' ..
+      'and `__eq`.' },
    ['return'] = { comment = 'Returns values from a function.' },
 
    -- Variables

--- a/tools/tiri_lsp/include/lsp_lib.tiri
+++ b/tools/tiri_lsp/include/lsp_lib.tiri
@@ -260,7 +260,8 @@ global FLUID_KEYWORDS = {
    ['choose'] = true, ['from'] = true, ['when'] = true,
 
    -- Declarations
-   ['function'] = true, ['local'] = true, ['global'] = true, ['extern'] = true, ['thunk'] = true,
+   ['function'] = true, ['metamethod'] = true, ['local'] = true, ['global'] = true, ['extern'] = true,
+   ['thunk'] = true,
    ['import'] = true, ['as'] = true, ['enum'] = true,
 
    -- Special

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -153,6 +153,21 @@ end
    assert(extern_keyword and extern_keyword.type is 0, 'extern should be highlighted as a keyword.')
 end
 
+@Test function MetamethodKeywordReceivesSemanticTokens()
+   -- The keyword is immediately followed by '(', so without an entry in FLUID_KEYWORDS the tokenizer
+   -- would fall back to emitting it as a function call rather than a keyword.
+   source = 'local mt = { __tostring = metamethod():str\n' ..
+      'return &name\n' ..
+      'end }\n'
+
+   tokens = tokenizeTiri(source)
+
+   metamethod_keyword = findToken(tokens, 0, 26, 'metamethod')
+
+   assert(metamethod_keyword and metamethod_keyword.type is 0,
+      'metamethod should be highlighted as a keyword, not a function call.')
+end
+
 @Test function ExternDiagnosticsUseCurrentParser()
    doc = makeDoc('extern runTest\nlocal runner = runTest\nprint(runner)\n')
    result = computeDiagnostics(doc)

--- a/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
+++ b/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
@@ -181,7 +181,7 @@
             },
             {
                "name": "storage.type.function.tiri",
-               "match": "\\b(function|method|thunk)\\b"
+               "match": "\\b(function|metamethod|thunk)\\b"
             },
             {
                "name": "storage.modifier.tiri",


### PR DESCRIPTION
* Updated the lexer, token definitions and parser to reserve 'metamethod' instead of 'method' for context-first function literals
* Freed 'method' for use as an ordinary identifier
* Updated reserved-keyword error messages and symbol metadata to reference 'metamethod'