### PR TITLE
[Tiri] Added a signed int8 array element type distinct from the unsigned byte buffer

### DIFF
--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -62,6 +62,12 @@ extern MSGID glDelayedCallMsgID;
    else return AET::MAX;
 }
 
+[[maybe_unused]] static AET ff_to_aet(int Type, NativeStructType NativeType)
+{
+   if ((Type & FD_BYTE) and NativeType IS NativeStructType::Int8) return AET::INT8;
+   return ff_to_aet(Type);
+}
+
 //********************************************************************************************************************
 
 struct CaseInsensitiveHashView {

--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -48,10 +48,10 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // activation bytecodes.  Version 0x8e adds the canonical regex.new identity used by regex literals.  Version 0x8f
 // separates object.create, object.new and object._state callable identities.  Version 0x90 accepts a struct reference
 // in struct.size, which shifts the generated fast-function ordering.  Version 0x92 expands private array member
-// identities with uint8, uint16, uint32 and uint64.  Older chunks are rejected rather than retaining compatibility
-// shims.
+// identities with uint8, uint16, uint32 and uint64.  Version 0x93 gives int8 its own signed array member identity.
+// Older chunks are rejected rather than retaining compatibility shims.
 
-constexpr uint8_t BCDUMP_VERSION = 0x92;
+constexpr uint8_t BCDUMP_VERSION = 0x93;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -79,7 +79,8 @@ const array_meta glArrayConversion[size_t(AET::MAX)] = {
    { uint8_t(LJ_TNUMX),    LUA_TNUMBER, true },         // AET::UINT8
    { uint8_t(LJ_TNUMX),    LUA_TNUMBER, true },         // AET::UINT16
    { uint8_t(LJ_TNUMX),    LUA_TNUMBER, true },         // AET::UINT32
-   { uint8_t(LJ_TNUMX),    LUA_TNUMBER, true }          // AET::UINT64
+   { uint8_t(LJ_TNUMX),    LUA_TNUMBER, true },         // AET::UINT64
+   { uint8_t(LJ_TNUMX),    LUA_TNUMBER, true }          // AET::INT8
 };
 
 //********************************************************************************************************************
@@ -142,6 +143,7 @@ static CSTRING elemtype_name(AET Type)
 {
    switch (Type) {
       case AET::BYTE:       return "char";
+      case AET::INT8:       return "int8";
       case AET::INT16:      return "int16";
       case AET::INT32:      return "int";
       case AET::INT64:      return "int64";
@@ -658,8 +660,11 @@ LJLIB_CF(array_concat)
             case AET::INT16:
                append_formatted(result, format, arr->get<int16_t>()[i]);
                break;
+            case AET::INT8:
+               append_formatted(result, format, int(arr->get<int8_t>()[i]));
+               break;
             case AET::BYTE:
-               append_formatted(result, format, arr->get<int8_t>()[i]);
+               append_formatted(result, format, unsigned(arr->get<uint8_t>()[i]));
                break;
             default:
                luaL_error(L, ERR::InvalidType, "concat() does not support %s types.", elemtype_name(arr->elemtype));
@@ -711,6 +716,9 @@ LJLIB_CF(array_concat)
                break;
             case AET::INT16:
                append_integer(result, arr->get<int16_t>()[i]);
+               break;
+            case AET::INT8:
+               append_integer(result, arr->get<int8_t>()[i]);
                break;
             case AET::BYTE:
                append_integer(result, arr->get<uint8_t>()[i]);
@@ -805,6 +813,7 @@ LJLIB_CF(array_first)
 
    switch (arr->elemtype) {
       case AET::BYTE:   lua_pushinteger(L, *(uint8_t *)elem); break;
+      case AET::INT8:   lua_pushinteger(L, *(int8_t *)elem); break;
       case AET::INT16:  lua_pushinteger(L, *(int16_t *)elem); break;
       case AET::INT32:  lua_pushinteger(L, *(int32_t *)elem); break;
       case AET::INT64:  lua_pushnumber(L, lua_Number(*(int64_t *)elem)); break;
@@ -884,6 +893,7 @@ LJLIB_CF(array_last)
 
    switch (arr->elemtype) {
       case AET::BYTE:   lua_pushinteger(L, *(uint8_t *)elem); break;
+      case AET::INT8:   lua_pushinteger(L, *(int8_t *)elem); break;
       case AET::INT16:  lua_pushinteger(L, *(int16_t *)elem); break;
       case AET::INT32:  lua_pushinteger(L, *(int32_t *)elem); break;
       case AET::INT64:  lua_pushnumber(L, lua_Number(*(int64_t *)elem)); break;
@@ -1127,6 +1137,7 @@ LJLIB_CF(array_pop)
       // Push the value to the stack
       switch (arr->elemtype) {
          case AET::BYTE:   lua_pushinteger(L, *(uint8_t *)elem); break;
+         case AET::INT8:   lua_pushinteger(L, *(int8_t *)elem); break;
          case AET::INT16:  lua_pushinteger(L, *(int16_t *)elem); break;
          case AET::INT32:  lua_pushinteger(L, *(int32_t *)elem); break;
          case AET::INT64:  lua_pushnumber(L, lua_Number(*(int64_t *)elem)); break;
@@ -1419,6 +1430,7 @@ static void fill_array_elements(lua_State *L, GCarray *Arr, cTValue *Value, int3
 
    switch (Arr->elemtype) {
       case AET::BYTE:   ARRAY_FILL_TYPE(uint8_t);
+      case AET::INT8:   ARRAY_FILL_TYPE(int8_t);
       case AET::INT16:  ARRAY_FILL_TYPE(int16_t);
       case AET::INT32:  ARRAY_FILL_TYPE(int32_t);
       case AET::INT64:  ARRAY_FILL_TYPE(int64_t);
@@ -1569,6 +1581,7 @@ static int32_t find_in_array(GCarray *Arr, lua_Number Value, int32_t Start, int3
    if (Step IS 1) {
       switch (Arr->elemtype) {
          case AET::BYTE:   return find_forward_contiguous<uint8_t>(data, Start, Stop, Value);
+         case AET::INT8:   return find_forward_contiguous<int8_t>(data, Start, Stop, Value);
          case AET::INT16:  return find_forward_contiguous<int16_t>(data, Start, Stop, Value);
          case AET::INT32:  return find_forward_contiguous<int32_t>(data, Start, Stop, Value);
          case AET::INT64:  return find_forward_contiguous<int64_t>(data, Start, Stop, Value);
@@ -1585,6 +1598,7 @@ static int32_t find_in_array(GCarray *Arr, lua_Number Value, int32_t Start, int3
    // Stepped search path (non-contiguous or reverse direction)
    switch (Arr->elemtype) {
       case AET::BYTE:   return find_stepped<uint8_t>(data, Start, Stop, Step, Value);
+      case AET::INT8:   return find_stepped<int8_t>(data, Start, Stop, Step, Value);
       case AET::INT16:  return find_stepped<int16_t>(data, Start, Stop, Step, Value);
       case AET::INT32:  return find_stepped<int32_t>(data, Start, Stop, Step, Value);
       case AET::INT64:  return find_stepped<int64_t>(data, Start, Stop, Step, Value);
@@ -1743,6 +1757,7 @@ LJLIB_CF(array_reverse)
 
    switch (arr->elemtype) {
       case AET::BYTE:   { auto *p = (uint8_t *)data; std::reverse(p, p + arr->len); break; }
+      case AET::INT8:   { auto *p = (int8_t *)data; std::reverse(p, p + arr->len); break; }
       case AET::INT16:  { auto *p = (int16_t *)data; std::reverse(p, p + arr->len); break; }
       case AET::INT32:  { auto *p = (int32_t *)data; std::reverse(p, p + arr->len); break; }
       case AET::INT64:  { auto *p = (int64_t *)data; std::reverse(p, p + arr->len); break; }
@@ -1983,6 +1998,7 @@ LJLIB_CF(array_sort)
 
    switch (arr->elemtype) {
       case AET::BYTE: quicksort(arr->get<uint8_t>(), 0, int32_t(arr->len - 1), descending); break;
+      case AET::INT8: quicksort(arr->get<int8_t>(), 0, int32_t(arr->len - 1), descending); break;
       case AET::INT16: quicksort(arr->get<int16_t>(), 0, int32_t(arr->len - 1), descending); break;
       case AET::INT32: quicksort(arr->get<int32_t>(), 0, int32_t(arr->len - 1), descending); break;
       case AET::INT64: quicksort(arr->get<int64_t>(), 0, int32_t(arr->len - 1), descending); break;
@@ -2033,6 +2049,7 @@ static void array_push_element(lua_State *L, GCarray *Arr, MSize Idx)
 
    switch (Arr->elemtype) {
       case AET::BYTE:   lua_pushinteger(L, *(uint8_t *)elem); break;
+      case AET::INT8:   lua_pushinteger(L, *(int8_t *)elem); break;
       case AET::INT16:  lua_pushinteger(L, *(int16_t *)elem); break;
       case AET::INT32:  lua_pushinteger(L, *(int32_t *)elem); break;
       case AET::INT64:  lua_pushnumber(L, lua_Number(*(int64_t *)elem)); break;

--- a/src/tiri/jit/src/lib/lib_struct.cpp
+++ b/src/tiri/jit/src/lib/lib_struct.cpp
@@ -176,7 +176,7 @@ static void write_array_field(lua_State *L, APTR Address, const struct_field &Fi
    }
 
    auto source = lua_toarray(L, StackIndex);
-   auto expected_type = ff_to_aet(Field.Type);
+   auto expected_type = ff_to_aet(Field.Type, Field.NativeType);
 
    if ((Field.Type & FD_VECTOR) and (Field.Type & FD_STRUCT) and (not (Field.Type & FD_PTR))) {
       if (not Field.TrivialElements) {
@@ -409,7 +409,7 @@ static bool read_primitive_field(lua_State *L, APTR Address, const struct_field 
          while (length < size_t(ArraySize) and ((CSTRING)Address)[length]) length++;
          lua_pushlstring(L, (CSTRING)Address, length);
       }
-      else lua_createarray(L, ArraySize, ff_to_aet(Type), (APTR *)Address, ARRAY_CACHED);
+      else lua_createarray(L, ArraySize, ff_to_aet(Type, Field.NativeType), (APTR *)Address, ARRAY_CACHED);
    }
    else if (Field.NativeType IS NativeStructType::Bool) lua_pushboolean(L, ((bool *)Address)[0]);
    else if (Field.NativeType IS NativeStructType::Char or Field.NativeType IS NativeStructType::Int8) {
@@ -627,7 +627,7 @@ void lj_struct_getfield_core(lua_State *L, GCstruct *Struct, struct_field &Field
    }
    else if ((Field.Type & FD_POINTER) and (Field.Type & FD_ARRAY)) {
       if (((APTR *)Address)[0]) {
-         make_array(L, ff_to_aet(Field.Type & ~FD_POINTER), -1, ((APTR *)Address)[0]);
+         make_array(L, ff_to_aet(Field.Type & ~FD_POINTER, Field.NativeType), -1, ((APTR *)Address)[0]);
       }
       else lua_pushnil(L);
    }
@@ -646,6 +646,9 @@ void lj_struct_getfield_core(lua_State *L, GCstruct *Struct, struct_field &Field
       else if (Field.Type & FD_WORD) {
          if (uns) push_vector_array<uint16_t>(L, Address, AET::UINT16);
          else push_vector_array<int16_t>(L, Address, AET::INT16);
+      }
+      else if ((Field.Type & FD_BYTE) and Field.NativeType IS NativeStructType::Int8) {
+         push_vector_array<int8_t>(L, Address, AET::INT8);
       }
       else if (Field.Type & FD_BYTE) push_vector_array<uint8_t>(L, Address, AET::BYTE);
       else struct_field_error(L, CurrentFrame, ERR::NoSupport,

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -533,6 +533,7 @@ static bool array_elem_irtype(AET ElemType, IRType &ResultType)
 {
    switch (ElemType) {
       case AET::BYTE:
+      case AET::INT8:
       case AET::INT16:
       case AET::INT32:
       case AET::UINT8:
@@ -571,7 +572,7 @@ static bool array_elemtype_from_string(GCstr *TypeStr, AET *Result)
    if (TypeStr->len IS 3 and memcmp(type_name, "int", 3) IS 0) *Result = AET::INT32;
    else if (TypeStr->len IS 4 and memcmp(type_name, "byte", 4) IS 0) *Result = AET::BYTE;
    else if (TypeStr->len IS 4 and memcmp(type_name, "char", 4) IS 0) *Result = AET::BYTE;
-   else if (TypeStr->len IS 4 and memcmp(type_name, "int8", 4) IS 0) *Result = AET::BYTE;
+   else if (TypeStr->len IS 4 and memcmp(type_name, "int8", 4) IS 0) *Result = AET::INT8;
    else if (TypeStr->len IS 5 and memcmp(type_name, "int16", 5) IS 0) *Result = AET::INT16;
    else if (TypeStr->len IS 5 and memcmp(type_name, "int64", 5) IS 0) *Result = AET::INT64;
    else if (TypeStr->len IS 5 and memcmp(type_name, "uint8", 5) IS 0) *Result = AET::UINT8;

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -3274,6 +3274,7 @@ static TRef rec_array_xload(jit_State *J, TRef ArrayRef, TRef IdxRef, GCarray *A
 
    switch (et) {
       case AET::BYTE:   shift = 0; break;
+      case AET::INT8:   shift = 0; break;
       case AET::INT16:  shift = 1; break;
       case AET::INT32:  shift = 2; break;
       case AET::UINT8:  shift = 0; break;
@@ -3316,6 +3317,10 @@ static TRef rec_array_xload(jit_State *J, TRef ArrayRef, TRef IdxRef, GCarray *A
          val = emitir(IRT(IR_XLOAD, IRT_U8), addr, 0);
          if (not LJ_DUALNUM)
             val = emitir(IRTN(IR_CONV), val, IRCONV_NUM_INT);
+         break;
+      case AET::INT8:
+         val = emitir(IRT(IR_XLOAD, IRT_I8), addr, 0);
+         if (not LJ_DUALNUM) val = emitir(IRTN(IR_CONV), val, IRCONV_NUM_INT);
          break;
       case AET::INT16:
          val = emitir(IRT(IR_XLOAD, IRT_I16), addr, 0);
@@ -3392,6 +3397,7 @@ static bool rec_array_xstore(jit_State *J, TRef ArrayRef, TRef IdxRef, TRef ValR
 
    switch (et) {
       case AET::BYTE:   shift = 0; break;
+      case AET::INT8:   shift = 0; break;
       case AET::INT16:  shift = 1; break;
       case AET::INT32:  shift = 2; break;
       case AET::UINT8:  shift = 0; break;
@@ -3416,7 +3422,7 @@ static bool rec_array_xstore(jit_State *J, TRef ArrayRef, TRef IdxRef, TRef ValR
        (et IS AET::UINT8 or et IS AET::UINT16 or et IS AET::UINT32 or et IS AET::UINT64)) return false;
 
    if (tref_isnum(ValRef)) {
-      if (et IS AET::BYTE or et IS AET::INT16 or et IS AET::INT32 or et IS AET::INT64 or
+      if (et IS AET::BYTE or et IS AET::INT8 or et IS AET::INT16 or et IS AET::INT32 or et IS AET::INT64 or
           et IS AET::UINT8 or et IS AET::UINT16 or et IS AET::UINT32 or et IS AET::UINT64) {
          emitir(IRTG(IR_GE, IRT_NUM), ValRef, lj_ir_knum(J, -DBL_MAX));
          emitir(IRTG(IR_LE, IRT_NUM), ValRef, lj_ir_knum(J, DBL_MAX));
@@ -3454,6 +3460,12 @@ static bool rec_array_xstore(jit_State *J, TRef ArrayRef, TRef IdxRef, TRef ValR
             ? emitir(IRTI(IR_CONV), ValRef, IRCONV_INT_NUM | IRCONV_ANY)
             : ValRef;
          emitir(IRT(IR_XSTORE, IRT_U8), addr, store_val);
+         break;
+      case AET::INT8:
+         store_val = tref_isnil(ValRef) ? ir.kint(0) : tref_isnum(ValRef)
+            ? emitir(IRTI(IR_CONV), ValRef, IRCONV_INT_NUM | IRCONV_ANY)
+            : ValRef;
+         emitir(IRT(IR_XSTORE, IRT_I8), addr, store_val);
          break;
       case AET::INT16:
          store_val = tref_isnil(ValRef) ? ir.kint(0) : tref_isnum(ValRef)

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -4577,7 +4577,7 @@ static bool test_static_descriptor_model(kt::Log &Log)
    constexpr std::array<ArrayMapping, 19> mappings = { {
       { "byte", AET::BYTE, TiriType::Num },
       { "char", AET::BYTE, TiriType::Num },
-      { "int8", AET::BYTE, TiriType::Num },
+      { "int8", AET::INT8, TiriType::Num },
       { "int16", AET::INT16, TiriType::Num },
       { "int", AET::INT32, TiriType::Num },
       { "int64", AET::INT64, TiriType::Num },

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -52,6 +52,7 @@ ArrayElementDescriptor describe_array_element(const GCarray *Array) noexcept
    result.known = true;
    switch (result.storage) {
       case AET::BYTE:
+      case AET::INT8:
       case AET::INT16:
       case AET::INT32:
       case AET::INT64:
@@ -86,6 +87,7 @@ std::string array_element_name(const ArrayElementDescriptor &Element)
    std::string_view name = "any";
    switch (public_array_storage(Element.storage)) {
       case AET::BYTE:   name = "byte"; break;
+      case AET::INT8:   name = "int8"; break;
       case AET::INT16:  name = "int16"; break;
       case AET::INT32:  name = "int"; break;
       case AET::INT64:  name = "int64"; break;
@@ -616,9 +618,10 @@ std::optional<ArrayElementDescriptor> describe_array_element(std::string_view Na
    ArrayElementDescriptor result;
    result.known = true;
 
-   if (Name IS "byte" or Name IS "char" or Name IS "int8") {
+   if (Name IS "byte" or Name IS "char") {
       result = { AET::BYTE, TiriType::Num, CLASSID::NIL, nullptr, true };
    }
+   else if (Name IS "int8") result = { AET::INT8, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "int16") result = { AET::INT16, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "int") result = { AET::INT32, TiriType::Num, CLASSID::NIL, nullptr, true };
    else if (Name IS "int64") result = { AET::INT64, TiriType::Num, CLASSID::NIL, nullptr, true };
@@ -662,7 +665,9 @@ std::optional<ArrayElementDescriptor> describe_array_element(const struct_field 
    else if (Field.Type & FD_INT64) result.storage = (Field.Type & FD_UNSIGNED) ? AET::UINT64 : AET::INT64;
    else if (Field.Type & FD_INT) result.storage = (Field.Type & FD_UNSIGNED) ? AET::UINT32 : AET::INT32;
    else if (Field.Type & FD_WORD) result.storage = (Field.Type & FD_UNSIGNED) ? AET::UINT16 : AET::INT16;
-   else if (Field.Type & FD_BYTE) result.storage = AET::BYTE;
+   else if (Field.Type & FD_BYTE) {
+      result.storage = Field.NativeType IS NativeStructType::Int8 ? AET::INT8 : AET::BYTE;
+   }
    else return std::nullopt;
 
    return result;

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -45,7 +45,8 @@ static const uint8_t glElemSizes[] = {
    sizeof(uint8_t),      // AET::UINT8
    sizeof(uint16_t),     // AET::UINT16
    sizeof(uint32_t),     // AET::UINT32
-   sizeof(uint64_t)      // AET::UINT64
+   sizeof(uint64_t),     // AET::UINT64
+   sizeof(int8_t)        // AET::INT8
 };
 
 //********************************************************************************************************************
@@ -109,6 +110,7 @@ static LJ_AINLINE ArrayElementResult array_validate_element(GCarray *Array, cTVa
    if (tvisnil(Value)) {
       switch (Array->elemtype) {
          case AET::BYTE:
+         case AET::INT8:
          case AET::INT16:
          case AET::INT32:
          case AET::INT64:
@@ -133,6 +135,7 @@ static LJ_AINLINE ArrayElementResult array_validate_element(GCarray *Array, cTVa
 
    switch (Array->elemtype) {
       case AET::BYTE:
+      case AET::INT8:
       case AET::INT16:
       case AET::INT64:
       case AET::UINT8:
@@ -248,6 +251,21 @@ static LJ_AINLINE void array_store_validated(lua_State *L, GCarray *Array, MSize
          }
          else *(uint8_t *)element = uint8_t(array_unsigned_integer(numV(Value), 8));
          return;
+      case AET::INT8: {
+         if (tvisint(Value) and intV(Value) >= std::numeric_limits<int8_t>::min() and
+               intV(Value) <= std::numeric_limits<int8_t>::max()) {
+            *(int8_t *)element = int8_t(intV(Value));
+            return;
+         }
+         if (tvisnum(Value) and numV(Value) >= std::numeric_limits<int8_t>::min() and
+               numV(Value) <= std::numeric_limits<int8_t>::max()) {
+            *(int8_t *)element = int8_t(numV(Value));
+            return;
+         }
+         uint8_t bits = tvisint(Value) ? uint8_t(intV(Value)) : uint8_t(array_unsigned_integer(numV(Value), 8));
+         std::memcpy(element, &bits, sizeof(bits));
+         return;
+      }
       case AET::INT16: {
          if (tvisint(Value) and intV(Value) >= std::numeric_limits<int16_t>::min() and
                intV(Value) <= std::numeric_limits<int16_t>::max()) {
@@ -363,6 +381,7 @@ void lj_array_store_new_values(lua_State *L, GCarray *Array, cTValue *Values, MS
       bool stored = false;
       switch (Array->elemtype) {
          case AET::BYTE:   stored = array_store_integer_sequence<uint8_t>(Array, Values, Count); break;
+         case AET::INT8:   stored = array_store_integer_sequence<int8_t>(Array, Values, Count); break;
          case AET::INT16:  stored = array_store_integer_sequence<int16_t>(Array, Values, Count); break;
          case AET::INT32:  stored = array_store_integer_sequence<int32_t>(Array, Values, Count); break;
          case AET::INT64:  stored = array_store_integer_sequence<int64_t>(Array, Values, Count); break;
@@ -716,6 +735,7 @@ GCtab * lj_array_to_table(lua_State *L, GCarray *Array)
 
       switch (Array->elemtype) {
          case AET::BYTE:   setintV(slot, *(uint8_t*)elem); break;
+         case AET::INT8:   setintV(slot, *(int8_t*)elem); break;
          case AET::INT16:  setintV(slot, *(int16_t*)elem); break;
          case AET::INT32:  setintV(slot, *(int32_t*)elem); break;
          case AET::INT64:  setnumV(slot, lua_Number(*(int64_t*)elem)); break;

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -825,6 +825,7 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
       const char *member = "any";
       switch (Entry.array_element_type) {
          case AET::BYTE:   member = "byte"; break;
+         case AET::INT8:   member = "int8"; break;
          case AET::INT16:  member = "int16"; break;
          case AET::INT32:  member = "int"; break;
          case AET::INT64:  member = "int64"; break;

--- a/src/tiri/jit/src/runtime/lj_obj.cpp
+++ b/src/tiri/jit/src/runtime/lj_obj.cpp
@@ -51,6 +51,7 @@ const void * lj_obj_ptr(global_State *g, cTValue *o)
 {
    switch(elemtype) {
       case AET::BYTE:    return FD_BYTE;
+      case AET::INT8:    return FD_BYTE;
       case AET::INT16:   return FD_WORD;
       case AET::INT32:   return FD_INT;
       case AET::INT64:   return FD_INT64;

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -1275,6 +1275,7 @@ enum class AET : uint8_t {
    UINT16,     // uint16_t
    UINT32,     // uint32_t
    UINT64,     // uint64_t
+   INT8,       // int8_t numeric storage
    MAX,
    VULNERABLE = PTR
 };

--- a/src/tiri/jit/src/runtime/lj_vmarray.cpp
+++ b/src/tiri/jit/src/runtime/lj_vmarray.cpp
@@ -44,6 +44,7 @@ static void arr_load_elem(lua_State *L, GCarray *Array, uint32_t Idx, TValue *Re
 
    switch (Array->elemtype) {
       case AET::BYTE:   setintV(Result, *(uint8_t*)elem); break;
+      case AET::INT8:   setintV(Result, *(int8_t*)elem); break;
       case AET::INT16:  setintV(Result, *(int16_t*)elem); break;
       case AET::INT32:  setintV(Result, *(int32_t*)elem); break;
       case AET::INT64:  setnumV(Result, lua_Number(*(int64_t*)elem)); break;

--- a/src/tiri/tests/test_array_element_validation.tiri
+++ b/src/tiri/tests/test_array_element_validation.tiri
@@ -22,7 +22,7 @@ function expect_failure(Action:func, Description:str)
 end
 
 @Test function NumericStringsAreNeverElements()
-   local element_types = array<str> { 'byte', 'int16', 'int', 'int64', 'uint8', 'uint16', 'uint', 'uint64',
+   local element_types = array<str> { 'byte', 'int8', 'int16', 'int', 'int64', 'uint8', 'uint16', 'uint', 'uint64',
       'float', 'double' }
 
    for _, element_type in element_types do
@@ -83,7 +83,7 @@ end
 end
 
 @Test function NilUsesTheTypedEmptyValue()
-   local numeric_types = array<str> { 'byte', 'int16', 'int', 'int64', 'uint8', 'uint16', 'uint', 'uint64',
+   local numeric_types = array<str> { 'byte', 'int8', 'int16', 'int', 'int64', 'uint8', 'uint16', 'uint', 'uint64',
       'float', 'double' }
    for _, element_type in numeric_types do
       local values = array.new(1, element_type)

--- a/src/tiri/tests/test_array_typed_syntax.tiri
+++ b/src/tiri/tests/test_array_typed_syntax.tiri
@@ -174,6 +174,47 @@ end
    assert(failed, 'array<uint8> accepted byte-buffer string input')
 end
 
+@Test function ArrayTypedInt8IsSignedAndDistinctFromByte()
+   local signed_values = array<int8> { -128, -1, 0, 127, 128, 255 }
+   local bytes = array<byte> { -1, 255 }
+   local legacy = array.of('int8', -128, 127)
+
+   assert(signed_values.type() is 'int8' and tostring(signed_values) is 'array<int8, 6>',
+      'int8 identity was not preserved')
+   assert(signed_values[0] is -128 and signed_values[1] is -1 and signed_values[3] is 127,
+      'int8 did not preserve signed values')
+   assert(signed_values[4] is -128 and signed_values[5] is -1, 'int8 values did not wrap as signed 8-bit integers')
+   assert(bytes.type() is 'char' and bytes[0] is 255 and bytes[1] is 255,
+      'byte did not remain an unsigned byte buffer')
+   assert(legacy.type() is 'int8' and legacy[0] is -128 and legacy[1] is 127,
+      'legacy int8 construction did not retain signed storage')
+
+   signed_values[0] = 255
+   signed_values.push(-129)
+   assert(signed_values[0] is -1 and signed_values.last() is 127, 'int8 mutation did not retain signed semantics')
+
+   local failed = false
+   try
+      signed_values.push('A')
+   except error_value
+      failed = true
+   end
+   assert(failed, 'array<int8> incorrectly exposed byte-buffer string operations')
+
+   local function accept_int8(Values:array<int8>):num
+      return Values[0]
+   end
+
+   assert(accept_int8(signed_values) is -1, 'array<int8> did not satisfy its own binding contract')
+   failed = false
+   try
+      accept_int8(bytes)
+   except error_value
+      failed = true
+   end
+   assert(failed, 'array<byte> incorrectly satisfied an array<int8> binding contract')
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- Whitespace handling
 

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -1908,6 +1908,35 @@ end
    assert(trace_found is true, "Expected array.new(size, literal_type) to produce a JIT trace")
 end
 
+@Test(hotpath=80) function SignedInt8ArrayAccessTraces()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   function traced_signed_int8_array(Count)
+      local source = array<int8> { -128 }
+      local destination = array<int8, 1>
+      local total = 0
+
+      for i in {1 into Count} do
+         destination[0] = source[0] + i - 1
+         total += destination[0]
+      end
+
+      return total, destination[0]
+   end
+
+   local total = 0
+   local last = 0
+   for i in {0 to 80} do
+      total, last = traced_signed_int8_array(10)
+   end
+
+   assert(total is -1235 and last is -119,
+      f"Expected signed int8 trace result -1235/-119, got {total}/{last}")
+   assert(count_jit_traces(20) > 0, "Expected signed int8 array access to produce a JIT trace")
+end
+
 @Test(hotpath=80) function ArrayNewObjTypeTraces()
    jit.on()
    jit.flush()

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -371,7 +371,7 @@ end
    value.Bool = array<byte> { 0, 1 }
    value.Char = array<byte> { 65, 66 }
    value.Byte = array<byte> { 250, 251 }
-   value.Int8 = array<byte> { 1, 2 }
+   value.Int8 = array<int8> { -128, 127 }
    value.UInt8 = array<byte> { 3, 4 }
    value.Int16 = array<int16> { -12, 34 }
    value.UInt16 = array<uint16> { 123, 456 }
@@ -389,6 +389,8 @@ end
       'Initialiser assignment should populate a string vector')
    assert(value.Bool is array<byte> { 0, 1 } and value.Char is array<byte> { 65, 66 },
       'Byte-sized vector categories should round-trip')
+   assert(value.Int8 is array<int8> { -128, 127 } and value.Int8.type() is 'int8',
+      'Int8 vectors should preserve signed values and their distinct element identity')
    assert(value.Int16 is array<int16> { -12, 34 } and value.UInt16 is array<uint16> { 123, 456 },
       'Word-sized vector categories should round-trip')
    assert(value.Int64 is array<int64> { -9007199, 9007199 }, 'Int64 vectors should round-trip')

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -635,8 +635,11 @@ void make_array(lua_State *Lua, AET Type, int Elements, CPTR Data, std::string_v
             case AET::INT16:
                for (i=0; ((int16_t *)Data)[i]; i++);
                break;
-            case AET::BYTE:
+            case AET::INT8:
                for (i=0; ((int8_t *)Data)[i]; i++);
+               break;
+            case AET::BYTE:
+               for (i=0; ((uint8_t *)Data)[i]; i++);
                break;
             case AET::STRUCT: // Use make_struct_*() interfaces instead
             case AET::STR_GC:

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -305,11 +305,12 @@ template <typename T> static ERR array_values_to_vector(GCarray *Source, APTR Ad
    return ERR::Okay;
 }
 
-static ERR value_to_cpp_vector(lua_State *Lua, int StackIndex, int Type, APTR Address)
+static ERR value_to_cpp_vector(lua_State *Lua, int StackIndex, const struct_field &Field, APTR Address)
 {
+   const int type = Field.Type;
    if (lua_isarray(Lua, StackIndex)) {
       auto source = lua_toarray(Lua, StackIndex);
-      if (Type & FD_STRING) {
+      if (type & FD_STRING) {
          if ((source->elemtype != AET::STR_GC) and (source->elemtype != AET::CSTR) and
                (source->elemtype != AET::STR_CPP)) return ERR::InvalidType;
          auto &dest = ((kt::vector<std::string> *)Address)[0];
@@ -324,18 +325,21 @@ static ERR value_to_cpp_vector(lua_State *Lua, int StackIndex, int Type, APTR Ad
          }
          return ERR::Okay;
       }
-      if (source->elemtype != ff_to_aet(Type)) return ERR::InvalidType;
-      if (Type & FD_FLOAT) return array_values_to_vector<float>(source, Address);
-      if (Type & FD_DOUBLE) return array_values_to_vector<double>(source, Address);
-      if (Type & FD_INT64) return array_values_to_vector<int64_t>(source, Address);
-      if (Type & FD_INT) return array_values_to_vector<int>(source, Address);
-      if (Type & FD_WORD) return array_values_to_vector<int16_t>(source, Address);
-      if (Type & FD_BYTE) return array_values_to_vector<uint8_t>(source, Address);
+      if (source->elemtype != ff_to_aet(type, Field.NativeType)) return ERR::InvalidType;
+      if (type & FD_FLOAT) return array_values_to_vector<float>(source, Address);
+      if (type & FD_DOUBLE) return array_values_to_vector<double>(source, Address);
+      if (type & FD_INT64) return array_values_to_vector<int64_t>(source, Address);
+      if (type & FD_INT) return array_values_to_vector<int>(source, Address);
+      if (type & FD_WORD) return array_values_to_vector<int16_t>(source, Address);
+      if ((type & FD_BYTE) and Field.NativeType IS NativeStructType::Int8) {
+         return array_values_to_vector<int8_t>(source, Address);
+      }
+      if (type & FD_BYTE) return array_values_to_vector<uint8_t>(source, Address);
       return ERR::NoSupport;
    }
 
    if (not lua_istable(Lua, StackIndex)) return ERR::InvalidType;
-   if (Type & FD_STRING) {
+   if (type & FD_STRING) {
       auto &dest = ((kt::vector<std::string> *)Address)[0];
       size_t elements = lua_objlen(Lua, StackIndex);
       dest.resize(elements);
@@ -352,12 +356,15 @@ static ERR value_to_cpp_vector(lua_State *Lua, int StackIndex, int Type, APTR Ad
       }
       return ERR::Okay;
    }
-   if (Type & FD_FLOAT) return table_values_to_vector<float>(Lua, StackIndex, Type, Address);
-   if (Type & FD_DOUBLE) return table_values_to_vector<double>(Lua, StackIndex, Type, Address);
-   if (Type & FD_INT64) return table_values_to_vector<int64_t>(Lua, StackIndex, Type, Address);
-   if (Type & FD_INT) return table_values_to_vector<int>(Lua, StackIndex, Type, Address);
-   if (Type & FD_WORD) return table_values_to_vector<int16_t>(Lua, StackIndex, Type, Address);
-   if (Type & FD_BYTE) return table_values_to_vector<uint8_t>(Lua, StackIndex, Type, Address);
+   if (type & FD_FLOAT) return table_values_to_vector<float>(Lua, StackIndex, type, Address);
+   if (type & FD_DOUBLE) return table_values_to_vector<double>(Lua, StackIndex, type, Address);
+   if (type & FD_INT64) return table_values_to_vector<int64_t>(Lua, StackIndex, type, Address);
+   if (type & FD_INT) return table_values_to_vector<int>(Lua, StackIndex, type, Address);
+   if (type & FD_WORD) return table_values_to_vector<int16_t>(Lua, StackIndex, type, Address);
+   if ((type & FD_BYTE) and Field.NativeType IS NativeStructType::Int8) {
+      return table_values_to_vector<int8_t>(Lua, StackIndex, type, Address);
+   }
+   if (type & FD_BYTE) return table_values_to_vector<uint8_t>(Lua, StackIndex, type, Address);
    return ERR::NoSupport;
 }
 
@@ -429,7 +436,7 @@ static ERR value_to_cpp_vector(lua_State *Lua, int StackIndex, int Type, APTR Ad
                      assign_trivial_struct_vector(address, serial.data(), source->len, field.ElementStride);
                   }
                   else if (type & FD_VECTOR) {
-                     if (auto error = value_to_cpp_vector(Lua, -1, type, address); error != ERR::Okay) {
+                     if (auto error = value_to_cpp_vector(Lua, -1, field, address); error != ERR::Okay) {
                         destroy_struct_cpp_strings(Lua, struct_def, memory.get());
                         return error;
                      }
@@ -516,7 +523,7 @@ static ERR value_to_cpp_vector(lua_State *Lua, int StackIndex, int Type, APTR Ad
             }
             else {
                auto vector = (kt::vector<int> *)(address); // Uses int as a type-stable layout placeholder
-               make_array(Lua, ff_to_aet(type), vector->size(), vector->data());
+               make_array(Lua, ff_to_aet(type, field.NativeType), vector->size(), vector->data());
             }
          }
          else if (field.ArraySize IS -1) { // Pointer to a null-terminated array.
@@ -529,7 +536,7 @@ static ERR value_to_cpp_vector(lua_State *Lua, int StackIndex, int Type, APTR Ad
                }
                else lua_pushnil(Lua);
             }
-            else make_array(Lua, ff_to_aet(type), -1, ((CPTR *)address)[0]);
+            else make_array(Lua, ff_to_aet(type, field.NativeType), -1, ((CPTR *)address)[0]);
          }
          else { // It's an embedded array of fixed size.
             if (type & FD_STRUCT) {
@@ -538,7 +545,7 @@ static ERR value_to_cpp_vector(lua_State *Lua, int StackIndex, int Type, APTR Ad
                }
                else lua_pushnil(Lua);
             }
-            else make_array(Lua, ff_to_aet(type), field.ArraySize, address);
+            else make_array(Lua, ff_to_aet(type, field.NativeType), field.ArraySize, address);
          }
       }
       else if (type & FD_STRUCT) {
@@ -573,7 +580,10 @@ static ERR value_to_cpp_vector(lua_State *Lua, int StackIndex, int Type, APTR Ad
          if (type & FD_UNSIGNED) lua_pushinteger(Lua, ((uint16_t *)address)[0]);
          else lua_pushinteger(Lua, ((int16_t *)address)[0]);
       }
-      else if (type & FD_BYTE)   lua_pushinteger(Lua, ((uint8_t *)address)[0]);
+      else if ((type & FD_BYTE) and field.NativeType IS NativeStructType::Int8) {
+         lua_pushinteger(Lua, ((int8_t *)address)[0]);
+      }
+      else if (type & FD_BYTE) lua_pushinteger(Lua, ((uint8_t *)address)[0]);
       else lua_pushnil(Lua);
 
       lua_settable(Lua, -3);


### PR DESCRIPTION
* Introduced AET::INT8 with dedicated storage, validation, conversion and per-element accessors across the array runtime and library functions
* Recorded IRT_I8 loads and stores for int8 arrays so signed 8-bit element access compiles under the JIT
* Mapped the 'int8' element name to AET::INT8 in the parser and static type descriptors, decoupling it from 'byte'/'char'
* Propagated NativeType through struct vector conversion so Int8 struct fields round-trip as signed int8 arrays
* Bumped the bytecode dump version to 0x93 for the new signed array member identity