### PR TITLE
[Tiri] Migrated native callback subscriptions to context-capturing functions

### DIFF
--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -194,7 +194,7 @@ struct code_reader_handle {
 struct actionmonitor {
    GCobject *Object;           // Native GCobject for the subscription.
    const FunctionField *Args;  // The args of the action/method are stored here so that we can build the arg value table later.
-   int     Function;          // Index of function to call back.
+   FUNCTION Function;         // Function and context to call back.
    int     Reference;         // A custom reference to pass to the callback (optional)
    ACTIONID ActionID;          // Action being monitored.
    OBJECTID ObjectID;          // Object being monitored
@@ -236,12 +236,12 @@ struct actionmonitor {
 //********************************************************************************************************************
 
 struct eventsub {
-   int    Function;     // Lua function index
+   std::unique_ptr<FUNCTION> Function; // Stable callback storage used as the native subscription metadata.
    EVENTID EventID;      // Event message ID
    APTR    EventHandle;
 
-   eventsub(int pFunction, EVENTID pEventID, APTR pEventHandle) :
-      Function(pFunction), EventID(pEventID), EventHandle(pEventHandle) { }
+   eventsub(std::unique_ptr<FUNCTION> pFunction, EVENTID pEventID, APTR pEventHandle) :
+      Function(std::move(pFunction)), EventID(pEventID), EventHandle(pEventHandle) { }
 
    ~eventsub() {
       if (EventHandle) UnsubscribeEvent(EventHandle);
@@ -251,14 +251,14 @@ struct eventsub {
    eventsub& operator=(const eventsub &) = delete;
 
    eventsub(eventsub &&move) noexcept :
-      Function(move.Function), EventID(move.EventID), EventHandle(move.EventHandle) {
+      Function(std::move(move.Function)), EventID(move.EventID), EventHandle(move.EventHandle) {
       move.EventHandle = nullptr;
    }
 
    eventsub& operator=(eventsub &&move) noexcept {
       if (this != &move) {
          if (EventHandle) UnsubscribeEvent(EventHandle);
-         Function = move.Function;
+         Function = std::move(move.Function);
          EventID = move.EventID;
          EventHandle = move.EventHandle;
          move.EventHandle = nullptr;
@@ -271,10 +271,10 @@ struct eventsub {
 
 struct datarequest {
    OBJECTID SourceID;
-   int Callback;
+   FUNCTION Callback;
    int64_t TimeCreated;
 
-   datarequest(OBJECTID pSourceID, int pCallback) : SourceID(pSourceID), Callback(pCallback) {
+   datarequest(OBJECTID pSourceID, FUNCTION pCallback) : SourceID(pSourceID), Callback(pCallback) {
       TimeCreated = PreciseTime();
    }
 };
@@ -324,7 +324,7 @@ struct finput {
    APTR   KeyEvent;
    OBJECTID SurfaceID;
    int    InputHandle;
-   int    Callback;
+   FUNCTION Callback;
    int    InputValue;
    JTYPE  Mask;
    int8_t Mode;
@@ -411,6 +411,7 @@ ERR build_args(lua_State *, CSTRING, const struct FunctionField *, int, int8_t *
    CSTRING &);
 void cleanup_argbuffer(lua_State *, const struct FunctionField *, int, int8_t *, bool);
 [[nodiscard]] ERR capture_tiri_function(lua_State *, int, FUNCTION &);
+[[nodiscard]] ERR push_tiri_function(lua_State *, const FUNCTION &, LuaCallbackContextGuard &);
 void release_tiri_function(lua_State *, FUNCTION *);
 void release_consumed_tiri_function(lua_State *, FUNCTION *);
 const char * code_reader(lua_State *, void *, size_t *);

--- a/src/tiri/jit/src/lib/lib_object.cpp
+++ b/src/tiri/jit/src/lib/lib_object.cpp
@@ -883,6 +883,12 @@ static int object_subscribe(lua_State *Lua)
    kt::Log log("obj.subscribe");
    log.trace("Object: %d, Action: %s (ID %d)", def->uid, action, action_id);
 
+   FUNCTION client_function;
+   if (auto error = capture_tiri_function(Lua, function_argument, client_function); error != ERR::Okay) {
+      release_object(def);
+      luaL_argerror(Lua, function_argument, "Function expected.");
+   }
+
    auto callback = C_FUNCTION(notify_action);
    callback.Context = Lua->script;
    if (auto error = SubscribeAction(obj, action_id, &callback); !error) {
@@ -894,8 +900,7 @@ static int object_subscribe(lua_State *Lua)
       }
       else acsub.Reference = 0;
 
-      lua_pushvalue(Lua, function_argument);
-      acsub.Function = luaL_ref(Lua, LUA_REGISTRYINDEX);
+      acsub.Function = client_function;
       acsub.Object   = def;
       acsub.Args     = arglist;
       acsub.ObjectID = def->uid;
@@ -905,6 +910,7 @@ static int object_subscribe(lua_State *Lua)
    }
    else {
       release_object(def);
+      release_tiri_function(Lua, &client_function);
       luaL_error(Lua, error);
    }
    return 0;
@@ -932,7 +938,7 @@ static int object_unsubscribe(lua_State *Lua)
    std::erase_if(Lua->script->ActionList, [&](auto& item) {
       bool should_remove = (item.ObjectID IS def->uid) and ((action_id IS AC::NIL) or (item.ActionID IS action_id));
       if (should_remove) {
-         luaL_unref(Lua, LUA_REGISTRYINDEX, item.Function);
+         release_tiri_function(Lua, &item.Function);
          if (item.Reference) luaL_unref(Lua, LUA_REGISTRYINDEX, item.Reference);
       }
       return should_remove;

--- a/src/tiri/tests/test_contextual_member_calls.tiri
+++ b/src/tiri/tests/test_contextual_member_calls.tiri
@@ -470,7 +470,7 @@ end
    assert(&name is nil, 'Stack and collection lifecycle work should restore the root context')
 end
 
-@Test function DelayedCallbacksAreUnbound()
+@Test function DelayedCallbacksCaptureTheirRegistrationContext()
    &glDelayedContextName = 'root'
    &glDelayedObservedContext = nil
    local receiver = entity { glDelayedContextName = 'receiver' }
@@ -484,13 +484,14 @@ end
 
    receiver.schedule()
    check processing.sleep(1.0)
-   assert(&glDelayedObservedContext is 'root',
-      'A delayed callback should begin unbound in the state root context')
+   assert(receiver.glDelayedObservedContext is 'receiver',
+      'A delayed callback should observe the context active when it was registered')
+   assert(&glDelayedObservedContext is nil, 'A delayed callback should restore the root context after it returns')
    &glDelayedContextName = nil
    &glDelayedObservedContext = nil
 end
 
-@Test function ActionCallbacksAreUnbound()
+@Test function ActionCallbacksCaptureTheirRegistrationContext()
    &glActionContextName = 'root'
    &glActionObservedContext = nil
    local receiver = entity { glActionContextName = 'receiver' }
@@ -521,8 +522,9 @@ end
    end
 
    receiver.wait_for_free()
-   assert(&glActionObservedContext is 'root',
-      'An out-of-band action callback should begin unbound in the state root context')
+   assert(receiver.glActionObservedContext is 'receiver',
+      'An out-of-band action callback should observe the context active when it was registered')
+   assert(&glActionObservedContext is nil, 'An action callback should restore the root context after it returns')
 end
 
 @Test function ContextualTailCallsTransferOwnership()

--- a/src/tiri/tests/test_function_callback_context.tiri
+++ b/src/tiri/tests/test_function_callback_context.tiri
@@ -234,3 +234,20 @@ end
    assert(context.observed is 'jit callback context', 'JIT registration should retain its context')
    assert(&value is nil, 'JIT callback completion should restore the root context')
 end
+
+@Test function AsyncCallbacksCaptureTheirRegistrationContext()
+   local owner = entity { name = 'async callback context', observed = nil }
+   local script = obj.new('tiri', { statement=[[ ]] })
+
+   using owner do
+      async.script(script, function()
+         &observed = &name
+         processing.signal()
+      end)
+   end
+
+   wait_for_callback('async callback capture')
+   assert(owner.observed is 'async callback context',
+      'An async callback should observe the context active when it was registered')
+   assert(&name is nil, 'An async callback should restore the root context after it returns')
+end

--- a/src/tiri/tiri_async.cpp
+++ b/src/tiri/tiri_async.cpp
@@ -30,7 +30,7 @@ additional functionality in the future.
 // Message payload for thread completion callbacks (used by script, action, and method)
 
 struct ThreadMsg {
-   int      Callback; // Client callback reference
+   FUNCTION Callback; // Client callback and captured context
    int      ObjRef;   // Registry reference that pins the GCobject from GC collection
    extTiri *Owner;    // The parent script that owns the registry references
    double   Key;      // Client-provided key value forwarded to the callback
@@ -55,13 +55,12 @@ static void msg_thread_complete(ACTIONID ActionID, OBJECTPTR Object, ERR Error, 
    auto tiri = (extTiri *)Msg->Owner;
    auto lua = tiri->Lua;
 
-   if (Msg->Callback != LUA_NOREF) {
-      LuaContextRootGuard context_guard(lua);
+   if (Msg->Callback.defined()) {
       if ((Object) and (Object->baseClassID() IS CLASSID::SCRIPT)) {
          auto args = std::to_array<ScriptArg>({
             { "Object", Object, FD_OBJECTPTR }
          });
-         Msg->Owner->callback(Msg->Callback, args.data(), int(args.size()), nullptr);
+         Msg->Owner->callback(Msg->Callback.scriptValue(), args.data(), int(args.size()), nullptr);
       }
       else {
          auto args = std::to_array<ScriptArg>({
@@ -70,9 +69,9 @@ static void msg_thread_complete(ACTIONID ActionID, OBJECTPTR Object, ERR Error, 
             { "Error",    int(Error) },
             { "Key",      Msg->Key }
          });
-         Msg->Owner->callback(Msg->Callback, args.data(), int(args.size()), nullptr);
+         Msg->Owner->callback(Msg->Callback.scriptValue(), args.data(), int(args.size()), nullptr);
       }
-      luaL_unref(lua, LUA_REGISTRYINDEX, Msg->Callback); // Drop the procedure reference
+      release_tiri_function(lua, &Msg->Callback);
    }
 
    // Unpin the GCobject from the registry and release the pin on the underlying object.
@@ -122,10 +121,11 @@ static int async_script(lua_State *Lua)
       }
    }
 
-   int client_callback = LUA_NOREF;
+   FUNCTION client_callback;
    if (lua_isfunction(Lua, 2)) {
-      lua_pushvalue(Lua, 2);
-      client_callback = luaL_ref(Lua, LUA_REGISTRYINDEX);
+      if (capture_tiri_function(Lua, 2, client_callback) != ERR::Okay) {
+         luaL_argerror(Lua, 2, "Function expected.");
+      }
    }
 
    // Pin the script in the registry so the GC cannot collect it while the thread is running.
@@ -138,7 +138,7 @@ static int async_script(lua_State *Lua)
    if (AsyncAction(AC::Activate, gc_script->ptr, nullptr, &callback) != ERR::Okay) {
       gc_script->ptr->unpin(true);
       luaL_unref(Lua, LUA_REGISTRYINDEX, obj_ref);
-      luaL_unref(Lua, LUA_REGISTRYINDEX, client_callback);
+      release_tiri_function(Lua, &client_callback);
       delete msg;
       luaL_error(Lua, "Failed to run script in new thread.");
    }
@@ -148,17 +148,14 @@ static int async_script(lua_State *Lua)
 
 //********************************************************************************************************************
 
-static int ref_async_callback(lua_State *Lua, int ArgIndex)
+static FUNCTION capture_async_callback(lua_State *Lua, int ArgIndex)
 {
-   int client_callback = LUA_NOREF;
+   FUNCTION client_callback;
    auto type = lua_type(Lua, ArgIndex);
-   if (type IS LUA_TSTRING) {
-      lua_getglobal(Lua, lua_tostring(Lua, ArgIndex));
-      client_callback = luaL_ref(Lua, LUA_REGISTRYINDEX);
-   }
-   else if (type IS LUA_TFUNCTION) {
-      lua_pushvalue(Lua, ArgIndex);
-      client_callback = luaL_ref(Lua, LUA_REGISTRYINDEX);
+   if ((type IS LUA_TSTRING) or (type IS LUA_TFUNCTION)) {
+      if (capture_tiri_function(Lua, ArgIndex, client_callback) != ERR::Okay) {
+         luaL_argerror(Lua, ArgIndex, "Function reference expected.");
+      }
    }
 
    return client_callback;
@@ -167,7 +164,7 @@ static int ref_async_callback(lua_State *Lua, int ArgIndex)
 static int dispatch_async_object_call(lua_State *Lua, GCobject *GcObj, CSTRING Name, const FunctionField *Args,
    int ArgsSize, AC ActionID, bool HasResults, CSTRING ResultError)
 {
-   int client_callback = ref_async_callback(Lua, 3);
+   FUNCTION client_callback = capture_async_callback(Lua, 3);
 
    // Pin the object and GCobject to prevent destruction while the thread is running.
 
@@ -182,7 +179,7 @@ static int dispatch_async_object_call(lua_State *Lua, GCobject *GcObj, CSTRING N
    auto abort = [&]() {
       GcObj->ptr->unpin(true);
       luaL_unref(Lua, LUA_REGISTRYINDEX, obj_ref);
-      luaL_unref(Lua, LUA_REGISTRYINDEX, client_callback);
+      release_tiri_function(Lua, &client_callback);
       delete msg;
    };
 

--- a/src/tiri/tiri_class.cpp
+++ b/src/tiri/tiri_class.cpp
@@ -247,7 +247,11 @@ void notify_action(OBJECTPTR Object, ACTIONID ActionID, ERR Result, APTR Args)
 
             log.msg(VLF::BRANCH|VLF::DETAIL, "Action notification for object #%d, action %d.  Top: %d", Object->UID, int(ActionID), lua_gettop(Self->Lua));
 
-            lua_rawgeti(Self->Lua, LUA_REGISTRYINDEX, scan.Function); // +1 stack: Get the function reference
+            LuaCallbackContextGuard callback_context(Self->Lua);
+            if (push_tiri_function(Self->Lua, scan.Function, callback_context) != ERR::Okay) {
+               log.warning("Action subscription callback is no longer valid.");
+               return;
+            }
             push_object_id(Self->Lua, Object->UID);  // +1: Pass the object ID
             lua_newtable(Self->Lua);  // +1: Table to store the parameters
 
@@ -273,9 +277,8 @@ void notify_action(OBJECTPTR Object, ACTIONID ActionID, ERR Result, APTR Args)
          if (ActionID IS AC::Free) {
             std::erase_if(Self->ActionList, [&](auto &item) {
                if (item.ObjectID IS Object->UID) {
-                  if (item.Function) {
-                     luaL_unref(Self->Lua, LUA_REGISTRYINDEX, item.Function);
-                     item.Function = 0;
+                  if (item.Function.defined()) {
+                     release_tiri_function(Self->Lua, &item.Function);
                   }
                   if (item.Reference) {
                      luaL_unref(Self->Lua, LUA_REGISTRYINDEX, item.Reference);
@@ -375,7 +378,14 @@ static ERR TIRI_DataFeed(extTiri *Self, struct acDataFeed *Args)
 
             int step = GetResource(RES::LOG_DEPTH); // Required as thrown errors cause the debugger to lose its step position
 
-               lua_rawgeti(Self->Lua, LUA_REGISTRYINDEX, it->Callback); // +1 Reference to callback
+            {
+               LuaCallbackContextGuard callback_context(Self->Lua);
+               if (push_tiri_function(Self->Lua, it->Callback, callback_context) != ERR::Okay) {
+                  SetResource(RES::LOG_DEPTH, step);
+                  release_tiri_function(Self->Lua, &it->Callback);
+                  it = Self->Requests.erase(it);
+                  continue;
+               }
                lua_newtable(Self->Lua); // +1 Item table
 
                if (auto xml = objXML::create::local(fl::Statement(
@@ -412,10 +422,11 @@ static ERR TIRI_DataFeed(extTiri *Self, struct acDataFeed *Args)
                   }
                }
                else lua_pop(Self->Lua, 2);
+            }
 
             SetResource(RES::LOG_DEPTH, step);
 
-            if (it->Callback) luaL_unref(Self->Lua, LUA_REGISTRYINDEX, it->Callback);
+            release_tiri_function(Self->Lua, &it->Callback);
             it = Self->Requests.erase(it);
             continue;
          }

--- a/src/tiri/tiri_functions.cpp
+++ b/src/tiri/tiri_functions.cpp
@@ -90,12 +90,16 @@ static void receive_event(kt::Event *Info, int InfoSize, APTR CallbackMeta)
 {
    auto tiri = (extTiri *)CurrentContext();
    auto lua = tiri->Lua;
-   LuaContextRootGuard context_guard(lua);
+   LuaCallbackContextGuard callback_context(lua);
 
    kt::Log log(__FUNCTION__);
    log.trace("Received event $%.8x%.8x", (int)((Info->EventID>>32) & 0xffffffff), (int)(Info->EventID & 0xffffffff));
 
-   lua_rawgeti(lua, LUA_REGISTRYINDEX, intptr_t(CallbackMeta));
+   auto function = (FUNCTION *)CallbackMeta;
+   if (push_tiri_function(lua, *function, callback_context) != ERR::Okay) {
+      log.warning("Event subscription callback is no longer valid.");
+      return;
+   }
 
    lua_pushnumber(lua, Info->EventID);
    lua_newtable(lua);
@@ -117,7 +121,7 @@ int fcmd_unsubscribe_event(lua_State *Lua)
 
       auto erased = std::erase_if(Lua->script->EventList, [&](const auto& event) {
          if (event.EventHandle IS handle) {
-            luaL_unref(Lua, LUA_REGISTRYINDEX, event.Function);
+            release_tiri_function(Lua, event.Function.get());
             return true;
          }
          return false;
@@ -196,17 +200,20 @@ int fcmd_subscribe_event(lua_State *Lua)
 
    if (not event_id) luaL_argerror(Lua, 1, "Failed to build event ID.");
 
+   auto client_function = std::make_unique<FUNCTION>();
+   if (capture_tiri_function(Lua, 2, *client_function) != ERR::Okay) {
+      luaL_argerror(Lua, 2, "Function expected.");
+   }
+
    APTR handle;
-   lua_settop(Lua, 2);
-   auto client_function = luaL_ref(Lua, LUA_REGISTRYINDEX);
-   if (auto error = SubscribeEvent(event_id, C_FUNCTION(receive_event, client_function), &handle); !error) {
+   if (auto error = SubscribeEvent(event_id, C_FUNCTION(receive_event, client_function.get()), &handle); !error) {
       auto Self = Lua->script;
-      Self->EventList.emplace_back(client_function, event_id, handle);
+      Self->EventList.emplace_back(std::move(client_function), event_id, handle);
       lua_pushinteger(Lua, int(error)); // 1: Error code
       lua_pushlightuserdata(Lua, handle); // 2: Handle
    }
    else {
-      luaL_unref(Lua, LUA_REGISTRYINDEX, client_function);
+      release_tiri_function(Lua, client_function.get());
       lua_pushinteger(Lua, int(error)); // Error code
       lua_pushnil(Lua); // Handle
    }

--- a/src/tiri/tiri_input.cpp
+++ b/src/tiri/tiri_input.cpp
@@ -150,9 +150,7 @@ static void release_input_subscription(lua_State *Lua, struct finput *Input)
 
    if ((object_id) and (GetClassID(object_id) != CLASSID::SURFACE)) luaL_argerror(Lua, 1, "Surface object required.");
 
-   int function_type = lua_type(Lua, 2);
-   if ((function_type IS LUA_TFUNCTION) or (function_type IS LUA_TSTRING));
-   else luaL_argerror(Lua, 2, "Function reference required.");
+   if (lua_type(Lua, 2) != LUA_TFUNCTION) luaL_argerror(Lua, 2, "Function reference required.");
 
    log.traceBranch("Surface: %d", object_id);
 
@@ -314,9 +312,7 @@ static void release_input_subscription(lua_State *Lua, struct finput *Input)
 
    int device_id = lua_tointeger(Lua, 3); // Optional
 
-   int function_type = lua_type(Lua, 4);
-   if ((function_type IS LUA_TFUNCTION) or (function_type IS LUA_TSTRING));
-   else luaL_argerror(Lua, 4, "Function reference required.");
+   if (lua_type(Lua, 4) != LUA_TFUNCTION) luaL_argerror(Lua, 4, "Function reference required.");
 
    ERR error = ERR::Okay;
    {

--- a/src/tiri/tiri_input.cpp
+++ b/src/tiri/tiri_input.cpp
@@ -55,7 +55,7 @@ static void key_event(evKey *, int, struct finput *);
 static void release_input_subscription(lua_State *Lua, struct finput *Input)
 {
    if (Input->InputValue)  { luaL_unref(Lua, LUA_REGISTRYINDEX, Input->InputValue); Input->InputValue = 0; }
-   if (Input->Callback)    { luaL_unref(Lua, LUA_REGISTRYINDEX, Input->Callback); Input->Callback = 0; }
+   release_tiri_function(Lua, &Input->Callback);
    if (Input->KeyEvent)    { UnsubscribeEvent(Input->KeyEvent); Input->KeyEvent = nullptr; }
    if (Input->InputHandle) { gfx::UnsubscribeInput(Input->InputHandle); Input->InputHandle = 0; }
 }
@@ -87,7 +87,11 @@ static void release_input_subscription(lua_State *Lua, struct finput *Input)
             while ((Events->Next) and ((Events->Next->Flags & JTYPE::MOVEMENT) != JTYPE::NIL)) Events = Events->Next;
          }
 
-         lua_rawgeti(Self->Lua, LUA_REGISTRYINDEX, list->Callback); // +1 Reference to callback
+         LuaCallbackContextGuard callback_context(Self->Lua);
+         if (push_tiri_function(Self->Lua, list->Callback, callback_context) != ERR::Okay) {
+            log.warning("Input subscription callback is no longer valid.");
+            return ERR::InvalidData;
+         }
          lua_rawgeti(Self->Lua, LUA_REGISTRYINDEX, list->InputValue); // +1 Optional input value registered by the Tiri client
          if (!named_struct_to_table(Self->Lua, "InputEvent", Events)) { // +1 Input message
             if (lua_pcall(Self->Lua, 2, 0, 0)) {
@@ -169,7 +173,7 @@ static void release_input_subscription(lua_State *Lua, struct finput *Input)
    else sub_keyevent = true; // Global subscription independent of any surface.
 
 
-   if (auto input = (struct finput *)lua_newuserdata(Lua, sizeof(struct finput))) {
+   if (auto input = new (lua_newuserdata(Lua, sizeof(struct finput))) finput {}) {
       luaL_getmetatable(Lua, "Tiri.input");
       lua_setmetatable(Lua, -2);
 
@@ -177,18 +181,12 @@ static void release_input_subscription(lua_State *Lua, struct finput *Input)
       input->Script      = Lua->script;
       input->SurfaceID   = object_id;
       input->KeyEvent    = nullptr;
-      input->Callback    = 0;
       input->InputValue  = 0;
       input->Mask        = JTYPE::NIL;
       input->Mode        = FIM_KEYBOARD;
       input->Next        = nullptr;
-      if (function_type IS LUA_TFUNCTION) {
-         lua_pushvalue(Lua, 2);
-         input->Callback = luaL_ref(Lua, LUA_REGISTRYINDEX);
-      }
-      else {
-         lua_getglobal(Lua, lua_tostringview(Lua, 2));
-         input->Callback = luaL_ref(Lua, LUA_REGISTRYINDEX);
+      if (capture_tiri_function(Lua, 2, input->Callback) != ERR::Okay) {
+         luaL_argerror(Lua, 2, "Function reference required.");
       }
 
       lua_pushvalue(Lua, lua_gettop(Lua)); // Take a copy of the Tiri.input object
@@ -198,7 +196,7 @@ static void release_input_subscription(lua_State *Lua, struct finput *Input)
          if (auto error = SubscribeEvent(EVID_IO_KEYBOARD_KEYPRESS, C_FUNCTION(key_event, input),
                &input->KeyEvent); error != ERR::Okay) {
             if (input->InputValue) { luaL_unref(Lua, LUA_REGISTRYINDEX, input->InputValue); input->InputValue = 0; }
-            if (input->Callback)   { luaL_unref(Lua, LUA_REGISTRYINDEX, input->Callback); input->Callback = 0; }
+            release_tiri_function(Lua, &input->Callback);
             luaL_error(Lua, error, "Failed to subscribe to keyboard input events.");
          }
       }
@@ -251,18 +249,9 @@ static void release_input_subscription(lua_State *Lua, struct finput *Input)
       if (int(datatype) <= 0) luaL_argerror(Lua, 3, "Datatype invalid");
    }
 
-   int callback_ref = 0;
-   auto function_type = lua_type(Lua, 4);
-   if (function_type IS LUA_TFUNCTION) {
-      lua_pushvalue(Lua, 4);
-      callback_ref = luaL_ref(Lua, LUA_REGISTRYINDEX);
-      tiri->Requests.emplace_back(source_id, callback_ref);
-   }
-   else if (function_type IS LUA_TSTRING) {
-      lua_getglobal(Lua, lua_tostringview(Lua, 4));
-      callback_ref = luaL_ref(Lua, LUA_REGISTRYINDEX);
-      tiri->Requests.emplace_back(source_id, callback_ref);
-   }
+   FUNCTION callback;
+   if (capture_tiri_function(Lua, 4, callback) != ERR::Okay) luaL_argerror(Lua, 4, "Function expected.");
+   tiri->Requests.emplace_back(source_id, callback);
 
    {
       // The source will return a DATA::RECEIPT for the items that we've asked for (see the DataFeed action).
@@ -278,16 +267,12 @@ static void release_input_subscription(lua_State *Lua, struct finput *Input)
          auto error = acDataFeed(*src, Lua->script, DATA::REQUEST,
             std::span<const int8_t>((const int8_t *)&dcr, sizeof(dcr)));
          if (error != ERR::Okay) {
-            if (callback_ref) {
-               bool request_found = false;
-               for (auto it = tiri->Requests.begin(); it != tiri->Requests.end(); it++) {
-                  if ((it->SourceID IS source_id) and (it->Callback IS callback_ref)) {
-                     tiri->Requests.erase(it);
-                     request_found = true;
-                     break;
-                  }
+            for (auto it = tiri->Requests.begin(); it != tiri->Requests.end(); it++) {
+               if ((it->SourceID IS source_id) and it->Callback.identical(callback)) {
+                  release_tiri_function(Lua, &it->Callback);
+                  tiri->Requests.erase(it);
+                  break;
                }
-               if (request_found) luaL_unref(Lua, LUA_REGISTRYINDEX, callback_ref);
             }
 
             src.unlock();
@@ -296,16 +281,12 @@ static void release_input_subscription(lua_State *Lua, struct finput *Input)
          }
       }
       else {
-         if (callback_ref) {
-            bool request_found = false;
-            for (auto it = tiri->Requests.begin(); it != tiri->Requests.end(); it++) {
-               if ((it->SourceID IS source_id) and (it->Callback IS callback_ref)) {
-                  tiri->Requests.erase(it);
-                  request_found = true;
-                  break;
-               }
+         for (auto it = tiri->Requests.begin(); it != tiri->Requests.end(); it++) {
+            if ((it->SourceID IS source_id) and it->Callback.identical(callback)) {
+               release_tiri_function(Lua, &it->Callback);
+               tiri->Requests.erase(it);
+               break;
             }
-            if (request_found) luaL_unref(Lua, LUA_REGISTRYINDEX, callback_ref);
          }
          luaL_error(Lua, ERR::AccessObject, "Failed to access data source #%d.", source_id);
       }
@@ -352,19 +333,14 @@ static void release_input_subscription(lua_State *Lua, struct finput *Input)
    log.msg("Surface: %d, Mask: $%.8x, Device: %d", object_id, int(mask), device_id);
 
    struct finput *input;
-   if ((input = (struct finput *)lua_newuserdata(Lua, sizeof(struct finput)))) {
+   if ((input = new (lua_newuserdata(Lua, sizeof(struct finput))) finput {})) {
       luaL_getmetatable(Lua, "Tiri.input");
       lua_setmetatable(Lua, -2);
 
       input->SurfaceID = object_id;
 
-      if (function_type IS LUA_TFUNCTION) {
-         lua_pushvalue(Lua, 4);
-         input->Callback = luaL_ref(Lua, LUA_REGISTRYINDEX);
-      }
-      else {
-         lua_getglobal(Lua, lua_tostringview(Lua, 4));
-         input->Callback = luaL_ref(Lua, LUA_REGISTRYINDEX);
+      if (capture_tiri_function(Lua, 4, input->Callback) != ERR::Okay) {
+         luaL_argerror(Lua, 4, "Function reference required.");
       }
 
       lua_pushvalue(Lua, lua_gettop(Lua)); // Take a copy of the Tiri.input object
@@ -381,7 +357,7 @@ static void release_input_subscription(lua_State *Lua, struct finput *Input)
             &input->InputHandle)) != ERR::Okay) {
          if (input->InputHandle) { gfx::UnsubscribeInput(input->InputHandle); input->InputHandle = 0; }
          if (input->InputValue)  { luaL_unref(Lua, LUA_REGISTRYINDEX, input->InputValue); input->InputValue = 0; }
-         if (input->Callback)    { luaL_unref(Lua, LUA_REGISTRYINDEX, input->Callback); input->Callback = 0; }
+         release_tiri_function(Lua, &input->Callback);
          luaL_error(Lua, error);
       }
 
@@ -419,7 +395,8 @@ static void release_input_subscription(lua_State *Lua, struct finput *Input)
 
    auto input = (struct finput *)lua_touserdata(Lua, 1);
    if (input) {
-      log.traceBranch("Surface: %d, CallbackRef: %d, KeyEvent: %p", input->SurfaceID, input->Callback, input->KeyEvent);
+      log.traceBranch("Surface: %d, CallbackRef: %u, KeyEvent: %p", input->SurfaceID,
+         input->Callback.procedureID(), input->KeyEvent);
 
       if (input->SurfaceID)   input->SurfaceID = 0;
       release_input_subscription(Lua, input);
@@ -462,7 +439,11 @@ static void key_event(evKey *Event, int Size, struct finput *Input)
    LuaContextRootGuard context_guard(lua);
    int depth = GetResource(RES::LOG_DEPTH); // Required because thrown errors cause the debugger to lose its step position
    int top = lua_gettop(lua);
-   lua_rawgeti(lua, LUA_REGISTRYINDEX, Input->Callback); // Get the function reference in Lua and place it on the stack
+   LuaCallbackContextGuard callback_context(lua);
+   if (push_tiri_function(lua, Input->Callback, callback_context) != ERR::Okay) {
+      log.warning("Keyboard input callback is no longer valid.");
+      return;
+   }
    lua_rawgeti(lua, LUA_REGISTRYINDEX, Input->InputValue); // Arg: Input value registered by the client
    lua_pushinteger(lua, Input->SurfaceID);  // Arg: Surface (if applicable)
    lua_pushinteger(lua, uint32_t(Event->Qualifiers)); // Arg: Key Flags

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -438,8 +438,8 @@ static ERR callable_arg_type(const FunctionField &Field, ffi_type *&Type, std::s
 
 //********************************************************************************************************************
 // Accumulate the bridge-owned temporaries one argument can require.  The classification must agree with the
-// marshalling loop in module_call_inner(); a temporary counted here but not used is merely wasteful, whereas one used
-// but not counted would overflow a bounded store.
+// marshalling loop in module_call_inner().  A temporary counted here but not used is merely wasteful, whereas one
+// used but not counted would overflow a bounded store.
 
 static void profile_arg(const FunctionField &Field, marshalling_profile &Profile)
 {
@@ -457,7 +457,7 @@ static void profile_arg(const FunctionField &Field, marshalling_profile &Profile
       return;
    }
 
-   if (argtype & FD_FUNCTION) return; // The single FUNCTION reserve lives in the frame, not a store
+   if (argtype & FD_FUNCTION) return; // Isolated function lives in the frame, not a store
 
    if (argtype & FD_STR) {
       if (argtype & FD_CPP) {

--- a/src/tiri/tiri_objects_calls.cpp
+++ b/src/tiri/tiri_objects_calls.cpp
@@ -171,6 +171,28 @@ ERR capture_tiri_function(lua_State *Lua, int ValueIndex, FUNCTION &Function)
    return ERR::Okay;
 }
 
+ERR push_tiri_function(lua_State *Lua, const FUNCTION &Function, LuaCallbackContextGuard &ContextGuard)
+{
+   if ((not Function.isScript()) or (Function.Context != Lua->script)) return ERR::Args;
+
+   if (Function.contextID() > 0) {
+      lua_rawgeti(Lua, LUA_REGISTRYINDEX, Function.contextID());
+      if (lua_type(Lua, -1) != LUA_TTABLE) {
+         lua_pop(Lua, 1);
+         return ERR::InvalidData;
+      }
+
+      ContextGuard.activate(tabV(Lua->top - 1));
+      lua_pop(Lua, 1);
+   }
+
+   lua_rawgeti(Lua, LUA_REGISTRYINDEX, int(Function.procedureID()));
+   if (lua_type(Lua, -1) IS LUA_TFUNCTION) return ERR::Okay;
+
+   lua_pop(Lua, 1);
+   return ERR::NotFound;
+}
+
 void release_tiri_function(lua_State *Lua, FUNCTION *Function)
 {
    if ((not Function) or (not Function->isScript())) return;

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -448,7 +448,7 @@ static int processing_get(lua_State *Lua)
 
 struct delay_msg {
    lua_State *lua;
-   int ref;
+   FUNCTION function;
 };
 
 ERR delayed_msg_handler(APTR Meta, int MsgID, MSGID MsgType, std::span<std::byte> Message)
@@ -457,14 +457,15 @@ ERR delayed_msg_handler(APTR Meta, int MsgID, MSGID MsgType, std::span<std::byte
 
    auto msg = (delay_msg *)Message.data();
    auto lua = msg->lua;
-   lua_rawgeti(lua, LUA_REGISTRYINDEX, msg->ref); // Get the function from the registry
-   luaL_unref(lua, LUA_REGISTRYINDEX, msg->ref); // Remove it
 
    kt::SwitchContext ctx(lua->script);
-   LuaContextRootGuard context_guard(lua);
-   if (lua_pcall(lua, 0, 0, 0)) {
-      process_error(lua->script, "delayedCall()");
+   LuaCallbackContextGuard callback_context(lua);
+   auto callback_error = push_tiri_function(lua, msg->function, callback_context);
+   if (callback_error IS ERR::Okay) {
+      if (lua_pcall(lua, 0, 0, 0)) process_error(lua->script, "delayedCall()");
    }
+   else kt::Log(__FUNCTION__).warning("Delayed callback is no longer valid: %s", GetErrorMsg(callback_error));
+   release_tiri_function(lua, &msg->function);
    collect_garbage(lua);
    return ERR::Okay;
 }
@@ -472,9 +473,12 @@ ERR delayed_msg_handler(APTR Meta, int MsgID, MSGID MsgType, std::span<std::byte
 static int processing_delayed_call(lua_State *Lua)
 {
    if (lua_type(Lua, 1) IS LUA_TFUNCTION) {
-      delay_msg msg = { Lua, luaL_ref(Lua, LUA_REGISTRYINDEX) };
+      delay_msg msg = { Lua, FUNCTION() };
+      if (capture_tiri_function(Lua, 1, msg.function) != ERR::Okay) {
+         luaL_error(Lua, "Expected a function to register as a message hook.");
+      }
       if (SendMessage(glDelayedCallMsgID, MSF::NIL, std::span((const int8_t *)&msg, sizeof(msg))) != ERR::Okay) {
-         luaL_unref(Lua, LUA_REGISTRYINDEX, msg.ref);
+         release_tiri_function(Lua, &msg.function);
          luaL_error(Lua, ERR::MessageOperation);
       }
    }


### PR DESCRIPTION
* Replaced raw registry integer callback references with FUNCTION values across action monitors, event subscriptions, data requests, input handlers, async dispatch and delayed calls
* Added push_tiri_function() to restore a callback's captured registration context via LuaCallbackContextGuard before invocation
* Native callbacks now observe the context active at registration time and restore the root context on return, instead of always dispatching unbound
* Stored eventsub callbacks in a std::unique_ptr<FUNCTION> to provide stable subscription metadata for the native event handler
* Placement-new the finput userdata so its FUNCTION Callback member is properly constructed
* [Test] Updated contextual member call and async callback tests to assert registration-context capture and root-context restoration