### PR TITLE
[Tiri] Added unsigned integer array element types

### DIFF
--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -47,10 +47,11 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // existing contextual call sequence.  Version 0x8d adds materialised temporary context blocks and consuming close
 // activation bytecodes.  Version 0x8e adds the canonical regex.new identity used by regex literals.  Version 0x8f
 // separates object.create, object.new and object._state callable identities.  Version 0x90 accepts a struct reference
-// in struct.size, which shifts the generated fast-function ordering.  Older chunks are rejected rather than retaining
-// compatibility shims.
+// in struct.size, which shifts the generated fast-function ordering.  Version 0x92 expands private array member
+// identities with uint8, uint16, uint32 and uint64.  Older chunks are rejected rather than retaining compatibility
+// shims.
 
-constexpr uint8_t BCDUMP_VERSION = 0x91;
+constexpr uint8_t BCDUMP_VERSION = 0x92;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -75,7 +75,11 @@ const array_meta glArrayConversion[size_t(AET::MAX)] = {
    { uint8_t(LJ_TARRAY),   LUA_TARRAY, false },         // AET::ARRAY
    { uint8_t(LJ_TNIL),     0, false },                  // AET::ANY
    { uint8_t(LJ_TUDATA),   LUA_TUSERDATA, false },      // AET::STRUCT
-   { uint8_t(LJ_TOBJECT),  LUA_TOBJECT, false }         // AET::OBJECT
+   { uint8_t(LJ_TOBJECT),  LUA_TOBJECT, false },        // AET::OBJECT
+   { uint8_t(LJ_TNUMX),    LUA_TNUMBER, true },         // AET::UINT8
+   { uint8_t(LJ_TNUMX),    LUA_TNUMBER, true },         // AET::UINT16
+   { uint8_t(LJ_TNUMX),    LUA_TNUMBER, true },         // AET::UINT32
+   { uint8_t(LJ_TNUMX),    LUA_TNUMBER, true }          // AET::UINT64
 };
 
 //********************************************************************************************************************
@@ -141,6 +145,10 @@ static CSTRING elemtype_name(AET Type)
       case AET::INT16:      return "int16";
       case AET::INT32:      return "int";
       case AET::INT64:      return "int64";
+      case AET::UINT8:      return "uint8";
+      case AET::UINT16:     return "uint16";
+      case AET::UINT32:     return "uint32";
+      case AET::UINT64:     return "uint64";
       case AET::FLOAT:      return "float";
       case AET::DOUBLE:     return "double";
       case AET::PTR:        return "pointer";
@@ -231,6 +239,59 @@ static void append_integer(std::string &Result, int64_t Value)
 
       Result.append(text, size_t(end - text));
    }
+}
+
+//********************************************************************************************************************
+
+static void append_unsigned_integer(std::string &Result, uint64_t Value)
+{
+   constexpr size_t BUFFER_SIZE = 20;
+
+   if ((Result.capacity() - Result.size()) >= BUFFER_SIZE) {
+      const auto start = Result.size();
+      Result.resize(start + BUFFER_SIZE);
+
+      char *end = Result.data() + start + BUFFER_SIZE;
+      char *text = write_integer(end, Value, false);
+      const auto used = size_t(end - text);
+
+      memmove(Result.data() + start, text, used);
+      Result.resize(start + used);
+   }
+   else {
+      char buffer[BUFFER_SIZE];
+      char *end = buffer + BUFFER_SIZE;
+      char *text = write_integer(end, Value, false);
+      Result.append(text, size_t(end - text));
+   }
+}
+
+//********************************************************************************************************************
+
+static bool is_unsigned_format(CSTRING Format, bool Wide)
+{
+   for (const char *p = Format; *p; ++p) {
+      if (*p != '%') continue;
+      if (*(p + 1) IS '%') {
+         ++p;
+         continue;
+      }
+
+      unsigned long_count = 0;
+      for (++p; *p; ++p) {
+         if (*p IS 'l') {
+            ++long_count;
+            continue;
+         }
+         if (*p IS 'u' or *p IS 'o' or *p IS 'x' or *p IS 'X') {
+            return Wide ? long_count IS 2 : long_count IS 0;
+         }
+         if (*p IS 'd' or *p IS 'i' or *p IS 'c' or *p IS 's' or *p IS 'p' or *p IS 'f' or *p IS 'F' or
+             *p IS 'e' or *p IS 'E' or *p IS 'g' or *p IS 'G') return false;
+      }
+      return false;
+   }
+   return false;
 }
 
 //********************************************************************************************************************
@@ -532,6 +593,15 @@ LJLIB_CF(array_concat)
       if (format_count != 1) {
          luaL_error(L, ERR::Syntax, "Format string must contain exactly one format specifier, found %d", format_count);
       }
+
+      if (arr->elemtype IS AET::UINT8 or arr->elemtype IS AET::UINT16 or arr->elemtype IS AET::UINT32) {
+         if (not is_unsigned_format(format, false)) {
+            luaL_error(L, ERR::Syntax, "Unsigned arrays require an unsigned format without an l modifier");
+         }
+      }
+      else if (arr->elemtype IS AET::UINT64 and not is_unsigned_format(format, true)) {
+         luaL_error(L, ERR::Syntax, "array<uint64> requires an unsigned long long format such as %%llu");
+      }
    }
 
    std::string result;
@@ -569,6 +639,18 @@ LJLIB_CF(array_concat)
                break;
             case AET::INT64:
                append_formatted(result, format, arr->get<long long>()[i]);
+               break;
+            case AET::UINT8:
+               append_formatted(result, format, unsigned(arr->get<uint8_t>()[i]));
+               break;
+            case AET::UINT16:
+               append_formatted(result, format, unsigned(arr->get<uint16_t>()[i]));
+               break;
+            case AET::UINT32:
+               append_formatted(result, format, unsigned(arr->get<uint32_t>()[i]));
+               break;
+            case AET::UINT64:
+               append_formatted(result, format, (unsigned long long)arr->get<uint64_t>()[i]);
                break;
             case AET::INT32:
                append_formatted(result, format, arr->get<int>()[i]);
@@ -611,6 +693,18 @@ LJLIB_CF(array_concat)
                break;
             case AET::INT64:
                append_integer(result, arr->get<int64_t>()[i]);
+               break;
+            case AET::UINT8:
+               append_unsigned_integer(result, arr->get<uint8_t>()[i]);
+               break;
+            case AET::UINT16:
+               append_unsigned_integer(result, arr->get<uint16_t>()[i]);
+               break;
+            case AET::UINT32:
+               append_unsigned_integer(result, arr->get<uint32_t>()[i]);
+               break;
+            case AET::UINT64:
+               append_unsigned_integer(result, arr->get<uint64_t>()[i]);
                break;
             case AET::INT32:
                append_integer(result, arr->get<int32_t>()[i]);
@@ -714,6 +808,10 @@ LJLIB_CF(array_first)
       case AET::INT16:  lua_pushinteger(L, *(int16_t *)elem); break;
       case AET::INT32:  lua_pushinteger(L, *(int32_t *)elem); break;
       case AET::INT64:  lua_pushnumber(L, lua_Number(*(int64_t *)elem)); break;
+      case AET::UINT8:  lua_pushinteger(L, *(uint8_t *)elem); break;
+      case AET::UINT16: lua_pushinteger(L, *(uint16_t *)elem); break;
+      case AET::UINT32: lua_pushnumber(L, lua_Number(*(uint32_t *)elem)); break;
+      case AET::UINT64: lua_pushnumber(L, lua_Number(*(uint64_t *)elem)); break;
       case AET::FLOAT:  lua_pushnumber(L, *(float *)elem); break;
       case AET::DOUBLE: lua_pushnumber(L, *(double *)elem); break;
 
@@ -789,6 +887,10 @@ LJLIB_CF(array_last)
       case AET::INT16:  lua_pushinteger(L, *(int16_t *)elem); break;
       case AET::INT32:  lua_pushinteger(L, *(int32_t *)elem); break;
       case AET::INT64:  lua_pushnumber(L, lua_Number(*(int64_t *)elem)); break;
+      case AET::UINT8:  lua_pushinteger(L, *(uint8_t *)elem); break;
+      case AET::UINT16: lua_pushinteger(L, *(uint16_t *)elem); break;
+      case AET::UINT32: lua_pushnumber(L, lua_Number(*(uint32_t *)elem)); break;
+      case AET::UINT64: lua_pushnumber(L, lua_Number(*(uint64_t *)elem)); break;
       case AET::FLOAT:  lua_pushnumber(L, *(float *)elem); break;
       case AET::DOUBLE: lua_pushnumber(L, *(double *)elem); break;
       case AET::STR_GC: {
@@ -1028,6 +1130,10 @@ LJLIB_CF(array_pop)
          case AET::INT16:  lua_pushinteger(L, *(int16_t *)elem); break;
          case AET::INT32:  lua_pushinteger(L, *(int32_t *)elem); break;
          case AET::INT64:  lua_pushnumber(L, lua_Number(*(int64_t *)elem)); break;
+         case AET::UINT8:  lua_pushinteger(L, *(uint8_t *)elem); break;
+         case AET::UINT16: lua_pushinteger(L, *(uint16_t *)elem); break;
+         case AET::UINT32: lua_pushnumber(L, lua_Number(*(uint32_t *)elem)); break;
+         case AET::UINT64: lua_pushnumber(L, lua_Number(*(uint64_t *)elem)); break;
          case AET::FLOAT:  lua_pushnumber(L, *(float *)elem); break;
          case AET::DOUBLE: lua_pushnumber(L, *(double *)elem); break;
 
@@ -1316,6 +1422,10 @@ static void fill_array_elements(lua_State *L, GCarray *Arr, cTValue *Value, int3
       case AET::INT16:  ARRAY_FILL_TYPE(int16_t);
       case AET::INT32:  ARRAY_FILL_TYPE(int32_t);
       case AET::INT64:  ARRAY_FILL_TYPE(int64_t);
+      case AET::UINT8:  ARRAY_FILL_TYPE(uint8_t);
+      case AET::UINT16: ARRAY_FILL_TYPE(uint16_t);
+      case AET::UINT32: ARRAY_FILL_TYPE(uint32_t);
+      case AET::UINT64: ARRAY_FILL_TYPE(uint64_t);
       case AET::FLOAT:  ARRAY_FILL_TYPE(float);
       case AET::DOUBLE: ARRAY_FILL_TYPE(double);
       case AET::STR_GC:
@@ -1462,6 +1572,10 @@ static int32_t find_in_array(GCarray *Arr, lua_Number Value, int32_t Start, int3
          case AET::INT16:  return find_forward_contiguous<int16_t>(data, Start, Stop, Value);
          case AET::INT32:  return find_forward_contiguous<int32_t>(data, Start, Stop, Value);
          case AET::INT64:  return find_forward_contiguous<int64_t>(data, Start, Stop, Value);
+         case AET::UINT8:  return find_forward_contiguous<uint8_t>(data, Start, Stop, Value);
+         case AET::UINT16: return find_forward_contiguous<uint16_t>(data, Start, Stop, Value);
+         case AET::UINT32: return find_forward_contiguous<uint32_t>(data, Start, Stop, Value);
+         case AET::UINT64: return find_forward_contiguous<uint64_t>(data, Start, Stop, Value);
          case AET::FLOAT:  return find_forward_contiguous<float>(data, Start, Stop, Value);
          case AET::DOUBLE: return find_forward_contiguous<double>(data, Start, Stop, Value);
          default: return -1;
@@ -1474,6 +1588,10 @@ static int32_t find_in_array(GCarray *Arr, lua_Number Value, int32_t Start, int3
       case AET::INT16:  return find_stepped<int16_t>(data, Start, Stop, Step, Value);
       case AET::INT32:  return find_stepped<int32_t>(data, Start, Stop, Step, Value);
       case AET::INT64:  return find_stepped<int64_t>(data, Start, Stop, Step, Value);
+      case AET::UINT8:  return find_stepped<uint8_t>(data, Start, Stop, Step, Value);
+      case AET::UINT16: return find_stepped<uint16_t>(data, Start, Stop, Step, Value);
+      case AET::UINT32: return find_stepped<uint32_t>(data, Start, Stop, Step, Value);
+      case AET::UINT64: return find_stepped<uint64_t>(data, Start, Stop, Step, Value);
       case AET::FLOAT:  return find_stepped<float>(data, Start, Stop, Step, Value);
       case AET::DOUBLE: return find_stepped<double>(data, Start, Stop, Step, Value);
       default: return -1;
@@ -1628,6 +1746,10 @@ LJLIB_CF(array_reverse)
       case AET::INT16:  { auto *p = (int16_t *)data; std::reverse(p, p + arr->len); break; }
       case AET::INT32:  { auto *p = (int32_t *)data; std::reverse(p, p + arr->len); break; }
       case AET::INT64:  { auto *p = (int64_t *)data; std::reverse(p, p + arr->len); break; }
+      case AET::UINT8:  { auto *p = (uint8_t *)data; std::reverse(p, p + arr->len); break; }
+      case AET::UINT16: { auto *p = (uint16_t *)data; std::reverse(p, p + arr->len); break; }
+      case AET::UINT32: { auto *p = (uint32_t *)data; std::reverse(p, p + arr->len); break; }
+      case AET::UINT64: { auto *p = (uint64_t *)data; std::reverse(p, p + arr->len); break; }
       case AET::FLOAT:  { auto *p = (float *)data; std::reverse(p, p + arr->len); break; }
       case AET::DOUBLE: { auto *p = (double *)data; std::reverse(p, p + arr->len); break; }
       case AET::PTR:    { auto *p = (void **)data; std::reverse(p, p + arr->len); break; }
@@ -1864,6 +1986,10 @@ LJLIB_CF(array_sort)
       case AET::INT16: quicksort(arr->get<int16_t>(), 0, int32_t(arr->len - 1), descending); break;
       case AET::INT32: quicksort(arr->get<int32_t>(), 0, int32_t(arr->len - 1), descending); break;
       case AET::INT64: quicksort(arr->get<int64_t>(), 0, int32_t(arr->len - 1), descending); break;
+      case AET::UINT8: quicksort(arr->get<uint8_t>(), 0, int32_t(arr->len - 1), descending); break;
+      case AET::UINT16: quicksort(arr->get<uint16_t>(), 0, int32_t(arr->len - 1), descending); break;
+      case AET::UINT32: quicksort(arr->get<uint32_t>(), 0, int32_t(arr->len - 1), descending); break;
+      case AET::UINT64: quicksort(arr->get<uint64_t>(), 0, int32_t(arr->len - 1), descending); break;
       case AET::FLOAT: quicksort(arr->get<float>(), 0, int32_t(arr->len - 1), descending); break;
       case AET::DOUBLE: quicksort(arr->get<double>(), 0, int32_t(arr->len - 1), descending); break;
       case AET::STR_GC: {
@@ -1910,6 +2036,10 @@ static void array_push_element(lua_State *L, GCarray *Arr, MSize Idx)
       case AET::INT16:  lua_pushinteger(L, *(int16_t *)elem); break;
       case AET::INT32:  lua_pushinteger(L, *(int32_t *)elem); break;
       case AET::INT64:  lua_pushnumber(L, lua_Number(*(int64_t *)elem)); break;
+      case AET::UINT8:  lua_pushinteger(L, *(uint8_t *)elem); break;
+      case AET::UINT16: lua_pushinteger(L, *(uint16_t *)elem); break;
+      case AET::UINT32: lua_pushnumber(L, lua_Number(*(uint32_t *)elem)); break;
+      case AET::UINT64: lua_pushnumber(L, lua_Number(*(uint64_t *)elem)); break;
       case AET::FLOAT:  lua_pushnumber(L, *(float *)elem); break;
       case AET::DOUBLE: lua_pushnumber(L, *(double *)elem); break;
       case AET::STR_GC: {

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -535,9 +535,13 @@ static bool array_elem_irtype(AET ElemType, IRType &ResultType)
       case AET::BYTE:
       case AET::INT16:
       case AET::INT32:
+      case AET::UINT8:
+      case AET::UINT16:
          ResultType = LJ_DUALNUM ? IRT_INT : IRT_NUM;
          return true;
       case AET::INT64:
+      case AET::UINT32:
+      case AET::UINT64:
       case AET::FLOAT:
       case AET::DOUBLE:
          ResultType = IRT_NUM;
@@ -570,6 +574,10 @@ static bool array_elemtype_from_string(GCstr *TypeStr, AET *Result)
    else if (TypeStr->len IS 4 and memcmp(type_name, "int8", 4) IS 0) *Result = AET::BYTE;
    else if (TypeStr->len IS 5 and memcmp(type_name, "int16", 5) IS 0) *Result = AET::INT16;
    else if (TypeStr->len IS 5 and memcmp(type_name, "int64", 5) IS 0) *Result = AET::INT64;
+   else if (TypeStr->len IS 5 and memcmp(type_name, "uint8", 5) IS 0) *Result = AET::UINT8;
+   else if (TypeStr->len IS 6 and memcmp(type_name, "uint16", 6) IS 0) *Result = AET::UINT16;
+   else if (TypeStr->len IS 6 and memcmp(type_name, "uint32", 6) IS 0) *Result = AET::UINT32;
+   else if (TypeStr->len IS 6 and memcmp(type_name, "uint64", 6) IS 0) *Result = AET::UINT64;
    else if (TypeStr->len IS 5 and memcmp(type_name, "float", 5) IS 0) *Result = AET::FLOAT;
    else if (TypeStr->len IS 6 and memcmp(type_name, "double", 6) IS 0) *Result = AET::DOUBLE;
    else if (TypeStr->len IS 6 and memcmp(type_name, "string", 6) IS 0) *Result = AET::STR_GC;

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -3276,8 +3276,12 @@ static TRef rec_array_xload(jit_State *J, TRef ArrayRef, TRef IdxRef, GCarray *A
       case AET::BYTE:   shift = 0; break;
       case AET::INT16:  shift = 1; break;
       case AET::INT32:  shift = 2; break;
+      case AET::UINT8:  shift = 0; break;
+      case AET::UINT16: shift = 1; break;
+      case AET::UINT32: shift = 2; break;
       case AET::FLOAT:  shift = 2; break;
       case AET::INT64:  shift = 3; break;
+      case AET::UINT64: shift = 3; break;
       case AET::DOUBLE: shift = 3; break;
       case AET::STR_GC: shift = 3; break;  // GCRef is 8 bytes
       case AET::TABLE:  shift = 3; break;  // GCRef is 8 bytes
@@ -3327,6 +3331,22 @@ static TRef rec_array_xload(jit_State *J, TRef ArrayRef, TRef IdxRef, GCarray *A
          val = emitir(IRT(IR_XLOAD, IRT_I64), addr, 0);
          val = emitir(IRTN(IR_CONV), val, (IRT_NUM << IRCONV_DSH) | IRT_I64);
          break;
+      case AET::UINT8:
+         val = emitir(IRT(IR_XLOAD, IRT_U8), addr, 0);
+         if (not LJ_DUALNUM) val = emitir(IRTN(IR_CONV), val, IRCONV_NUM_INT);
+         break;
+      case AET::UINT16:
+         val = emitir(IRT(IR_XLOAD, IRT_U16), addr, 0);
+         if (not LJ_DUALNUM) val = emitir(IRTN(IR_CONV), val, IRCONV_NUM_INT);
+         break;
+      case AET::UINT32:
+         val = emitir(IRT(IR_XLOAD, IRT_U32), addr, 0);
+         val = emitir(IRTN(IR_CONV), val, (IRT_NUM << IRCONV_DSH) | IRT_U32);
+         break;
+      case AET::UINT64:
+         val = emitir(IRT(IR_XLOAD, IRT_U64), addr, 0);
+         val = emitir(IRTN(IR_CONV), val, (IRT_NUM << IRCONV_DSH) | IRT_U64);
+         break;
       case AET::FLOAT:
          val = emitir(IRT(IR_XLOAD, IRT_FLOAT), addr, 0);
          val = emitir(IRTN(IR_CONV), val, (IRT_NUM << IRCONV_DSH) | IRT_FLOAT);
@@ -3374,8 +3394,12 @@ static bool rec_array_xstore(jit_State *J, TRef ArrayRef, TRef IdxRef, TRef ValR
       case AET::BYTE:   shift = 0; break;
       case AET::INT16:  shift = 1; break;
       case AET::INT32:  shift = 2; break;
+      case AET::UINT8:  shift = 0; break;
+      case AET::UINT16: shift = 1; break;
+      case AET::UINT32: shift = 2; break;
       case AET::FLOAT:  shift = 2; break;
       case AET::INT64:  shift = 3; break;
+      case AET::UINT64: shift = 3; break;
       case AET::DOUBLE: shift = 3; break;
       case AET::STR_GC: shift = 3; is_gc_type = true; break;
       case AET::TABLE:  shift = 3; is_gc_type = true; break;
@@ -3386,7 +3410,8 @@ static bool rec_array_xstore(jit_State *J, TRef ArrayRef, TRef IdxRef, TRef ValR
    if (not is_gc_type and not (tref_isnumber(ValRef) or tref_isnil(ValRef))) return false;
 
    if (tref_isnum(ValRef)) {
-      if (et IS AET::BYTE or et IS AET::INT16 or et IS AET::INT32 or et IS AET::INT64) {
+      if (et IS AET::BYTE or et IS AET::INT16 or et IS AET::INT32 or et IS AET::INT64 or
+          et IS AET::UINT8 or et IS AET::UINT16 or et IS AET::UINT32 or et IS AET::UINT64) {
          emitir(IRTG(IR_GE, IRT_NUM), ValRef, lj_ir_knum(J, -DBL_MAX));
          emitir(IRTG(IR_LE, IRT_NUM), ValRef, lj_ir_knum(J, DBL_MAX));
       }
@@ -3445,6 +3470,34 @@ static bool rec_array_xstore(jit_State *J, TRef ArrayRef, TRef IdxRef, TRef ValR
             store_val = emitir(IRT(IR_CONV, IRT_I64), ValRef,
                (IRT_I64 << IRCONV_DSH) | IRT_NUM | IRCONV_ANY);
          emitir(IRT(IR_XSTORE, IRT_I64), addr, store_val);
+         break;
+      case AET::UINT8:
+         store_val = tref_isnil(ValRef) ? ir.kint(0) : tref_isnum(ValRef)
+            ? emitir(IRTI(IR_CONV), ValRef, IRCONV_INT_NUM | IRCONV_ANY) : ValRef;
+         emitir(IRT(IR_XSTORE, IRT_U8), addr, store_val);
+         break;
+      case AET::UINT16:
+         store_val = tref_isnil(ValRef) ? ir.kint(0) : tref_isnum(ValRef)
+            ? emitir(IRTI(IR_CONV), ValRef, IRCONV_INT_NUM | IRCONV_ANY) : ValRef;
+         emitir(IRT(IR_XSTORE, IRT_U16), addr, store_val);
+         break;
+      case AET::UINT32:
+         if (tref_isnil(ValRef)) store_val = ir.kint(0);
+         else if (tref_isint(ValRef)) {
+            store_val = emitir(IRT(IR_CONV, IRT_U32), ValRef,
+               (IRT_U32 << IRCONV_DSH) | IRT_INT | IRCONV_SEXT);
+         }
+         else store_val = emitir(IRT(IR_CONV, IRT_U32), ValRef, (IRT_U32 << IRCONV_DSH) | IRT_NUM | IRCONV_ANY);
+         emitir(IRT(IR_XSTORE, IRT_U32), addr, store_val);
+         break;
+      case AET::UINT64:
+         if (tref_isnil(ValRef)) store_val = lj_ir_kint64(J, 0);
+         else if (tref_isint(ValRef)) {
+            store_val = emitir(IRT(IR_CONV, IRT_U64), ValRef,
+               (IRT_U64 << IRCONV_DSH) | IRT_INT | IRCONV_SEXT);
+         }
+         else store_val = emitir(IRT(IR_CONV, IRT_U64), ValRef, (IRT_U64 << IRCONV_DSH) | IRT_NUM | IRCONV_ANY);
+         emitir(IRT(IR_XSTORE, IRT_U64), addr, store_val);
          break;
       case AET::FLOAT:
          store_val = tref_isnil(ValRef) ? lj_ir_knum(J, 0) : tref_isint(ValRef)

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -3409,6 +3409,12 @@ static bool rec_array_xstore(jit_State *J, TRef ArrayRef, TRef IdxRef, TRef ValR
    // For numeric types, the value must be a number
    if (not is_gc_type and not (tref_isnumber(ValRef) or tref_isnil(ValRef))) return false;
 
+   // Floating-point to unsigned conversions do not consistently implement the interpreter's modulo semantics across
+   // widths and backends.  Keep integer values on the inline path, but use the checked runtime store for numeric
+   // values.
+   if (tref_isnum(ValRef) and
+       (et IS AET::UINT8 or et IS AET::UINT16 or et IS AET::UINT32 or et IS AET::UINT64)) return false;
+
    if (tref_isnum(ValRef)) {
       if (et IS AET::BYTE or et IS AET::INT16 or et IS AET::INT32 or et IS AET::INT64 or
           et IS AET::UINT8 or et IS AET::UINT16 or et IS AET::UINT32 or et IS AET::UINT64) {

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1471,7 +1471,7 @@ static bool test_signature_metadata_roundtrip(kt::Log &Log)
       "   Value: int\n"
       "end\n"
       "local function outer(Value:num!, Flexible:any, Untyped, Item:struct<SignatureLayout>, Generic:struct, "
-      "Object:obj, Numbers:array<int>, Records:array<struct<SignatureLayout>>, ...):func\n"
+      "Object:obj, Numbers:array<int>, Records:array<struct<SignatureLayout>>, Masks:array<uint32>, ...):func\n"
       "   local function inner(Text:str!):<str!, num, ...>\n"
       "      return Text, Value, Value\n"
       "   end\n"
@@ -1494,7 +1494,7 @@ static bool test_signature_metadata_roundtrip(kt::Log &Log)
 
    const ProtoSignature *outer_signature = proto_signature(outer);
    const ProtoSignature *inner_signature = proto_signature(inner);
-   if (not outer_signature or outer_signature->parameter_count != 8 or outer_signature->result_count != 1 or
+   if (not outer_signature or outer_signature->parameter_count != 9 or outer_signature->result_count != 1 or
        not (outer_signature->flags & proto_signature_flag(ProtoSignatureFlag::ExplicitResults)) or
        not (outer_signature->flags & proto_signature_flag(ProtoSignatureFlag::ParameterVariadic))) {
       Log.error("outer prototype signature header is incomplete");
@@ -1514,7 +1514,8 @@ static bool test_signature_metadata_roundtrip(kt::Log &Log)
        outer_params[6].type != TiriType::Array or proto_array_member(outer_params[6]) != AET::INT32 or
        outer_params[6].constraint != 0 or outer_params[7].type != TiriType::Array or
        proto_array_member(outer_params[7]) != AET::STRUCT or
-       outer_params[7].constraint != struct_key("SignatureLayout")) {
+       outer_params[7].constraint != struct_key("SignatureLayout") or outer_params[8].type != TiriType::Array or
+       proto_array_member(outer_params[8]) != AET::UINT32 or outer_params[8].constraint != 0) {
       Log.error("outer prototype parameter entries lost type, provenance, strength or constraint data");
       return false;
    }
@@ -1716,7 +1717,7 @@ static bool test_old_bytecode_versions_rejected(kt::Log &Log)
    // replaced it with BC_MODACT.  Gate E selected format rejection over a compatibility shim.
 
    for (uint8_t version : { uint8_t(0x81), uint8_t(0x83), uint8_t(0x85), uint8_t(0x86), uint8_t(0x8e),
-      uint8_t(0x90) }) {
+      uint8_t(0x90), uint8_t(0x91) }) {
       std::string old_dump = dump;
       old_dump[3] = char(version);
       if (lua_load(L, std::string_view(old_dump.data(), old_dump.size()), "old-version") IS 0) {
@@ -4555,6 +4556,12 @@ static bool test_static_descriptor_model(kt::Log &Log)
       Log.error("a mismatched array member descriptor satisfied an exact contract");
       return false;
    }
+   StaticValueDescriptor uint_array = int_array;
+   uint_array.array_element = { AET::UINT32, TiriType::Num, CLASSID::NIL, nullptr, true };
+   if (static_value_satisfies_contract(uint_array, int_array_contract)) {
+      Log.error("a signed and unsigned array member identity matched a contract");
+      return false;
+   }
    StaticValueDescriptor joined_arrays = join_static_descriptors(int_array, string_array);
    if (joined_arrays.primary != TiriType::Any or joined_arrays.array_element.known or
        joined_arrays.proof != StaticProof::Advisory) {
@@ -4567,13 +4574,17 @@ static bool test_static_descriptor_model(kt::Log &Log)
       AET storage;
       TiriType logical_type;
    };
-   constexpr std::array<ArrayMapping, 15> mappings = { {
+   constexpr std::array<ArrayMapping, 19> mappings = { {
       { "byte", AET::BYTE, TiriType::Num },
       { "char", AET::BYTE, TiriType::Num },
       { "int8", AET::BYTE, TiriType::Num },
       { "int16", AET::INT16, TiriType::Num },
       { "int", AET::INT32, TiriType::Num },
       { "int64", AET::INT64, TiriType::Num },
+      { "uint8", AET::UINT8, TiriType::Num },
+      { "uint16", AET::UINT16, TiriType::Num },
+      { "uint32", AET::UINT32, TiriType::Num },
+      { "uint64", AET::UINT64, TiriType::Num },
       { "float", AET::FLOAT, TiriType::Num },
       { "double", AET::DOUBLE, TiriType::Num },
       { "str", AET::STR_GC, TiriType::Str },

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -55,6 +55,10 @@ ArrayElementDescriptor describe_array_element(const GCarray *Array) noexcept
       case AET::INT16:
       case AET::INT32:
       case AET::INT64:
+      case AET::UINT8:
+      case AET::UINT16:
+      case AET::UINT32:
+      case AET::UINT64:
       case AET::FLOAT:
       case AET::DOUBLE: result.logical_type = TiriType::Num; break;
       case AET::STR_GC: result.logical_type = TiriType::Str; break;
@@ -85,6 +89,10 @@ std::string array_element_name(const ArrayElementDescriptor &Element)
       case AET::INT16:  name = "int16"; break;
       case AET::INT32:  name = "int"; break;
       case AET::INT64:  name = "int64"; break;
+      case AET::UINT8:  name = "uint8"; break;
+      case AET::UINT16: name = "uint16"; break;
+      case AET::UINT32: name = "uint32"; break;
+      case AET::UINT64: name = "uint64"; break;
       case AET::FLOAT:  name = "float"; break;
       case AET::DOUBLE: name = "double"; break;
       case AET::STR_GC: name = "str"; break;
@@ -614,6 +622,10 @@ std::optional<ArrayElementDescriptor> describe_array_element(std::string_view Na
    else if (Name IS "int16") result = { AET::INT16, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "int") result = { AET::INT32, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "int64") result = { AET::INT64, TiriType::Num, CLASSID::NIL, nullptr, true };
+   else if (Name IS "uint8") result = { AET::UINT8, TiriType::Num, CLASSID::NIL, nullptr, true };
+   else if (Name IS "uint16") result = { AET::UINT16, TiriType::Num, CLASSID::NIL, nullptr, true };
+   else if (Name IS "uint32") result = { AET::UINT32, TiriType::Num, CLASSID::NIL, nullptr, true };
+   else if (Name IS "uint64") result = { AET::UINT64, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "float") result = { AET::FLOAT, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "double") result = { AET::DOUBLE, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "str") result = { AET::STR_GC, TiriType::Str, CLASSID::NIL, nullptr, true };

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -15,6 +15,7 @@
 
 #include <cstring>
 #include <cfloat>
+#include <climits>
 #include <cmath>
 #include <limits>
 #include <kotuku/main.h>
@@ -40,7 +41,11 @@ static const uint8_t glElemSizes[] = {
    sizeof(GCRef),        // AET::ARRAY
    sizeof(TValue),       // AET::ANY
    0,                    // AET::STRUCT (variable)
-   sizeof(GCRef)         // AET::OBJECT
+   sizeof(GCRef),        // AET::OBJECT
+   sizeof(uint8_t),      // AET::UINT8
+   sizeof(uint16_t),     // AET::UINT16
+   sizeof(uint32_t),     // AET::UINT32
+   sizeof(uint64_t)      // AET::UINT64
 };
 
 //********************************************************************************************************************
@@ -107,6 +112,10 @@ static LJ_AINLINE ArrayElementResult array_validate_element(GCarray *Array, cTVa
          case AET::INT16:
          case AET::INT32:
          case AET::INT64:
+         case AET::UINT8:
+         case AET::UINT16:
+         case AET::UINT32:
+         case AET::UINT64:
          case AET::FLOAT:
          case AET::DOUBLE:
          case AET::STR_GC:
@@ -126,6 +135,10 @@ static LJ_AINLINE ArrayElementResult array_validate_element(GCarray *Array, cTVa
       case AET::BYTE:
       case AET::INT16:
       case AET::INT64:
+      case AET::UINT8:
+      case AET::UINT16:
+      case AET::UINT32:
+      case AET::UINT64:
          return array_validate_integer(Value);
       case AET::INT32: {
          uint32_t bits;
@@ -190,12 +203,6 @@ static uint64_t array_unsigned_integer(lua_Number Value, unsigned Bits)
 {
    double modulus = std::ldexp(1.0, int(Bits));
    double reduced = std::fmod(std::trunc(Value), modulus);
-   if (Bits IS 64) {
-      double signed_limit = std::ldexp(1.0, 63);
-      if (reduced >= signed_limit) reduced -= modulus;
-      else if (reduced < -signed_limit) reduced += modulus;
-      return uint64_t(int64_t(reduced));
-   }
    if (reduced < 0) reduced += modulus;
    return uint64_t(reduced);
 }
@@ -210,6 +217,15 @@ static LJ_AINLINE void array_store_int32(void *Element, cTValue *Value)
       return;
    }
    std::memcpy(Element, &bits, sizeof(bits));
+}
+
+//********************************************************************************************************************
+
+template<typename T>
+static LJ_AINLINE void array_store_unsigned(void *Element, cTValue *Value)
+{
+   T value = tvisint(Value) ? T(intV(Value)) : T(array_unsigned_integer(numV(Value), sizeof(T) * CHAR_BIT));
+   std::memcpy(Element, &value, sizeof(value));
 }
 
 //********************************************************************************************************************
@@ -261,6 +277,18 @@ static LJ_AINLINE void array_store_validated(lua_State *L, GCarray *Array, MSize
          std::memcpy(element, &bits, sizeof(bits));
          return;
       }
+      case AET::UINT8:
+         array_store_unsigned<uint8_t>(element, Value);
+         return;
+      case AET::UINT16:
+         array_store_unsigned<uint16_t>(element, Value);
+         return;
+      case AET::UINT32:
+         array_store_unsigned<uint32_t>(element, Value);
+         return;
+      case AET::UINT64:
+         array_store_unsigned<uint64_t>(element, Value);
+         return;
       case AET::FLOAT:
          *(float *)element = tvisint(Value) ? float(intV(Value)) : float(numV(Value));
          return;
@@ -338,6 +366,10 @@ void lj_array_store_new_values(lua_State *L, GCarray *Array, cTValue *Values, MS
          case AET::INT16:  stored = array_store_integer_sequence<int16_t>(Array, Values, Count); break;
          case AET::INT32:  stored = array_store_integer_sequence<int32_t>(Array, Values, Count); break;
          case AET::INT64:  stored = array_store_integer_sequence<int64_t>(Array, Values, Count); break;
+         case AET::UINT8:  stored = array_store_integer_sequence<uint8_t>(Array, Values, Count); break;
+         case AET::UINT16: stored = array_store_integer_sequence<uint16_t>(Array, Values, Count); break;
+         case AET::UINT32: stored = array_store_integer_sequence<uint32_t>(Array, Values, Count); break;
+         case AET::UINT64: stored = array_store_integer_sequence<uint64_t>(Array, Values, Count); break;
          case AET::FLOAT:  stored = array_store_integer_sequence<float>(Array, Values, Count); break;
          case AET::DOUBLE: stored = array_store_integer_sequence<double>(Array, Values, Count); break;
          default: break;
@@ -687,6 +719,10 @@ GCtab * lj_array_to_table(lua_State *L, GCarray *Array)
          case AET::INT16:  setintV(slot, *(int16_t*)elem); break;
          case AET::INT32:  setintV(slot, *(int32_t*)elem); break;
          case AET::INT64:  setnumV(slot, lua_Number(*(int64_t*)elem)); break;
+         case AET::UINT8:  setintV(slot, *(uint8_t*)elem); break;
+         case AET::UINT16: setintV(slot, *(uint16_t*)elem); break;
+         case AET::UINT32: setnumV(slot, lua_Number(*(uint32_t*)elem)); break;
+         case AET::UINT64: setnumV(slot, lua_Number(*(uint64_t*)elem)); break;
          case AET::FLOAT:  setnumV(slot, *(float*)elem); break;
          case AET::DOUBLE: setnumV(slot, *(double*)elem); break;
          case AET::TABLE: {

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -203,7 +203,7 @@ static uint64_t array_unsigned_integer(lua_Number Value, unsigned Bits)
 {
    double modulus = std::ldexp(1.0, int(Bits));
    double reduced = std::fmod(std::trunc(Value), modulus);
-   if (reduced < 0) reduced += modulus;
+   if (reduced < 0) return uint64_t(0) - uint64_t(-reduced);
    return uint64_t(reduced);
 }
 

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -828,6 +828,10 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
          case AET::INT16:  member = "int16"; break;
          case AET::INT32:  member = "int"; break;
          case AET::INT64:  member = "int64"; break;
+         case AET::UINT8:  member = "uint8"; break;
+         case AET::UINT16: member = "uint16"; break;
+         case AET::UINT32: member = "uint32"; break;
+         case AET::UINT64: member = "uint64"; break;
          case AET::FLOAT:  member = "float"; break;
          case AET::DOUBLE: member = "double"; break;
          case AET::CSTR:

--- a/src/tiri/jit/src/runtime/lj_obj.cpp
+++ b/src/tiri/jit/src/runtime/lj_obj.cpp
@@ -54,6 +54,10 @@ const void * lj_obj_ptr(global_State *g, cTValue *o)
       case AET::INT16:   return FD_WORD;
       case AET::INT32:   return FD_INT;
       case AET::INT64:   return FD_INT64;
+      case AET::UINT8:   return FD_BYTE;
+      case AET::UINT16:  return FD_WORD;
+      case AET::UINT32:  return FD_INT;
+      case AET::UINT64:  return FD_INT64;
       case AET::FLOAT:   return FD_FLOAT;
       case AET::DOUBLE:  return FD_DOUBLE;
       case AET::PTR:     return FD_POINTER;

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -1270,6 +1270,11 @@ enum class AET : uint8_t {
    ANY,        // TValue (mixed type storage)
    STRUCT,     // Structured data (uses structdef)
    OBJECT,     // OBJECTPTR for external object references originating from the Kotuku API; otherwise GCobject
+   // Appended to preserve the serialised ordinals above.
+   UINT8,      // uint8_t numeric storage (not a byte buffer)
+   UINT16,     // uint16_t
+   UINT32,     // uint32_t
+   UINT64,     // uint64_t
    MAX,
    VULNERABLE = PTR
 };

--- a/src/tiri/jit/src/runtime/lj_vmarray.cpp
+++ b/src/tiri/jit/src/runtime/lj_vmarray.cpp
@@ -47,6 +47,10 @@ static void arr_load_elem(lua_State *L, GCarray *Array, uint32_t Idx, TValue *Re
       case AET::INT16:  setintV(Result, *(int16_t*)elem); break;
       case AET::INT32:  setintV(Result, *(int32_t*)elem); break;
       case AET::INT64:  setnumV(Result, lua_Number(*(int64_t*)elem)); break;
+      case AET::UINT8:  setintV(Result, *(uint8_t*)elem); break;
+      case AET::UINT16: setintV(Result, *(uint16_t*)elem); break;
+      case AET::UINT32: setnumV(Result, lua_Number(*(uint32_t*)elem)); break;
+      case AET::UINT64: setnumV(Result, lua_Number(*(uint64_t*)elem)); break;
       case AET::FLOAT:  setnumV(Result, *(float*)elem); break;
       case AET::DOUBLE: setnumV(Result, *(double*)elem); break;
 

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -150,6 +150,72 @@ static bool test_array_creation_int32(kt::Log &Log)
 }
 
 //********************************************************************************************************************
+
+static bool test_unsigned_array_types(kt::Log &Log)
+{
+   LuaStateHolder holder;
+   lua_State *lua = holder.get();
+   if (not lua) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+   luaL_openlibs(lua);
+
+   struct UnsignedArrayCase {
+      AET type;
+      uint8_t size;
+      uint64_t value;
+   };
+   constexpr std::array<UnsignedArrayCase, 4> cases = { {
+      { AET::UINT8, sizeof(uint8_t), 255 },
+      { AET::UINT16, sizeof(uint16_t), 65535 },
+      { AET::UINT32, sizeof(uint32_t), 4294967295ULL },
+      { AET::UINT64, sizeof(uint64_t), 9007199254740991ULL }
+   } };
+
+   for (const auto &test : cases) {
+      GCarray *array = lj_array_new(lua, 1, test.type);
+      if (not array or array->elemsize != test.size or array->elemtype != test.type) {
+         Log.error("unsigned array allocation has the wrong layout for type %d", int(test.type));
+         return false;
+      }
+
+      switch (test.type) {
+         case AET::UINT8:  array->get<uint8_t>()[0] = uint8_t(test.value); break;
+         case AET::UINT16: array->get<uint16_t>()[0] = uint16_t(test.value); break;
+         case AET::UINT32: array->get<uint32_t>()[0] = uint32_t(test.value); break;
+         case AET::UINT64: array->get<uint64_t>()[0] = uint64_t(test.value); break;
+         default: return false;
+      }
+
+      TValue result;
+      lj_arr_getidx(lua, array, 0, &result);
+      if (test.type IS AET::UINT8 or test.type IS AET::UINT16) {
+         const bool matches = (tvisint(&result) and intV(&result) IS int32_t(test.value)) or
+            (tvisnum(&result) and numberVint(&result) IS int32_t(test.value));
+         if (not matches) {
+            Log.error("unsigned small-width array readback failed for type %d", int(test.type));
+            return false;
+         }
+      }
+      else if (not tvisnum(&result) or numV(&result) != lua_Number(test.value)) {
+         Log.error("unsigned wide array readback failed for type %d", int(test.type));
+         return false;
+      }
+   }
+
+   GCarray *wrapped = lj_array_new(lua, 1, AET::UINT32);
+   TValue negative;
+   setintV(&negative, -1);
+   lj_arr_setidx(lua, wrapped, 0, &negative);
+   if (wrapped->get<uint32_t>()[0] != std::numeric_limits<uint32_t>::max()) {
+      Log.error("unsigned array negative conversion did not wrap modulo its width");
+      return false;
+   }
+   return true;
+}
+
+//********************************************************************************************************************
 // Null-terminated pointer fields use a negative array size as a sentinel.  The struct reader must scan the pointed-to
 // values before creating the cached array rather than passing that sentinel to the unsigned array allocator.
 
@@ -1214,10 +1280,11 @@ static bool test_lib_array_double_type(kt::Log &Log)
 
 void array_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 32> Tests = { {
+   constexpr std::array<TestCase, 33> Tests = { {
       // Core Data Structures
       { "array_creation_byte", test_array_creation_byte },
       { "array_creation_int32", test_array_creation_int32 },
+      { "unsigned_array_types", test_unsigned_array_types },
       { "struct_pointer_array_sentinel", test_struct_pointer_array_sentinel },
       { "struct_to_table_string_vector", test_struct_to_table_string_vector },
       { "array_creation_double", test_array_creation_double },

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -212,6 +212,22 @@ static bool test_unsigned_array_types(kt::Log &Log)
       Log.error("unsigned array negative conversion did not wrap modulo its width");
       return false;
    }
+
+   GCarray *wide_wrapped = lj_array_new(lua, 1, AET::UINT64);
+   TValue negative_number;
+   setnumV(&negative_number, -1.0);
+   lj_arr_setidx(lua, wide_wrapped, 0, &negative_number);
+   if (wide_wrapped->get<uint64_t>()[0] != std::numeric_limits<uint64_t>::max()) {
+      Log.error("uint64 array conversion lost a negative numeric value during modulo reduction");
+      return false;
+   }
+
+   setnumV(&negative_number, -4294967295.0);
+   lj_arr_setidx(lua, wide_wrapped, 0, &negative_number);
+   if (wide_wrapped->get<uint64_t>()[0] != UINT64_C(18446744069414584321)) {
+      Log.error("uint64 array conversion produced incorrect modulo bits for a wide negative number");
+      return false;
+   }
    return true;
 }
 

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -65,6 +65,20 @@ end
    end
    assert(words[0] is 33167 and masks[0] is 2147484047 and counters[0] is 9007199254740399,
       'hot unsigned array indexing diverged from interpreter behaviour')
+
+   local bytes = array<uint8, 1>
+   local wide_words = array<uint16, 1>
+   local negative_counters = array<uint64, 2>
+   for i in {0 to 400} do
+      bytes[0] = 4294967295.0
+      wide_words[0] = 4294967295.0
+      negative_counters[0] = -1.0
+      negative_counters[1] = -4294967295.0
+   end
+   assert(bytes.concat('', '%u') is '255' and wide_words.concat('', '%u') is '65535',
+      'hot small-width unsigned stores narrowed numeric values before modulo conversion')
+   assert(negative_counters.concat(',', '%llu') is '18446744073709551615,18446744069414584321',
+      'hot uint64 stores did not preserve negative numeric values modulo 64 bits')
 end
 
 @Test function IntegerArrayConcat()

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -36,6 +36,37 @@ end
       'named-structure binding identity should be accepted')
 end
 
+@Test function UnsignedArrayBindingAndHotIndexing()
+   function identity_uint8(Value:array<uint8>):array<uint8> return Value end
+   function identity_uint16(Value:array<uint16>):array<uint16> return Value end
+   function identity_uint32(Value:array<uint32>):array<uint32> return Value end
+   function identity_uint64(Value:array<uint64>):array<uint64> return Value end
+
+   assert(identity_uint8(array<uint8> {}) != nil and identity_uint16(array<uint16> {}) != nil,
+      'small unsigned array contracts were rejected')
+   assert(identity_uint32(array<uint32> {}) != nil and identity_uint64(array<uint64> {}) != nil,
+      'wide unsigned array contracts were rejected')
+
+   local contract_failed = false
+   try
+      identity_uint32(array<int> {})
+   except error_value
+      contract_failed = true
+   end
+   assert(contract_failed, 'signed array satisfied an unsigned array contract')
+
+   local words = array<uint16, 1>
+   local masks = array<uint32, 1>
+   local counters = array<uint64, 1>
+   for i in {0 to 400} do
+      words[0] = 32768 + i
+      masks[0] = 2147483648 + i
+      counters[0] = 9007199254740000 + i
+   end
+   assert(words[0] is 33167 and masks[0] is 2147484047 and counters[0] is 9007199254740399,
+      'hot unsigned array indexing diverged from interpreter behaviour')
+end
+
 @Test function IntegerArrayConcat()
    int_array = array<int, 5>
    int_array[0] = 10

--- a/src/tiri/tests/test_array_element_validation.tiri
+++ b/src/tiri/tests/test_array_element_validation.tiri
@@ -22,7 +22,8 @@ function expect_failure(Action:func, Description:str)
 end
 
 @Test function NumericStringsAreNeverElements()
-   local element_types = array<str> { 'byte', 'int16', 'int', 'int64', 'float', 'double' }
+   local element_types = array<str> { 'byte', 'int16', 'int', 'int64', 'uint8', 'uint16', 'uint32', 'uint64',
+      'float', 'double' }
 
    for _, element_type in element_types do
       local indexed = array.new(1, element_type)
@@ -82,7 +83,8 @@ end
 end
 
 @Test function NilUsesTheTypedEmptyValue()
-   local numeric_types = array<str> { 'byte', 'int16', 'int', 'int64', 'float', 'double' }
+   local numeric_types = array<str> { 'byte', 'int16', 'int', 'int64', 'uint8', 'uint16', 'uint32', 'uint64',
+      'float', 'double' }
    for _, element_type in numeric_types do
       local values = array.new(1, element_type)
       values[0] = 9

--- a/src/tiri/tests/test_array_manip.tiri
+++ b/src/tiri/tests/test_array_manip.tiri
@@ -92,6 +92,28 @@ end
    assert(arr.getString() is 'ABCD', 'getString should return ABCD')
 end
 
+@Test function UnsignedArrayMutationAndAlgorithms()
+   local bytes = array<uint8> { -1, 256, 1.9 }
+   assert(bytes[0] is 255 and bytes[1] is 0 and bytes[2] is 1, 'uint8 construction did not wrap and truncate')
+   bytes.push(2)
+   bytes.insert(1, 257)
+   bytes.fill(-1, 2, 1)
+   assert(bytes[1] is 1 and bytes[2] is 255, 'uint8 mutation did not preserve modulo conversion')
+
+   local values = array<uint32> { 2147483648, 3, 4294967295 }
+   values.sort()
+   assert(values[0] is 3 and values[1] is 2147483648 and values.find(4294967295) is 2,
+      'uint32 ordering or find used signed comparison')
+   local copy = values.clone().slice({0 into 1})
+   assert(copy.type() is 'uint32' and copy[1] is 2147483648, 'uint32 clone or slice lost its identity')
+
+   local words = array<uint16> { 1, 2, 3 }
+   local mapped = words.map(Value => num: Value + 65535).filter(Value => bool: Value is 0)
+   assert(mapped.type() is 'uint16' and #mapped is 1 and mapped[0] is 0, 'unsigned map/filter lost modulo storage')
+   assert(array<uint64> { 9007199254740991 }.concat('', '%llu') is '9007199254740991',
+      'uint64 concat did not use an unsigned long long format')
+end
+
 @Test function ArrayPushByteString()
    empty = array<byte>
    len = empty.push('')

--- a/src/tiri/tests/test_array_typed_syntax.tiri
+++ b/src/tiri/tests/test_array_typed_syntax.tiri
@@ -134,6 +134,30 @@ end
    assert(table_arr.type() is 'table', "table should be 'table'")
 end
 
+@Test function ArrayTypedUnsignedTypes()
+   local uint8_arr = array<uint8>
+   local uint16_arr = array<uint16, 2>
+   local uint32_arr = array<uint32> { 0, 4294967295 }
+   local uint64_arr = array<uint64, 2> { 1, 9007199254740991 }
+   local legacy_new = array.new(1, 'uint16')
+   local legacy_of = array.of('uint8', 255)
+
+   assert(uint8_arr.type() is 'uint8' and tostring(uint8_arr) is 'array<uint8, 0>', 'uint8 identity was not preserved')
+   assert(uint16_arr.type() is 'uint16' and #uint16_arr is 2, 'uint16 fixed-size syntax failed')
+   assert(uint32_arr.type() is 'uint32' and uint32_arr[1] is 4294967295, 'uint32 literal lost its range')
+   assert(uint64_arr.type() is 'uint64' and uint64_arr[1] is 9007199254740991, 'uint64 literal lost exact data')
+   assert(legacy_new.type() is 'uint16' and legacy_of.type() is 'uint8' and legacy_of[0] is 255,
+      'legacy unsigned constructors did not retain their element types')
+
+   local failed = false
+   try
+      uint8_arr.push('A')
+   except error_value
+      failed = true
+   end
+   assert(failed, 'array<uint8> accepted byte-buffer string input')
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- Whitespace handling
 


### PR DESCRIPTION
* Extended the AET enumeration and array metadata tables to carry the four unsigned element types with correct storage sizes and numeric coercion
* [JIT] Recorded unsigned array loads and stores with width-appropriate XLOAD/XSTORE and conversions, including range guards for numeric stores
* Added modulo-width conversion for unsigned stores so out-of-range and negative values wrap correctly, replacing the signed reinterpretation path in array_unsigned_integer
* Taught array.concat to require an unsigned format specifier for unsigned arrays and to emit uint64 via unsigned long long
* Recognised uint8/uint16/uint32/uint64 across the parser type descriptors, contract type naming and array-to-table conversion
* Bumped the bytecode dump version to 0x92 and rejected 0x91 chunks