### PR TITLE
[Tiri] Standardised debug.validate() source positions on 1-based coords

### DIFF
--- a/src/tiri/jit/AGENTS.md
+++ b/src/tiri/jit/AGENTS.md
@@ -188,10 +188,10 @@ The table exposed to Tiri is zero-indexed and has this shape:
          name = "greet",
          kind = "function",
          signature = "greet(Name: str):str",
-         line = 0,
-         column = 0,
-         endLine = 6,
-         endColumn = 1,
+         line = 1,
+         column = 1,
+         endLine = 7,
+         endColumn = 2,
          annotations = {
             [0] = { name = "Doc", args = { text = "..." } }
          },

--- a/src/tiri/jit/src/lib/lib_debug.cpp
+++ b/src/tiri/jit/src/lib/lib_debug.cpp
@@ -1008,20 +1008,22 @@ LJLIB_CF(debug_traceback)
 // Returns a table with:
 //   success     - boolean: true if no errors
 //   diagnostics - array of diagnostic entries, each containing:
-//     line      - 0-based line number
-//     column    - 0-based column number
-//     endColumn - 0-based end column (column + 1 as approximation)
+//     line      - 1-based line number
+//     column    - 1-based column number
+//     endColumn - 1-based exclusive end column (column + 1 as approximation)
 //     severity  - 0=Info, 1=Warning, 2=Error
 //     code      - string error code (e.g., "UnexpectedToken")
 //     message   - human-readable error message
 //   tips        - array of code improvement hints (LSP severity 4), each containing:
-//     line      - 0-based line number
-//     column    - 0-based column number
-//     endColumn - 0-based end column
+//     line      - 1-based line number
+//     column    - 1-based column number
+//     endColumn - 1-based exclusive end column
 //     severity  - 3 (Hint - maps to LSP severity 4)
 //     priority  - 1=critical, 2=medium, 3=low
 //     category  - hint category (e.g., "performance", "code-quality")
 //     message   - human-readable improvement suggestion
+//
+// All source positions returned by debug.validate() are 1-based.  A value of zero indicates an unavailable position.
 //
 // The optional second argument may be an options table for richer control:
 //   flags - a string of comma/space separated flags (e.g. "symbols" to include parsed symbol metadata)
@@ -1071,6 +1073,13 @@ static void set_table_int(lua_State *L, CSTRING Key, int Value)
 {
    lua_pushinteger(L, Value);
    lua_setfield(L, -2, Key);
+}
+
+static int source_position(BCLine Position)
+{
+   if (not Position.isValid()) return 0;
+   int position = Position.lineNumber();
+   return position > 0 ? position : 0;
 }
 
 static void push_annotation_metadata(lua_State *L, const std::vector<ParserAnnotationMetadata> &Annotations)
@@ -1162,10 +1171,8 @@ static void push_fields_metadata(lua_State *L, const std::vector<ParserStructFie
       set_table_string(L, "name", field.name);
       set_table_string(L, "type", field.type);
       set_table_string(L, "doc", field.doc);
-      int32_t line = field.span.line.lineNumber();
-      int32_t column = field.span.column.lineNumber();
-      set_table_int(L, "line", line > 0 ? line - 1 : 0);
-      set_table_int(L, "column", column > 0 ? column - 1 : 0);
+      set_table_int(L, "line", source_position(field.span.line));
+      set_table_int(L, "column", source_position(field.span.column));
       lua_rawseti(L, -2, idx++);
    }
 }
@@ -1182,10 +1189,10 @@ static void push_symbol_metadata(lua_State *L, const ParserSymbolCollection *Sym
       set_table_string(L, "name", symbol.name);
       set_table_string(L, "kind", symbol.kind);
       set_table_string(L, "signature", symbol.signature);
-      set_table_int(L, "line", symbol.span.line > 0 ? int(symbol.span.line) - 1 : 0);
-      set_table_int(L, "column", symbol.span.column > 0 ? int(symbol.span.column) - 1 : 0);
-      set_table_int(L, "endLine", symbol.end_span.line > 0 ? int(symbol.end_span.line) - 1 : 0);
-      set_table_int(L, "endColumn", symbol.end_span.column > 0 ? int(symbol.end_span.column) - 1 : 0);
+      set_table_int(L, "line", source_position(symbol.span.line));
+      set_table_int(L, "column", source_position(symbol.span.column));
+      set_table_int(L, "endLine", source_position(symbol.end_span.line));
+      set_table_int(L, "endColumn", source_position(symbol.end_span.column));
 
       push_params_metadata(L, symbol.params);
       lua_setfield(L, -2, "params");
@@ -1276,12 +1283,11 @@ LJLIB_CF(debug_validate)
          lua_newtable(L);  // diagnostic entry
 
          SourceSpan span = entry.token.span();
-         // LSP uses 0-based line/column, Tiri parser uses 1-based
-         int32_t line = span.line.lineNumber();
-         int32_t column = span.column.lineNumber();
-         settabsi(L, "line", line > 0 ? line - 1 : 0);
-         settabsi(L, "column", column > 0 ? column - 1 : 0);
-         settabsi(L, "endColumn", column);  // Already correct after -1 adjustment
+         int line = source_position(span.line);
+         int column = source_position(span.column);
+         settabsi(L, "line", line);
+         settabsi(L, "column", column);
+         settabsi(L, "endColumn", column > 0 ? column + 1 : 0);
          settabsi(L, "severity", int(entry.severity));
          settabss(L, "code", diagnostic_code_name(entry.code));
          settabss(L, "message", entry.message.empty() ? "Syntax error" : entry.message.c_str());
@@ -1311,12 +1317,11 @@ LJLIB_CF(debug_validate)
          lua_newtable(L);  // tip entry
 
          SourceSpan span = entry.token.span();
-         // LSP uses 0-based line/column, Tiri parser uses 1-based
-         int32_t line = span.line.lineNumber();
-         int32_t column = span.column.lineNumber();
-         settabsi(L, "line", line > 0 ? line - 1 : 0);
-         settabsi(L, "column", column > 0 ? column - 1 : 0);
-         settabsi(L, "endColumn", column);  // Already correct after -1 adjustment
+         int line = source_position(span.line);
+         int column = source_position(span.column);
+         settabsi(L, "line", line);
+         settabsi(L, "column", column);
+         settabsi(L, "endColumn", column > 0 ? column + 1 : 0);
          settabsi(L, "severity", 3);  // Hint severity (maps to LSP severity 4)
          settabsi(L, "priority", entry.priority);
          settabss(L, "category", category_name(entry.category));

--- a/src/tiri/tests/test_debug.tiri
+++ b/src/tiri/tests/test_debug.tiri
@@ -412,6 +412,16 @@ end
    assert(type(result.tips) is 'table', "tips should be a table")
 end
 
+@Test function ValidateTipCoordinatesAreOneBased()
+   result = debug.validate('local unused_validate_position = 1')
+   assert(#result.tips > 0, 'An unused local should produce a tip')
+
+   tip = result.tips[0]
+   assert(tip.line is 1, f"Expected tip on line 1, got {tip.line}")
+   assert(tip.column is 7, f"Expected tip at column 7, got {tip.column}")
+   assert(tip.endColumn is 8, f"Expected tip to end after column 7, got {tip.endColumn}")
+end
+
 function hasTipMessage(Result, Message)
    if not Result.tips then return false end
    for tip in values(Result.tips) do
@@ -791,8 +801,8 @@ end
    assert(point and point.kind is 'struct', "Expected a struct symbol for ValidatePoint")
    assert(point.signature is 'struct ValidatePoint', "Unexpected struct signature: " .. tostring(point.signature))
    assert(#point.fields is 2, "Expected two ValidatePoint fields, got " .. #point.fields)
-   assert(point.line is 0, "Struct symbol line should be 0-based, got " .. point.line)
-   assert(point.endLine is 3, "Struct endLine should sit on the end keyword, got " .. point.endLine)
+   assert(point.line is 1, "Struct symbol line should be 1-based, got " .. point.line)
+   assert(point.endLine is 4, "Struct endLine should sit on the end keyword, got " .. point.endLine)
 
    assert(user and user.kind is 'struct', "Expected a struct symbol for ValidateUser")
    assert(#user.fields is 8, "Expected eight ValidateUser fields, got " .. #user.fields)
@@ -809,10 +819,24 @@ end
    assert(fields.Home.type is 'struct<ValidatePoint>', "Embedded struct types should be preserved")
    assert(fields.Next.type is 'ptr<ValidatePoint>', "Struct pointer types should be preserved")
    assert(fields.List.type is 'ptr<ValidatePoint[]>', "Null-terminated list types should be preserved")
-   assert(fields.Name.line is 7, "Field lines should be 0-based, got " .. fields.Name.line)
+   assert(fields.Name.line is 8, "Field lines should be 1-based, got " .. fields.Name.line)
 
    -- Functions should carry an empty fields array rather than nil for consistency.
    assert(greet.fields != nil and #greet.fields is 0, "Function symbols should have an empty fields array")
+end
+
+@Test function ValidateSymbolCoordinatesAreOneBased()
+   result = debug.validate('struct ValidateCoordinates\n   Value: int\nend', { symbols = true })
+   assert(result.success is true, 'Struct declaration should validate')
+   assert(#result.symbols is 1, 'Expected one struct symbol')
+
+   symbol = result.symbols[0]
+   assert(symbol.line is 1, f"Expected symbol on line 1, got {symbol.line}")
+   assert(symbol.column is 8, f"Expected symbol at column 8, got {symbol.column}")
+   assert(symbol.endLine is 3, f"Expected symbol to end on line 3, got {symbol.endLine}")
+   assert(#symbol.fields is 1, 'Expected one struct field')
+   assert(symbol.fields[0].line is 2, f"Expected field on line 2, got {symbol.fields[0].line}")
+   assert(symbol.fields[0].column is 4, f"Expected field at column 4, got {symbol.fields[0].column}")
 end
 
 @Test function ValidateStructRevalidationIsSideEffectFree()

--- a/src/tiri/tests/test_import_type_analysis.tiri
+++ b/src/tiri/tests/test_import_type_analysis.tiri
@@ -31,7 +31,7 @@ local y:num = probe_add(1, 2)
    local diag = result.diagnostics[0]
    assert(diag.file is 'import_type_error_helper.tiri',
       f"Diagnostic should be attributed to the imported file, got '{tostring(diag.file)}'")
-   assert(diag.line is 5, f"Expected 0-based line 5 for the helper's type error, got {diag.line}")
+   assert(diag.line is 6, f"Expected line 6 for the helper's type error, got {diag.line}")
    assert(diag.code is 'TypeMismatchAssignment', f"Unexpected diagnostic code '{diag.code}'")
    assert(diag.message.find('cannot assign', 0, true) != nil,
       f"Unexpected diagnostic message: {diag.message}")
@@ -73,7 +73,7 @@ local bad:num = 'oops'
    local diag = result.diagnostics[0]
    assert(diag.file is nil,
       f"Main buffer diagnostics should carry no file attribution, got '{tostring(diag.file)}'")
-   assert(diag.line is 1, f"Expected 0-based line 1 for the main source error, got {diag.line}")
+   assert(diag.line is 2, f"Expected line 2 for the main source error, got {diag.line}")
    assert(diag.code is 'TypeMismatchAssignment', f"Unexpected diagnostic code '{diag.code}'")
 end
 

--- a/src/tiri/tests/test_malformed_syntax.tiri
+++ b/src/tiri/tests/test_malformed_syntax.tiri
@@ -58,8 +58,9 @@ end
    diag = result.diagnostics[0]
    assert(diag.code is 'DeprecatedSyntax', f"Expected DeprecatedSyntax, got {diag.code}")
    assert(diag.severity is 2, f"Expected error severity, got {diag.severity}")
-   assert(diag.line is 0, f"Expected diagnostic on line 0, got {diag.line}")
-   assert(diag.column is 6, f"Expected diagnostic on '=' at column 6, got {diag.column}")
+   assert(diag.line is 1, f"Expected diagnostic on line 1, got {diag.line}")
+   assert(diag.column is 7, f"Expected diagnostic on '=' at column 7, got {diag.column}")
+   assert(diag.endColumn is 8, f"Expected diagnostic to end after column 7, got {diag.endColumn}")
    assert(diag.message.find('inclusive range'), "Diagnostic should identify inclusive range syntax")
 
    replacement = debug.validate("for i in {0 into 8} do print(i) end")

--- a/tools/tiri_lsp/include/lsp_lib.tiri
+++ b/tools/tiri_lsp/include/lsp_lib.tiri
@@ -427,6 +427,14 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Compute diagnostics for a document using debug.validate()
 
+-- Convert a 1-based debug.validate() source position to the 0-based LSP equivalent.  Zero remains the sentinel for
+-- an unavailable source position.
+
+function validationPositionToLsp(Position:num):num
+   if Position > 0 then return Position - 1 end
+   return 0
+end
+
 -- Helper to check if character is alphanumeric or underscore
 
 function isIdentChar(C)
@@ -515,6 +523,10 @@ global function computeDiagnostics(Doc:table)
       rebuildLineIndex(Doc)
 
       for diag in values(result.diagnostics) do
+         source_line = validationPositionToLsp(diag.line)
+         source_column = validationPositionToLsp(diag.column)
+         source_end_column = validationPositionToLsp(diag.endColumn)
+
          -- Map severity: C++ (0=Info,1=Warn,2=Error) -> LSP (1=Error,2=Warn,3=Info)
          lsp_severity = 3  -- Default to Info
          if diag.severity is 2 then lsp_severity = 1      -- Error
@@ -522,21 +534,21 @@ global function computeDiagnostics(Doc:table)
          end
 
          -- Compute a meaningful range if not provided by the parser
-         start_col = diag.column
-         end_col = diag.endColumn
+         start_col = source_column
+         end_col = source_end_column
          if end_col <= start_col+1 then
-            start_col, end_col = computeErrorRange(Doc, diag.line, diag.column)
+            start_col, end_col = computeErrorRange(Doc, source_line, source_column)
          end
 
-         -- The parser reports byte columns; convert to UTF-16 for the client.
-         diag_line = getLine(Doc, diag.line) or ''
+         -- debug.validate() reports 1-based byte columns; convert them to UTF-16 after adapting to LSP coordinates.
+         diag_line = getLine(Doc, source_line) or ''
          start_col = byteColToUtf16Col(diag_line, start_col)
          end_col = byteColToUtf16Col(diag_line, end_col)
 
          lsp_diags.push({
             range = {
-               start = { line = diag.line, character = start_col },
-               ['end'] = { line = diag.line, character = end_col }
+               start = { line = source_line, character = start_col },
+               ['end'] = { line = source_line, character = end_col }
             },
             severity = lsp_severity,
             source = 'tiri',
@@ -549,21 +561,24 @@ global function computeDiagnostics(Doc:table)
    -- Add tips as LSP Hint diagnostics (severity 4)
    if result.tips then
       for tip in values(result.tips) do
-         start_col = tip.column
-         end_col = tip.endColumn
+         source_line = validationPositionToLsp(tip.line)
+         source_column = validationPositionToLsp(tip.column)
+         source_end_column = validationPositionToLsp(tip.endColumn)
+         start_col = source_column
+         end_col = source_end_column
          if end_col <= start_col+1 then
-            start_col, end_col = computeErrorRange(Doc, tip.line, tip.column)
+            start_col, end_col = computeErrorRange(Doc, source_line, source_column)
          end
 
-         -- The parser reports byte columns; convert to UTF-16 for the client.
-         tip_line = getLine(Doc, tip.line) or ''
+         -- debug.validate() reports 1-based byte columns; convert them to UTF-16 after adapting to LSP coordinates.
+         tip_line = getLine(Doc, source_line) or ''
          start_col = byteColToUtf16Col(tip_line, start_col)
          end_col = byteColToUtf16Col(tip_line, end_col)
 
          lsp_diags.push({
             range = {
-               start = { line = tip.line, character = start_col },
-               ['end'] = { line = tip.line, character = end_col }
+               start = { line = source_line, character = start_col },
+               ['end'] = { line = source_line, character = end_col }
             },
             severity = 4,  -- LSP Hint
             source = 'tiri',


### PR DESCRIPTION
* Reworked lib_debug.cpp to emit 1-based line/column positions with a shared source_position() helper, using zero as the sentinel for unavailable positions
* Set endColumn to a 1-based exclusive end column
* [LSP] Converted 1-based validation positions back to 0-based LSP coordinates via validationPositionToLsp() in lsp_lib.tiri
* [Doc] Updated debug.validate() documentation and AGENTS.md to reflect 1-based positions