### PR TITLE
[Tiri] Added receiver-first dispatch to arithmetic metamethods

### DIFF
--- a/scripts/tempus.tiri
+++ b/scripts/tempus.tiri
@@ -1692,8 +1692,8 @@ end
 @input Second offset
 @result True when first is smaller
 ]])
-tempus.mtOffset.__lt = function(A:table!, B:table!):bool
-   return tempus._fields(A, 'Offset').seconds < tempus._fields(B, 'Offset').seconds
+tempus.mtOffset.__lt = function(A:table!, Other:table!):bool
+   return tempus._fields(A, 'Offset').seconds < tempus._fields(Other, 'Offset').seconds
 end
 
 @Doc(text=[[
@@ -1702,8 +1702,8 @@ end
 @input Second offset
 @result True when first is not larger
 ]])
-tempus.mtOffset.__le = function(A:table!, B:table!):bool
-   return tempus._fields(A, 'Offset').seconds <= tempus._fields(B, 'Offset').seconds
+tempus.mtOffset.__le = function(A:table!, Other:table!):bool
+   return tempus._fields(A, 'Offset').seconds <= tempus._fields(Other, 'Offset').seconds
 end
 
 @Doc(text=[[
@@ -1843,8 +1843,8 @@ end
 @input Second date
 @result True when equal
 ]])
-tempus.mtLocalDate.__eq = function(A:table!, B:table!):bool
-   return compare_date_fields(tempus._fields(A, 'LocalDate'), tempus._fields(B, 'LocalDate')) is 0
+tempus.mtLocalDate.__eq = metamethod(Other:table!):bool
+   return compare_date_fields(tempus._fields(&&, 'LocalDate'), tempus._fields(Other, 'LocalDate')) is 0
 end
 
 @Doc(text=[[
@@ -1853,8 +1853,8 @@ end
 @input Second date
 @result True when first is earlier
 ]])
-tempus.mtLocalDate.__lt = function(A:table!, B:table!):bool
-   return compare_date_fields(tempus._fields(A, 'LocalDate'), tempus._fields(B, 'LocalDate')) < 0
+tempus.mtLocalDate.__lt = metamethod(Other:table!):bool
+   return compare_date_fields(tempus._fields(&&, 'LocalDate'), tempus._fields(Other, 'LocalDate')) < 0
 end
 
 @Doc(text=[[

--- a/scripts/tempus.tiri
+++ b/scripts/tempus.tiri
@@ -1466,13 +1466,13 @@ end
 @input Duration value
 @result Instant value
 ]])
-tempus.mtInstant.__add = function(A:table!, B:table!, LhsDispatch:bool):table
-   a = tempus._fields(A, 'Instant')
-   if tempus.isDuration(B) then
-      b = tempus._fields(B, 'Duration')
+tempus.mtInstant.__add = metamethod(Other:table!, LhsDispatch:bool):table
+   a = tempus._fields(&&, 'Instant')
+   if tempus.isDuration(Other) then
+      b = tempus._fields(Other, 'Duration')
       return new_instant(a.epoch_second + b.seconds, a.nano + b.nano)
    end
-   unsupported_operation(A, '+', B)
+   unsupported_operation(&&, '+', Other)
 end
 
 @Doc(text=[[
@@ -1481,17 +1481,17 @@ end
 @input Duration or Instant value
 @result Instant or Duration value
 ]])
-tempus.mtInstant.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
+tempus.mtInstant.__sub = function(A:table!, Other:table!, LhsDispatch:bool):table
    a = tempus._fields(A, 'Instant')
-   if tempus.isDuration(B) then
-      b = tempus._fields(B, 'Duration')
+   if tempus.isDuration(Other) then
+      b = tempus._fields(Other, 'Duration')
       return new_instant(a.epoch_second - b.seconds, a.nano - b.nano)
    end
-   if tempus.isInstant(B) then
-      b = tempus._fields(B, 'Instant')
+   if tempus.isInstant(Other) then
+      b = tempus._fields(Other, 'Instant')
       return new_duration(a.epoch_second - b.epoch_second, a.nano - b.nano)
    end
-   unsupported_operation(A, '-', B)
+   unsupported_operation(A, '-', Other)
 end
 
 @Doc(text=[[
@@ -1576,9 +1576,9 @@ end
 @input Second duration
 @result True when equal
 ]])
-tempus.mtDuration.__eq = function(A:table!, B:table!):bool
+tempus.mtDuration.__eq = function(A:table!, Other:table!):bool
    a = tempus._fields(A, 'Duration')
-   b = tempus._fields(B, 'Duration')
+   b = tempus._fields(Other, 'Duration')
    return a.seconds is b.seconds and a.nano is b.nano
 end
 
@@ -1588,9 +1588,9 @@ end
 @input Second duration
 @result True when first is shorter
 ]])
-tempus.mtDuration.__lt = function(A:table!, B:table!):bool
+tempus.mtDuration.__lt = function(A:table!, Other:table!):bool
    a = tempus._fields(A, 'Duration')
-   b = tempus._fields(B, 'Duration')
+   b = tempus._fields(Other, 'Duration')
    return compare_pair(a.seconds, a.nano, b.seconds, b.nano) < 0
 end
 
@@ -1600,9 +1600,9 @@ end
 @input Second duration
 @result True when first is not longer
 ]])
-tempus.mtDuration.__le = function(A:table!, B:table!):bool
+tempus.mtDuration.__le = function(A:table!, Other:table!):bool
    a = tempus._fields(A, 'Duration')
-   b = tempus._fields(B, 'Duration')
+   b = tempus._fields(Other, 'Duration')
    return compare_pair(a.seconds, a.nano, b.seconds, b.nano) <= 0
 end
 
@@ -1612,13 +1612,13 @@ end
 @input Second duration
 @result Duration value
 ]])
-tempus.mtDuration.__add = function(A:table!, B:table!, LhsDispatch:bool):table
+tempus.mtDuration.__add = function(A:table!, Other:table!, LhsDispatch:bool):table
    a = tempus._fields(A, 'Duration')
-   if tempus.isDuration(B) then
-      b = tempus._fields(B, 'Duration')
+   if tempus.isDuration(Other) then
+      b = tempus._fields(Other, 'Duration')
       return new_duration(a.seconds + b.seconds, a.nano + b.nano)
    end
-   unsupported_operation(A, '+', B)
+   unsupported_operation(A, '+', Other)
 end
 
 @Doc(text=[[
@@ -1627,13 +1627,13 @@ end
 @input Second duration
 @result Duration value
 ]])
-tempus.mtDuration.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
+tempus.mtDuration.__sub = function(A:table!, Other:table!, LhsDispatch:bool):table
    a = tempus._fields(A, 'Duration')
-   if tempus.isDuration(B) then
-      b = tempus._fields(B, 'Duration')
+   if tempus.isDuration(Other) then
+      b = tempus._fields(Other, 'Duration')
       return new_duration(a.seconds - b.seconds, a.nano - b.nano)
    end
-   unsupported_operation(A, '-', B)
+   unsupported_operation(A, '-', Other)
 end
 
 @Doc(text=[[
@@ -1682,8 +1682,8 @@ end
 @input Second offset
 @result True when equal
 ]])
-tempus.mtOffset.__eq = function(A:table!, B:table!):bool
-   return tempus._fields(A, 'Offset').seconds is tempus._fields(B, 'Offset').seconds
+tempus.mtOffset.__eq = function(A:table!, Other:table!):bool
+   return tempus._fields(A, 'Offset').seconds is tempus._fields(Other, 'Offset').seconds
 end
 
 @Doc(text=[[

--- a/scripts/tempus.tiri
+++ b/scripts/tempus.tiri
@@ -93,29 +93,30 @@ function tempus._fields(Value:any!, TypeName:str!):table
    return value_storage[Value].fields
 end
 
-function tempus._valueIndex(Self:table!, Key:any!):any
-   local state = value_storage[Self]
+tempus._valueIndex = metamethod(Key:any!):any
+   local state = value_storage[&&]
    if state is nil then return nil end
 
    local metatable = metatable_by_type[state.type_name]
    local member_function = rawget(metatable, Key)
    if member_function != nil then
       -- Ordinary table field calls do not receive an implicit receiver, so bind the Tempus value here.
+      local receiver = &&
       return function(...):any
-         return member_function(Self, ...)
+         return member_function(receiver, ...)
       end
    end
 
    return state.fields[Key]
 end
 
-function tempus._immutableError(Self:table!, Key:any!, Value:any!)
-   type_name = tempus._typeOf(Self) ?? 'Value'
+tempus._immutableError = metamethod(Key:any!, Value:any!)
+   type_name = tempus._typeOf(&&) ?? 'Value'
    error(f"tempus.{type_name} is immutable: Cannot set {Key}")
 end
 
-function tempus._tostring(Self:table!):str
-   type_name = tempus._typeOf(Self) ?? 'Value'
+tempus._tostring = metamethod():str
+   type_name = tempus._typeOf(&&) ?? 'Value'
    return f"tempus.{type_name}"
 end
 
@@ -587,7 +588,7 @@ end
 
 function make_constructor(Name:str!):table
    return setmetatable({}, {
-      __call = function(Self, ...)
+      __call = metamethod(...)
          raise ERR_NotInitialised, f"tempus.{Name} is not implemented yet."
       end
    })
@@ -1017,7 +1018,7 @@ end
 @input Nanosecond adjustment
 @result Instant value
 ]])
-getmetatable(tempus.instant).__call = function(Self, EpochSecond:any!, Nano:any):table
+getmetatable(tempus.instant).__call = metamethod(EpochSecond:any!, Nano:any):table
    return new_instant(EpochSecond, Nano ?? 0)
 end
 
@@ -1084,7 +1085,7 @@ end
 @input Table with hours, minutes, seconds, millis, or nanos
 @result Duration value
 ]])
-getmetatable(tempus.duration).__call = function(Self, KV:any!):table
+getmetatable(tempus.duration).__call = metamethod(KV:any!):table
    tempus._requireTable('duration', KV)
 
    seconds = tempus._requireInteger('hours', KV.hours ?? 0) * 3600 +
@@ -1139,7 +1140,7 @@ end
 @input Offset seconds
 @result Offset value
 ]])
-getmetatable(tempus.offset).__call = function(Self, Seconds:any!):table
+getmetatable(tempus.offset).__call = metamethod(Seconds:any!):table
    return new_offset(Seconds)
 end
 
@@ -1171,7 +1172,7 @@ end
 @input Day of month
 @result LocalDate value
 ]])
-getmetatable(tempus.localDate).__call = function(Self, Year:any!, Month:any!, Day:any!):table
+getmetatable(tempus.localDate).__call = metamethod(Year:any!, Month:any!, Day:any!):table
    return new_local_date(Year, Month, Day)
 end
 
@@ -1204,7 +1205,7 @@ end
 @input Nanosecond
 @result LocalTime value
 ]])
-getmetatable(tempus.localTime).__call = function(Self, Hour:any!, Minute:any, Second:any, Nano:any):table
+getmetatable(tempus.localTime).__call = metamethod(Hour:any!, Minute:any, Second:any, Nano:any):table
    return new_local_time(Hour, Minute ?? 0, Second ?? 0, Nano ?? 0)
 end
 
@@ -1244,7 +1245,7 @@ end
 @result LocalDateTime value
 ]])
 getmetatable(tempus.localDateTime).__call =
-   function(Self, Year:any!, Month:any!, Day:any!, Hour:any, Minute:any, Second:any, Nano:any):table
+   metamethod(Year:any!, Month:any!, Day:any!, Hour:any, Minute:any, Second:any, Nano:any):table
       return new_local_date_time(Year, Month, Day, Hour ?? 0, Minute ?? 0, Second ?? 0, Nano ?? 0)
    end
 
@@ -1279,7 +1280,7 @@ end
 @input Offset value
 @result OffsetDateTime value
 ]])
-getmetatable(tempus.offsetDateTime).__call = function(Self, LocalDateTime:any!, Offset:any!):table
+getmetatable(tempus.offsetDateTime).__call = metamethod(LocalDateTime:any!, Offset:any!):table
    return new_offset_date_time(LocalDateTime, Offset)
 end
 
@@ -1344,7 +1345,7 @@ end
 @input Table with years, months, weeks, or days
 @result Period value
 ]])
-getmetatable(tempus.period).__call = function(Self, KV:any!):table
+getmetatable(tempus.period).__call = metamethod(KV:any!):table
    tempus._requireTable('period', KV)
    return new_period(KV.years ?? 0, KV.months ?? 0, KV.weeks ?? 0, KV.days ?? 0)
 end
@@ -1379,7 +1380,7 @@ end
 @input Stop instant
 @result Interval value
 ]])
-getmetatable(tempus.interval).__call = function(Self, Start:any!, Stop:any!):table
+getmetatable(tempus.interval).__call = metamethod(Start:any!, Stop:any!):table
    return new_interval(Start, Stop)
 end
 
@@ -1416,8 +1417,8 @@ end
 @desc Convert this instant to text
 @result ISO instant text
 ]])
-tempus.mtInstant.__tostring = function(Self:table!):str
-   fields = tempus._fields(Self, 'Instant')
+tempus.mtInstant.__tostring = metamethod():str
+   fields = tempus._fields(&&, 'Instant')
    date_fields, time_fields = epoch_second_to_local(fields.epoch_second, fields.nano)
    return f"{format_year(date_fields.year)}-{pad_int(date_fields.month, 2)}-{pad_int(date_fields.day, 2)}T" ..
       f"{pad_int(time_fields.hour, 2)}:{pad_int(time_fields.minute, 2)}:{pad_int(time_fields.second, 2)}" ..
@@ -1430,9 +1431,9 @@ end
 @input Second instant
 @result True when equal
 ]])
-tempus.mtInstant.__eq = function(A:table!, B:table!):bool
-   a = tempus._fields(A, 'Instant')
-   b = tempus._fields(B, 'Instant')
+tempus.mtInstant.__eq = metamethod(Other:table!):bool
+   a = tempus._fields(&&, 'Instant')
+   b = tempus._fields(Other, 'Instant')
    return a.epoch_second is b.epoch_second and a.nano is b.nano
 end
 
@@ -1442,10 +1443,11 @@ end
 @input Second instant
 @result True when first is earlier
 ]])
-tempus.mtInstant.__lt = function(A:table!, B:table!, LhsDispatch:bool):bool
-   if not LhsDispatch then A, B = B, A end
-   a = tempus._fields(A, 'Instant')
-   b = tempus._fields(B, 'Instant')
+tempus.mtInstant.__lt = metamethod(Other:table!, LHS:bool):bool
+   local left, right = &&, Other
+   if not LHS then left, right = Other, && end
+   a = tempus._fields(left, 'Instant')
+   b = tempus._fields(right, 'Instant')
    return compare_pair(a.epoch_second, a.nano, b.epoch_second, b.nano) < 0
 end
 
@@ -1455,10 +1457,11 @@ end
 @input Second instant
 @result True when first is not later
 ]])
-tempus.mtInstant.__le = function(A:table!, B:table!, LhsDispatch:bool):bool
-   if not LhsDispatch then A, B = B, A end
-   a = tempus._fields(A, 'Instant')
-   b = tempus._fields(B, 'Instant')
+tempus.mtInstant.__le = metamethod(Other:table!, LHS:bool):bool
+   local left:table, right:table = &&, Other
+   if not LHS then left, right = Other, && end
+   a = tempus._fields(left, 'Instant')
+   b = tempus._fields(right, 'Instant')
    return compare_pair(a.epoch_second, a.nano, b.epoch_second, b.nano) <= 0
 end
 
@@ -1468,7 +1471,7 @@ end
 @input Duration value
 @result Instant value
 ]])
-tempus.mtInstant.__add = metamethod(Other:table!, LhsDispatch:bool):table
+tempus.mtInstant.__add = metamethod(Other:table!, LHS:bool):table
    a = tempus._fields(&&, 'Instant')
    if tempus.isDuration(Other) then
       b = tempus._fields(Other, 'Duration')
@@ -1483,8 +1486,8 @@ end
 @input Duration or Instant value
 @result Instant or Duration value
 ]])
-tempus.mtInstant.__sub = function(A:table!, Other:table!, LhsDispatch:bool):table
-   a = tempus._fields(A, 'Instant')
+tempus.mtInstant.__sub = metamethod(Other:table!, LHS:bool):table
+   a = tempus._fields(&&, 'Instant')
    if tempus.isDuration(Other) then
       b = tempus._fields(Other, 'Duration')
       return new_instant(a.epoch_second - b.seconds, a.nano - b.nano)
@@ -1493,7 +1496,7 @@ tempus.mtInstant.__sub = function(A:table!, Other:table!, LhsDispatch:bool):tabl
       b = tempus._fields(Other, 'Instant')
       return new_duration(a.epoch_second - b.epoch_second, a.nano - b.nano)
    end
-   unsupported_operation(A, '-', Other)
+   unsupported_operation(&&, '-', Other)
 end
 
 @Doc(text=[[
@@ -1548,8 +1551,8 @@ end
 @desc Convert this duration to text
 @result ISO duration text
 ]])
-tempus.mtDuration.__tostring = function(Self:table!):str
-   fields = tempus._fields(Self, 'Duration')
+tempus.mtDuration.__tostring = metamethod():str
+   fields = tempus._fields(&&, 'Duration')
    seconds = fields.seconds
    nano = fields.nano
    negative = seconds < 0
@@ -1578,8 +1581,8 @@ end
 @input Second duration
 @result True when equal
 ]])
-tempus.mtDuration.__eq = function(A:table!, Other:table!):bool
-   a = tempus._fields(A, 'Duration')
+tempus.mtDuration.__eq = metamethod(Other:table!):bool
+   a = tempus._fields(&&, 'Duration')
    b = tempus._fields(Other, 'Duration')
    return a.seconds is b.seconds and a.nano is b.nano
 end
@@ -1590,10 +1593,11 @@ end
 @input Second duration
 @result True when first is shorter
 ]])
-tempus.mtDuration.__lt = function(A:table!, Other:table!, LhsDispatch:bool):bool
-   if not LhsDispatch then A, Other = Other, A end
-   a = tempus._fields(A, 'Duration')
-   b = tempus._fields(Other, 'Duration')
+tempus.mtDuration.__lt = metamethod(Other:table!, LHS:bool):bool
+   local left:table, right:table = &&, Other
+   if not LHS then left, right = Other, && end
+   a = tempus._fields(left, 'Duration')
+   b = tempus._fields(right, 'Duration')
    return compare_pair(a.seconds, a.nano, b.seconds, b.nano) < 0
 end
 
@@ -1603,10 +1607,11 @@ end
 @input Second duration
 @result True when first is not longer
 ]])
-tempus.mtDuration.__le = function(A:table!, Other:table!, LhsDispatch:bool):bool
-   if not LhsDispatch then A, Other = Other, A end
-   a = tempus._fields(A, 'Duration')
-   b = tempus._fields(Other, 'Duration')
+tempus.mtDuration.__le = metamethod(Other:table!, LHS:bool):bool
+   local left:table, right:table = &&, Other
+   if not LHS then left, right = Other, && end
+   a = tempus._fields(left, 'Duration')
+   b = tempus._fields(right, 'Duration')
    return compare_pair(a.seconds, a.nano, b.seconds, b.nano) <= 0
 end
 
@@ -1616,13 +1621,13 @@ end
 @input Second duration
 @result Duration value
 ]])
-tempus.mtDuration.__add = function(A:table!, Other:table!, LhsDispatch:bool):table
-   a = tempus._fields(A, 'Duration')
+tempus.mtDuration.__add = metamethod(Other:table!, LHS:bool):table
+   a = tempus._fields(&&, 'Duration')
    if tempus.isDuration(Other) then
       b = tempus._fields(Other, 'Duration')
       return new_duration(a.seconds + b.seconds, a.nano + b.nano)
    end
-   unsupported_operation(A, '+', Other)
+   unsupported_operation(&&, '+', Other)
 end
 
 @Doc(text=[[
@@ -1631,21 +1636,21 @@ end
 @input Second duration
 @result Duration value
 ]])
-tempus.mtDuration.__sub = function(A:table!, Other:table!, LhsDispatch:bool):table
-   a = tempus._fields(A, 'Duration')
+tempus.mtDuration.__sub = metamethod(Other:table!, LHS:bool):table
+   a = tempus._fields(&&, 'Duration')
    if tempus.isDuration(Other) then
       b = tempus._fields(Other, 'Duration')
       return new_duration(a.seconds - b.seconds, a.nano - b.nano)
    end
-   unsupported_operation(A, '-', Other)
+   unsupported_operation(&&, '-', Other)
 end
 
 @Doc(text=[[
 @desc Negate this duration
 @result Duration value
 ]])
-tempus.mtDuration.__unm = function(Self:table!):table
-   fields = tempus._fields(Self, 'Duration')
+tempus.mtDuration.__unm = metamethod():table
+   fields = tempus._fields(&&, 'Duration')
    return new_duration(-fields.seconds, -fields.nano)
 end
 
@@ -1661,16 +1666,16 @@ end
 @desc Negate this offset
 @result Offset value
 ]])
-tempus.mtOffset.__unm = function(Self:table!):table
-   return new_offset(-tempus._fields(Self, 'Offset').seconds)
+tempus.mtOffset.__unm = metamethod():table
+   return new_offset(-tempus._fields(&&, 'Offset').seconds)
 end
 
 @Doc(text=[[
 @desc Convert this offset to text
 @result Offset text
 ]])
-tempus.mtOffset.__tostring = function(Self:table!):str
-   seconds = tempus._fields(Self, 'Offset').seconds
+tempus.mtOffset.__tostring = metamethod():str
+   seconds = tempus._fields(&&, 'Offset').seconds
    if seconds is 0 then return 'Z' end
 
    sign = seconds < 0 ? '-' : '+'
@@ -1686,8 +1691,8 @@ end
 @input Second offset
 @result True when equal
 ]])
-tempus.mtOffset.__eq = function(A:table!, Other:table!):bool
-   return tempus._fields(A, 'Offset').seconds is tempus._fields(Other, 'Offset').seconds
+tempus.mtOffset.__eq = metamethod(Other:table!):bool
+   return tempus._fields(&&, 'Offset').seconds is tempus._fields(Other, 'Offset').seconds
 end
 
 @Doc(text=[[
@@ -1696,9 +1701,10 @@ end
 @input Second offset
 @result True when first is smaller
 ]])
-tempus.mtOffset.__lt = function(A:table!, Other:table!, LhsDispatch:bool):bool
-   if not LhsDispatch then A, Other = Other, A end
-   return tempus._fields(A, 'Offset').seconds < tempus._fields(Other, 'Offset').seconds
+tempus.mtOffset.__lt = metamethod(Other:table!, LHS:bool):bool
+   local left:table, right:table = &&, Other
+   if not LHS then left, right = Other, && end
+   return tempus._fields(left, 'Offset').seconds < tempus._fields(right, 'Offset').seconds
 end
 
 @Doc(text=[[
@@ -1707,9 +1713,10 @@ end
 @input Second offset
 @result True when first is not larger
 ]])
-tempus.mtOffset.__le = function(A:table!, Other:table!, LhsDispatch:bool):bool
-   if not LhsDispatch then A, Other = Other, A end
-   return tempus._fields(A, 'Offset').seconds <= tempus._fields(Other, 'Offset').seconds
+tempus.mtOffset.__le = metamethod(Other:table!, LHS:bool):bool
+   local left:table, right:table = &&, Other
+   if not LHS then left, right = Other, && end
+   return tempus._fields(left, 'Offset').seconds <= tempus._fields(right, 'Offset').seconds
 end
 
 @Doc(text=[[
@@ -1806,13 +1813,13 @@ end
 @input Period value
 @result LocalDate value
 ]])
-tempus.mtLocalDate.__add = function(A:table!, B:table!, LhsDispatch:bool):table
-   a = tempus._fields(A, 'LocalDate')
-   if tempus.isPeriod(B) then
-      fields = date_plus_period_fields(a, tempus._fields(B, 'Period'), 1)
+tempus.mtLocalDate.__add = metamethod(Other:table!, LHS:bool):table
+   a = tempus._fields(&&, 'LocalDate')
+   if tempus.isPeriod(Other) then
+      fields = date_plus_period_fields(a, tempus._fields(Other, 'Period'), 1)
       return new_local_date(fields.year, fields.month, fields.day)
    end
-   unsupported_operation(A, '+', B)
+   unsupported_operation(&&, '+', Other)
 end
 
 @Doc(text=[[
@@ -1821,25 +1828,25 @@ end
 @input Period or LocalDate value
 @result LocalDate or Period value
 ]])
-tempus.mtLocalDate.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
-   a = tempus._fields(A, 'LocalDate')
-   if tempus.isPeriod(B) then
-      fields = date_plus_period_fields(a, tempus._fields(B, 'Period'), -1)
+tempus.mtLocalDate.__sub = metamethod(Other:table!, LHS:bool):table
+   a = tempus._fields(&&, 'LocalDate')
+   if tempus.isPeriod(Other) then
+      fields = date_plus_period_fields(a, tempus._fields(Other, 'Period'), -1)
       return new_local_date(fields.year, fields.month, fields.day)
    end
-   if tempus.isLocalDate(B) then
-      b = tempus._fields(B, 'LocalDate')
+   if tempus.isLocalDate(Other) then
+      b = tempus._fields(Other, 'LocalDate')
       return new_period(0, 0, 0, days_from_civil(a.year, a.month, a.day) - days_from_civil(b.year, b.month, b.day))
    end
-   unsupported_operation(A, '-', B)
+   unsupported_operation(&&, '-', Other)
 end
 
 @Doc(text=[[
 @desc Convert this date to text
 @result ISO date text
 ]])
-tempus.mtLocalDate.__tostring = function(Self:table!):str
-   fields = tempus._fields(Self, 'LocalDate')
+tempus.mtLocalDate.__tostring = metamethod():str
+   fields = tempus._fields(&&, 'LocalDate')
    return f"{format_year(fields.year)}-{pad_int(fields.month, 2)}-{pad_int(fields.day, 2)}"
 end
 
@@ -1859,8 +1866,8 @@ end
 @input Second date
 @result True when first is earlier
 ]])
-tempus.mtLocalDate.__lt = metamethod(Other:table!, LhsDispatch:bool):bool
-   if LhsDispatch then
+tempus.mtLocalDate.__lt = metamethod(Other:table!, LHS:bool):bool
+   if LHS then
       return compare_date_fields(tempus._fields(&&, 'LocalDate'), tempus._fields(Other, 'LocalDate')) < 0
    end
    return compare_date_fields(tempus._fields(Other, 'LocalDate'), tempus._fields(&&, 'LocalDate')) < 0
@@ -1872,9 +1879,10 @@ end
 @input Second date
 @result True when first is not later
 ]])
-tempus.mtLocalDate.__le = function(A:table!, B:table!, LhsDispatch:bool):bool
-   if not LhsDispatch then A, B = B, A end
-   return compare_date_fields(tempus._fields(A, 'LocalDate'), tempus._fields(B, 'LocalDate')) <= 0
+tempus.mtLocalDate.__le = metamethod(Other:table!, LHS:bool):bool
+   local left:table, right:table = &&, Other
+   if not LHS then left, right = Other, && end
+   return compare_date_fields(tempus._fields(left, 'LocalDate'), tempus._fields(right, 'LocalDate')) <= 0
 end
 
 @Doc(text=[[
@@ -1927,8 +1935,8 @@ end
 @desc Convert this time to text
 @result ISO time text
 ]])
-tempus.mtLocalTime.__tostring = function(Self:table!):str
-   fields = tempus._fields(Self, 'LocalTime')
+tempus.mtLocalTime.__tostring = metamethod():str
+   fields = tempus._fields(&&, 'LocalTime')
    return f"{pad_int(fields.hour, 2)}:{pad_int(fields.minute, 2)}:{pad_int(fields.second, 2)}" ..
       format_nano(fields.nano)
 end
@@ -1939,8 +1947,8 @@ end
 @input Second time
 @result True when equal
 ]])
-tempus.mtLocalTime.__eq = function(A:table!, B:table!):bool
-   return compare_time_fields(tempus._fields(A, 'LocalTime'), tempus._fields(B, 'LocalTime')) is 0
+tempus.mtLocalTime.__eq = metamethod(Other:table!):bool
+   return compare_time_fields(tempus._fields(&&, 'LocalTime'), tempus._fields(Other, 'LocalTime')) is 0
 end
 
 @Doc(text=[[
@@ -1949,9 +1957,10 @@ end
 @input Second time
 @result True when first is earlier
 ]])
-tempus.mtLocalTime.__lt = function(A:table!, B:table!, LhsDispatch:bool):bool
-   if not LhsDispatch then A, B = B, A end
-   return compare_time_fields(tempus._fields(A, 'LocalTime'), tempus._fields(B, 'LocalTime')) < 0
+tempus.mtLocalTime.__lt = metamethod(Other:table!, LHS:bool):bool
+   local left:table, right:table = &&, Other
+   if not LHS then left, right = Other, && end
+   return compare_time_fields(tempus._fields(left, 'LocalTime'), tempus._fields(right, 'LocalTime')) < 0
 end
 
 @Doc(text=[[
@@ -1960,9 +1969,10 @@ end
 @input Second time
 @result True when first is not later
 ]])
-tempus.mtLocalTime.__le = function(A:table!, B:table!, LhsDispatch:bool):bool
-   if not LhsDispatch then A, B = B, A end
-   return compare_time_fields(tempus._fields(A, 'LocalTime'), tempus._fields(B, 'LocalTime')) <= 0
+tempus.mtLocalTime.__le = metamethod(Other:table!, LHS:bool):bool
+   local left:table, right:table = &&, Other
+   if not LHS then left, right = Other, && end
+   return compare_time_fields(tempus._fields(left, 'LocalTime'), tempus._fields(right, 'LocalTime')) <= 0
 end
 
 @Doc(text=[[
@@ -1971,12 +1981,12 @@ end
 @input Duration value
 @result LocalTime value
 ]])
-tempus.mtLocalTime.__add = function(A:table!, B:table!, LhsDispatch:bool):table
-   if tempus.isDuration(B) then
-      fields = time_plus_duration_fields(tempus._fields(A, 'LocalTime'), tempus._fields(B, 'Duration'), 1)
+tempus.mtLocalTime.__add = metamethod(Other:table!, LHS:bool):table
+   if tempus.isDuration(Other) then
+      fields = time_plus_duration_fields(tempus._fields(&&, 'LocalTime'), tempus._fields(Other, 'Duration'), 1)
       return new_local_time(fields.hour, fields.minute, fields.second, fields.nano)
    end
-   unsupported_operation(A, '+', B)
+   unsupported_operation(&&, '+', Other)
 end
 
 @Doc(text=[[
@@ -1985,12 +1995,12 @@ end
 @input Duration value
 @result LocalTime value
 ]])
-tempus.mtLocalTime.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
-   if tempus.isDuration(B) then
-      fields = time_plus_duration_fields(tempus._fields(A, 'LocalTime'), tempus._fields(B, 'Duration'), -1)
+tempus.mtLocalTime.__sub = metamethod(Other:table!, LHS:bool):table
+   if tempus.isDuration(Other) then
+      fields = time_plus_duration_fields(tempus._fields(&&, 'LocalTime'), tempus._fields(Other, 'Duration'), -1)
       return new_local_time(fields.hour, fields.minute, fields.second, fields.nano)
    end
-   unsupported_operation(A, '-', B)
+   unsupported_operation(&&, '-', Other)
 end
 
 @Doc(text=[[
@@ -2077,25 +2087,25 @@ end
 @input Duration or Period value
 @result LocalDateTime value
 ]])
-tempus.mtLocalDateTime.__add = function(A:table!, B:table!, LhsDispatch:bool):table
-   a = tempus._fields(A, 'LocalDateTime')
+tempus.mtLocalDateTime.__add = metamethod(Other:table!, LHS:bool):table
+   a = tempus._fields(&&, 'LocalDateTime')
    date_fields = tempus._fields(a.date, 'LocalDate')
    time_fields = tempus._fields(a.time, 'LocalTime')
 
-   if tempus.isDuration(B) then
+   if tempus.isDuration(Other) then
       new_date_fields, new_time_fields =
-         local_date_time_plus_duration_fields(date_fields, time_fields, tempus._fields(B, 'Duration'), 1)
+         local_date_time_plus_duration_fields(date_fields, time_fields, tempus._fields(Other, 'Duration'), 1)
       return new_local_date_time(new_date_fields.year, new_date_fields.month, new_date_fields.day,
          new_time_fields.hour, new_time_fields.minute, new_time_fields.second, new_time_fields.nano)
    end
 
-   if tempus.isPeriod(B) then
-      new_date_fields = date_plus_period_fields(date_fields, tempus._fields(B, 'Period'), 1)
+   if tempus.isPeriod(Other) then
+      new_date_fields = date_plus_period_fields(date_fields, tempus._fields(Other, 'Period'), 1)
       return new_local_date_time(new_date_fields.year, new_date_fields.month, new_date_fields.day,
          time_fields.hour, time_fields.minute, time_fields.second, time_fields.nano)
    end
 
-   unsupported_operation(A, '+', B)
+   unsupported_operation(&&, '+', Other)
 end
 
 @Doc(text=[[
@@ -2104,33 +2114,33 @@ end
 @input Duration or Period value
 @result LocalDateTime value
 ]])
-tempus.mtLocalDateTime.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
-   a = tempus._fields(A, 'LocalDateTime')
+tempus.mtLocalDateTime.__sub = metamethod(Other:table!, LHS:bool):table
+   a = tempus._fields(&&, 'LocalDateTime')
    date_fields = tempus._fields(a.date, 'LocalDate')
    time_fields = tempus._fields(a.time, 'LocalTime')
 
-   if tempus.isDuration(B) then
+   if tempus.isDuration(Other) then
       new_date_fields, new_time_fields =
-         local_date_time_plus_duration_fields(date_fields, time_fields, tempus._fields(B, 'Duration'), -1)
+         local_date_time_plus_duration_fields(date_fields, time_fields, tempus._fields(Other, 'Duration'), -1)
       return new_local_date_time(new_date_fields.year, new_date_fields.month, new_date_fields.day,
          new_time_fields.hour, new_time_fields.minute, new_time_fields.second, new_time_fields.nano)
    end
 
-   if tempus.isPeriod(B) then
-      new_date_fields = date_plus_period_fields(date_fields, tempus._fields(B, 'Period'), -1)
+   if tempus.isPeriod(Other) then
+      new_date_fields = date_plus_period_fields(date_fields, tempus._fields(Other, 'Period'), -1)
       return new_local_date_time(new_date_fields.year, new_date_fields.month, new_date_fields.day,
          time_fields.hour, time_fields.minute, time_fields.second, time_fields.nano)
    end
 
-   unsupported_operation(A, '-', B)
+   unsupported_operation(&&, '-', Other)
 end
 
 @Doc(text=[[
 @desc Convert this local date-time to text
 @result ISO local date-time text
 ]])
-tempus.mtLocalDateTime.__tostring = function(Self:table!):str
-   fields = tempus._fields(Self, 'LocalDateTime')
+tempus.mtLocalDateTime.__tostring = metamethod():str
+   fields = tempus._fields(&&, 'LocalDateTime')
    return f'{fields.date}T{fields.time}'
 end
 
@@ -2140,9 +2150,9 @@ end
 @input Second local date-time
 @result True when equal
 ]])
-tempus.mtLocalDateTime.__eq = function(A:table!, B:table!):bool
-   a = tempus._fields(A, 'LocalDateTime')
-   b = tempus._fields(B, 'LocalDateTime')
+tempus.mtLocalDateTime.__eq = metamethod(Other:table!):bool
+   a = tempus._fields(&&, 'LocalDateTime')
+   b = tempus._fields(Other, 'LocalDateTime')
    return a.date is b.date and a.time is b.time
 end
 
@@ -2152,10 +2162,11 @@ end
 @input Second local date-time
 @result True when first is earlier
 ]])
-tempus.mtLocalDateTime.__lt = function(A:table!, B:table!, LhsDispatch:bool):bool
-   if not LhsDispatch then A, B = B, A end
-   a = tempus._fields(A, 'LocalDateTime')
-   b = tempus._fields(B, 'LocalDateTime')
+tempus.mtLocalDateTime.__lt = metamethod(Other:table!, LHS:bool):bool
+   local left:table, right:table = &&, Other
+   if not LHS then left, right = Other, && end
+   a = tempus._fields(left, 'LocalDateTime')
+   b = tempus._fields(right, 'LocalDateTime')
    date_compare = compare_date_fields(tempus._fields(a.date, 'LocalDate'),
       tempus._fields(b.date, 'LocalDate'))
    if date_compare != 0 then return date_compare < 0 end
@@ -2168,9 +2179,10 @@ end
 @input Second local date-time
 @result True when first is not later
 ]])
-tempus.mtLocalDateTime.__le = function(A:table!, B:table!, LhsDispatch:bool):bool
-   if not LhsDispatch then A, B = B, A end
-   return A < B or A is B
+tempus.mtLocalDateTime.__le = metamethod(Other:table!, LHS:bool):bool
+   local left:table, right:table = &&, Other
+   if not LHS then left, right = Other, && end
+   return left < right or left is right
 end
 
 @Doc(text=[[
@@ -2250,8 +2262,8 @@ end
 @desc Convert this offset date-time to text
 @result ISO offset date-time text
 ]])
-tempus.mtOffsetDateTime.__tostring = function(Self:table!):str
-   fields = tempus._fields(Self, 'OffsetDateTime')
+tempus.mtOffsetDateTime.__tostring = metamethod():str
+   fields = tempus._fields(&&, 'OffsetDateTime')
    return tostring(fields.local_date_time) .. tostring(fields.offset)
 end
 
@@ -2261,10 +2273,10 @@ end
 @input Second offset date-time
 @result True when equal
 ]])
-tempus.mtOffsetDateTime.__eq = function(A:table!, B:table!):bool
-   a = tempus._fields(A, 'OffsetDateTime')
-   b = tempus._fields(B, 'OffsetDateTime')
-   return offset_date_time_instant(A) is offset_date_time_instant(B) and a.offset is b.offset
+tempus.mtOffsetDateTime.__eq = metamethod(Other:table!):bool
+   a = tempus._fields(&&, 'OffsetDateTime')
+   b = tempus._fields(Other, 'OffsetDateTime')
+   return offset_date_time_instant(&&) is offset_date_time_instant(Other) and a.offset is b.offset
 end
 
 @Doc(text=[[
@@ -2273,9 +2285,10 @@ end
 @input Second offset date-time
 @result True when first is earlier
 ]])
-tempus.mtOffsetDateTime.__lt = function(A:table!, B:table!, LhsDispatch:bool):bool
-   if not LhsDispatch then A, B = B, A end
-   return offset_date_time_instant(A) < offset_date_time_instant(B)
+tempus.mtOffsetDateTime.__lt = metamethod(Other:table!, LHS:bool):bool
+   local left:table, right:table = &&, Other
+   if not LHS then left, right = Other, && end
+   return offset_date_time_instant(left) < offset_date_time_instant(right)
 end
 
 @Doc(text=[[
@@ -2284,9 +2297,10 @@ end
 @input Second offset date-time
 @result True when first is not later
 ]])
-tempus.mtOffsetDateTime.__le = function(A:table!, B:table!, LhsDispatch:bool):bool
-   if not LhsDispatch then A, B = B, A end
-   return offset_date_time_instant(A) <= offset_date_time_instant(B)
+tempus.mtOffsetDateTime.__le = metamethod(Other:table!, LHS:bool):bool
+   local left:table, right:table = &&, Other
+   if not LHS then left, right = Other, && end
+   return offset_date_time_instant(left) <= offset_date_time_instant(right)
 end
 
 @Doc(text=[[
@@ -2295,13 +2309,13 @@ end
 @input Duration or Period value
 @result OffsetDateTime value
 ]])
-tempus.mtOffsetDateTime.__add = function(A:table!, B:table!, LhsDispatch:bool):table
-   fields = tempus._fields(A, 'OffsetDateTime')
-   if tempus.isDuration(B) then
-      return offset_date_time_from_instant(offset_date_time_instant(A) + B, fields.offset)
+tempus.mtOffsetDateTime.__add = metamethod(Other:table!, LHS:bool):table
+   fields = tempus._fields(&&, 'OffsetDateTime')
+   if tempus.isDuration(Other) then
+      return offset_date_time_from_instant(offset_date_time_instant(&&) + Other, fields.offset)
    end
-   if tempus.isPeriod(B) then return new_offset_date_time(fields.local_date_time + B, fields.offset) end
-   unsupported_operation(A, '+', B)
+   if tempus.isPeriod(Other) then return new_offset_date_time(fields.local_date_time + Other, fields.offset) end
+   unsupported_operation(&&, '+', Other)
 end
 
 @Doc(text=[[
@@ -2310,14 +2324,14 @@ end
 @input Duration, Period, or OffsetDateTime value
 @result OffsetDateTime or Duration value
 ]])
-tempus.mtOffsetDateTime.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
-   fields = tempus._fields(A, 'OffsetDateTime')
-   if tempus.isDuration(B) then
-      return offset_date_time_from_instant(offset_date_time_instant(A) - B, fields.offset)
+tempus.mtOffsetDateTime.__sub = metamethod(Other:table!, LHS:bool):table
+   fields = tempus._fields(&&, 'OffsetDateTime')
+   if tempus.isDuration(Other) then
+      return offset_date_time_from_instant(offset_date_time_instant(&&) - Other, fields.offset)
    end
-   if tempus.isPeriod(B) then return new_offset_date_time(fields.local_date_time - B, fields.offset) end
-   if tempus.isOffsetDateTime(B) then return offset_date_time_instant(A) - offset_date_time_instant(B) end
-   unsupported_operation(A, '-', B)
+   if tempus.isPeriod(Other) then return new_offset_date_time(fields.local_date_time - Other, fields.offset) end
+   if tempus.isOffsetDateTime(Other) then return offset_date_time_instant(&&) - offset_date_time_instant(Other) end
+   unsupported_operation(&&, '-', Other)
 end
 
 @Doc(text=[[
@@ -2445,9 +2459,9 @@ end
 @desc Convert this zoned date-time to text
 @result ISO zoned date-time text
 ]])
-tempus.mtZonedDateTime.__tostring = function(Self:table!):str
-   fields = tempus._fields(Self, 'ZonedDateTime')
-   return tostring(Self.localDateTime()) .. tostring(Self.offset()) .. '[' .. fields.zone.id() .. ']'
+tempus.mtZonedDateTime.__tostring = metamethod():str
+   fields = tempus._fields(&&, 'ZonedDateTime')
+   return tostring(&&.localDateTime()) .. tostring(&&.offset()) .. '[' .. fields.zone.id() .. ']'
 end
 
 @Doc(text=[[
@@ -2456,9 +2470,9 @@ end
 @input Second zoned date-time
 @result True when equal
 ]])
-tempus.mtZonedDateTime.__eq = function(A:table!, B:table!):bool
-   a = tempus._fields(A, 'ZonedDateTime')
-   b = tempus._fields(B, 'ZonedDateTime')
+tempus.mtZonedDateTime.__eq = metamethod(Other:table!):bool
+   a = tempus._fields(&&, 'ZonedDateTime')
+   b = tempus._fields(Other, 'ZonedDateTime')
    return a.instant is b.instant and a.zone is b.zone
 end
 
@@ -2468,9 +2482,10 @@ end
 @input Second zoned date-time
 @result True when first is earlier
 ]])
-tempus.mtZonedDateTime.__lt = function(A:table!, B:table!, LhsDispatch:bool):bool
-   if not LhsDispatch then A, B = B, A end
-   return tempus._fields(A, 'ZonedDateTime').instant < tempus._fields(B, 'ZonedDateTime').instant
+tempus.mtZonedDateTime.__lt = metamethod(Other:table!, LHS:bool):bool
+   local left:table, right:table = &&, Other
+   if not LHS then left, right = Other, && end
+   return tempus._fields(left, 'ZonedDateTime').instant < tempus._fields(right, 'ZonedDateTime').instant
 end
 
 @Doc(text=[[
@@ -2479,9 +2494,10 @@ end
 @input Second zoned date-time
 @result True when first is not later
 ]])
-tempus.mtZonedDateTime.__le = function(A:table!, B:table!, LhsDispatch:bool):bool
-   if not LhsDispatch then A, B = B, A end
-   return tempus._fields(A, 'ZonedDateTime').instant <= tempus._fields(B, 'ZonedDateTime').instant
+tempus.mtZonedDateTime.__le = metamethod(Other:table!, LHS:bool):bool
+   local left:table, right:table = &&, Other
+   if not LHS then left, right = Other, && end
+   return tempus._fields(left, 'ZonedDateTime').instant <= tempus._fields(right, 'ZonedDateTime').instant
 end
 
 @Doc(text=[[
@@ -2490,14 +2506,14 @@ end
 @input Duration or Period value
 @result ZonedDateTime value
 ]])
-tempus.mtZonedDateTime.__add = function(A:table!, B:table!, LhsDispatch:bool):table
-   fields = tempus._fields(A, 'ZonedDateTime')
-   if tempus.isDuration(B) then return new_zoned_date_time(fields.instant + B, fields.zone) end
-   if tempus.isPeriod(B) then
-      local adjusted = A.localDateTime() + B
+tempus.mtZonedDateTime.__add = metamethod(Other:table!, LHS:bool):table
+   fields = tempus._fields(&&, 'ZonedDateTime')
+   if tempus.isDuration(Other) then return new_zoned_date_time(fields.instant + Other, fields.zone) end
+   if tempus.isPeriod(Other) then
+      local adjusted = &&.localDateTime() + Other
       return adjusted.toZonedDateTime(fields.zone)
    end
-   unsupported_operation(A, '+', B)
+   unsupported_operation(&&, '+', Other)
 end
 
 @Doc(text=[[
@@ -2506,15 +2522,15 @@ end
 @input Duration, Period, or ZonedDateTime value
 @result ZonedDateTime or Duration value
 ]])
-tempus.mtZonedDateTime.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
-   fields = tempus._fields(A, 'ZonedDateTime')
-   if tempus.isDuration(B) then return new_zoned_date_time(fields.instant - B, fields.zone) end
-   if tempus.isPeriod(B) then
-      local adjusted = A.localDateTime() - B
+tempus.mtZonedDateTime.__sub = metamethod(Other:table!, LHS:bool):table
+   fields = tempus._fields(&&, 'ZonedDateTime')
+   if tempus.isDuration(Other) then return new_zoned_date_time(fields.instant - Other, fields.zone) end
+   if tempus.isPeriod(Other) then
+      local adjusted = &&.localDateTime() - Other
       return adjusted.toZonedDateTime(fields.zone)
    end
-   if tempus.isZonedDateTime(B) then return fields.instant - B.instant() end
-   unsupported_operation(A, '-', B)
+   if tempus.isZonedDateTime(Other) then return fields.instant - Other.instant() end
+   unsupported_operation(&&, '-', Other)
 end
 
 @Doc(text=[[
@@ -2533,8 +2549,8 @@ end
 @desc Convert this period to text
 @result ISO period text
 ]])
-tempus.mtPeriod.__tostring = function(Self:table!):str
-   fields = tempus._fields(Self, 'Period')
+tempus.mtPeriod.__tostring = metamethod():str
+   fields = tempus._fields(&&, 'Period')
    text = 'P'
    if fields.years != 0 then text ..= tostring(fields.years) .. 'Y' end
    if fields.months != 0 then text ..= tostring(fields.months) .. 'M' end
@@ -2550,9 +2566,9 @@ end
 @input Second period
 @result True when equal
 ]])
-tempus.mtPeriod.__eq = function(A:table!, B:table!):bool
-   a = tempus._fields(A, 'Period')
-   b = tempus._fields(B, 'Period')
+tempus.mtPeriod.__eq = metamethod(Other:table!):bool
+   a = tempus._fields(&&, 'Period')
+   b = tempus._fields(Other, 'Period')
    return a.years is b.years and a.months is b.months and a.weeks is b.weeks and a.days is b.days
 end
 
@@ -2562,13 +2578,13 @@ end
 @input Second period
 @result Period value
 ]])
-tempus.mtPeriod.__add = function(A:table!, B:table!, LhsDispatch:bool):table
-   a = tempus._fields(A, 'Period')
-   if tempus.isPeriod(B) then
-      b = tempus._fields(B, 'Period')
+tempus.mtPeriod.__add = metamethod(Other:table!, LHS:bool):table
+   a = tempus._fields(&&, 'Period')
+   if tempus.isPeriod(Other) then
+      b = tempus._fields(Other, 'Period')
       return new_period(a.years + b.years, a.months + b.months, a.weeks + b.weeks, a.days + b.days)
    end
-   unsupported_operation(A, '+', B)
+   unsupported_operation(&&, '+', Other)
 end
 
 @Doc(text=[[
@@ -2577,21 +2593,21 @@ end
 @input Second period
 @result Period value
 ]])
-tempus.mtPeriod.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
-   a = tempus._fields(A, 'Period')
-   if tempus.isPeriod(B) then
-      b = tempus._fields(B, 'Period')
+tempus.mtPeriod.__sub = metamethod(Other:table!, LHS:bool):table
+   a = tempus._fields(&&, 'Period')
+   if tempus.isPeriod(Other) then
+      b = tempus._fields(Other, 'Period')
       return new_period(a.years - b.years, a.months - b.months, a.weeks - b.weeks, a.days - b.days)
    end
-   unsupported_operation(A, '-', B)
+   unsupported_operation(&&, '-', Other)
 end
 
 @Doc(text=[[
 @desc Negate this period
 @result Period value
 ]])
-tempus.mtPeriod.__unm = function(Self:table!):table
-   fields = tempus._fields(Self, 'Period')
+tempus.mtPeriod.__unm = metamethod():table
+   fields = tempus._fields(&&, 'Period')
    return new_period(-fields.years, -fields.months, -fields.weeks, -fields.days)
 end
 
@@ -2689,8 +2705,8 @@ end
 @desc Convert this interval to text
 @result Interval text
 ]])
-tempus.mtInterval.__tostring = function(Self:table!):str
-   fields = tempus._fields(Self, 'Interval')
+tempus.mtInterval.__tostring = metamethod():str
+   fields = tempus._fields(&&, 'Interval')
    return f'{fields.start}/{fields.stop}'
 end
 
@@ -2700,9 +2716,9 @@ end
 @input Second interval
 @result True when equal
 ]])
-tempus.mtInterval.__eq = function(A:table!, B:table!):bool
-   a = tempus._fields(A, 'Interval')
-   b = tempus._fields(B, 'Interval')
+tempus.mtInterval.__eq = metamethod(Other:table!):bool
+   a = tempus._fields(&&, 'Interval')
+   b = tempus._fields(Other, 'Interval')
    return a.start is b.start and a.stop is b.stop
 end
 
@@ -2798,8 +2814,8 @@ end
 @desc Convert this zone to text
 @result Zone ID
 ]])
-tempus.mtZone.__tostring = function(Self:table!):str
-   return tempus._fields(Self, 'Zone').id
+tempus.mtZone.__tostring = metamethod():str
+   return tempus._fields(&&, 'Zone').id
 end
 
 @Doc(text=[[
@@ -2808,8 +2824,8 @@ end
 @input Second zone
 @result True when equal
 ]])
-tempus.mtZone.__eq = function(A:table!, B:table!):bool
-   return tempus._fields(A, 'Zone').id is tempus._fields(B, 'Zone').id
+tempus.mtZone.__eq = metamethod(Other:table!):bool
+   return tempus._fields(&&, 'Zone').id is tempus._fields(Other, 'Zone').id
 end
 
 @Doc(text=[[
@@ -2872,8 +2888,8 @@ end
 @desc Convert this clock to text
 @result Clock description
 ]])
-tempus.mtClock.__tostring = function(Self:table!):str
-   return f"tempus.Clock({tempus._fields(Self, 'Clock').kind})"
+tempus.mtClock.__tostring = metamethod():str
+   return f"tempus.Clock({tempus._fields(&&, 'Clock').kind})"
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -2902,7 +2918,7 @@ end
 @input Zone ID, or nil for local
 @result Zone value
 ]])
-getmetatable(tempus.zone).__call = function(Self, ZoneID:any):table
+getmetatable(tempus.zone).__call = metamethod(ZoneID:any):table
    return new_zone(ZoneID)
 end
 
@@ -2943,7 +2959,7 @@ end
 @input Zone value
 @result ZonedDateTime value
 ]])
-getmetatable(tempus.zonedDateTime).__call = function(Self, Instant:any!, Zone:any!):table
+getmetatable(tempus.zonedDateTime).__call = metamethod(Instant:any!, Zone:any!):table
    return new_zoned_date_time(Instant, Zone)
 end
 

--- a/scripts/tempus.tiri
+++ b/scripts/tempus.tiri
@@ -1466,7 +1466,7 @@ end
 @input Duration value
 @result Instant value
 ]])
-tempus.mtInstant.__add = function(A:table!, B:table!):table
+tempus.mtInstant.__add = function(A:table!, B:table!, LhsDispatch:bool):table
    a = tempus._fields(A, 'Instant')
    if tempus.isDuration(B) then
       b = tempus._fields(B, 'Duration')
@@ -1481,7 +1481,7 @@ end
 @input Duration or Instant value
 @result Instant or Duration value
 ]])
-tempus.mtInstant.__sub = function(A:table!, B:table!):table
+tempus.mtInstant.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
    a = tempus._fields(A, 'Instant')
    if tempus.isDuration(B) then
       b = tempus._fields(B, 'Duration')
@@ -1612,7 +1612,7 @@ end
 @input Second duration
 @result Duration value
 ]])
-tempus.mtDuration.__add = function(A:table!, B:table!):table
+tempus.mtDuration.__add = function(A:table!, B:table!, LhsDispatch:bool):table
    a = tempus._fields(A, 'Duration')
    if tempus.isDuration(B) then
       b = tempus._fields(B, 'Duration')
@@ -1627,7 +1627,7 @@ end
 @input Second duration
 @result Duration value
 ]])
-tempus.mtDuration.__sub = function(A:table!, B:table!):table
+tempus.mtDuration.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
    a = tempus._fields(A, 'Duration')
    if tempus.isDuration(B) then
       b = tempus._fields(B, 'Duration')
@@ -1800,7 +1800,7 @@ end
 @input Period value
 @result LocalDate value
 ]])
-tempus.mtLocalDate.__add = function(A:table!, B:table!):table
+tempus.mtLocalDate.__add = function(A:table!, B:table!, LhsDispatch:bool):table
    a = tempus._fields(A, 'LocalDate')
    if tempus.isPeriod(B) then
       fields = date_plus_period_fields(a, tempus._fields(B, 'Period'), 1)
@@ -1815,7 +1815,7 @@ end
 @input Period or LocalDate value
 @result LocalDate or Period value
 ]])
-tempus.mtLocalDate.__sub = function(A:table!, B:table!):table
+tempus.mtLocalDate.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
    a = tempus._fields(A, 'LocalDate')
    if tempus.isPeriod(B) then
       fields = date_plus_period_fields(a, tempus._fields(B, 'Period'), -1)
@@ -1959,7 +1959,7 @@ end
 @input Duration value
 @result LocalTime value
 ]])
-tempus.mtLocalTime.__add = function(A:table!, B:table!):table
+tempus.mtLocalTime.__add = function(A:table!, B:table!, LhsDispatch:bool):table
    if tempus.isDuration(B) then
       fields = time_plus_duration_fields(tempus._fields(A, 'LocalTime'), tempus._fields(B, 'Duration'), 1)
       return new_local_time(fields.hour, fields.minute, fields.second, fields.nano)
@@ -1973,7 +1973,7 @@ end
 @input Duration value
 @result LocalTime value
 ]])
-tempus.mtLocalTime.__sub = function(A:table!, B:table!):table
+tempus.mtLocalTime.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
    if tempus.isDuration(B) then
       fields = time_plus_duration_fields(tempus._fields(A, 'LocalTime'), tempus._fields(B, 'Duration'), -1)
       return new_local_time(fields.hour, fields.minute, fields.second, fields.nano)
@@ -2065,7 +2065,7 @@ end
 @input Duration or Period value
 @result LocalDateTime value
 ]])
-tempus.mtLocalDateTime.__add = function(A:table!, B:table!):table
+tempus.mtLocalDateTime.__add = function(A:table!, B:table!, LhsDispatch:bool):table
    a = tempus._fields(A, 'LocalDateTime')
    date_fields = tempus._fields(a.date, 'LocalDate')
    time_fields = tempus._fields(a.time, 'LocalTime')
@@ -2092,7 +2092,7 @@ end
 @input Duration or Period value
 @result LocalDateTime value
 ]])
-tempus.mtLocalDateTime.__sub = function(A:table!, B:table!):table
+tempus.mtLocalDateTime.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
    a = tempus._fields(A, 'LocalDateTime')
    date_fields = tempus._fields(a.date, 'LocalDate')
    time_fields = tempus._fields(a.time, 'LocalTime')
@@ -2279,7 +2279,7 @@ end
 @input Duration or Period value
 @result OffsetDateTime value
 ]])
-tempus.mtOffsetDateTime.__add = function(A:table!, B:table!):table
+tempus.mtOffsetDateTime.__add = function(A:table!, B:table!, LhsDispatch:bool):table
    fields = tempus._fields(A, 'OffsetDateTime')
    if tempus.isDuration(B) then
       return offset_date_time_from_instant(offset_date_time_instant(A) + B, fields.offset)
@@ -2294,7 +2294,7 @@ end
 @input Duration, Period, or OffsetDateTime value
 @result OffsetDateTime or Duration value
 ]])
-tempus.mtOffsetDateTime.__sub = function(A:table!, B:table!):table
+tempus.mtOffsetDateTime.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
    fields = tempus._fields(A, 'OffsetDateTime')
    if tempus.isDuration(B) then
       return offset_date_time_from_instant(offset_date_time_instant(A) - B, fields.offset)
@@ -2472,7 +2472,7 @@ end
 @input Duration or Period value
 @result ZonedDateTime value
 ]])
-tempus.mtZonedDateTime.__add = function(A:table!, B:table!):table
+tempus.mtZonedDateTime.__add = function(A:table!, B:table!, LhsDispatch:bool):table
    fields = tempus._fields(A, 'ZonedDateTime')
    if tempus.isDuration(B) then return new_zoned_date_time(fields.instant + B, fields.zone) end
    if tempus.isPeriod(B) then
@@ -2488,7 +2488,7 @@ end
 @input Duration, Period, or ZonedDateTime value
 @result ZonedDateTime or Duration value
 ]])
-tempus.mtZonedDateTime.__sub = function(A:table!, B:table!):table
+tempus.mtZonedDateTime.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
    fields = tempus._fields(A, 'ZonedDateTime')
    if tempus.isDuration(B) then return new_zoned_date_time(fields.instant - B, fields.zone) end
    if tempus.isPeriod(B) then
@@ -2544,7 +2544,7 @@ end
 @input Second period
 @result Period value
 ]])
-tempus.mtPeriod.__add = function(A:table!, B:table!):table
+tempus.mtPeriod.__add = function(A:table!, B:table!, LhsDispatch:bool):table
    a = tempus._fields(A, 'Period')
    if tempus.isPeriod(B) then
       b = tempus._fields(B, 'Period')
@@ -2559,7 +2559,7 @@ end
 @input Second period
 @result Period value
 ]])
-tempus.mtPeriod.__sub = function(A:table!, B:table!):table
+tempus.mtPeriod.__sub = function(A:table!, B:table!, LhsDispatch:bool):table
    a = tempus._fields(A, 'Period')
    if tempus.isPeriod(B) then
       b = tempus._fields(B, 'Period')

--- a/scripts/tempus.tiri
+++ b/scripts/tempus.tiri
@@ -1442,7 +1442,8 @@ end
 @input Second instant
 @result True when first is earlier
 ]])
-tempus.mtInstant.__lt = function(A:table!, B:table!):bool
+tempus.mtInstant.__lt = function(A:table!, B:table!, LhsDispatch:bool):bool
+   if not LhsDispatch then A, B = B, A end
    a = tempus._fields(A, 'Instant')
    b = tempus._fields(B, 'Instant')
    return compare_pair(a.epoch_second, a.nano, b.epoch_second, b.nano) < 0
@@ -1454,7 +1455,8 @@ end
 @input Second instant
 @result True when first is not later
 ]])
-tempus.mtInstant.__le = function(A:table!, B:table!):bool
+tempus.mtInstant.__le = function(A:table!, B:table!, LhsDispatch:bool):bool
+   if not LhsDispatch then A, B = B, A end
    a = tempus._fields(A, 'Instant')
    b = tempus._fields(B, 'Instant')
    return compare_pair(a.epoch_second, a.nano, b.epoch_second, b.nano) <= 0
@@ -1588,7 +1590,8 @@ end
 @input Second duration
 @result True when first is shorter
 ]])
-tempus.mtDuration.__lt = function(A:table!, Other:table!):bool
+tempus.mtDuration.__lt = function(A:table!, Other:table!, LhsDispatch:bool):bool
+   if not LhsDispatch then A, Other = Other, A end
    a = tempus._fields(A, 'Duration')
    b = tempus._fields(Other, 'Duration')
    return compare_pair(a.seconds, a.nano, b.seconds, b.nano) < 0
@@ -1600,7 +1603,8 @@ end
 @input Second duration
 @result True when first is not longer
 ]])
-tempus.mtDuration.__le = function(A:table!, Other:table!):bool
+tempus.mtDuration.__le = function(A:table!, Other:table!, LhsDispatch:bool):bool
+   if not LhsDispatch then A, Other = Other, A end
    a = tempus._fields(A, 'Duration')
    b = tempus._fields(Other, 'Duration')
    return compare_pair(a.seconds, a.nano, b.seconds, b.nano) <= 0
@@ -1692,7 +1696,8 @@ end
 @input Second offset
 @result True when first is smaller
 ]])
-tempus.mtOffset.__lt = function(A:table!, Other:table!):bool
+tempus.mtOffset.__lt = function(A:table!, Other:table!, LhsDispatch:bool):bool
+   if not LhsDispatch then A, Other = Other, A end
    return tempus._fields(A, 'Offset').seconds < tempus._fields(Other, 'Offset').seconds
 end
 
@@ -1702,7 +1707,8 @@ end
 @input Second offset
 @result True when first is not larger
 ]])
-tempus.mtOffset.__le = function(A:table!, Other:table!):bool
+tempus.mtOffset.__le = function(A:table!, Other:table!, LhsDispatch:bool):bool
+   if not LhsDispatch then A, Other = Other, A end
    return tempus._fields(A, 'Offset').seconds <= tempus._fields(Other, 'Offset').seconds
 end
 
@@ -1853,8 +1859,11 @@ end
 @input Second date
 @result True when first is earlier
 ]])
-tempus.mtLocalDate.__lt = metamethod(Other:table!):bool
-   return compare_date_fields(tempus._fields(&&, 'LocalDate'), tempus._fields(Other, 'LocalDate')) < 0
+tempus.mtLocalDate.__lt = metamethod(Other:table!, LhsDispatch:bool):bool
+   if LhsDispatch then
+      return compare_date_fields(tempus._fields(&&, 'LocalDate'), tempus._fields(Other, 'LocalDate')) < 0
+   end
+   return compare_date_fields(tempus._fields(Other, 'LocalDate'), tempus._fields(&&, 'LocalDate')) < 0
 end
 
 @Doc(text=[[
@@ -1863,7 +1872,8 @@ end
 @input Second date
 @result True when first is not later
 ]])
-tempus.mtLocalDate.__le = function(A:table!, B:table!):bool
+tempus.mtLocalDate.__le = function(A:table!, B:table!, LhsDispatch:bool):bool
+   if not LhsDispatch then A, B = B, A end
    return compare_date_fields(tempus._fields(A, 'LocalDate'), tempus._fields(B, 'LocalDate')) <= 0
 end
 
@@ -1939,7 +1949,8 @@ end
 @input Second time
 @result True when first is earlier
 ]])
-tempus.mtLocalTime.__lt = function(A:table!, B:table!):bool
+tempus.mtLocalTime.__lt = function(A:table!, B:table!, LhsDispatch:bool):bool
+   if not LhsDispatch then A, B = B, A end
    return compare_time_fields(tempus._fields(A, 'LocalTime'), tempus._fields(B, 'LocalTime')) < 0
 end
 
@@ -1949,7 +1960,8 @@ end
 @input Second time
 @result True when first is not later
 ]])
-tempus.mtLocalTime.__le = function(A:table!, B:table!):bool
+tempus.mtLocalTime.__le = function(A:table!, B:table!, LhsDispatch:bool):bool
+   if not LhsDispatch then A, B = B, A end
    return compare_time_fields(tempus._fields(A, 'LocalTime'), tempus._fields(B, 'LocalTime')) <= 0
 end
 
@@ -2140,7 +2152,8 @@ end
 @input Second local date-time
 @result True when first is earlier
 ]])
-tempus.mtLocalDateTime.__lt = function(A:table!, B:table!):bool
+tempus.mtLocalDateTime.__lt = function(A:table!, B:table!, LhsDispatch:bool):bool
+   if not LhsDispatch then A, B = B, A end
    a = tempus._fields(A, 'LocalDateTime')
    b = tempus._fields(B, 'LocalDateTime')
    date_compare = compare_date_fields(tempus._fields(a.date, 'LocalDate'),
@@ -2155,7 +2168,8 @@ end
 @input Second local date-time
 @result True when first is not later
 ]])
-tempus.mtLocalDateTime.__le = function(A:table!, B:table!):bool
+tempus.mtLocalDateTime.__le = function(A:table!, B:table!, LhsDispatch:bool):bool
+   if not LhsDispatch then A, B = B, A end
    return A < B or A is B
 end
 
@@ -2259,7 +2273,8 @@ end
 @input Second offset date-time
 @result True when first is earlier
 ]])
-tempus.mtOffsetDateTime.__lt = function(A:table!, B:table!):bool
+tempus.mtOffsetDateTime.__lt = function(A:table!, B:table!, LhsDispatch:bool):bool
+   if not LhsDispatch then A, B = B, A end
    return offset_date_time_instant(A) < offset_date_time_instant(B)
 end
 
@@ -2269,7 +2284,8 @@ end
 @input Second offset date-time
 @result True when first is not later
 ]])
-tempus.mtOffsetDateTime.__le = function(A:table!, B:table!):bool
+tempus.mtOffsetDateTime.__le = function(A:table!, B:table!, LhsDispatch:bool):bool
+   if not LhsDispatch then A, B = B, A end
    return offset_date_time_instant(A) <= offset_date_time_instant(B)
 end
 
@@ -2452,7 +2468,8 @@ end
 @input Second zoned date-time
 @result True when first is earlier
 ]])
-tempus.mtZonedDateTime.__lt = function(A:table!, B:table!):bool
+tempus.mtZonedDateTime.__lt = function(A:table!, B:table!, LhsDispatch:bool):bool
+   if not LhsDispatch then A, B = B, A end
    return tempus._fields(A, 'ZonedDateTime').instant < tempus._fields(B, 'ZonedDateTime').instant
 end
 
@@ -2462,7 +2479,8 @@ end
 @input Second zoned date-time
 @result True when first is not later
 ]])
-tempus.mtZonedDateTime.__le = function(A:table!, B:table!):bool
+tempus.mtZonedDateTime.__le = function(A:table!, B:table!, LhsDispatch:bool):bool
+   if not LhsDispatch then A, B = B, A end
    return tempus._fields(A, 'ZonedDateTime').instant <= tempus._fields(B, 'ZonedDateTime').instant
 end
 

--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -50,7 +50,7 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // in struct.size, which shifts the generated fast-function ordering.  Older chunks are rejected rather than retaining
 // compatibility shims.
 
-constexpr uint8_t BCDUMP_VERSION = 0x90;
+constexpr uint8_t BCDUMP_VERSION = 0x91;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/debug/lj_errmsg.h
+++ b/src/tiri/jit/src/debug/lj_errmsg.h
@@ -34,9 +34,6 @@ ERRDEF(OPARITH,  "perform arithmetic on")
 ERRDEF(OPCAT,    "Concatenate")
 ERRDEF(OPLEN,    "Get length of")
 ERRDEF(LENMM,    "__len metamethod must return a number")
-ERRDEF(CTXMMBIN, "context-first __%s handler selected from the right operand; use an ordinary function for "
-                  "provider-ambiguous methods")
-
 // Type checks.
 ERRDEF(BADSELF,  "Calling " LUA_QS " on bad self (%s)")
 ERRDEF(BADARG,   "Bad argument #%d to " LUA_QS " (%s)")

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -974,6 +974,10 @@ static void build_subroutines(BuildCtx *ctx)
   |  bl extern lj_meta_arith  // (lua_State *L, TValue *ra,*rb,*rc, BCReg op)
   |  // Returns NULL (finished) or TValue * (metamethod).
   |  cbz CRET1, ->cont_nop
+  |  ldrb TMP0w, [PC, #-8+OFS_OP]
+  |  cmp TMP0w, #BC_UNM
+  |  beq ->vmeta_binop
+  |  b ->vmeta_binop3
   |
   |  // Call metamethod for binary op.
   |->vmeta_binop:
@@ -983,6 +987,15 @@ static void build_subroutines(BuildCtx *ctx)
   |  add PC, TMP1, #FRAME_CONT
   |  mov BASE, CRET1
   |   mov NARGS8:RC, #16		// 2 args for func(o1, o2).
+  |  b ->vm_call_dispatch
+  |
+  |->vmeta_binop3:
+  |  // BASE = old base, CRET1 = new base, stack = cont/func/receiver/other/lhs_dispatch
+  |  sub TMP1, CRET1, BASE
+  |   str PC, [CRET1, #-24]		// [cont|PC]
+  |  add PC, TMP1, #FRAME_CONT
+  |  mov BASE, CRET1
+  |   mov NARGS8:RC, #24		// 3 args for func(receiver, other, lhs_dispatch).
   |  b ->vm_call_dispatch
   |
   |->vmeta_len:

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -865,7 +865,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  // Returns 0/1 or TValue * (metamethod).
   |3:
   |  cmp CRET1, #1
-  |  bhi ->vmeta_binop
+  |  bhi ->vmeta_binop3
   |4:
   |   ldrh RBw, [PC, # OFS_RD]
   |    add PC, PC, #8			// Skip past JMP instruction (64-bit BCIns)
@@ -2989,7 +2989,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  // Returns NULL (finished) or TValue * (metamethod).
     |  ldrb RBw, [PC, #-8+OFS_RB]
     |   ldr BASE, L->base
-    |   cbnz CRET1, ->vmeta_binop
+    |   cbnz CRET1, ->vmeta_binop3
     |  ldr TMP0, [BASE, RB, lsl #3]
     |  str TMP0, [BASE, RA, lsl #3]	// Copy result to RA.
     |  ins_next

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -1255,7 +1255,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  // Returns 0/1 or TValue * (metamethod).
   |3:
   |  cmplwi CRET1, 1
-  |  bgt ->vmeta_binop
+  |  bgt ->vmeta_binop3
   |  subfic CRET1, CRET1, 0
   |4:
   |  ld INS, 0(PC)                        // Fetch full 64-bit instruction
@@ -4425,7 +4425,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  // Returns NULL (finished) or TValue * (metamethod).
     |  cmplwi CRET1, 0
     |   lp BASE, L->base
-    |  bne ->vmeta_binop
+    |  bne ->vmeta_binop3
     |  ins_next1
     |.if FPU
     |  lfdx f0, BASE, SAVE0		// Copy result from RB to RA.

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -1394,6 +1394,10 @@ static void build_subroutines(BuildCtx *ctx)
   |  // Returns NULL (finished) or TValue * (metamethod).
   |  cmplwi CRET1, 0
   |  beq ->cont_nop
+  |  lbz TMP1, -8(PC)
+  |  cmpwi TMP1, BC_UNM
+  |  beq ->vmeta_binop
+  |  b ->vmeta_binop3
   |
   |  // Call metamethod for binary op.
   |->vmeta_binop:
@@ -1404,6 +1408,16 @@ static void build_subroutines(BuildCtx *ctx)
   |  addi PC, TMP1, FRAME_CONT
   |   mr BASE, CRET1
   |  li NARGS8:RC, 16			// 2 args for func(o1, o2).
+  |  b ->vm_call_dispatch
+  |
+  |->vmeta_binop3:
+  |  // BASE = old base, CRET1 = new base, stack = cont/func/receiver/other/lhs_dispatch
+  |  sub TMP1, CRET1, BASE
+  |   stw PC, -16(CRET1)		// [cont|PC]
+  |   mr TMP2, BASE
+  |  addi PC, TMP1, FRAME_CONT
+  |   mr BASE, CRET1
+  |  li NARGS8:RC, 24			// 3 args for func(receiver, other, lhs_dispatch).
   |  b ->vm_call_dispatch
   |
   |->vmeta_len:

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -1233,6 +1233,9 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov BASE, L:RB->base
   |  test RC, RC
   |  jz ->cont_nop
+  |  cmp PC_OP, BC_UNM
+  |  je ->vmeta_binop
+  |  jmp ->vmeta_binop3
   |
   |  // Call metamethod for binary op.
   |->vmeta_binop:
@@ -1242,6 +1245,15 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov [RA-24], PC       // [cont|PC]
   |  lea PC, [RC+FRAME_CONT]
   |  mov NARGS:RDd, 2+1       // 2 args for func(o1, o2).
+  |  jmp ->vm_call_dispatch
+  |
+  |->vmeta_binop3:
+  |  // BASE = base, RC = new base, stack = cont/func/receiver/other/lhs_dispatch
+  |  mov RA, RC
+  |  sub RC, BASE
+  |  mov [RA-24], PC       // [cont|PC]
+  |  lea PC, [RC+FRAME_CONT]
+  |  mov NARGS:RDd, 3+1       // 3 args for func(receiver, other, lhs_dispatch).
   |  jmp ->vm_call_dispatch
   |
   |->vmeta_len:

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -1078,7 +1078,7 @@ static void build_subroutines(BuildCtx *ctx)
   |3:
   |  mov BASE, L:RB->base
   |  cmp RC, 1
-  |  ja ->vmeta_binop
+  |  ja ->vmeta_binop3
   |4:
   |  lea PC, [PC+8]               // Skip past 64-bit JMP instruction
   |  jb >6
@@ -3662,7 +3662,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  // NULL (finished) or TValue * (metamethod) returned in eax (RC).
     |  mov BASE, L:RB->base
     |  test RC, RC
-    |  jnz ->vmeta_binop
+    |  jnz ->vmeta_binop3
     |  movzx RBd, PC_RB       // Copy result to Stk[RA] from Stk[RB].
     |  movzx RAd, PC_RA
     |  mov RC, [BASE+RB*8]

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -2579,8 +2579,9 @@ static GCstr * array_concat_value(lua_State *L, cTValue *Value)
 
 static int array_concat_meta(lua_State *L)
 {
-   cTValue *left = L->base;
-   cTValue *right = L->base + 1;
+   const bool lhs_dispatch = boolV(L->base + 2);
+   cTValue *left = lhs_dispatch ? L->base : L->base + 1;
+   cTValue *right = lhs_dispatch ? L->base + 1 : L->base;
 
    GCstr *left_str = array_concat_value(L, left);
    if (not left_str) lj_err_optype(L, left, ErrMsg::OPCAT);

--- a/src/tiri/jit/src/lj_api.cpp
+++ b/src/tiri/jit/src/lj_api.cpp
@@ -526,7 +526,7 @@ extern int lua_lessthan(lua_State *L, int idx1, int idx2)
    else {
       TValue *base = lj_meta_comp(L, o1, o2, 0);
       if ((uintptr_t)base <= 1) return (int)(uintptr_t)base;
-      return tvistruecond(MetaCall::invoke(L, base, 2, 1));
+      return tvistruecond(MetaCall::invoke(L, base, 3, 1));
    }
 }
 

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -248,8 +248,8 @@ typedef struct CCallInfo {
   _(ANY,        lj_env_check_override, 5, S, NIL, CCI_L|CCI_T) \
   /* Permanent contextual table designation */ \
   _(ANY,        lj_tab_mark_contextual_jit, 1, S, NIL, 0) \
-  _(ANY,        lj_context_begin_block_jit, 4, S, NIL, CCI_L) \
-  _(ANY,        lj_context_end_block_jit,   2, S, NIL, CCI_L) \
+  _(ANY,        lj_context_begin_block_jit, 5, S, NIL, CCI_L) \
+  _(ANY,        lj_context_end_block_jit,   3, S, NIL, CCI_L) \
   \
   // End of list.
 
@@ -286,8 +286,8 @@ extern "C" void lj_try_leave(lua_State *L);
 // Permanent contextual designation of a recorded table (see lj_state.cpp).
 extern "C" void lj_tab_mark_contextual_jit(GCtab *Table) noexcept;
 extern "C" void lj_context_begin_block_jit(
-   lua_State *L, GCtab *Table, uint32_t BlockIndex, uint32_t EntrySlots);
-extern "C" void lj_context_end_block_jit(lua_State *L, uint32_t BlockIndex) noexcept;
+   lua_State *L, GCtab *Table, TValue *OwnerBase, uint32_t BlockIndex, uint32_t EntrySlots);
+extern "C" void lj_context_end_block_jit(lua_State *L, TValue *OwnerBase, uint32_t BlockIndex) noexcept;
 
 // Environment mutation boundary (see lj_meta.cpp).
 extern "C" void lj_env_check(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value);

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1855,9 +1855,9 @@ nocheck:
 }
 
 //********************************************************************************************************************
-// Record call to arithmetic metamethod.
+// Record call to arithmetic or concatenation metamethod.
 
-static TRef rec_mm_arith(jit_State *J, RecordIndex* ix, MMS mm)
+static TRef rec_mm_binop(jit_State *J, RecordIndex* ix, MMS mm)
 {
    // Preserve the source operand pair before metatable lookup repurposes RecordIndex scratch fields.
    TRef left = ix->tab;
@@ -1866,7 +1866,7 @@ static TRef rec_mm_arith(jit_State *J, RecordIndex* ix, MMS mm)
    copyTV(J->L, &leftv, &ix->tabv);
    copyTV(J->L, &rightv, &ix->keyv);
 
-   bool arithmetic = mm >= MM_add and mm <= MM_pow;
+   bool receiver_first = (mm >= MM_add and mm <= MM_pow) or mm IS MM_concat;
    BCREG func = rec_mm_prep(J, mm IS MM_concat ? lj_cont_cat : lj_cont_ra);
    TRef* base = J->base + func;
    TValue* basev = J->L->base + func;
@@ -1883,7 +1883,7 @@ static TRef rec_mm_arith(jit_State *J, RecordIndex* ix, MMS mm)
          ix->tab = right;
          copyTV(J->L, &ix->tabv, &rightv);
          if (lj_record_mm_lookup(J, ix, mm)) {  //  Lookup mm on 2nd operand.
-            if (arithmetic) {
+            if (receiver_first) {
                receiver = right;
                other = left;
                copyTV(J->L, &receiverv, &rightv);
@@ -1903,7 +1903,7 @@ ok:
    base[FRC::HEADER_SIZE + 1] = other;
    copyTV(J->L, basev + FRC::HEADER_SIZE, &receiverv);
    copyTV(J->L, basev + FRC::HEADER_SIZE + 1, &otherv);
-   if (arithmetic) {
+   if (receiver_first) {
       base[FRC::HEADER_SIZE + 2] = lhs_dispatch ? TREF_TRUE : TREF_FALSE;
       setboolV(basev + FRC::HEADER_SIZE + 2, lhs_dispatch);
       lj_record_call(J, func, 3);
@@ -1972,6 +1972,27 @@ static void rec_mm_callcomp(jit_State *J, RecordIndex* ix, int op)
 }
 
 //********************************************************************************************************************
+// Call a receiver-first ordered comparison metamethod.
+
+static void rec_mm_callcomp3(jit_State *J, RecordIndex* ix, int op, TRef receiver, TValue *ReceiverValue,
+   TRef other, TValue *OtherValue, bool lhs_dispatch)
+{
+   BCREG func = rec_mm_prep(J, (op & 1) ? lj_cont_condf : lj_cont_condt);
+   TRef* base = J->base + func;
+   TValue* tv = J->L->base + func;
+   base[0] = ix->mobj;
+   base[1] = 0;
+   base[FRC::HEADER_SIZE] = receiver;
+   base[FRC::HEADER_SIZE + 1] = other;
+   base[FRC::HEADER_SIZE + 2] = lhs_dispatch ? TREF_TRUE : TREF_FALSE;
+   copyTV(J->L, tv, &ix->mobjv);
+   copyTV(J->L, tv + FRC::HEADER_SIZE, ReceiverValue);
+   copyTV(J->L, tv + FRC::HEADER_SIZE + 1, OtherValue);
+   setboolV(tv + FRC::HEADER_SIZE + 2, lhs_dispatch);
+   lj_record_call(J, func, 3);
+}
+
+//********************************************************************************************************************
 // Record call to equality comparison metamethod.
 
 static void rec_mm_equal(jit_State *J, RecordIndex* ix, int op)
@@ -2017,13 +2038,24 @@ static void rec_mm_comp(jit_State *J, RecordIndex* ix, int op)
    copyTV(J->L, &ix->tabv, &ix->valv);
    while (true) {
       MMS mm = (op & 2) ? MM_le : MM_lt;  //  Try __le + __lt or only __lt.
+      TRef receiver = ix->val;
+      TRef other = ix->key;
+      TValue receiverv, otherv;
+      copyTV(J->L, &receiverv, &ix->valv);
+      copyTV(J->L, &otherv, &ix->keyv);
+      bool lhs_dispatch = true;
       if (not lj_record_mm_lookup(J, ix, mm)) {  // Lookup mm on 1st operand.
          ix->tab = ix->key;
          copyTV(J->L, &ix->tabv, &ix->keyv);
          if (not lj_record_mm_lookup(J, ix, mm))  //  Lookup mm on 2nd operand.
             goto nomatch;
+         receiver = ix->key;
+         other = ix->val;
+         copyTV(J->L, &receiverv, &ix->keyv);
+         copyTV(J->L, &otherv, &ix->valv);
+         lhs_dispatch = false;
       }
-      rec_mm_callcomp(J, ix, op);
+      rec_mm_callcomp3(J, ix, op, receiver, &receiverv, other, &otherv, lhs_dispatch);
       return;
 
    nomatch:
@@ -2884,7 +2916,7 @@ static TRef rec_cat(jit_State *J, BCREG baseslot, BCREG topslot)
    ix.tab = top[-1];
    ix.key = top[0];
    memcpy(savetv, &J->L->base[topslot - 1], sizeof(savetv));  //  Save slots.
-   rec_mm_arith(J, &ix, MM_concat);  //  Call __concat metamethod.
+   rec_mm_binop(J, &ix, MM_concat);  //  Call __concat metamethod.
    memcpy(&J->L->base[topslot - 1], savetv, sizeof(savetv));  //  Restore slots.
    return 0;  //  No result yet.
 }
@@ -3182,7 +3214,7 @@ static TRef rec_arith_op(jit_State *J, RecordOps *ops)
          if (tref_isnumber(rc)) return lj_opt_narrow_unm(J, rc, rcv);
          ix->tab = rc;
          copyTV(J->L, &ix->tabv, rcv);
-         return rec_mm_arith(J, ix, MM_unm);
+         return rec_mm_binop(J, ix, MM_unm);
 
       case BC_ADDNV: case BC_SUBNV: case BC_MULNV: case BC_DIVNV: case BC_MODNV:
          // Swap rb/rc and rbv/rcv. rav is temp.
@@ -3193,7 +3225,7 @@ static TRef rec_arith_op(jit_State *J, RecordOps *ops)
          if (op IS BC_MODNV) {
             if (tref_isnumber(rb) and tref_isnumber(rc))
                return lj_opt_narrow_mod(J, rb, rc, rbv, rcv);
-            return rec_mm_arith(J, ix, MM_mod);
+            return rec_mm_binop(J, ix, MM_mod);
          }
          [[fallthrough]];
 
@@ -3202,18 +3234,18 @@ static TRef rec_arith_op(jit_State *J, RecordOps *ops)
          MMS mm = bcmode_mm(op);
          if (tref_isnumber(rb) and tref_isnumber(rc))
             return lj_opt_narrow_arith(J, rb, rc, rbv, rcv, (IROp)((int)mm - (int)MM_add + (int)IR_ADD));
-         return rec_mm_arith(J, ix, mm);
+         return rec_mm_binop(J, ix, mm);
       }
 
       case BC_MODVN: case BC_MODVV:
          if (tref_isnumber(rb) and tref_isnumber(rc))
             return lj_opt_narrow_mod(J, rb, rc, rbv, rcv);
-         return rec_mm_arith(J, ix, MM_mod);
+         return rec_mm_binop(J, ix, MM_mod);
 
       case BC_POW:
          if (tref_isnumber(rb) and tref_isnumber(rc))
             return lj_opt_narrow_pow(J, rb, rc, rbv, rcv);
-         return rec_mm_arith(J, ix, MM_pow);
+         return rec_mm_binop(J, ix, MM_pow);
 
       default:
          return 0;
@@ -4679,13 +4711,22 @@ void lj_record_ins(jit_State *J)
       // Block activations are installed physically. Materialise any virtual call receivers first so current-context
       // lookup observes the block before the enclosing receiver, matching interpreter stack order.
       rec_context_materialise(J, ContextMaterialisationReason::UnsupportedBoundary);
-      lj_ir_call(J, IRCALL_lj_context_begin_block_jit, ra, lj_ir_kint(J, int32_t(bc_d(*pc))),
-         lj_ir_kint(J, int32_t(bc_a(*pc)) + 1));
+      {
+         IRBuilder ir(J);
+         TRef owner_base = rec_stack_slot_addr(J, ir, int32_t(J->baseslot));
+         lj_ir_call(J, IRCALL_lj_context_begin_block_jit, ra, owner_base, lj_ir_kint(J, int32_t(bc_d(*pc))),
+            lj_ir_kint(J, int32_t(bc_a(*pc)) + 1));
+      }
       J->needsnap = 1;
       break;
 
    case BC_CTXEND:
-      lj_ir_call(J, IRCALL_lj_context_end_block_jit, lj_ir_kint(J, int32_t(bc_d(*pc))));
+      {
+         IRBuilder ir(J);
+         TRef owner_base = rec_stack_slot_addr(J, ir, int32_t(J->baseslot));
+         lj_ir_call(J, IRCALL_lj_context_end_block_jit, owner_base,
+            lj_ir_kint(J, int32_t(bc_d(*pc))));
+      }
       J->needsnap = 1;
       break;
 

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1859,19 +1859,37 @@ nocheck:
 
 static TRef rec_mm_arith(jit_State *J, RecordIndex* ix, MMS mm)
 {
-   // Set up metamethod call first to save ix->tab and ix->tabv.
+   // Preserve the source operand pair before metatable lookup repurposes RecordIndex scratch fields.
+   TRef left = ix->tab;
+   TRef right = ix->key;
+   TValue leftv, rightv;
+   copyTV(J->L, &leftv, &ix->tabv);
+   copyTV(J->L, &rightv, &ix->keyv);
+
+   bool arithmetic = mm >= MM_add and mm <= MM_pow;
    BCREG func = rec_mm_prep(J, mm IS MM_concat ? lj_cont_cat : lj_cont_ra);
    TRef* base = J->base + func;
    TValue* basev = J->L->base + func;
-   base[FRC::HEADER_SIZE] = ix->tab; base[FRC::HEADER_SIZE + 1] = ix->key;  // Args at base[2], base[3]
-   copyTV(J->L, basev + FRC::HEADER_SIZE, &ix->tabv);
-   copyTV(J->L, basev + FRC::HEADER_SIZE + 1, &ix->keyv);
+
+   TRef receiver = left;
+   TRef other = right;
+   TValue receiverv, otherv;
+   copyTV(J->L, &receiverv, &leftv);
+   copyTV(J->L, &otherv, &rightv);
+   bool lhs_dispatch = true;
+
    if (not lj_record_mm_lookup(J, ix, mm)) {  // Lookup mm on 1st operand.
       if (mm != MM_unm) {
-         ix->tab = ix->key;
-         copyTV(J->L, &ix->tabv, &ix->keyv);
-         if (lj_record_mm_lookup(J, ix, mm))  //  Lookup mm on 2nd operand.
+         ix->tab = right;
+         copyTV(J->L, &ix->tabv, &rightv);
+         if (lj_record_mm_lookup(J, ix, mm)) {  //  Lookup mm on 2nd operand.
+            receiver = right;
+            other = left;
+            copyTV(J->L, &receiverv, &rightv);
+            copyTV(J->L, &otherv, &leftv);
+            lhs_dispatch = false;
             goto ok;
+         }
       }
       lj_trace_err(J, LJ_TRERR_NOMM);
    }
@@ -1879,7 +1897,16 @@ ok:
    base[0] = ix->mobj;
    base[1] = 0;
    copyTV(J->L, basev + 0, &ix->mobjv);
-   lj_record_call(J, func, 2);
+   base[FRC::HEADER_SIZE] = receiver;
+   base[FRC::HEADER_SIZE + 1] = other;
+   copyTV(J->L, basev + FRC::HEADER_SIZE, &receiverv);
+   copyTV(J->L, basev + FRC::HEADER_SIZE + 1, &otherv);
+   if (arithmetic) {
+      base[FRC::HEADER_SIZE + 2] = lhs_dispatch ? TREF_TRUE : TREF_FALSE;
+      setboolV(basev + FRC::HEADER_SIZE + 2, lhs_dispatch);
+      lj_record_call(J, func, 3);
+   }
+   else lj_record_call(J, func, 2);
    return 0;  //  No result yet.
 }
 

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1883,11 +1883,13 @@ static TRef rec_mm_arith(jit_State *J, RecordIndex* ix, MMS mm)
          ix->tab = right;
          copyTV(J->L, &ix->tabv, &rightv);
          if (lj_record_mm_lookup(J, ix, mm)) {  //  Lookup mm on 2nd operand.
-            receiver = right;
-            other = left;
-            copyTV(J->L, &receiverv, &rightv);
-            copyTV(J->L, &otherv, &leftv);
-            lhs_dispatch = false;
+            if (arithmetic) {
+               receiver = right;
+               other = left;
+               copyTV(J->L, &receiverv, &rightv);
+               copyTV(J->L, &otherv, &leftv);
+               lhs_dispatch = false;
+            }
             goto ok;
          }
       }

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1715,7 +1715,8 @@ static bool test_old_bytecode_versions_rejected(kt::Log &Log)
    // 0x86 is included deliberately: Phase 5 removed the compiler-private binder referenced by those chunks and
    // replaced it with BC_MODACT.  Gate E selected format rejection over a compatibility shim.
 
-   for (uint8_t version : { uint8_t(0x81), uint8_t(0x83), uint8_t(0x85), uint8_t(0x86), uint8_t(0x8e) }) {
+   for (uint8_t version : { uint8_t(0x81), uint8_t(0x83), uint8_t(0x85), uint8_t(0x86), uint8_t(0x8e),
+      uint8_t(0x90) }) {
       std::string old_dump = dump;
       old_dump[3] = char(version);
       if (lua_load(L, std::string_view(old_dump.data(), old_dump.size()), "old-version") IS 0) {

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -202,6 +202,30 @@ TValue * mmcall(lua_State *L, ASMFunction cont, cTValue *mo, cTValue *a, cTValue
    return top;  //  Return new base.
 }
 
+// Setup a receiver-first binary metamethod call.  This is intentionally separate from mmcall(): concat, ordering
+// and the receiver-stable binary metamethods retain their two-argument ABI until they are converted explicitly.
+
+static TValue * mmcall_arith(lua_State *L, ASMFunction cont, cTValue *Method, cTValue *Receiver,
+   cTValue *Other, bool LhsDispatch)
+{
+   //           |-- framesize -> top       top+1       top+2 top+3      top+4      top+5
+   // before:   [func slots ...]
+   // mm setup: [func slots ...] [cont|?]  [mo|tmtype] [receiver] [other] [lhs dispatch]
+   // in asm:   [func slots ...] [cont|PC] [mo|delta]  [receiver] [other] [lhs dispatch]
+   //           ^-- func base                          ^-- mm base
+
+   TValue *top = L->top;
+   if (curr_funcisL(L)) top = curr_topL(L);
+   setcont(top++, cont);
+   setnilV(top++);
+   copyTV(L, top++, Method);
+   setnilV(top++);
+   copyTV(L, top++, Receiver);
+   copyTV(L, top++, Other);
+   setboolV(top, LhsDispatch);
+   return top - 2;  //  Return new base.
+}
+
 // A context-first handler establishes its first actual table argument as the current context.  Binary metamethods
 // may find their callable on the right operand while preserving ordinary left/right argument order, which would make
 // that context silently wrong.  Reject that shape before a Lua frame is created.
@@ -366,18 +390,22 @@ TValue * lj_meta_arith(lua_State *L, TValue *ra, cTValue *rb, cTValue *rc, BCREG
    }
    else {
       cTValue *mo = lj_meta_lookup(L, rb, mm);
-      cTValue *provider = rb;
+      cTValue *receiver = rb;
+      cTValue *other = rc;
+      bool lhs_dispatch = true;
       if (tvisnil(mo)) {
          mo = lj_meta_lookup(L, rc, mm);
-         provider = rc;
+         receiver = rc;
+         other = rb;
+         lhs_dispatch = false;
          if (tvisnil(mo)) {
             if (str2num(rb, &tempb) IS nullptr) rc = rb;
             lj_err_optype(L, rc, ErrMsg::OPARITH);
             return nullptr;  //  unreachable
          }
       }
-      reject_context_first_binary_mismatch(L, mo, provider, rb, strdata(mmname_str(G(L), mm)) + 2);
-      return mmcall(L, lj_cont_ra, mo, rb, rc);
+      if (mm IS MM_unm) return mmcall(L, lj_cont_ra, mo, rb, rc);
+      return mmcall_arith(L, lj_cont_ra, mo, receiver, other, lhs_dispatch);
    }
 }
 

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -202,10 +202,10 @@ TValue * mmcall(lua_State *L, ASMFunction cont, cTValue *mo, cTValue *a, cTValue
    return top;  //  Return new base.
 }
 
-// Setup a receiver-first binary metamethod call.  This is intentionally separate from mmcall(): concat, ordering
-// and the receiver-stable binary metamethods retain their two-argument ABI until they are converted explicitly.
+// Setup a receiver-first binary metamethod call.  This remains separate from mmcall() so receiver-stable binary
+// metamethods retain their two-argument ABI.
 
-static TValue * mmcall_arith(lua_State *L, ASMFunction cont, cTValue *Method, cTValue *Receiver,
+static TValue * mmcall_binop3(lua_State *L, ASMFunction cont, cTValue *Method, cTValue *Receiver,
    cTValue *Other, bool LhsDispatch)
 {
    //           |-- framesize -> top       top+1       top+2 top+3      top+4      top+5
@@ -224,18 +224,6 @@ static TValue * mmcall_arith(lua_State *L, ASMFunction cont, cTValue *Method, cT
    copyTV(L, top++, Other);
    setboolV(top, LhsDispatch);
    return top - 2;  //  Return new base.
-}
-
-// A context-first handler establishes its first actual table argument as the current context.  Binary metamethods
-// may find their callable on the right operand while preserving ordinary left/right argument order, which would make
-// that context silently wrong.  Reject that shape before a Lua frame is created.
-
-static void reject_context_first_binary_mismatch(lua_State *L, cTValue *Method, cTValue *Provider,
-   cTValue *FirstArgument, CSTRING Name)
-{
-   if (not tvisfunc(Method) or not func_context_first_argument(funcV(Method))) return;
-   if (tvistab(Provider) and tvistab(FirstArgument) and tabV(Provider) IS tabV(FirstArgument)) return;
-   lj_err_msgv(L, ErrMsg::CTXMMBIN, Name);
 }
 
 //********************************************************************************************************************
@@ -405,7 +393,7 @@ TValue * lj_meta_arith(lua_State *L, TValue *ra, cTValue *rb, cTValue *rc, BCREG
          }
       }
       if (mm IS MM_unm) return mmcall(L, lj_cont_ra, mo, rb, rc);
-      return mmcall_arith(L, lj_cont_ra, mo, receiver, other, lhs_dispatch);
+      return mmcall_binop3(L, lj_cont_ra, mo, receiver, other, lhs_dispatch);
    }
 }
 
@@ -431,10 +419,14 @@ TValue * lj_meta_cat(lua_State *L, TValue *top, int left)
 
       if (not (tvisstr(top) or tvisnumber(top)) or !(tvisstr(top - 1) or tvisnumber(top - 1))) {
          cTValue *mo = lj_meta_lookup(L, top - 1, MM_concat);
-         cTValue *provider = top - 1;
+         cTValue *receiver = top - 1;
+         cTValue *other = top;
+         bool lhs_dispatch = true;
          if (tvisnil(mo)) {
             mo = lj_meta_lookup(L, top, MM_concat);
-            provider = top;
+            receiver = top;
+            other = top - 1;
+            lhs_dispatch = false;
             if (tvisnil(mo)) {
                if (tvisstr(top - 1) or tvisnumber(top - 1)) top++;
                lj_err_optype(L, top - 1, ErrMsg::OPCAT);
@@ -442,25 +434,25 @@ TValue * lj_meta_cat(lua_State *L, TValue *top, int left)
             }
          }
 
-         reject_context_first_binary_mismatch(L, mo, provider, top - 1, "concat");
-
          // One of the top two elements is not a string, call __cat metamethod:
          //
          // before:    [...][CAT stack .........................]
          //                                 top-1     top         top+1 top+2
          // pick two:  [...][CAT stack ...] [o1]      [o2]
-         // setup mm:  [...][CAT stack ...] [cont|?]  [mo|tmtype] [o1]  [o2]
-         // in asm:    [...][CAT stack ...] [cont|PC] [mo|delta]  [o1]  [o2]
-         //            ^-- func base                              ^-- mm base
+         // setup mm:  [...][CAT stack ...] [cont|?]  [mo|tmtype] [receiver] [other] [lhs dispatch]
+         // in asm:    [...][CAT stack ...] [cont|PC] [mo|delta]  [receiver] [other] [lhs dispatch]
+         //            ^-- func base                                ^-- mm base
          // after mm:  [...][CAT stack ...] <--push-- [result]
          // next step: [...][CAT stack .............]
 
-         copyTV(L, top + 2 * LJ_FR2 + 2, top);  //  Carefully ordered stack copies!
-         copyTV(L, top + 2 * LJ_FR2 + 1, top - 1);
+         copyTV(L, top + 2 * LJ_FR2 + 3, other);  //  Carefully ordered stack copies!
+         copyTV(L, top + 2 * LJ_FR2 + 2, other);
+         copyTV(L, top + 2 * LJ_FR2 + 1, receiver);
          copyTV(L, top + LJ_FR2, mo);
          setcont(top - 1, lj_cont_cat);
          setnilV(top);
          setnilV(top + 2);
+         setboolV(top + 2 * LJ_FR2 + 3, lhs_dispatch);
          top += 2;
          return top + 1;  //  Trigger metamethod call.
       }
@@ -671,10 +663,14 @@ TValue * lj_meta_comp(lua_State *L, cTValue *o1, cTValue *o2, int op)
          ASMFunction cont = (op & 1) ? lj_cont_condf : lj_cont_condt;
          MMS mm = (op & 2) ? MM_le : MM_lt;
          cTValue *mo = lj_meta_lookup(L, o1, mm);
-         cTValue *provider = o1;
+         cTValue *receiver = o1;
+         cTValue *other = o2;
+         bool lhs_dispatch = true;
          if (tvisnil(mo)) {
             mo = lj_meta_lookup(L, o2, mm);
-            provider = o2;
+            receiver = o2;
+            other = o1;
+            lhs_dispatch = false;
          }
          if (tvisnil(mo)) {
             if (op & 2) {  // MM_le not found: retry with MM_lt.
@@ -685,8 +681,7 @@ TValue * lj_meta_comp(lua_State *L, cTValue *o1, cTValue *o2, int op)
             lj_err_comp(L, o1, o2);
             return nullptr;
          }
-         reject_context_first_binary_mismatch(L, mo, provider, o1, strdata(mmname_str(G(L), mm)) + 2);
-         return mmcall(L, cont, mo, o1, o2);
+         return mmcall_binop3(L, cont, mo, receiver, other, lhs_dispatch);
       }
    }
 }

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -381,35 +381,42 @@ extern "C" void lj_context_begin_block(lua_State *L, uint32_t Slot, uint32_t Blo
    frame.entry_slots = proto->context_blocks[BlockIndex].entry_slots;
 }
 
-extern "C" void lj_context_end_block(lua_State *L, uint32_t BlockIndex) noexcept
+static void context_end_block(lua_State *L, const TValue *OwnerBase, uint32_t BlockIndex) noexcept
 {
    lj_assertL(not L->context_stack.empty(), "temporary context block stack underflow");
    if (L->context_stack.empty()) return;
+   ptrdiff_t owner_base = savestack(L, OwnerBase);
    lua_State::ContextFrame &frame = L->context_stack.back();
    lj_assertL(frame.owner_kind IS lua_State::ContextFrame::OwnerKind::Block and
-      frame.owner_base IS savestack(L, L->base) and frame.block_index IS BlockIndex,
+      frame.owner_base IS owner_base and frame.block_index IS BlockIndex,
       "unbalanced temporary context block");
    if (frame.owner_kind IS lua_State::ContextFrame::OwnerKind::Block and
-       frame.owner_base IS savestack(L, L->base) and frame.block_index IS BlockIndex) {
+       frame.owner_base IS owner_base and frame.block_index IS BlockIndex) {
       L->context_stack.pop_back();
       lj_context_debug_physical_leave(L);
       L->context_active = context_has_visible_override(L);
    }
 }
 
-extern "C" void lj_context_begin_block_jit(
-   lua_State *L, GCtab *Table, uint32_t BlockIndex, uint32_t EntrySlots)
+extern "C" void lj_context_end_block(lua_State *L, uint32_t BlockIndex) noexcept
 {
-   lj_context_push(L, Table, L->base);
+   context_end_block(L, L->base, BlockIndex);
+}
+
+extern "C" void lj_context_begin_block_jit(
+   lua_State *L, GCtab *Table, TValue *OwnerBase, uint32_t BlockIndex, uint32_t EntrySlots)
+{
+   lj_context_push(L, Table, OwnerBase);
    lua_State::ContextFrame &frame = L->context_stack.back();
    frame.owner_kind = lua_State::ContextFrame::OwnerKind::Block;
    frame.block_index = uint16_t(BlockIndex);
    frame.entry_slots = BCREG(EntrySlots);
 }
 
-extern "C" void lj_context_end_block_jit(lua_State *L, uint32_t BlockIndex) noexcept
+extern "C" void lj_context_end_block_jit(
+   lua_State *L, TValue *OwnerBase, uint32_t BlockIndex) noexcept
 {
-   lj_context_end_block(L, BlockIndex);
+   context_end_block(L, OwnerBase, BlockIndex);
 }
 
 extern "C" void lj_close_arm(lua_State *L, uint32_t Slot)

--- a/src/tiri/jit/src/runtime/lj_state.h
+++ b/src/tiri/jit/src/runtime/lj_state.h
@@ -61,8 +61,9 @@ extern "C" LJ_FUNC void lj_tab_designate_contextual(lua_State *L, uint32_t Slot)
 extern "C" LJ_FUNC void lj_context_begin_block(lua_State *L, uint32_t Slot, uint32_t BlockIndex);
 extern "C" LJ_FUNC void lj_context_end_block(lua_State *L, uint32_t BlockIndex) noexcept;
 extern "C" LJ_FUNC void lj_context_begin_block_jit(
-   lua_State *L, GCtab *Table, uint32_t BlockIndex, uint32_t EntrySlots);
-extern "C" LJ_FUNC void lj_context_end_block_jit(lua_State *L, uint32_t BlockIndex) noexcept;
+   lua_State *L, GCtab *Table, TValue *OwnerBase, uint32_t BlockIndex, uint32_t EntrySlots);
+extern "C" LJ_FUNC void lj_context_end_block_jit(
+   lua_State *L, TValue *OwnerBase, uint32_t BlockIndex) noexcept;
 extern "C" LJ_FUNC void lj_close_arm(lua_State *L, uint32_t Slot);
 extern "C" LJ_FUNC void lj_close_consume(lua_State *L, uint32_t Slot);
 LJ_FUNC uint64_t lj_close_take_armed(

--- a/src/tiri/jit/src/runtime/lj_thunk.cpp
+++ b/src/tiri/jit/src/runtime/lj_thunk.cpp
@@ -212,6 +212,19 @@ static void resolve_binary_operands(lua_State *L, TValue &FirstCopy, TValue &Sec
    if (lj_is_thunk(Second)) Second = lj_thunk_resolve(L, udataV(Second));
 }
 
+static void resolve_arithmetic_operands(lua_State *L, TValue &FirstCopy, TValue &SecondCopy,
+   cTValue *&First, cTValue *&Second)
+{
+   const bool lhs_dispatch = boolV(L->base + 2);
+   resolve_binary_operands(L, FirstCopy, SecondCopy, First, Second);
+   // Native arithmetic helpers calculate in source order even though the provider is now the first runtime argument.
+   if (not lhs_dispatch) {
+      cTValue *source_left = Second;
+      Second = First;
+      First = source_left;
+   }
+}
+
 //********************************************************************************************************************
 // Binary arithmetic metamethods
 
@@ -219,7 +232,7 @@ static int thunk_add(lua_State *L)
 {
    TValue a_copy, b_copy;
    cTValue *a, *b;
-   resolve_binary_operands(L, a_copy, b_copy, a, b);
+   resolve_arithmetic_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number result = getnumvalue(a) + getnumvalue(b);
@@ -235,7 +248,7 @@ static int thunk_sub(lua_State *L)
 {
    TValue a_copy, b_copy;
    cTValue *a, *b;
-   resolve_binary_operands(L, a_copy, b_copy, a, b);
+   resolve_arithmetic_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number result = getnumvalue(a) - getnumvalue(b);
@@ -251,7 +264,7 @@ static int thunk_mul(lua_State *L)
 {
    TValue a_copy, b_copy;
    cTValue *a, *b;
-   resolve_binary_operands(L, a_copy, b_copy, a, b);
+   resolve_arithmetic_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number result = getnumvalue(a) * getnumvalue(b);
@@ -267,7 +280,7 @@ static int thunk_div(lua_State *L)
 {
    TValue a_copy, b_copy;
    cTValue *a, *b;
-   resolve_binary_operands(L, a_copy, b_copy, a, b);
+   resolve_arithmetic_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number result = getnumvalue(a) / getnumvalue(b);
@@ -283,7 +296,7 @@ static int thunk_mod(lua_State *L)
 {
    TValue a_copy, b_copy;
    cTValue *a, *b;
-   resolve_binary_operands(L, a_copy, b_copy, a, b);
+   resolve_arithmetic_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number na = getnumvalue(a);
@@ -301,7 +314,7 @@ static int thunk_pow(lua_State *L)
 {
    TValue a_copy, b_copy;
    cTValue *a, *b;
-   resolve_binary_operands(L, a_copy, b_copy, a, b);
+   resolve_arithmetic_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number result = pow(getnumvalue(a), getnumvalue(b));

--- a/src/tiri/jit/src/runtime/lj_thunk.cpp
+++ b/src/tiri/jit/src/runtime/lj_thunk.cpp
@@ -212,12 +212,12 @@ static void resolve_binary_operands(lua_State *L, TValue &FirstCopy, TValue &Sec
    if (lj_is_thunk(Second)) Second = lj_thunk_resolve(L, udataV(Second));
 }
 
-static void resolve_arithmetic_operands(lua_State *L, TValue &FirstCopy, TValue &SecondCopy,
+static void resolve_receiver_first_binary_operands(lua_State *L, TValue &FirstCopy, TValue &SecondCopy,
    cTValue *&First, cTValue *&Second)
 {
    const bool lhs_dispatch = boolV(L->base + 2);
    resolve_binary_operands(L, FirstCopy, SecondCopy, First, Second);
-   // Native arithmetic helpers calculate in source order even though the provider is now the first runtime argument.
+   // Native helpers calculate in source order even though the provider is now the first runtime argument.
    if (not lhs_dispatch) {
       cTValue *source_left = Second;
       Second = First;
@@ -232,7 +232,7 @@ static int thunk_add(lua_State *L)
 {
    TValue a_copy, b_copy;
    cTValue *a, *b;
-   resolve_arithmetic_operands(L, a_copy, b_copy, a, b);
+   resolve_receiver_first_binary_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number result = getnumvalue(a) + getnumvalue(b);
@@ -248,7 +248,7 @@ static int thunk_sub(lua_State *L)
 {
    TValue a_copy, b_copy;
    cTValue *a, *b;
-   resolve_arithmetic_operands(L, a_copy, b_copy, a, b);
+   resolve_receiver_first_binary_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number result = getnumvalue(a) - getnumvalue(b);
@@ -264,7 +264,7 @@ static int thunk_mul(lua_State *L)
 {
    TValue a_copy, b_copy;
    cTValue *a, *b;
-   resolve_arithmetic_operands(L, a_copy, b_copy, a, b);
+   resolve_receiver_first_binary_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number result = getnumvalue(a) * getnumvalue(b);
@@ -280,7 +280,7 @@ static int thunk_div(lua_State *L)
 {
    TValue a_copy, b_copy;
    cTValue *a, *b;
-   resolve_arithmetic_operands(L, a_copy, b_copy, a, b);
+   resolve_receiver_first_binary_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number result = getnumvalue(a) / getnumvalue(b);
@@ -296,7 +296,7 @@ static int thunk_mod(lua_State *L)
 {
    TValue a_copy, b_copy;
    cTValue *a, *b;
-   resolve_arithmetic_operands(L, a_copy, b_copy, a, b);
+   resolve_receiver_first_binary_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number na = getnumvalue(a);
@@ -314,7 +314,7 @@ static int thunk_pow(lua_State *L)
 {
    TValue a_copy, b_copy;
    cTValue *a, *b;
-   resolve_arithmetic_operands(L, a_copy, b_copy, a, b);
+   resolve_receiver_first_binary_operands(L, a_copy, b_copy, a, b);
 
    if (tvisnumber(a) and tvisnumber(b)) {
       lua_Number result = pow(getnumvalue(a), getnumvalue(b));
@@ -348,7 +348,7 @@ static int thunk_concat(lua_State *L)
 {
    TValue a_copy, b_copy;
    cTValue *a, *b;
-   resolve_binary_operands(L, a_copy, b_copy, a, b);
+   resolve_receiver_first_binary_operands(L, a_copy, b_copy, a, b);
    lj_assertL(a != nullptr, "Invalid LHS (null)");
    lj_assertL(b != nullptr, "Invalid RHS (null)");
    copyTV(L, L->top, a);
@@ -424,7 +424,7 @@ static int thunk_lt(lua_State *L)
 {
    TValue a_copy, b_copy;
    cTValue *a, *b;
-   resolve_binary_operands(L, a_copy, b_copy, a, b);
+   resolve_receiver_first_binary_operands(L, a_copy, b_copy, a, b);
 
    int result;
    if (tvisnumber(a) and tvisnumber(b)) {
@@ -453,7 +453,7 @@ static int thunk_le(lua_State *L)
 {
    TValue a_copy, b_copy;
    cTValue *a, *b;
-   resolve_binary_operands(L, a_copy, b_copy, a, b);
+   resolve_receiver_first_binary_operands(L, a_copy, b_copy, a, b);
 
    int result;
    if (tvisnumber(a) and tvisnumber(b)) {

--- a/src/tiri/jit/src/runtime/stack_helpers.h
+++ b/src/tiri/jit/src/runtime/stack_helpers.h
@@ -393,8 +393,10 @@ namespace MetaCall {
 
    inline int invokeConcat(lua_State* L, TValue* top) noexcept {
       int consumed = int(L->top - (top - 2 * LJ_FR2));
-      L->top = top + 2;
+      L->top = top + 3;
       lj_vm_call(L, top, 1 + 1);
+      // lj_vm_call() restores top to the metamethod base irrespective of its argument count.  Keep the
+      // concatenation result in the same replacement slot as the two-argument layout.
       L->top -= 1 + LJ_FR2;
       copyTV(L, L->top - 1, L->top + LJ_FR2);
       return consumed;

--- a/src/tiri/jit/src/runtime/stack_helpers.h
+++ b/src/tiri/jit/src/runtime/stack_helpers.h
@@ -350,7 +350,8 @@ namespace MetaCall {
    [[nodiscard]] inline TValue* invoke(lua_State* L, TValue* base, int slotsUsed, int nresults = 1) noexcept {
       L->top = base + slotsUsed;
       lj_vm_call(L, base, nresults + 1);
-      L->top -= slotsUsed + LJ_FR2;
+      // The result replaces the metamethod slot, so caller restoration is independent of the argument count.
+      L->top -= 2 + LJ_FR2;
       return Frame::result(L);
    }
 

--- a/src/tiri/tests/test_compound.tiri
+++ b/src/tiri/tests/test_compound.tiri
@@ -42,9 +42,9 @@ end
 
 function shadowed_tostring_append_call_shape()
    local mt = {
-      __concat = function(Receiver, Other, LhsDispatch)
-         if LhsDispatch then return Receiver.val .. Other end
-         return Other .. Receiver.val
+      __concat = metamethod(Other, LhsDispatch)
+         if LhsDispatch then return &val .. Other end
+         return Other .. &val
       end
    }
    local tostring = function(Value)
@@ -514,9 +514,9 @@ end
 
 @Test function ArrayConcatAssignmentPreservesRhsMetamethodConcat()
    mt = {
-      __concat = function(Receiver, Other, LhsDispatch)
-         if LhsDispatch then return Receiver.val .. Other end
-         return Other .. Receiver.val
+      __concat = metamethod(Other, LhsDispatch)
+         if LhsDispatch then return &val .. Other end
+         return Other .. &val
       end
    }
    local obj = setmetatable({ val = 'data' }, mt)

--- a/src/tiri/tests/test_compound.tiri
+++ b/src/tiri/tests/test_compound.tiri
@@ -42,8 +42,8 @@ end
 
 function shadowed_tostring_append_call_shape()
    local mt = {
-      __concat = metamethod(Other, LhsDispatch)
-         if LhsDispatch then return &val .. Other end
+      __concat = metamethod(Other, LHS)
+         if LHS then return &val .. Other end
          return Other .. &val
       end
    }
@@ -514,8 +514,8 @@ end
 
 @Test function ArrayConcatAssignmentPreservesRhsMetamethodConcat()
    mt = {
-      __concat = metamethod(Other, LhsDispatch)
-         if LhsDispatch then return &val .. Other end
+      __concat = metamethod(Other, LHS)
+         if LHS then return &val .. Other end
          return Other .. &val
       end
    }

--- a/src/tiri/tests/test_compound.tiri
+++ b/src/tiri/tests/test_compound.tiri
@@ -42,9 +42,9 @@ end
 
 function shadowed_tostring_append_call_shape()
    local mt = {
-      __concat = function(A, B)
-         if type(A) is 'table' then return A.val .. B end
-         return A .. B.val
+      __concat = function(Receiver, Other, LhsDispatch)
+         if LhsDispatch then return Receiver.val .. Other end
+         return Other .. Receiver.val
       end
    }
    local tostring = function(Value)
@@ -514,9 +514,9 @@ end
 
 @Test function ArrayConcatAssignmentPreservesRhsMetamethodConcat()
    mt = {
-      __concat = function(A, B)
-         if type(A) is 'table' then return A.val .. B end
-         return A .. B.val
+      __concat = function(Receiver, Other, LhsDispatch)
+         if LhsDispatch then return Receiver.val .. Other end
+         return Other .. Receiver.val
       end
    }
    local obj = setmetatable({ val = 'data' }, mt)

--- a/src/tiri/tests/test_metatables.tiri
+++ b/src/tiri/tests/test_metatables.tiri
@@ -61,6 +61,11 @@ function source_arithmetic_operands(Receiver, Other, LhsDispatch):<any, any>
    return Other, Receiver
 end
 
+function source_binary_operands(Receiver, Other, LhsDispatch):<any, any>
+   if LhsDispatch then return Receiver, Other end
+   return Other, Receiver
+end
+
 function newVec(X, Y):table
    vec_mt = {
       __add = function(Receiver, Other, LhsDispatch)
@@ -248,8 +253,14 @@ end
 
 cmp_mt = {
    __eq = function(A, B) return A.val is B.val end,
-   __lt = function(A, B) return A.val < B.val end,
-   __le = function(A, B) return A.val <= B.val end
+   __lt = function(Receiver, Other, LhsDispatch)
+      local source_left, source_right = source_binary_operands(Receiver, Other, LhsDispatch)
+      return source_left.val < source_right.val
+   end,
+   __le = function(Receiver, Other, LhsDispatch)
+      local source_left, source_right = source_binary_operands(Receiver, Other, LhsDispatch)
+      return source_left.val <= source_right.val
+   end
 }
 
 function newComparable(Val)
@@ -293,6 +304,65 @@ end
    assert(a >= b, ">= should work via __le")
    c = newComparable(5)
    assert(a >= c, ">= with equal values should work via __le")
+end
+
+@Test function ProviderAmbiguousBinaryMetamethodsUseReceiverFirstDispatch()
+   local function concat_probe(Receiver:table!, Other, LhsDispatch:bool):str
+      local source_left, source_right = source_binary_operands(Receiver, Other, LhsDispatch)
+      return f'{Receiver.name}:{LhsDispatch}:{source_left.name ?? source_left}{source_right.name ?? source_right}'
+   end
+
+   local concat_mt = { __concat = concat_probe }
+   local concat_left = setmetatable({ name = 'concat left' }, concat_mt)
+   local concat_right = setmetatable({ name = 'concat right' }, concat_mt)
+   assert(concat_left .. concat_right is 'concat left:true:concat leftconcat right',
+      '__concat should pass the left provider first')
+   assert({ name = 'concat source left' } .. concat_right is 'concat right:false:concat source leftconcat right',
+      '__concat should pass a right provider first')
+   assert(concat_left .. concat_right .. '!' is 'concat left:true:concat leftconcat right:true:concat right!',
+      'chained __concat should preserve the continuation result')
+
+   local concatenated:any = { name = 'concat source left' }
+   concatenated ..= concat_right
+   assert(concatenated is 'concat right:false:concat source leftconcat right',
+      '..= should use the receiver-first __concat convention')
+
+   local observed = ''
+   local function operand_value(Value):num
+      if type(Value) is 'table' then return Value.value end
+      return Value
+   end
+   local function ordering_probe(Receiver:table!, Other, LhsDispatch:bool):bool
+      observed = f'{Receiver.name}:{LhsDispatch}'
+      local source_left, source_right = source_binary_operands(Receiver, Other, LhsDispatch)
+      return operand_value(source_left) < operand_value(source_right)
+   end
+
+   local function ordering_le_probe(Receiver:table!, Other, LhsDispatch:bool):bool
+      observed = f'{Receiver.name}:{LhsDispatch}'
+      local source_left, source_right = source_binary_operands(Receiver, Other, LhsDispatch)
+      return operand_value(source_left) <= operand_value(source_right)
+   end
+
+   local ordering_mt = { __lt = ordering_probe, __le = ordering_le_probe }
+   local order_left = setmetatable({ name = 'order left', value = 2 }, ordering_mt)
+   local order_right = setmetatable({ name = 'order right', value = 3 }, ordering_mt)
+   assert(order_left < order_right and observed is 'order left:true',
+      '__lt should retain left-provider priority')
+   assert(2 < order_right and observed is 'order right:false',
+      '__lt should identify a right provider')
+   assert(order_right > 2 and observed is 'order right:false',
+      '> should report the swapped effective pair')
+   assert(order_right >= 3 and observed is 'order right:false',
+      '>= should report the swapped effective pair')
+
+   local fallback_mt = { __lt = ordering_probe }
+   local fallback_left = setmetatable({ name = 'fallback left', value = 1 }, fallback_mt)
+   local fallback_right = setmetatable({ name = 'fallback right', value = 2 }, fallback_mt)
+   assert(fallback_left <= fallback_right and observed is 'fallback right:true',
+      '__le fallback should describe its reversed effective pair')
+   assert(fallback_left <= 2 and observed is 'fallback left:false',
+      '__le fallback should identify a provider on the effective right side')
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -428,14 +498,15 @@ end
 
 @Test function MetaConcat()
    mt = {
-      __concat = function(A, B):table
-         if type(A) is 'table' and type(B) is 'table' then
-            return setmetatable({ val = A.val .. B.val }, getmetatable(A))
+      __concat = function(Receiver, Other, LhsDispatch):table
+         local source_left, source_right = source_binary_operands(Receiver, Other, LhsDispatch)
+         if type(source_left) is 'table' and type(source_right) is 'table' then
+            return setmetatable({ val = source_left.val .. source_right.val }, getmetatable(source_left))
          end
-         if type(A) is 'table' then
-            return setmetatable({ val = A.val .. B }, getmetatable(A))
+         if type(source_left) is 'table' then
+            return setmetatable({ val = source_left.val .. source_right }, getmetatable(source_left))
          end
-         return setmetatable({ val = A .. B.val }, getmetatable(B))
+         return setmetatable({ val = source_left .. source_right.val }, getmetatable(source_right))
       end
    }
    a = setmetatable({ val = 'hello' }, mt)
@@ -446,11 +517,12 @@ end
 
 @Test function MetaConcatWithString()
    mt = {
-      __concat = function(A, B)
-         if type(A) is 'table' then
-            return A.val .. B
+      __concat = function(Receiver, Other, LhsDispatch)
+         local source_left, source_right = source_binary_operands(Receiver, Other, LhsDispatch)
+         if type(source_left) is 'table' then
+            return source_left.val .. source_right
          end
-         return A .. B.val
+         return source_left .. source_right.val
       end
    }
    local obj = setmetatable({ val = 'data' }, mt)

--- a/src/tiri/tests/test_metatables.tiri
+++ b/src/tiri/tests/test_metatables.tiri
@@ -56,26 +56,51 @@ end
 
 -- Helper: create a simple 2D vector type with arithmetic metamethods
 
+function source_arithmetic_operands(Receiver, Other, LhsDispatch):<any, any>
+   if LhsDispatch then return Receiver, Other end
+   return Other, Receiver
+end
+
 function newVec(X, Y):table
    vec_mt = {
-      __add = function(A, B) return newVec(A.x + B.x, A.y + B.y) end,
-      __sub = function(A, B) return newVec(A.x - B.x, A.y - B.y) end,
-      __mul = function(A, B)
-         if type(B) is 'number' then return newVec(A.x * B, A.y * B) end
-         if type(A) is 'number' then return newVec(A * B.x, A * B.y) end
-         return newVec(A.x * B.x, A.y * B.y)
+      __add = function(Receiver, Other, LhsDispatch)
+         local source_left, source_right = source_arithmetic_operands(Receiver, Other, LhsDispatch)
+         return newVec(source_left.x + source_right.x, source_left.y + source_right.y)
       end,
-      __div = function(A, B)
-         if type(B) is 'number' then return newVec(A.x / B, A.y / B) end
-         return newVec(A.x / B.x, A.y / B.y)
+      __sub = function(Receiver, Other, LhsDispatch)
+         local source_left, source_right = source_arithmetic_operands(Receiver, Other, LhsDispatch)
+         return newVec(source_left.x - source_right.x, source_left.y - source_right.y)
       end,
-      __mod = function(A, B)
-         if type(B) is 'number' then return newVec(A.x % B, A.y % B) end
-         return newVec(A.x % B.x, A.y % B.y)
+      __mul = function(Receiver, Other, LhsDispatch)
+         local source_left, source_right = source_arithmetic_operands(Receiver, Other, LhsDispatch)
+         if type(source_right) is 'number' then
+            return newVec(source_left.x * source_right, source_left.y * source_right)
+         end
+         if type(source_left) is 'number' then
+            return newVec(source_left * source_right.x, source_left * source_right.y)
+         end
+         return newVec(source_left.x * source_right.x, source_left.y * source_right.y)
       end,
-      __pow = function(A, B)
-         if type(B) is 'number' then return newVec(A.x ** B, A.y ** B) end
-         return newVec(A.x ** B.x, A.y ** B.y)
+      __div = function(Receiver, Other, LhsDispatch)
+         local source_left, source_right = source_arithmetic_operands(Receiver, Other, LhsDispatch)
+         if type(source_right) is 'number' then
+            return newVec(source_left.x / source_right, source_left.y / source_right)
+         end
+         return newVec(source_left.x / source_right.x, source_left.y / source_right.y)
+      end,
+      __mod = function(Receiver, Other, LhsDispatch)
+         local source_left, source_right = source_arithmetic_operands(Receiver, Other, LhsDispatch)
+         if type(source_right) is 'number' then
+            return newVec(source_left.x % source_right, source_left.y % source_right)
+         end
+         return newVec(source_left.x % source_right.x, source_left.y % source_right.y)
+      end,
+      __pow = function(Receiver, Other, LhsDispatch)
+         local source_left, source_right = source_arithmetic_operands(Receiver, Other, LhsDispatch)
+         if type(source_right) is 'number' then
+            return newVec(source_left.x ** source_right, source_left.y ** source_right)
+         end
+         return newVec(source_left.x ** source_right.x, source_left.y ** source_right.y)
       end,
       __unm = function(A) return newVec(-A.x, -A.y) end
    }
@@ -137,11 +162,66 @@ end
    assert(v2.y is 9, "__pow: y should be 9, got " .. v2.y)
 end
 
+@Test function ArithmeticMetamethodsUseReceiverFirstDispatch()
+   local function probe(Receiver:table!, Other, LhsDispatch:bool):str
+      return f'{Receiver.name}:{Other.name ?? Other}:{LhsDispatch}'
+   end
+
+   local arithmetic_mt = {
+      __add = probe, __sub = probe, __mul = probe, __div = probe, __mod = probe, __pow = probe
+   }
+   local left = setmetatable({ name = 'left' }, arithmetic_mt)
+   local right = setmetatable({ name = 'right' }, arithmetic_mt)
+
+   assert(left + right is 'left:right:true', '__add should retain the left provider')
+   assert(left - right is 'left:right:true', '__sub should retain the left provider')
+   assert(left * right is 'left:right:true', '__mul should retain the left provider')
+   assert(left / right is 'left:right:true', '__div should retain the left provider')
+   assert(left % right is 'left:right:true', '__mod should retain the left provider')
+   assert(left ** right is 'left:right:true', '__pow should retain the left provider')
+
+   local rhs = setmetatable({ name = 'right' }, arithmetic_mt)
+   assert({ name = 'left' } + rhs is 'right:left:false', '__add should reverse arguments for a right provider')
+   assert({ name = 'left' } - rhs is 'right:left:false', '__sub should reverse arguments for a right provider')
+   assert({ name = 'left' } * rhs is 'right:left:false', '__mul should reverse arguments for a right provider')
+   assert({ name = 'left' } / rhs is 'right:left:false', '__div should reverse arguments for a right provider')
+   assert({ name = 'left' } % rhs is 'right:left:false', '__mod should reverse arguments for a right provider')
+   assert({ name = 'left' } ** rhs is 'right:left:false', '__pow should reverse arguments for a right provider')
+
+   local left_priority = setmetatable({ name = 'left priority' }, { __add = probe })
+   local right_priority = setmetatable({ name = 'right priority' }, {
+      __add = function(Receiver:table!, Other, LhsDispatch:bool):str return Receiver.name end
+   })
+   assert(left_priority + right_priority is 'left priority:right priority:true',
+      'the left handler should win when the operands have different metatables')
+
+   local variadic_rhs = setmetatable({ name = 'variadic right' }, {
+      __add = function(Receiver:table!, ...):str
+         local other, lhs_dispatch = ...
+         return f'{Receiver.name}:{other.name}:{lhs_dispatch}'
+      end
+   })
+   assert({ name = 'variadic left' } + variadic_rhs is 'variadic right:variadic left:false',
+      'a variadic arithmetic handler should receive Other and LhsDispatch after its receiver')
+
+   local result:any = { name = 'left' }
+   result += rhs
+   assert(result is 'right:left:false', 'compound arithmetic should use the corresponding receiver-first operation')
+end
+
 @Test function MetaUnm()
    v = newVec(5, -3)
    v2 = -v
    assert(v2.x is -5, "__unm: x should be -5, got " .. v2.x)
    assert(v2.y is 3, "__unm: y should be 3, got " .. v2.y)
+
+   local operand = setmetatable({}, {
+      __unm = function(...):table return {...} end
+   })
+   local arguments = -operand
+   assert(#arguments is 2, '__unm should retain its two-argument compatibility ABI')
+   assert(arguments[0] is operand and arguments[1] is operand,
+      '__unm should receive the operand in both compatibility argument slots')
 end
 
 @Test function ArithmeticChaining()
@@ -707,7 +787,10 @@ function newWrapped(Val)
    return setmetatable({ val = Val }, wrapped_mt)
 end
 
-wrapped_mt.__add      = function(A, B):table return newWrapped(A.val + B.val) end
+wrapped_mt.__add      = function(Receiver, Other, LhsDispatch:bool):table
+   local source_left, source_right = source_arithmetic_operands(Receiver, Other, LhsDispatch)
+   return newWrapped(source_left.val + source_right.val)
+end
 wrapped_mt.__tostring = function(Self):str return 'Wrapped(' .. Self.val .. ')' end
 wrapped_mt.__eq       = function(A, B):bool return A.val is B.val end
 wrapped_mt.__len      = function(Self):num return Self.val end

--- a/src/tiri/tests/test_metatables.tiri
+++ b/src/tiri/tests/test_metatables.tiri
@@ -69,43 +69,43 @@ end
 function newVec(X, Y):table
    vec_mt = {
       __add = metamethod(Other, LHS)
-         local source_left, source_right = source_arithmetic_operands(&&, Other, LHS)
-         return newVec(source_left.x + source_right.x, source_left.y + source_right.y)
+         local sl, sr = source_arithmetic_operands(&&, Other, LHS)
+         return newVec(sl.x + sr.x, sl.y + sr.y)
       end,
       __sub = metamethod(Other, LHS)
-         local source_left, source_right = source_arithmetic_operands(&&, Other, LHS)
-         return newVec(source_left.x - source_right.x, source_left.y - source_right.y)
+         local sl, sr = source_arithmetic_operands(&&, Other, LHS)
+         return newVec(sl.x - sr.x, sl.y - sr.y)
       end,
       __mul = metamethod(Other, LHS)
-         local source_left, source_right = source_arithmetic_operands(&&, Other, LHS)
-         if type(source_right) is 'number' then
-            return newVec(source_left.x * source_right, source_left.y * source_right)
+         local sl, sr = source_arithmetic_operands(&&, Other, LHS)
+         if type(sr) is 'number' then
+            return newVec(sl.x * sr, sl.y * sr)
          end
-         if type(source_left) is 'number' then
-            return newVec(source_left * source_right.x, source_left * source_right.y)
+         if type(sl) is 'number' then
+            return newVec(sl * sr.x, sl * sr.y)
          end
-         return newVec(source_left.x * source_right.x, source_left.y * source_right.y)
+         return newVec(sl.x * sr.x, sl.y * sr.y)
       end,
       __div = metamethod(Other, LHS)
-         local source_left, source_right = source_arithmetic_operands(&&, Other, LHS)
-         if type(source_right) is 'number' then
-            return newVec(source_left.x / source_right, source_left.y / source_right)
+         local sl, sr = source_arithmetic_operands(&&, Other, LHS)
+         if type(sr) is 'number' then
+            return newVec(sl.x / sr, sl.y / sr)
          end
-         return newVec(source_left.x / source_right.x, source_left.y / source_right.y)
+         return newVec(sl.x / sr.x, sl.y / sr.y)
       end,
       __mod = metamethod(Other, LHS)
-         local source_left, source_right = source_arithmetic_operands(&&, Other, LHS)
-         if type(source_right) is 'number' then
-            return newVec(source_left.x % source_right, source_left.y % source_right)
+         local sl, sr = source_arithmetic_operands(&&, Other, LHS)
+         if type(sr) is 'number' then
+            return newVec(sl.x % sr, sl.y % sr)
          end
-         return newVec(source_left.x % source_right.x, source_left.y % source_right.y)
+         return newVec(sl.x % sr.x, sl.y % sr.y)
       end,
       __pow = metamethod(Other, LHS)
-         local source_left, source_right = source_arithmetic_operands(&&, Other, LHS)
-         if type(source_right) is 'number' then
-            return newVec(source_left.x ** source_right, source_left.y ** source_right)
+         local sl, sr = source_arithmetic_operands(&&, Other, LHS)
+         if type(sr) is 'number' then
+            return newVec(sl.x ** sr, sl.y ** sr)
          end
-         return newVec(source_left.x ** source_right.x, source_left.y ** source_right.y)
+         return newVec(sl.x ** sr.x, sl.y ** sr.y)
       end,
       __unm = metamethod() return newVec(-&x, -&y) end
    }
@@ -254,12 +254,12 @@ end
 cmp_mt = {
    __eq = metamethod(Other) return &val is Other.val end,
    __lt = metamethod(Other, LHS)
-      local source_left, source_right = source_binary_operands(&&, Other, LHS)
-      return source_left.val < source_right.val
+      local sl, sr = source_binary_operands(&&, Other, LHS)
+      return sl.val < sr.val
    end,
    __le = metamethod(Other, LHS)
-      local source_left, source_right = source_binary_operands(&&, Other, LHS)
-      return source_left.val <= source_right.val
+      local sl, sr = source_binary_operands(&&, Other, LHS)
+      return sl.val <= sr.val
    end
 }
 
@@ -308,8 +308,8 @@ end
 
 @Test function ProviderAmbiguousBinaryMetamethodsUseReceiverFirstDispatch()
    local concat_probe = metamethod(Other, LHS:bool):str
-      local source_left, source_right = source_binary_operands(&&, Other, LHS)
-      return f'{&name}:{LHS}:{source_left.name ?? source_left}{source_right.name ?? source_right}'
+      local sl, sr = source_binary_operands(&&, Other, LHS)
+      return f'{&name}:{LHS}:{sl.name ?? sl}{sr.name ?? sr}'
    end
 
    local concat_mt = { __concat = concat_probe }
@@ -334,14 +334,14 @@ end
    end
    local ordering_probe = metamethod(Other, LHS:bool):bool
       observed = f'{&name}:{LHS}'
-      local source_left, source_right = source_binary_operands(&&, Other, LHS)
-      return operand_value(source_left) < operand_value(source_right)
+      local sl, sr = source_binary_operands(&&, Other, LHS)
+      return operand_value(sl) < operand_value(sr)
    end
 
    local ordering_le_probe = metamethod(Other, LHS:bool):bool
       observed = f'{&name}:{LHS}'
-      local source_left, source_right = source_binary_operands(&&, Other, LHS)
-      return operand_value(source_left) <= operand_value(source_right)
+      local sl, sr = source_binary_operands(&&, Other, LHS)
+      return operand_value(sl) <= operand_value(sr)
    end
 
    local ordering_mt = { __lt = ordering_probe, __le = ordering_le_probe }
@@ -499,14 +499,14 @@ end
 @Test function MetaConcat()
    mt = {
       __concat = metamethod(Other, LHS):table
-         local source_left, source_right = source_binary_operands(&&, Other, LHS)
-         if type(source_left) is 'table' and type(source_right) is 'table' then
-            return setmetatable({ val = source_left.val .. source_right.val }, getmetatable(source_left))
+         local sl, sr = source_binary_operands(&&, Other, LHS)
+         if type(sl) is 'table' and type(sr) is 'table' then
+            return setmetatable({ val = sl.val .. sr.val }, getmetatable(sl))
          end
-         if type(source_left) is 'table' then
-            return setmetatable({ val = source_left.val .. source_right }, getmetatable(source_left))
+         if type(sl) is 'table' then
+            return setmetatable({ val = sl.val .. sr }, getmetatable(sl))
          end
-         return setmetatable({ val = source_left .. source_right.val }, getmetatable(source_right))
+         return setmetatable({ val = sl .. sr.val }, getmetatable(sr))
       end
    }
    a = setmetatable({ val = 'hello' }, mt)
@@ -518,11 +518,11 @@ end
 @Test function MetaConcatWithString()
    mt = {
       __concat = metamethod(Other, LHS)
-         local source_left, source_right = source_binary_operands(&&, Other, LHS)
-         if type(source_left) is 'table' then
-            return source_left.val .. source_right
+         local sl, sr = source_binary_operands(&&, Other, LHS)
+         if type(sl) is 'table' then
+            return sl.val .. sr
          end
-         return source_left .. source_right.val
+         return sl .. sr.val
       end
    }
    local obj = setmetatable({ val = 'data' }, mt)
@@ -860,8 +860,8 @@ function newWrapped(Val)
 end
 
 wrapped_mt.__add      = metamethod(Other, LHS:bool):table
-   local source_left, source_right = source_arithmetic_operands(&&, Other, LHS)
-   return newWrapped(source_left.val + source_right.val)
+   local sl, sr = source_arithmetic_operands(&&, Other, LHS)
+   return newWrapped(sl.val + sr.val)
 end
 wrapped_mt.__tostring = metamethod():str return 'Wrapped(' .. &val .. ')' end
 wrapped_mt.__eq       = metamethod(Other):bool return &val is Other.val end

--- a/src/tiri/tests/test_metatables.tiri
+++ b/src/tiri/tests/test_metatables.tiri
@@ -68,16 +68,16 @@ end
 
 function newVec(X, Y):table
    vec_mt = {
-      __add = function(Receiver, Other, LhsDispatch)
-         local source_left, source_right = source_arithmetic_operands(Receiver, Other, LhsDispatch)
+      __add = metamethod(Other, LhsDispatch)
+         local source_left, source_right = source_arithmetic_operands(&&, Other, LhsDispatch)
          return newVec(source_left.x + source_right.x, source_left.y + source_right.y)
       end,
-      __sub = function(Receiver, Other, LhsDispatch)
-         local source_left, source_right = source_arithmetic_operands(Receiver, Other, LhsDispatch)
+      __sub = metamethod(Other, LhsDispatch)
+         local source_left, source_right = source_arithmetic_operands(&&, Other, LhsDispatch)
          return newVec(source_left.x - source_right.x, source_left.y - source_right.y)
       end,
-      __mul = function(Receiver, Other, LhsDispatch)
-         local source_left, source_right = source_arithmetic_operands(Receiver, Other, LhsDispatch)
+      __mul = metamethod(Other, LhsDispatch)
+         local source_left, source_right = source_arithmetic_operands(&&, Other, LhsDispatch)
          if type(source_right) is 'number' then
             return newVec(source_left.x * source_right, source_left.y * source_right)
          end
@@ -86,28 +86,28 @@ function newVec(X, Y):table
          end
          return newVec(source_left.x * source_right.x, source_left.y * source_right.y)
       end,
-      __div = function(Receiver, Other, LhsDispatch)
-         local source_left, source_right = source_arithmetic_operands(Receiver, Other, LhsDispatch)
+      __div = metamethod(Other, LhsDispatch)
+         local source_left, source_right = source_arithmetic_operands(&&, Other, LhsDispatch)
          if type(source_right) is 'number' then
             return newVec(source_left.x / source_right, source_left.y / source_right)
          end
          return newVec(source_left.x / source_right.x, source_left.y / source_right.y)
       end,
-      __mod = function(Receiver, Other, LhsDispatch)
-         local source_left, source_right = source_arithmetic_operands(Receiver, Other, LhsDispatch)
+      __mod = metamethod(Other, LhsDispatch)
+         local source_left, source_right = source_arithmetic_operands(&&, Other, LhsDispatch)
          if type(source_right) is 'number' then
             return newVec(source_left.x % source_right, source_left.y % source_right)
          end
          return newVec(source_left.x % source_right.x, source_left.y % source_right.y)
       end,
-      __pow = function(Receiver, Other, LhsDispatch)
-         local source_left, source_right = source_arithmetic_operands(Receiver, Other, LhsDispatch)
+      __pow = metamethod(Other, LhsDispatch)
+         local source_left, source_right = source_arithmetic_operands(&&, Other, LhsDispatch)
          if type(source_right) is 'number' then
             return newVec(source_left.x ** source_right, source_left.y ** source_right)
          end
          return newVec(source_left.x ** source_right.x, source_left.y ** source_right.y)
       end,
-      __unm = function(A) return newVec(-A.x, -A.y) end
+      __unm = metamethod() return newVec(-&x, -&y) end
    }
    return setmetatable({ x = X, y = Y }, vec_mt)
 end
@@ -168,8 +168,8 @@ end
 end
 
 @Test function ArithmeticMetamethodsUseReceiverFirstDispatch()
-   local function probe(Receiver:table!, Other, LhsDispatch:bool):str
-      return f'{Receiver.name}:{Other.name ?? Other}:{LhsDispatch}'
+   local probe = metamethod(Other, LhsDispatch:bool):str
+      return f'{&name}:{Other.name ?? Other}:{LhsDispatch}'
    end
 
    local arithmetic_mt = {
@@ -195,15 +195,15 @@ end
 
    local left_priority = setmetatable({ name = 'left priority' }, { __add = probe })
    local right_priority = setmetatable({ name = 'right priority' }, {
-      __add = function(Receiver:table!, Other, LhsDispatch:bool):str return Receiver.name end
+      __add = metamethod(Other, LhsDispatch:bool):str return &name end
    })
    assert(left_priority + right_priority is 'left priority:right priority:true',
       'the left handler should win when the operands have different metatables')
 
    local variadic_rhs = setmetatable({ name = 'variadic right' }, {
-      __add = function(Receiver:table!, ...):str
+      __add = metamethod(...):str
          local other, lhs_dispatch = ...
-         return f'{Receiver.name}:{other.name}:{lhs_dispatch}'
+         return f'{&name}:{other.name}:{lhs_dispatch}'
       end
    })
    assert({ name = 'variadic left' } + variadic_rhs is 'variadic right:variadic left:false',
@@ -253,12 +253,12 @@ end
 
 cmp_mt = {
    __eq = function(A, B) return A.val is B.val end,
-   __lt = function(Receiver, Other, LhsDispatch)
-      local source_left, source_right = source_binary_operands(Receiver, Other, LhsDispatch)
+   __lt = metamethod(Other, LhsDispatch)
+      local source_left, source_right = source_binary_operands(&&, Other, LhsDispatch)
       return source_left.val < source_right.val
    end,
-   __le = function(Receiver, Other, LhsDispatch)
-      local source_left, source_right = source_binary_operands(Receiver, Other, LhsDispatch)
+   __le = metamethod(Other, LhsDispatch)
+      local source_left, source_right = source_binary_operands(&&, Other, LhsDispatch)
       return source_left.val <= source_right.val
    end
 }
@@ -307,9 +307,9 @@ end
 end
 
 @Test function ProviderAmbiguousBinaryMetamethodsUseReceiverFirstDispatch()
-   local function concat_probe(Receiver:table!, Other, LhsDispatch:bool):str
-      local source_left, source_right = source_binary_operands(Receiver, Other, LhsDispatch)
-      return f'{Receiver.name}:{LhsDispatch}:{source_left.name ?? source_left}{source_right.name ?? source_right}'
+   local concat_probe = metamethod(Other, LhsDispatch:bool):str
+      local source_left, source_right = source_binary_operands(&&, Other, LhsDispatch)
+      return f'{&name}:{LhsDispatch}:{source_left.name ?? source_left}{source_right.name ?? source_right}'
    end
 
    local concat_mt = { __concat = concat_probe }
@@ -332,15 +332,15 @@ end
       if type(Value) is 'table' then return Value.value end
       return Value
    end
-   local function ordering_probe(Receiver:table!, Other, LhsDispatch:bool):bool
-      observed = f'{Receiver.name}:{LhsDispatch}'
-      local source_left, source_right = source_binary_operands(Receiver, Other, LhsDispatch)
+   local ordering_probe = metamethod(Other, LhsDispatch:bool):bool
+      observed = f'{&name}:{LhsDispatch}'
+      local source_left, source_right = source_binary_operands(&&, Other, LhsDispatch)
       return operand_value(source_left) < operand_value(source_right)
    end
 
-   local function ordering_le_probe(Receiver:table!, Other, LhsDispatch:bool):bool
-      observed = f'{Receiver.name}:{LhsDispatch}'
-      local source_left, source_right = source_binary_operands(Receiver, Other, LhsDispatch)
+   local ordering_le_probe = metamethod(Other, LhsDispatch:bool):bool
+      observed = f'{&name}:{LhsDispatch}'
+      local source_left, source_right = source_binary_operands(&&, Other, LhsDispatch)
       return operand_value(source_left) <= operand_value(source_right)
    end
 
@@ -498,8 +498,8 @@ end
 
 @Test function MetaConcat()
    mt = {
-      __concat = function(Receiver, Other, LhsDispatch):table
-         local source_left, source_right = source_binary_operands(Receiver, Other, LhsDispatch)
+      __concat = metamethod(Other, LhsDispatch):table
+         local source_left, source_right = source_binary_operands(&&, Other, LhsDispatch)
          if type(source_left) is 'table' and type(source_right) is 'table' then
             return setmetatable({ val = source_left.val .. source_right.val }, getmetatable(source_left))
          end
@@ -517,8 +517,8 @@ end
 
 @Test function MetaConcatWithString()
    mt = {
-      __concat = function(Receiver, Other, LhsDispatch)
-         local source_left, source_right = source_binary_operands(Receiver, Other, LhsDispatch)
+      __concat = metamethod(Other, LhsDispatch)
+         local source_left, source_right = source_binary_operands(&&, Other, LhsDispatch)
          if type(source_left) is 'table' then
             return source_left.val .. source_right
          end
@@ -859,15 +859,15 @@ function newWrapped(Val)
    return setmetatable({ val = Val }, wrapped_mt)
 end
 
-wrapped_mt.__add      = function(Receiver, Other, LhsDispatch:bool):table
-   local source_left, source_right = source_arithmetic_operands(Receiver, Other, LhsDispatch)
+wrapped_mt.__add      = metamethod(Other, LhsDispatch:bool):table
+   local source_left, source_right = source_arithmetic_operands(&&, Other, LhsDispatch)
    return newWrapped(source_left.val + source_right.val)
 end
-wrapped_mt.__tostring = function(Self):str return 'Wrapped(' .. Self.val .. ')' end
+wrapped_mt.__tostring = metamethod():str return 'Wrapped(' .. &val .. ')' end
 wrapped_mt.__eq       = function(A, B):bool return A.val is B.val end
-wrapped_mt.__len      = function(Self):num return Self.val end
-wrapped_mt.__call     = function(Self):num return Self.val end
-wrapped_mt.__unm      = function(Self):table return newWrapped(-Self.val) end
+wrapped_mt.__len      = metamethod():num return &val end
+wrapped_mt.__call     = metamethod():num return &val end
+wrapped_mt.__unm      = metamethod():table return newWrapped(-&val) end
 
 @Test function CombinedMetamethods()
 

--- a/src/tiri/tests/test_metatables.tiri
+++ b/src/tiri/tests/test_metatables.tiri
@@ -23,7 +23,7 @@ end
 
 @Test function RemoveMetatable()
    t = {}
-   mt = { __index = function() return 'value' end }
+   mt = { __index = metamethod() return 'value' end }
    setmetatable(t, mt)
    assert(getmetatable(t) is mt, "Should have metatable before removal")
 
@@ -32,7 +32,7 @@ end
 end
 
 @Test function SharedMetatable()
-   mt = { __index = function(Self, Key) return Key .. '_default' end }
+   mt = { __index = metamethod(Key) return Key .. '_default' end }
    a = setmetatable({}, mt)
    b = setmetatable({}, mt)
    assert(getmetatable(a) is getmetatable(b), "Both tables should share the same metatable")
@@ -42,8 +42,8 @@ end
 
 @Test function ReplaceMetatable()
    t = {}
-   mt1 = { __index = function() return 'first' end }
-   mt2 = { __index = function() return 'second' end }
+   mt1 = { __index = metamethod() return 'first' end }
+   mt2 = { __index = metamethod() return 'second' end }
    setmetatable(t, mt1)
    assert(t.x is 'first', "Should use first metatable")
    setmetatable(t, mt2)
@@ -56,28 +56,28 @@ end
 
 -- Helper: create a simple 2D vector type with arithmetic metamethods
 
-function source_arithmetic_operands(Receiver, Other, LhsDispatch):<any, any>
-   if LhsDispatch then return Receiver, Other end
+function source_arithmetic_operands(Receiver, Other, LHS):<any, any>
+   if LHS then return Receiver, Other end
    return Other, Receiver
 end
 
-function source_binary_operands(Receiver, Other, LhsDispatch):<any, any>
-   if LhsDispatch then return Receiver, Other end
+function source_binary_operands(Receiver, Other, LHS):<any, any>
+   if LHS then return Receiver, Other end
    return Other, Receiver
 end
 
 function newVec(X, Y):table
    vec_mt = {
-      __add = metamethod(Other, LhsDispatch)
-         local source_left, source_right = source_arithmetic_operands(&&, Other, LhsDispatch)
+      __add = metamethod(Other, LHS)
+         local source_left, source_right = source_arithmetic_operands(&&, Other, LHS)
          return newVec(source_left.x + source_right.x, source_left.y + source_right.y)
       end,
-      __sub = metamethod(Other, LhsDispatch)
-         local source_left, source_right = source_arithmetic_operands(&&, Other, LhsDispatch)
+      __sub = metamethod(Other, LHS)
+         local source_left, source_right = source_arithmetic_operands(&&, Other, LHS)
          return newVec(source_left.x - source_right.x, source_left.y - source_right.y)
       end,
-      __mul = metamethod(Other, LhsDispatch)
-         local source_left, source_right = source_arithmetic_operands(&&, Other, LhsDispatch)
+      __mul = metamethod(Other, LHS)
+         local source_left, source_right = source_arithmetic_operands(&&, Other, LHS)
          if type(source_right) is 'number' then
             return newVec(source_left.x * source_right, source_left.y * source_right)
          end
@@ -86,22 +86,22 @@ function newVec(X, Y):table
          end
          return newVec(source_left.x * source_right.x, source_left.y * source_right.y)
       end,
-      __div = metamethod(Other, LhsDispatch)
-         local source_left, source_right = source_arithmetic_operands(&&, Other, LhsDispatch)
+      __div = metamethod(Other, LHS)
+         local source_left, source_right = source_arithmetic_operands(&&, Other, LHS)
          if type(source_right) is 'number' then
             return newVec(source_left.x / source_right, source_left.y / source_right)
          end
          return newVec(source_left.x / source_right.x, source_left.y / source_right.y)
       end,
-      __mod = metamethod(Other, LhsDispatch)
-         local source_left, source_right = source_arithmetic_operands(&&, Other, LhsDispatch)
+      __mod = metamethod(Other, LHS)
+         local source_left, source_right = source_arithmetic_operands(&&, Other, LHS)
          if type(source_right) is 'number' then
             return newVec(source_left.x % source_right, source_left.y % source_right)
          end
          return newVec(source_left.x % source_right.x, source_left.y % source_right.y)
       end,
-      __pow = metamethod(Other, LhsDispatch)
-         local source_left, source_right = source_arithmetic_operands(&&, Other, LhsDispatch)
+      __pow = metamethod(Other, LHS)
+         local source_left, source_right = source_arithmetic_operands(&&, Other, LHS)
          if type(source_right) is 'number' then
             return newVec(source_left.x ** source_right, source_left.y ** source_right)
          end
@@ -168,8 +168,8 @@ end
 end
 
 @Test function ArithmeticMetamethodsUseReceiverFirstDispatch()
-   local probe = metamethod(Other, LhsDispatch:bool):str
-      return f'{&name}:{Other.name ?? Other}:{LhsDispatch}'
+   local probe = metamethod(Other, LHS:bool):str
+      return f'{&name}:{Other.name ?? Other}:{LHS}'
    end
 
    local arithmetic_mt = {
@@ -195,7 +195,7 @@ end
 
    local left_priority = setmetatable({ name = 'left priority' }, { __add = probe })
    local right_priority = setmetatable({ name = 'right priority' }, {
-      __add = metamethod(Other, LhsDispatch:bool):str return &name end
+      __add = metamethod(Other, LHS:bool):str return &name end
    })
    assert(left_priority + right_priority is 'left priority:right priority:true',
       'the left handler should win when the operands have different metatables')
@@ -207,7 +207,7 @@ end
       end
    })
    assert({ name = 'variadic left' } + variadic_rhs is 'variadic right:variadic left:false',
-      'a variadic arithmetic handler should receive Other and LhsDispatch after its receiver')
+      'a variadic arithmetic handler should receive Other and LHS after its receiver')
 
    local result:any = { name = 'left' }
    result += rhs
@@ -221,12 +221,12 @@ end
    assert(v2.y is 3, "__unm: y should be 3, got " .. v2.y)
 
    local operand = setmetatable({}, {
-      __unm = function(...):table return {...} end
+      __unm = metamethod(...):table return {...} end
    })
    local arguments = -operand
-   assert(#arguments is 2, '__unm should retain its two-argument compatibility ABI')
-   assert(arguments[0] is operand and arguments[1] is operand,
-      '__unm should receive the operand in both compatibility argument slots')
+   assert(#arguments is 1, '__unm should retain its two-argument compatibility ABI')
+   assert(arguments[0] is operand,
+      '__unm should receive the operand in the compatibility argument slot')
 end
 
 @Test function ArithmeticChaining()
@@ -252,13 +252,13 @@ end
 -- Shared metatable so that __eq is invoked (both operands must share the same metatable)
 
 cmp_mt = {
-   __eq = function(A, B) return A.val is B.val end,
-   __lt = metamethod(Other, LhsDispatch)
-      local source_left, source_right = source_binary_operands(&&, Other, LhsDispatch)
+   __eq = metamethod(Other) return &val is Other.val end,
+   __lt = metamethod(Other, LHS)
+      local source_left, source_right = source_binary_operands(&&, Other, LHS)
       return source_left.val < source_right.val
    end,
-   __le = metamethod(Other, LhsDispatch)
-      local source_left, source_right = source_binary_operands(&&, Other, LhsDispatch)
+   __le = metamethod(Other, LHS)
+      local source_left, source_right = source_binary_operands(&&, Other, LHS)
       return source_left.val <= source_right.val
    end
 }
@@ -307,9 +307,9 @@ end
 end
 
 @Test function ProviderAmbiguousBinaryMetamethodsUseReceiverFirstDispatch()
-   local concat_probe = metamethod(Other, LhsDispatch:bool):str
-      local source_left, source_right = source_binary_operands(&&, Other, LhsDispatch)
-      return f'{&name}:{LhsDispatch}:{source_left.name ?? source_left}{source_right.name ?? source_right}'
+   local concat_probe = metamethod(Other, LHS:bool):str
+      local source_left, source_right = source_binary_operands(&&, Other, LHS)
+      return f'{&name}:{LHS}:{source_left.name ?? source_left}{source_right.name ?? source_right}'
    end
 
    local concat_mt = { __concat = concat_probe }
@@ -332,15 +332,15 @@ end
       if type(Value) is 'table' then return Value.value end
       return Value
    end
-   local ordering_probe = metamethod(Other, LhsDispatch:bool):bool
-      observed = f'{&name}:{LhsDispatch}'
-      local source_left, source_right = source_binary_operands(&&, Other, LhsDispatch)
+   local ordering_probe = metamethod(Other, LHS:bool):bool
+      observed = f'{&name}:{LHS}'
+      local source_left, source_right = source_binary_operands(&&, Other, LHS)
       return operand_value(source_left) < operand_value(source_right)
    end
 
-   local ordering_le_probe = metamethod(Other, LhsDispatch:bool):bool
-      observed = f'{&name}:{LhsDispatch}'
-      local source_left, source_right = source_binary_operands(&&, Other, LhsDispatch)
+   local ordering_le_probe = metamethod(Other, LHS:bool):bool
+      observed = f'{&name}:{LHS}'
+      local source_left, source_right = source_binary_operands(&&, Other, LHS)
       return operand_value(source_left) <= operand_value(source_right)
    end
 
@@ -369,33 +369,33 @@ end
 -- String & Length Metamethods
 
 @Test function MetaToString()
-   mt = { __tostring = function(Self) return 'MyObject(' .. Self.val .. ')' end }
+   mt = { __tostring = metamethod() return 'MyObject(' .. &val .. ')' end }
    local obj = setmetatable({ val = 42 }, mt)
    result = tostring(obj)
    assert(result is 'MyObject(42)', "__tostring should return custom string, got '" .. result .. "'")
 end
 
 @Test function MetaToStringInConcat()
-   mt = { __tostring = function(Self) return 'item' end }
+   mt = { __tostring = metamethod() return 'item' end }
    local obj = setmetatable({}, mt)
    result = 'The ' .. tostring(obj) .. ' is here'
    assert(result is 'The item is here', "__tostring used in concatenation, got '" .. result .. "'")
 end
 
 @Test function MetaLen()
-   mt = { __len = function(Self):num return Self.custom_size end }
+   mt = { __len = metamethod():num return &custom_size end }
    local obj = setmetatable({ custom_size = 42 }, mt)
    assert(#obj is 42, "__len should return custom length, got " .. #obj)
 end
 
 @Test function MetaLenZero()
-   mt = { __len = function(Self) return 0 end }
+   mt = { __len = metamethod() return 0 end }
    local obj = setmetatable({ 'a', 'b', 'c' }, mt)
    assert(#obj is 0, "__len returning 0 should override actual length")
 end
 
 @Test function MetaLenRejectsNonNumericResults()
-   local string_length = setmetatable({}, { __len = function(Self):any return 'invalid' end })
+   local string_length = setmetatable({}, { __len = metamethod():any return 'invalid' end })
    try
       local result = #string_length
    except err
@@ -405,7 +405,7 @@ end
       error('A string __len result should fail')
    end
 
-   local nil_length = setmetatable({}, { __len = function(Self):num return nil end })
+   local nil_length = setmetatable({}, { __len = metamethod():num return nil end })
    try
       local result = #nil_length
    except err
@@ -418,7 +418,7 @@ end
 
 @Test function MetaLenOverridesStringKeyClassification()
    -- A table addressed with a string key normally has no length, but __len takes precedence.
-   local obj = setmetatable({ 1, 2 }, { __len = function(Self):num return 7 end })
+   local obj = setmetatable({ 1, 2 }, { __len = metamethod():num return 7 end })
    obj.name = 'x'
    assert(#obj is 7, "__len should override the string-key classification, got " .. tostring(#obj))
 
@@ -433,7 +433,7 @@ end
 
 @Test function MetaLenAbsentLeavesPureTableNumerical()
    -- A metatable without __len must not disturb the ordinary numerical length.
-   local obj = setmetatable({ 1, 2, 3 }, { __index = function(Self, Key) return nil end })
+   local obj = setmetatable({ 1, 2, 3 }, { __index = metamethod(Key) return nil end })
    assert(#obj is 3, "A pure table with an unrelated metatable should keep its length, got " .. tostring(#obj))
 end
 
@@ -449,7 +449,7 @@ end
    -- A __newindex that diverts the store classifies the table that actually receives it, not the proxy.
    local backing = { 1, 2, 3 }
    local proxy = setmetatable({ 1, 2, 3 }, {
-      __newindex = function(Self, Key, Value) rawset(backing, Key, Value) end
+      __newindex = metamethod(Key, Value) rawset(backing, Key, Value) end
    })
    proxy.name = 'x'
    assert(#proxy is 3, "The proxy should not be classified by a diverted store, got " .. tostring(#proxy))
@@ -460,7 +460,7 @@ end
    -- The same diversion rule applies to any non-numeric key, not just strings.
    local backing = { 1, 2, 3 }
    local proxy = setmetatable({ 1, 2, 3 }, {
-      __newindex = function(Self, Key, Value) rawset(backing, Key, Value) end
+      __newindex = metamethod(Key, Value) rawset(backing, Key, Value) end
    })
    proxy[true] = 'x'
    assert(#proxy is 3, "The proxy should not be classified by a diverted store, got " .. tostring(#proxy))
@@ -469,7 +469,7 @@ end
 
 @Test function MetaLenOverridesNonNumericKeyClassification()
    -- __len takes precedence over the classification regardless of which key type caused it.
-   local obj = setmetatable({ 1, 2 }, { __len = function(Self):num return 7 end })
+   local obj = setmetatable({ 1, 2 }, { __len = metamethod():num return 7 end })
    obj[true] = 'x'
    assert(#obj is 7, "__len should override a boolean-key classification, got " .. tostring(#obj))
 
@@ -498,8 +498,8 @@ end
 
 @Test function MetaConcat()
    mt = {
-      __concat = metamethod(Other, LhsDispatch):table
-         local source_left, source_right = source_binary_operands(&&, Other, LhsDispatch)
+      __concat = metamethod(Other, LHS):table
+         local source_left, source_right = source_binary_operands(&&, Other, LHS)
          if type(source_left) is 'table' and type(source_right) is 'table' then
             return setmetatable({ val = source_left.val .. source_right.val }, getmetatable(source_left))
          end
@@ -517,8 +517,8 @@ end
 
 @Test function MetaConcatWithString()
    mt = {
-      __concat = metamethod(Other, LhsDispatch)
-         local source_left, source_right = source_binary_operands(&&, Other, LhsDispatch)
+      __concat = metamethod(Other, LHS)
+         local source_left, source_right = source_binary_operands(&&, Other, LHS)
          if type(source_left) is 'table' then
             return source_left.val .. source_right
          end
@@ -537,7 +537,7 @@ end
 -- Indexing: __index and __newindex
 
 @Test function MetaIndexFunction()
-   mt = { __index = function(Self, Key) return Key .. '_default' end }
+   mt = { __index = metamethod(Key) return Key .. '_default' end }
    t = setmetatable({}, mt)
    assert(t.foo is 'foo_default', "__index function should provide default, got '" .. tostring(t.foo) .. "'")
    assert(t.bar is 'bar_default', "__index function should work for any key")
@@ -575,9 +575,9 @@ end
 @Test function MetaNewIndex()
    log = {}
    mt = {
-      __newindex = function(Self, Key, Value)
+      __newindex = metamethod(Key, Value)
          log.insert(Key .. '=' .. tostring(Value))
-         rawset(Self, Key, Value)
+         rawset(&&, Key, Value)
       end
    }
    t = setmetatable({}, mt)
@@ -593,7 +593,7 @@ end
 
 @Test function MetaNewIndexReadOnly()
    mt = {
-      __newindex = function(Self, Key, Value)
+      __newindex = metamethod(Key, Value)
          error("Cannot modify read-only table: key '" .. Key .. "'")
       end
    }
@@ -612,9 +612,9 @@ end
    -- __newindex is only called for NEW keys; existing keys bypass it
    call_count = 0
    mt = {
-      __newindex = function(Self, Key, Value)
+      __newindex = metamethod(Key, Value)
          call_count++
-         rawset(Self, Key, Value)
+         rawset(&&, Key, Value)
       end
    }
    t = setmetatable({}, mt)
@@ -630,10 +630,10 @@ end
    -- Classic proxy pattern: separate storage from the proxy object
    storage = {}
    mt = {
-      __index = function(Self, Key):any
+      __index = metamethod(Key):any
          return storage[Key]
       end,
-      __newindex = function(Self, Key, Value)
+      __newindex = metamethod(Key, Value)
          storage[Key] = Value
       end
    }
@@ -652,21 +652,21 @@ end
 -- Callable Tables (__call)
 
 @Test function MetaCallBasic()
-   mt = { __call = function(Self) return 'called' end }
+   mt = { __call = metamethod() return 'called' end }
    t = setmetatable({}, mt)
    result = t()
    assert(result is 'called', "__call basic should return 'called', got '" .. tostring(result) .. "'")
 end
 
 @Test function MetaCallWithArgs()
-   mt = { __call = function(Self, A, B) return A + B end }
+   mt = { __call = metamethod(A, B) return A + B end }
    t = setmetatable({}, mt)
    result = t(3, 4)
    assert(result is 7, "__call with args should return 7, got " .. result)
 end
 
 @Test function MetaCallMultipleReturns()
-   mt = { __call = function(Self, X):<num, num, num> return X, X * 2, X * 3 end }
+   mt = { __call = metamethod(X):<num, num, num> return X, X * 2, X * 3 end }
    t = setmetatable({}, mt)
    a, b, c = t(5)
    assert(a is 5, "__call first return should be 5, got " .. a)
@@ -676,8 +676,8 @@ end
 
 @Test function MetaCallSelfAccess()
    mt = {
-      __call = function(Self, Key):any
-         return Self.data[Key]
+      __call = metamethod(Key):any
+         return &data[Key]
       end
    }
    t = setmetatable({ data = { a = 1, b = 2, c = 3 } }, mt)
@@ -689,7 +689,7 @@ end
 @Test function MetaCallAsFactory()
    -- Callable table acting as a constructor/factory
    Point = setmetatable({}, {
-      __call = function(Self, X, Y)
+      __call = metamethod(X, Y)
          return { x = X, y = Y }
       end
    })
@@ -705,7 +705,7 @@ end
 @Test function MetaProtectedGetmetatable()
    mt = {
       __metatable = 'protected',
-      __index = function() return 'value' end
+      __index = metamethod() return 'value' end
    }
    t = setmetatable({}, mt)
    result = getmetatable(t)
@@ -729,7 +729,7 @@ end
 -- Rawget and Rawset
 
 @Test function RawgetBypassesIndex()
-   mt = { __index = function() return 'metamethod' end }
+   mt = { __index = metamethod() return 'metamethod' end }
    t = setmetatable({ real = 'actual' }, mt)
    assert(t.missing is 'metamethod', "Normal access should use __index")
    assert(rawget(t, 'missing') is nil, "rawget should bypass __index")
@@ -739,9 +739,9 @@ end
 @Test function RawsetBypassesNewindex()
    call_count = 0
    mt = {
-      __newindex = function(Self, Key, Value)
+      __newindex = metamethod(Key, Value)
          call_count++
-         rawset(Self, Key, Value)
+         rawset(&&, Key, Value)
       end
    }
    t = setmetatable({}, mt)
@@ -776,11 +776,11 @@ end
    function createCounting()
       state = { reads = 0, writes = 0, data = {} }
       mt = {
-         __index = function(Self, Key):any
+         __index = metamethod(Key):any
             state.reads++
             return state.data[Key]
          end,
-         __newindex = function(Self, Key, Value):any
+         __newindex = metamethod(Key, Value):any
             state.writes++
             state.data[Key] = Value
          end
@@ -859,12 +859,12 @@ function newWrapped(Val)
    return setmetatable({ val = Val }, wrapped_mt)
 end
 
-wrapped_mt.__add      = metamethod(Other, LhsDispatch:bool):table
-   local source_left, source_right = source_arithmetic_operands(&&, Other, LhsDispatch)
+wrapped_mt.__add      = metamethod(Other, LHS:bool):table
+   local source_left, source_right = source_arithmetic_operands(&&, Other, LHS)
    return newWrapped(source_left.val + source_right.val)
 end
 wrapped_mt.__tostring = metamethod():str return 'Wrapped(' .. &val .. ')' end
-wrapped_mt.__eq       = function(A, B):bool return A.val is B.val end
+wrapped_mt.__eq       = metamethod(Other):bool return &val is Other.val end
 wrapped_mt.__len      = metamethod():num return &val end
 wrapped_mt.__call     = metamethod():num return &val end
 wrapped_mt.__unm      = metamethod():table return newWrapped(-&val) end

--- a/src/tiri/tests/test_method_functions.tiri
+++ b/src/tiri/tests/test_method_functions.tiri
@@ -79,23 +79,16 @@ end
    assert(#indexed is 13, 'A context-first __len should enter its operand')
 
    local arithmetic_mt = {
-      __add = metamethod(Other:table!):num
-         return &value + Other.value
+      __sub = metamethod(Other, LhsDispatch:bool):num
+         if LhsDispatch then return &value - Other.value end
+         return Other - &value
       end
    }
    local left = setmetatable({ value = 3 }, arithmetic_mt)
    local right = setmetatable({ value = 4 }, arithmetic_mt)
-   assert(left + right is 7, 'A left-provider context-first arithmetic handler should enter the left operand')
-
-   local failed = false
-   try
-      local result = 1 + left
-   except e
-      failed = true
-      assert(e.message.find('right operand') != nil,
-         'A right-provider context-first arithmetic handler should report its ambiguity')
-   end
-   assert(failed, 'A right-provider context-first arithmetic handler must not enter the left operand')
+   assert(left - right is -1, 'A left-provider context-first arithmetic handler should enter the left operand')
+   assert(1 - left is -2,
+      'A right-provider context-first arithmetic handler should enter the provider and receive a false dispatch flag')
 end
 
 @Test function ReceiverStableHandlersAndVarargsKeepTheirRuntimeLayout()

--- a/src/tiri/tests/test_method_functions.tiri
+++ b/src/tiri/tests/test_method_functions.tiri
@@ -112,15 +112,17 @@ end
       'Varargs should begin after the hidden context argument')
 end
 
-@Test function BinaryConcatAndComparisonRejectRightProviders()
+@Test function BinaryConcatAndComparisonUseReceiverFirstDispatch()
    local concat_mt = {
-      __concat = metamethod(Other):str
-         return &value .. Other
+      __concat = metamethod(Other, LhsDispatch:bool):str
+         if LhsDispatch then return &value .. Other end
+         return Other .. &value
       end
    }
    local ordered_mt = {
-      __lt = metamethod(Other:table!):bool
-         return &value < Other.value
+      __lt = metamethod(Other, LhsDispatch:bool):bool
+         if LhsDispatch then return &value < Other.value end
+         return Other < &value
       end
    }
    local concat_value = setmetatable({ value = 'left' }, concat_mt)
@@ -130,25 +132,8 @@ end
    assert(concat_value .. '!' is 'left!', 'A left-provider context-first concat handler should enter the left table')
    assert(first < second, 'A left-provider context-first ordering handler should enter the left table')
 
-   local concat_failed = false
-   try
-      local result = '!' .. concat_value
-   except e
-      concat_failed = true
-      assert(e.message.find('right operand') != nil,
-         'A right-provider context-first concat handler should report its ambiguity')
-   end
-   assert(concat_failed, 'A right-provider context-first concat handler must fail')
-
-   local comparison_failed = false
-   try
-      local result = 0 < first
-   except e
-      comparison_failed = true
-      assert(e.message.find('right operand') != nil,
-         'A right-provider context-first ordering handler should report its ambiguity')
-   end
-   assert(comparison_failed, 'A right-provider context-first ordering handler must fail')
+   assert('!' .. concat_value is '!left', 'A right-provider context-first concat handler should enter its provider')
+   assert(0 < first, 'A right-provider context-first ordering handler should enter its provider')
 end
 
 @Test function MetamethodReturnsAndErrorsRestoreTheCallerContext()

--- a/src/tiri/tests/test_numeric_limits.tiri
+++ b/src/tiri/tests/test_numeric_limits.tiri
@@ -460,9 +460,17 @@ end
 
    debug.setMetatable('', {
       __unm = function(Value):num return 400 - tonumber(Value) end,
-      __add = function(Left, Right):num return 100 + tonumber(Left) + tonumber(Right) end,
-      __mod = function(Left, Right):num return 200 + (tonumber(Left) % tonumber(Right)) end,
-      __pow = function(Left, Right):num return 300 + (tonumber(Left) ** tonumber(Right)) end
+      __add = function(Receiver, Other, LhsDispatch:bool):num
+         return 100 + tonumber(Receiver) + tonumber(Other)
+      end,
+      __mod = function(Receiver, Other, LhsDispatch:bool):num
+         if LhsDispatch then return 200 + (tonumber(Receiver) % tonumber(Other)) end
+         return 200 + (tonumber(Other) % tonumber(Receiver))
+      end,
+      __pow = function(Receiver, Other, LhsDispatch:bool):num
+         if LhsDispatch then return 300 + (tonumber(Receiver) ** tonumber(Other)) end
+         return 300 + (tonumber(Other) ** tonumber(Receiver))
+      end
    })
 
    jit.off()

--- a/src/tiri/tests/test_table.tiri
+++ b/src/tiri/tests/test_table.tiri
@@ -403,6 +403,23 @@ end
    assert(t[1] is 9, "t[1] should be 9")
 end
 
+@Test function SortMetamethodPreservesComparisonOrder()
+   local function less_than(Receiver:table!, Other:table!, LhsDispatch:bool):bool
+      if not LhsDispatch then Receiver, Other = Other, Receiver end
+      return Receiver.value < Other.value
+   end
+
+   local comparison_mt = { __lt = less_than }
+   local values = {
+      setmetatable({ value = 2 }, comparison_mt),
+      setmetatable({ value = 1 }, comparison_mt)
+   }
+
+   values.sort()
+   assert(values[0].value is 1, "table.sort() should preserve the source order passed to __lt")
+   assert(values[1].value is 2, "table.sort() should order values through a receiver-first __lt")
+end
+
 -- Tests for table.clear()
 
 @Test function ClearArrayPart()

--- a/src/tiri/tests/test_tempus.tiri
+++ b/src/tiri/tests/test_tempus.tiri
@@ -433,7 +433,8 @@ end
    end)
 end
 
-@Test function DurationAndInstantArithmetic()
+@Test(hotpath=5)
+function DurationAndInstantArithmetic()
    base = tempus.duration { seconds = 1, nanos = 900000000 }
    addition = base + tempus.duration { seconds = 2, nanos = 200000000 }
 

--- a/src/tiri/tests/test_thunks.tiri
+++ b/src/tiri/tests/test_thunks.tiri
@@ -377,6 +377,7 @@ end
 
    result = a .. " " .. b
    assert(result is "Hello World", "Concatenation should produce 'Hello World', got '" .. result .. "'")
+   assert("Start " .. b is "Start World", "A right-provider thunk concat should preserve source order")
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -398,6 +399,8 @@ end
    -- Less than or equal
    assert(a <= b, "5 should be <= 10")
    assert(a <= c, "5 should be <= 5")
+   assert(5 < b, "5 should be < a right-provider thunk")
+   assert(5 <= b, "5 should be <= a right-provider thunk")
 
    -- Equality (thunk vs thunk - both must be thunks for __eq to trigger)
    assert(a is c, "Two thunks returning 5 should be equal") -- Note: This only works if both are thunks

--- a/src/tiri/tests/test_thunks.tiri
+++ b/src/tiri/tests/test_thunks.tiri
@@ -352,6 +352,15 @@ end
    -- Power
    assert(b ** 2 is 9, "3 ** 2 should be 9")
 
+   -- Right-hand thunk providers receive provider-first arguments but must preserve source-order arithmetic
+   assert(10 + b is 13, "10 + 3 should be 13 when the thunk provides the right-hand metamethod")
+   assert(10 - b is 7, "10 - 3 should be 7 when the thunk provides the right-hand metamethod")
+   assert(10 * b is 30, "10 * 3 should be 30 when the thunk provides the right-hand metamethod")
+   assert(10 / b > 3.3 and 10 / b < 3.4,
+      "10 / 3 should be ~3.33 when the thunk provides the right-hand metamethod")
+   assert(10 % b is 1, "10 % 3 should be 1 when the thunk provides the right-hand metamethod")
+   assert(2 ** b is 8, "2 ** 3 should be 8 when the thunk provides the right-hand metamethod")
+
    -- Unary minus
    assert(-a is -10, "-10 should be -10")
 end

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -142,7 +142,7 @@ end
    local captured = 1
    function capture() return captured end
    local pointer = debug.upvalueID(capture, 0)
-   local callable = setmetatable({}, { __call = function(Self):table return Self end })
+   local callable = setmetatable({}, { __call = metamethod():table return && end })
 
    assert(accept_nil(nil) is nil, 'nil should satisfy nil')
    assert(accept_bool(true) is true, 'true should satisfy bool')
@@ -423,7 +423,7 @@ end
    local object = obj.new('time')
    local sequence = {0 to 3}
    local proxy = newproxy(true)
-   local callable = setmetatable({}, { __call = function() return true end })
+   local callable = setmetatable({}, { __call = metamethod():bool return true end })
 
    assert(checked_nil(nil) is nil, 'nil should satisfy a nil result contract')
    assert(checked_bool(true), 'bool should satisfy a bool result contract')
@@ -520,7 +520,7 @@ end
    global glContractClosed:bool = false
    function checked_close():num
       local resource <close> = setmetatable({}, {
-         __close = function(Self, Error)
+         __close = metamethod(Error)
             glContractClosed = true
          end
       })
@@ -646,7 +646,7 @@ end
    local closed = false
    expect_contract_failure(function()
       local resource <close>:num = dynamic_value(setmetatable({}, {
-         __close = function(Self, Error)
+         __close = metamethod(Error)
             closed = true
          end
       }))
@@ -656,7 +656,7 @@ end
    local grouped_closed = false
    function dynamic_close_pair():<any, any>
       return setmetatable({}, {
-         __close = function(Self, Error)
+         __close = metamethod(Error)
             grouped_closed = true
          end
       }), 'wrong'
@@ -788,7 +788,7 @@ end
 
    local value = 1
    local overloaded:any = setmetatable({}, {
-      __add = metamethod(Other, LhsDispatch:bool):str return 'wrong' end
+      __add = metamethod(Other, LHS:bool):str return 'wrong' end
    })
    expect_contract_failure(function() value += overloaded end, 'overloaded compound assignment')
    assert(value is 1, 'A rejected overloaded compound result must preserve the sticky local')
@@ -796,7 +796,7 @@ end
 
 @Test function VariantMutationInvalidatesStaticProof()
    local overloaded:any = setmetatable({}, {
-      __add = metamethod(Other, LhsDispatch:bool):str return 'wrong' end
+      __add = metamethod(Other, LHS:bool):str return 'wrong' end
    })
 
    local compound_source:any = 1

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -788,7 +788,7 @@ end
 
    local value = 1
    local overloaded:any = setmetatable({}, {
-      __add = function(Receiver, Other, LhsDispatch:bool):str return 'wrong' end
+      __add = metamethod(Other, LhsDispatch:bool):str return 'wrong' end
    })
    expect_contract_failure(function() value += overloaded end, 'overloaded compound assignment')
    assert(value is 1, 'A rejected overloaded compound result must preserve the sticky local')
@@ -796,7 +796,7 @@ end
 
 @Test function VariantMutationInvalidatesStaticProof()
    local overloaded:any = setmetatable({}, {
-      __add = function(Receiver, Other, LhsDispatch:bool):str return 'wrong' end
+      __add = metamethod(Other, LhsDispatch:bool):str return 'wrong' end
    })
 
    local compound_source:any = 1

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -788,7 +788,7 @@ end
 
    local value = 1
    local overloaded:any = setmetatable({}, {
-      __add = function(Left, Right):str return 'wrong' end
+      __add = function(Receiver, Other, LhsDispatch:bool):str return 'wrong' end
    })
    expect_contract_failure(function() value += overloaded end, 'overloaded compound assignment')
    assert(value is 1, 'A rejected overloaded compound result must preserve the sticky local')
@@ -796,7 +796,7 @@ end
 
 @Test function VariantMutationInvalidatesStaticProof()
    local overloaded:any = setmetatable({}, {
-      __add = function(Left, Right):str return 'wrong' end
+      __add = function(Receiver, Other, LhsDispatch:bool):str return 'wrong' end
    })
 
    local compound_source:any = 1


### PR DESCRIPTION
* Reworked lj_meta_arith to pass the provider as the receiver and append an LhsDispatch boolean, adding mmcall_arith for the three-argument arithmetic ABI whilst leaving __unm on the two-argument path
* Updated the JIT recorder to preserve the source operand pair and record the receiver/other/lhs_dispatch arguments for arithmetic metamethods
* Added the ->vmeta_binop3 dispatch path across the x64, arm64 and ppc VM cores to call arithmetic metamethods with three arguments
* Resolved thunk arithmetic operands in source order when the right operand provides the metamethod
* Bumped BCDUMP_VERSION to 0x91 and rejected 0x90 chunks
* [Script] Threaded the LhsDispatch argument through the tempus arithmetic metamethods