### PR TITLE
[Tiri] Renamed the uint32 array element type to uint

### DIFF
--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -55,10 +55,10 @@ extern MSGID glDelayedCallMsgID;
    }
    else if (Type & FD_FLOAT)   return AET::FLOAT;
    else if (Type & FD_DOUBLE)  return AET::DOUBLE;
-   else if (Type & FD_INT64)   return AET::INT64;
-   else if (Type & FD_INT)     return AET::INT32;
-   else if (Type & FD_WORD)    return AET::INT16;
-   else if (Type & FD_BYTE)    return AET::BYTE;
+   else if (Type & FD_INT64)   return (Type & FD_UNSIGNED) ? AET::UINT64 : AET::INT64;
+   else if (Type & FD_INT)     return (Type & FD_UNSIGNED) ? AET::UINT32 : AET::INT32;
+   else if (Type & FD_WORD)    return (Type & FD_UNSIGNED) ? AET::UINT16 : AET::INT16;
+   else if (Type & FD_BYTE)    return AET::BYTE; // Bare byte storage is unsigned (uint8_t); no signed variant exists
    else return AET::MAX;
 }
 

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -147,7 +147,7 @@ static CSTRING elemtype_name(AET Type)
       case AET::INT64:      return "int64";
       case AET::UINT8:      return "uint8";
       case AET::UINT16:     return "uint16";
-      case AET::UINT32:     return "uint32";
+      case AET::UINT32:     return "uint";
       case AET::UINT64:     return "uint64";
       case AET::FLOAT:      return "float";
       case AET::DOUBLE:     return "double";

--- a/src/tiri/jit/src/lib/lib_struct.cpp
+++ b/src/tiri/jit/src/lib/lib_struct.cpp
@@ -632,11 +632,21 @@ void lj_struct_getfield_core(lua_State *L, GCstruct *Struct, struct_field &Field
       else lua_pushnil(L);
    }
    else if ((Field.Type & FD_VECTOR) and (not (Field.Type & FD_STRING))) {
+      const bool uns = (Field.Type & FD_UNSIGNED) != 0;
       if (Field.Type & FD_FLOAT) push_vector_array<float>(L, Address, AET::FLOAT);
       else if (Field.Type & FD_DOUBLE) push_vector_array<double>(L, Address, AET::DOUBLE);
-      else if (Field.Type & FD_INT64) push_vector_array<int64_t>(L, Address, AET::INT64);
-      else if (Field.Type & FD_INT) push_vector_array<int>(L, Address, AET::INT32);
-      else if (Field.Type & FD_WORD) push_vector_array<int16_t>(L, Address, AET::INT16);
+      else if (Field.Type & FD_INT64) {
+         if (uns) push_vector_array<uint64_t>(L, Address, AET::UINT64);
+         else push_vector_array<int64_t>(L, Address, AET::INT64);
+      }
+      else if (Field.Type & FD_INT) {
+         if (uns) push_vector_array<uint32_t>(L, Address, AET::UINT32);
+         else push_vector_array<int>(L, Address, AET::INT32);
+      }
+      else if (Field.Type & FD_WORD) {
+         if (uns) push_vector_array<uint16_t>(L, Address, AET::UINT16);
+         else push_vector_array<int16_t>(L, Address, AET::INT16);
+      }
       else if (Field.Type & FD_BYTE) push_vector_array<uint8_t>(L, Address, AET::BYTE);
       else struct_field_error(L, CurrentFrame, ERR::NoSupport,
          "Vector field '%s' uses an unsupported element type.", Field.Name.c_str());

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -576,7 +576,7 @@ static bool array_elemtype_from_string(GCstr *TypeStr, AET *Result)
    else if (TypeStr->len IS 5 and memcmp(type_name, "int64", 5) IS 0) *Result = AET::INT64;
    else if (TypeStr->len IS 5 and memcmp(type_name, "uint8", 5) IS 0) *Result = AET::UINT8;
    else if (TypeStr->len IS 6 and memcmp(type_name, "uint16", 6) IS 0) *Result = AET::UINT16;
-   else if (TypeStr->len IS 6 and memcmp(type_name, "uint32", 6) IS 0) *Result = AET::UINT32;
+   else if (TypeStr->len IS 4 and memcmp(type_name, "uint", 4) IS 0) *Result = AET::UINT32;
    else if (TypeStr->len IS 6 and memcmp(type_name, "uint64", 6) IS 0) *Result = AET::UINT64;
    else if (TypeStr->len IS 5 and memcmp(type_name, "float", 5) IS 0) *Result = AET::FLOAT;
    else if (TypeStr->len IS 6 and memcmp(type_name, "double", 6) IS 0) *Result = AET::DOUBLE;

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1471,7 +1471,7 @@ static bool test_signature_metadata_roundtrip(kt::Log &Log)
       "   Value: int\n"
       "end\n"
       "local function outer(Value:num!, Flexible:any, Untyped, Item:struct<SignatureLayout>, Generic:struct, "
-      "Object:obj, Numbers:array<int>, Records:array<struct<SignatureLayout>>, Masks:array<uint32>, ...):func\n"
+      "Object:obj, Numbers:array<int>, Records:array<struct<SignatureLayout>>, Masks:array<uint>, ...):func\n"
       "   local function inner(Text:str!):<str!, num, ...>\n"
       "      return Text, Value, Value\n"
       "   end\n"
@@ -4583,7 +4583,7 @@ static bool test_static_descriptor_model(kt::Log &Log)
       { "int64", AET::INT64, TiriType::Num },
       { "uint8", AET::UINT8, TiriType::Num },
       { "uint16", AET::UINT16, TiriType::Num },
-      { "uint32", AET::UINT32, TiriType::Num },
+      { "uint", AET::UINT32, TiriType::Num },
       { "uint64", AET::UINT64, TiriType::Num },
       { "float", AET::FLOAT, TiriType::Num },
       { "double", AET::DOUBLE, TiriType::Num },

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -91,7 +91,7 @@ std::string array_element_name(const ArrayElementDescriptor &Element)
       case AET::INT64:  name = "int64"; break;
       case AET::UINT8:  name = "uint8"; break;
       case AET::UINT16: name = "uint16"; break;
-      case AET::UINT32: name = "uint32"; break;
+      case AET::UINT32: name = "uint"; break;
       case AET::UINT64: name = "uint64"; break;
       case AET::FLOAT:  name = "float"; break;
       case AET::DOUBLE: name = "double"; break;
@@ -489,15 +489,15 @@ StaticResultSet describe_module_call_results(const FunctionField *Fields, lua_St
          element.logical_type = TiriType::Num;
       }
       else if (Field.Type & FD_INT64) {
-         element.storage = AET::INT64;
+         element.storage = (Field.Type & FD_UNSIGNED) ? AET::UINT64 : AET::INT64;
          element.logical_type = TiriType::Num;
       }
       else if (Field.Type & FD_INT) {
-         element.storage = AET::INT32;
+         element.storage = (Field.Type & FD_UNSIGNED) ? AET::UINT32 : AET::INT32;
          element.logical_type = TiriType::Num;
       }
       else if (Field.Type & FD_WORD) {
-         element.storage = AET::INT16;
+         element.storage = (Field.Type & FD_UNSIGNED) ? AET::UINT16 : AET::INT16;
          element.logical_type = TiriType::Num;
       }
       else if (Field.Type & FD_BYTE) {
@@ -624,7 +624,7 @@ std::optional<ArrayElementDescriptor> describe_array_element(std::string_view Na
    else if (Name IS "int64") result = { AET::INT64, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "uint8") result = { AET::UINT8, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "uint16") result = { AET::UINT16, TiriType::Num, CLASSID::NIL, nullptr, true };
-   else if (Name IS "uint32") result = { AET::UINT32, TiriType::Num, CLASSID::NIL, nullptr, true };
+   else if (Name IS "uint") result = { AET::UINT32, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "uint64") result = { AET::UINT64, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "float") result = { AET::FLOAT, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "double") result = { AET::DOUBLE, TiriType::Num, CLASSID::NIL, nullptr, true };
@@ -659,9 +659,9 @@ std::optional<ArrayElementDescriptor> describe_array_element(const struct_field 
    }
    else if (Field.Type & FD_FLOAT) result.storage = AET::FLOAT;
    else if (Field.Type & FD_DOUBLE) result.storage = AET::DOUBLE;
-   else if (Field.Type & FD_INT64) result.storage = AET::INT64;
-   else if (Field.Type & FD_INT) result.storage = AET::INT32;
-   else if (Field.Type & FD_WORD) result.storage = AET::INT16;
+   else if (Field.Type & FD_INT64) result.storage = (Field.Type & FD_UNSIGNED) ? AET::UINT64 : AET::INT64;
+   else if (Field.Type & FD_INT) result.storage = (Field.Type & FD_UNSIGNED) ? AET::UINT32 : AET::INT32;
+   else if (Field.Type & FD_WORD) result.storage = (Field.Type & FD_UNSIGNED) ? AET::UINT16 : AET::INT16;
    else if (Field.Type & FD_BYTE) result.storage = AET::BYTE;
    else return std::nullopt;
 

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -830,7 +830,7 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
          case AET::INT64:  member = "int64"; break;
          case AET::UINT8:  member = "uint8"; break;
          case AET::UINT16: member = "uint16"; break;
-         case AET::UINT32: member = "uint32"; break;
+         case AET::UINT32: member = "uint"; break;
          case AET::UINT64: member = "uint64"; break;
          case AET::FLOAT:  member = "float"; break;
          case AET::DOUBLE: member = "double"; break;

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -39,24 +39,24 @@ end
 @Test function UnsignedArrayBindingAndHotIndexing()
    function identity_uint8(Value:array<uint8>):array<uint8> return Value end
    function identity_uint16(Value:array<uint16>):array<uint16> return Value end
-   function identity_uint32(Value:array<uint32>):array<uint32> return Value end
+   function identity_uint(Value:array<uint>):array<uint> return Value end
    function identity_uint64(Value:array<uint64>):array<uint64> return Value end
 
    assert(identity_uint8(array<uint8> {}) != nil and identity_uint16(array<uint16> {}) != nil,
       'small unsigned array contracts were rejected')
-   assert(identity_uint32(array<uint32> {}) != nil and identity_uint64(array<uint64> {}) != nil,
+   assert(identity_uint(array<uint> {}) != nil and identity_uint64(array<uint64> {}) != nil,
       'wide unsigned array contracts were rejected')
 
    local contract_failed = false
    try
-      identity_uint32(array<int> {})
+      identity_uint(array<int> {})
    except error_value
       contract_failed = true
    end
    assert(contract_failed, 'signed array satisfied an unsigned array contract')
 
    local words = array<uint16, 1>
-   local masks = array<uint32, 1>
+   local masks = array<uint, 1>
    local counters = array<uint64, 1>
    for i in {0 to 400} do
       words[0] = 32768 + i

--- a/src/tiri/tests/test_array_element_validation.tiri
+++ b/src/tiri/tests/test_array_element_validation.tiri
@@ -22,7 +22,7 @@ function expect_failure(Action:func, Description:str)
 end
 
 @Test function NumericStringsAreNeverElements()
-   local element_types = array<str> { 'byte', 'int16', 'int', 'int64', 'uint8', 'uint16', 'uint32', 'uint64',
+   local element_types = array<str> { 'byte', 'int16', 'int', 'int64', 'uint8', 'uint16', 'uint', 'uint64',
       'float', 'double' }
 
    for _, element_type in element_types do
@@ -83,7 +83,7 @@ end
 end
 
 @Test function NilUsesTheTypedEmptyValue()
-   local numeric_types = array<str> { 'byte', 'int16', 'int', 'int64', 'uint8', 'uint16', 'uint32', 'uint64',
+   local numeric_types = array<str> { 'byte', 'int16', 'int', 'int64', 'uint8', 'uint16', 'uint', 'uint64',
       'float', 'double' }
    for _, element_type in numeric_types do
       local values = array.new(1, element_type)

--- a/src/tiri/tests/test_array_manip.tiri
+++ b/src/tiri/tests/test_array_manip.tiri
@@ -100,12 +100,12 @@ end
    bytes.fill(-1, 2, 1)
    assert(bytes[1] is 1 and bytes[2] is 255, 'uint8 mutation did not preserve modulo conversion')
 
-   local values = array<uint32> { 2147483648, 3, 4294967295 }
+   local values = array<uint> { 2147483648, 3, 4294967295 }
    values.sort()
    assert(values[0] is 3 and values[1] is 2147483648 and values.find(4294967295) is 2,
-      'uint32 ordering or find used signed comparison')
+      'uint ordering or find used signed comparison')
    local copy = values.clone().slice({0 into 1})
-   assert(copy.type() is 'uint32' and copy[1] is 2147483648, 'uint32 clone or slice lost its identity')
+   assert(copy.type() is 'uint' and copy[1] is 2147483648, 'uint clone or slice lost its identity')
 
    local words = array<uint16> { 1, 2, 3 }
    local mapped = words.map(Value => num: Value + 65535).filter(Value => bool: Value is 0)

--- a/src/tiri/tests/test_array_typed_syntax.tiri
+++ b/src/tiri/tests/test_array_typed_syntax.tiri
@@ -137,17 +137,33 @@ end
 @Test function ArrayTypedUnsignedTypes()
    local uint8_arr = array<uint8>
    local uint16_arr = array<uint16, 2>
-   local uint32_arr = array<uint32> { 0, 4294967295 }
+   local uint_arr = array<uint> { 0, 4294967295 }
    local uint64_arr = array<uint64, 2> { 1, 9007199254740991 }
    local legacy_new = array.new(1, 'uint16')
    local legacy_of = array.of('uint8', 255)
 
    assert(uint8_arr.type() is 'uint8' and tostring(uint8_arr) is 'array<uint8, 0>', 'uint8 identity was not preserved')
    assert(uint16_arr.type() is 'uint16' and #uint16_arr is 2, 'uint16 fixed-size syntax failed')
-   assert(uint32_arr.type() is 'uint32' and uint32_arr[1] is 4294967295, 'uint32 literal lost its range')
+   assert(uint_arr.type() is 'uint' and uint_arr[1] is 4294967295, 'uint literal lost its range')
    assert(uint64_arr.type() is 'uint64' and uint64_arr[1] is 9007199254740991, 'uint64 literal lost exact data')
    assert(legacy_new.type() is 'uint16' and legacy_of.type() is 'uint8' and legacy_of[0] is 255,
       'legacy unsigned constructors did not retain their element types')
+
+   local retired_name_failed = false
+   try
+      array.new(1, 'uint32')
+   except error_value
+      retired_name_failed = true
+   end
+   assert(retired_name_failed, 'array.new() accepted the retired uint32 element name')
+
+   retired_name_failed = false
+   try
+      exec([[local values = array<uint32> { 0 }]])
+   except error_value
+      retired_name_failed = true
+   end
+   assert(retired_name_failed, 'typed array syntax accepted the retired uint32 element name')
 
    local failed = false
    try

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -374,12 +374,12 @@ end
    value.Int8 = array<byte> { 1, 2 }
    value.UInt8 = array<byte> { 3, 4 }
    value.Int16 = array<int16> { -12, 34 }
-   value.UInt16 = array<int16> { 123, 456 }
-   value.UInt = array<int> { 4000000000 }
+   value.UInt16 = array<uint16> { 123, 456 }
+   value.UInt = array<uint> { 4000000000 }
    value.Int32 = array<int> { -123456, 654321 }
-   value.UInt32 = array<int> { 123456, 654321 }
+   value.UInt32 = array<uint> { 123456, 654321 }
    value.Int64 = array<int64> { -9007199, 9007199 }
-   value.UInt64 = array<int64> { 9007199, 18014398 }
+   value.UInt64 = array<uint64> { 9007199, 18014398 }
    value.Float = array<float> { 1.25, 2.5 }
    value.Double = array<double> { 3.5, 7.25 }
 
@@ -389,9 +389,16 @@ end
       'Initialiser assignment should populate a string vector')
    assert(value.Bool is array<byte> { 0, 1 } and value.Char is array<byte> { 65, 66 },
       'Byte-sized vector categories should round-trip')
-   assert(value.Int16 is array<int16> { -12, 34 } and value.UInt16 is array<int16> { 123, 456 },
+   assert(value.Int16 is array<int16> { -12, 34 } and value.UInt16 is array<uint16> { 123, 456 },
       'Word-sized vector categories should round-trip')
    assert(value.Int64 is array<int64> { -9007199, 9007199 }, 'Int64 vectors should round-trip')
+
+   -- Unsigned vector fields must retain their unsigned element type through materialisation, not decay to signed.
+   assert(value.UInt16.type() is 'uint16', "UInt16 vector field should report 'uint16', got '" .. value.UInt16.type() .. "'")
+   assert(value.UInt.type() is 'uint', "UInt vector field should report 'uint', got '" .. value.UInt.type() .. "'")
+   assert(value.UInt32.type() is 'uint', "UInt32 vector field should report 'uint', got '" .. value.UInt32.type() .. "'")
+   assert(value.UInt64.type() is 'uint64', "UInt64 vector field should report 'uint64', got '" .. value.UInt64.type() .. "'")
+   assert(value.Int16.type() is 'int16', "Int16 vector field should retain signed 'int16', got '" .. value.Int16.type() .. "'")
    assert(value.Float is array<float> { 1.25, 2.5 } and value.Double is array<double> { 3.5, 7.25 },
       'Floating-point vectors should round-trip')
 


### PR DESCRIPTION
* Renamed the uint32 element type to uint across the parser, JIT recorder, static descriptors and runtime contract naming
* Derived unsigned array element storage from FD_UNSIGNED so struct vector fields materialise as their unsigned type instead of decaying to signed
* [Test] Rejected the retired uint32 element name and asserted unsigned struct vector fields retain their identity through materialisation