### PR TITLE
[Tiri] Anchored function symbol coordinates to their declared names

### DIFF
--- a/src/tiri/jit/AGENTS.md
+++ b/src/tiri/jit/AGENTS.md
@@ -179,6 +179,19 @@ struct ParserSymbolMetadata {
 };
 ```
 
+For this source, the function name begins at line 5, column 10, and the terminating `end` token begins at line 7,
+column 1:
+
+```lua
+@Doc(text=[[
+@desc Returns a greeting.
+@input Person to greet
+]])
+function greet(Name: str):str
+   return "Hello " .. Name
+end
+```
+
 The table exposed to Tiri is zero-indexed and has this shape:
 
 ```lua
@@ -188,10 +201,10 @@ The table exposed to Tiri is zero-indexed and has this shape:
          name = "greet",
          kind = "function",
          signature = "greet(Name: str):str",
-         line = 1,
-         column = 1,
+         line = 5,
+         column = 10,
          endLine = 7,
-         endColumn = 2,
+         endColumn = 1,
          annotations = {
             [0] = { name = "Doc", args = { text = "..." } }
          },

--- a/src/tiri/jit/src/parser/parser_symbols.cpp
+++ b/src/tiri/jit/src/parser/parser_symbols.cpp
@@ -335,6 +335,12 @@ static std::string function_name_to_string(const FunctionNamePath &Path)
    return name;
 }
 
+static SourceSpan function_name_span(const FunctionNamePath &Path)
+{
+   if (Path.segments.empty()) return {};
+   return Path.segments.front().span;
+}
+
 static std::string expression_name_to_string(const ExprNode &Expression)
 {
    if (Expression.kind IS AstNodeKind::IdentifierExpr) {
@@ -351,6 +357,21 @@ static std::string expression_name_to_string(const ExprNode &Expression)
    }
 
    return {};
+}
+
+static SourceSpan expression_name_span(const ExprNode &Expression)
+{
+   if (Expression.kind IS AstNodeKind::IdentifierExpr) {
+      if (const auto *name = std::get_if<NameRef>(&Expression.data)) return name->identifier.span;
+   }
+
+   if (Expression.kind IS AstNodeKind::MemberExpr) {
+      if (const auto *member = std::get_if<MemberExprPayload>(&Expression.data)) {
+         if (member->table) return expression_name_span(*member->table);
+      }
+   }
+
+   return Expression.span;
 }
 
 static std::string annotation_type_to_string(
@@ -671,7 +692,7 @@ inline void collect_nested_function_body(ParserSymbolCollection &Collection, con
 }
 
 static void collect_assignment_functions(ParserSymbolCollection &Collection, const ExprNodeList &Targets,
-   const ExprNodeList &Values, SourceSpan Span)
+   const ExprNodeList &Values)
 {
    size_t count = Targets.size() < Values.size() ? Targets.size() : Values.size();
 
@@ -684,14 +705,15 @@ static void collect_assignment_functions(ParserSymbolCollection &Collection, con
       if (not function) continue;
 
       std::string name = expression_name_to_string(*target);
-      if (not name.empty()) Collection.symbols.push_back(make_function_symbol(name, *function, Span));
+      if (not name.empty()) {
+         Collection.symbols.push_back(make_function_symbol(name, *function, expression_name_span(*target)));
+      }
       collect_nested_function_body(Collection, *function);
    }
 }
 
 template <typename DeclPayload>
-static void collect_decl_functions(ParserSymbolCollection &Collection, const DeclPayload &Payload,
-   SourceSpan Span)
+static void collect_decl_functions(ParserSymbolCollection &Collection, const DeclPayload &Payload)
 {
    size_t count = Payload.names.size() < Payload.values.size() ? Payload.names.size() : Payload.values.size();
 
@@ -702,7 +724,8 @@ static void collect_decl_functions(ParserSymbolCollection &Collection, const Dec
       const auto *function = std::get_if<FunctionExprPayload>(&value->data);
       if (not function) continue;
 
-      Collection.symbols.push_back(make_function_symbol(identifier_to_string(Payload.names[i]), *function, Span));
+      Collection.symbols.push_back(make_function_symbol(identifier_to_string(Payload.names[i]), *function,
+         Payload.names[i].span));
       collect_nested_function_body(Collection, *function);
    }
 }
@@ -714,7 +737,7 @@ static void collect_from_statement(ParserSymbolCollection &Collection, const Stm
          const auto &payload = std::get<LocalFunctionStmtPayload>(Statement.data);
          if (payload.function) {
             Collection.symbols.push_back(make_function_symbol(identifier_to_string(payload.name),
-               *payload.function, Statement.span));
+               *payload.function, payload.name.span));
             collect_nested_function_body(Collection, *payload.function);
          }
          break;
@@ -723,24 +746,24 @@ static void collect_from_statement(ParserSymbolCollection &Collection, const Stm
          const auto &payload = std::get<FunctionStmtPayload>(Statement.data);
          if (payload.function) {
             Collection.symbols.push_back(make_function_symbol(function_name_to_string(payload.name),
-               *payload.function, Statement.span));
+               *payload.function, function_name_span(payload.name)));
             collect_nested_function_body(Collection, *payload.function);
          }
          break;
       }
       case AstNodeKind::LocalDeclStmt: {
          const auto &payload = std::get<LocalDeclStmtPayload>(Statement.data);
-         collect_decl_functions(Collection, payload, Statement.span);
+         collect_decl_functions(Collection, payload);
          break;
       }
       case AstNodeKind::GlobalDeclStmt: {
          const auto &payload = std::get<GlobalDeclStmtPayload>(Statement.data);
-         collect_decl_functions(Collection, payload, Statement.span);
+         collect_decl_functions(Collection, payload);
          break;
       }
       case AstNodeKind::AssignmentStmt: {
          const auto &payload = std::get<AssignmentStmtPayload>(Statement.data);
-         collect_assignment_functions(Collection, payload.targets, payload.values, Statement.span);
+         collect_assignment_functions(Collection, payload.targets, payload.values);
          break;
       }
       case AstNodeKind::IfStmt: {

--- a/src/tiri/tests/test_debug.tiri
+++ b/src/tiri/tests/test_debug.tiri
@@ -839,6 +839,43 @@ end
    assert(symbol.fields[0].column is 4, f"Expected field at column 4, got {symbol.fields[0].column}")
 end
 
+@Test function ValidateFunctionSymbolCoordinatesIdentifyNames()
+   result = debug.validate([[
+function named()
+end
+local assigned = function()
+end
+target = {}
+target.method = function()
+end
+local function localNamed()
+end
+global function globalNamed()
+end
+function outer()
+   function inner()
+   end
+end
+]], { symbols = true })
+   assert(result.success is true, 'Function declarations should validate')
+
+   symbols = {}
+   for symbol in values(result.symbols) do symbols[symbol.name] = symbol end
+
+   assert(symbols.named.column is 10, f"Expected named at column 10, got {symbols.named.column}")
+   assert(symbols.assigned.column is 7, f"Expected assigned at column 7, got {symbols.assigned.column}")
+   assert(symbols['target.method'].column is 1,
+      f"Expected target.method at column 1, got {symbols['target.method'].column}")
+   assert(symbols.localNamed.column is 16,
+      f"Expected localNamed at column 16, got {symbols.localNamed.column}")
+   assert(symbols.globalNamed.column is 17,
+      f"Expected globalNamed at column 17, got {symbols.globalNamed.column}")
+   assert(symbols.inner.column is 13, f"Expected inner at column 13, got {symbols.inner.column}")
+   assert(symbols.inner.endLine is 14, f"Expected inner to end on line 14, got {symbols.inner.endLine}")
+   assert(symbols.inner.endColumn is 4,
+      f"Expected inner end token at column 4, got {symbols.inner.endColumn}")
+end
+
 @Test function ValidateStructRevalidationIsSideEffectFree()
    -- Validation must not permanently register declared structs: an edited declaration would otherwise conflict
    -- with the version registered by an earlier validation of the same document.


### PR DESCRIPTION
* Reported function symbol source spans at the name identifier instead of the enclosing statement, covering named, assigned, member, local, global and nested declarations
* [Doc] Documented the name-based coordinate behaviour in AGENTS.md