### PR TITLE
[Tiri] Migrated string, array, table and regex range APIs to half-open semantics

### DIFF
--- a/apps/find.tiri
+++ b/apps/find.tiri
@@ -23,13 +23,13 @@ function parseSize(SizeStr:str!):<any, any>
    last_char = SizeStr.sub(-1).upper()
    if last_char is 'K' then
       multiplier = 1024
-      SizeStr = SizeStr.sub(0, -2)
+      SizeStr = SizeStr.sub(0, -1)
    elseif last_char is 'M' then
       multiplier = 1048576
-      SizeStr = SizeStr.sub(0, -2)
+      SizeStr = SizeStr.sub(0, -1)
    elseif last_char is 'G' then
       multiplier = 1073741824
-      SizeStr = SizeStr.sub(0, -2)
+      SizeStr = SizeStr.sub(0, -1)
    end
 
    bytes = tonumber(SizeStr) * multiplier
@@ -67,7 +67,7 @@ function parseModified(ModStr:str!):<any, any>
    assert(prefix is '+' or prefix is '-', f'Modified value must start with + or -: {ModStr}')
 
    unit = ModStr.sub(-1)
-   num = tonumber(ModStr.sub(1, -2))
+   num = tonumber(ModStr.sub(1, -1))
    assert(num, f'Invalid modified value: {ModStr}')
 
    offset_seconds = 0
@@ -268,7 +268,7 @@ Examples:
       -- For directories, FileName from io.splitPath() is empty; extract from the full path
       if display_name is '' or not display_name then
          trimmed = full_path
-         if trimmed.sub(-1) is '/' then trimmed = trimmed.sub(0, -2) end
+         if trimmed.sub(-1) is '/' then trimmed = trimmed.sub(0, -1) end
          _, display_name = io.splitPath(trimmed)
       end
 

--- a/scripts/gui/fileview.tiri
+++ b/scripts/gui/fileview.tiri
@@ -1085,7 +1085,7 @@ gui.fileview = function(Options)
       self.path ?! return
       if self.limitPath and self.limitPath.lower() is self.path.lower() then return end
 
-      reduced_path, count = rxParentFolder.extract(self.path.sub(0, -2))
+      reduced_path, count = rxParentFolder.extract(self.path.sub(0, -1))
 
       if count is 0 then
          self.browse(nil)

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -1658,6 +1658,8 @@ static void build_subroutines(BuildCtx *ctx)
   |   blo ->fff_fallback
   |    checkint CARG3, ->fff_fallback
   |    sxtw RB, CARG3w
+  |   cbz RB, ->fff_emptystr
+  |   sub RB, RB, #1		// Convert explicit exclusive stop to the inclusive endpoint used below.
   |1:
   |  ldr CARG2, [BASE, #8]
   |  checkstr CARG1, ->fff_fallback

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -1680,7 +1680,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  cmp CARG2, #0
   |  cinc CARG2, TMP0, lt		// if (start < 0) start += len
   |   cmp RB, #0
-  |   csel RB, RB, xzr, ge		// if (end < 0) end = 0
+  |   blt ->fff_emptystr		// An exclusive stop before the string remains an empty span.
   |  cmp CARG2, #0
   |  csel CARG2, CARG2, xzr, ge	// if (start < 0) start = 0 (zero-indexed)
   |   cmp RB, TMP1

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -2523,11 +2523,15 @@ static void build_subroutines(BuildCtx *ctx)
   |  checknum CARG3
   |   lwz TMP2, 20(BASE)
   |  bne ->fff_fallback
+  |  cmpwi TMP2, 0; beq ->fff_emptystr
+  |  addi TMP2, TMP2, -1		// Convert explicit exclusive stop to the inclusive endpoint used below.
   |1:
   |  checknum CARG2; bne ->fff_fallback
   |.else
   |  checknum CARG3; bge ->fff_fallback
   |  toint TMP2, f0
+  |  cmpwi TMP2, 0; beq ->fff_emptystr
+  |  addi TMP2, TMP2, -1		// Convert explicit exclusive stop to the inclusive endpoint used below.
   |1:
   |  checknum CARG2; bge ->fff_fallback
   |.endif

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -2524,6 +2524,8 @@ static void build_subroutines(BuildCtx *ctx)
   |   lwz TMP2, 20(BASE)
   |  bne ->fff_fallback
   |  cmpwi TMP2, 0; beq ->fff_emptystr
+  |  lis TMP3, 0x8000
+  |  cmpw TMP2, TMP3; beq ->fff_emptystr
   |  addi TMP2, TMP2, -1		// Convert explicit exclusive stop to the inclusive endpoint used below.
   |1:
   |  checknum CARG2; bne ->fff_fallback
@@ -2531,6 +2533,8 @@ static void build_subroutines(BuildCtx *ctx)
   |  checknum CARG3; bge ->fff_fallback
   |  toint TMP2, f0
   |  cmpwi TMP2, 0; beq ->fff_emptystr
+  |  lis TMP3, 0x8000
+  |  cmpw TMP2, TMP3; beq ->fff_emptystr
   |  addi TMP2, TMP2, -1		// Convert explicit exclusive stop to the inclusive endpoint used below.
   |1:
   |  checknum CARG2; bge ->fff_fallback

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -2051,9 +2051,9 @@ static void build_subroutines(BuildCtx *ctx)
   |  checknumtp [BASE+16], ->fff_fallback
   |  cvttsd2si TMPRd, qword [BASE+16]
   |.endif
-  |  // Convert exclusive end to inclusive: end = end - 1 (only for positive values)
+  |  // Convert the explicit exclusive stop to the inclusive endpoint used below.
   |  test TMPRd, TMPRd
-  |  jle >1
+  |  jz ->fff_emptystr
   |  sub TMPRd, 1
   |1:
   |  mov STR:RB, [BASE]

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -2054,6 +2054,8 @@ static void build_subroutines(BuildCtx *ctx)
   |  // Convert the explicit exclusive stop to the inclusive endpoint used below.
   |  test TMPRd, TMPRd
   |  jz ->fff_emptystr
+  |  cmp TMPRd, INT32_MIN
+  |  je ->fff_emptystr
   |  sub TMPRd, 1
   |1:
   |  mov STR:RB, [BASE]

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -416,19 +416,13 @@ static int32_t array_default_remaining(MSize Length, int32_t Start)
    return int32_t(Length - MSize(Start));
 }
 
-static array_range_span array_strict_inclusive_span(lua_State *L, MSize Length, int32_t Start, int32_t Stop,
-   bool Explicit)
+static array_range_span array_strict_half_open_span(lua_State *L, MSize Length, int32_t Start, int32_t Stop)
 {
-   if (Length IS 0) {
-      if (Explicit) lj_err_caller(L, ErrMsg::IDXRNG);
-      return { 0, -1, 1, true };
-   }
-
-   if (Start < 0 or Stop < 0 or MSize(Start) >= Length or MSize(Stop) >= Length) {
+   if (Start < 0 or Stop < 0 or MSize(Start) > Length or MSize(Stop) > Length) {
       lj_err_caller(L, ErrMsg::IDXRNG);
    }
 
-   if (Stop < Start) return { Start, Stop, 1, true };
+   if (Stop <= Start) return { Start, Stop, 1, true };
    return { Start, Stop, 1, false };
 }
 
@@ -530,13 +524,13 @@ static int array_push_find_result(lua_State *L, int32_t Result)
 }
 
 //********************************************************************************************************************
-// Usage: array.concat([Separator], [StringFormat], [Start], [End])
+// Usage: array.concat([Separator], [StringFormat], [Start], [Stop])
 //
 // Concatenates array elements into a string using the specified separator and optional format.
 //
 // Separator is placed between each concatenated element.  StringFormat optionally specifies how each element should be
 // formatted (e.g., "%d", "%f", "%s").  If no format is provided, the fastest available conversion path is used.
-// Start and End are optional zero-based, inclusive indexes.
+// Start and Stop are optional zero-based indexes defining a half-open span.
 
 LJLIB_CF(array_concat)
 {
@@ -548,9 +542,9 @@ LJLIB_CF(array_concat)
    auto separator = luaL_optlstring(L, 2, "", &separator_len);
    auto format = lua_isnoneornil(L, 3) ? nullptr : luaL_checkstring(L, 3);
    auto start = start_provided ? lj_lib_checkint(L, 4) : 0;
-   auto end = end_provided ? lj_lib_checkint(L, 5) : array_default_remaining(arr->len, 0) - 1;
+   auto stop = end_provided ? lj_lib_checkint(L, 5) : int32_t(arr->len);
 
-   auto span = array_strict_inclusive_span(L, arr->len, start, end, start_provided or end_provided);
+   auto span = array_strict_half_open_span(L, arr->len, start, stop);
    if (span.empty) {
       lua_pushstring(L, "");
       return 1;
@@ -607,9 +601,9 @@ LJLIB_CF(array_concat)
    }
 
    std::string result;
-   result.reserve(MSize(span.stop - span.start + 1) * 16);
+   result.reserve(MSize(span.stop - span.start) * 16);
 
-   for (MSize i = MSize(span.start); i <= MSize(span.stop); i++) {
+   for (MSize i = MSize(span.start); i < MSize(span.stop); i++) {
       if (i > MSize(span.start)) result.append(separator, separator_len);
 
       if (format) {
@@ -1693,6 +1687,12 @@ static int32_t find_string_in_array(GCarray *Arr, GCstr *SearchStr, int32_t Star
 LJLIB_CF(array_find)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
+   const bool stop_provided = not lua_isnoneornil(L, 4);
+   int32_t stop = stop_provided ? lj_lib_checkint(L, 4) : int32_t(arr->len);
+
+   if (stop < 0) stop += int32_t(arr->len);
+   if (stop < 0) stop = 0;
+   if (MSize(stop) > arr->len) stop = int32_t(arr->len);
 
    if (arr->elemtype IS AET::OBJECT) {
       auto search_uid = object_uid_from_value(L, 2);
@@ -1704,7 +1704,8 @@ LJLIB_CF(array_find)
 
       auto start = lj_lib_optint(L, 3, 0);
       if (not array_find_start(start, arr->len, &start)) return array_push_find_result(L, -1);
-      return array_push_find_result(L, find_object_in_array(arr, search_uid, start, int32_t(arr->len - 1), 1));
+      if (start >= stop) return array_push_find_result(L, -1);
+      return array_push_find_result(L, find_object_in_array(arr, search_uid, start, stop - 1, 1));
    }
    else if (arr->elemtype IS AET::STR_GC) { // Handle string arrays (STR_GC)
       GCstr *search_str = lj_lib_checkstr(L, 2);
@@ -1717,7 +1718,8 @@ LJLIB_CF(array_find)
 
       auto start = lj_lib_optint(L, 3, 0);
       if (not array_find_start(start, arr->len, &start)) return array_push_find_result(L, -1);
-      return array_push_find_result(L, find_string_in_array(arr, search_str, start, int32_t(arr->len - 1), 1));
+      if (start >= stop) return array_push_find_result(L, -1);
+      return array_push_find_result(L, find_string_in_array(arr, search_str, start, stop - 1, 1));
    }
 
    int ok;
@@ -1733,7 +1735,8 @@ LJLIB_CF(array_find)
    // Original integer-based find
    auto start = lj_lib_optint(L, 3, 0);
    if (not array_find_start(start, arr->len, &start)) return array_push_find_result(L, -1);
-   return array_push_find_result(L, find_in_array(arr, value, start, int32_t(arr->len - 1), 1));
+   if (start >= stop) return array_push_find_result(L, -1);
+   return array_push_find_result(L, find_in_array(arr, value, start, stop - 1, 1));
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/lib/lib_string.cpp
+++ b/src/tiri/jit/src/lib/lib_string.cpp
@@ -87,15 +87,17 @@ LJLIB_ASM(string_byte)      LJLIB_REC(string_range 0)
    GCstr *s = lj_lib_checkstr(L, 1);
    int32_t len = (int32_t)s->len;
    int32_t start = lj_lib_optint(L, 2, 0);  // 0-based: default start is 0
-   int32_t stop = lj_lib_optint(L, 3, start);
+   const bool stop_provided = not lua_isnoneornil(L, 3);
+   int32_t stop = stop_provided ? lj_lib_checkint(L, 3) : 0;
    int32_t n, i;
    const unsigned char *p;
-   if (stop < 0) stop += len;   // 0-based: -1 → len-1 (last char)
    if (start < 0) start += len;
    if (start < 0) start = 0;
-   if (stop > len - 1) stop = len - 1;  // 0-based: max valid index is len-1
-   if (start > stop) return FFH_RES(0);  //  Empty interval: return no results.
-   n = stop - start + 1;
+   if (not stop_provided) stop = start + 1;
+   else if (stop < 0) stop += len;
+   if (stop > len) stop = len;
+   if (start >= stop) return FFH_RES(0);  // Empty interval: return no results.
+   n = stop - start;
    if ((uint32_t)n > LUAI_MAXCSTACK) lj_err_caller(L, ErrMsg::STRSLC);
    lj_state_checkstack(L, (MSize)n);
    p = (const unsigned char*)strdata(s) + start;
@@ -125,11 +127,7 @@ LJLIB_ASM(string_sub)      LJLIB_REC(string_range 1)
 {
    lj_lib_checkstr(L, 1);
    lj_lib_checkint(L, 2);
-   int32_t end_val = lj_lib_optint(L, 3, -1);
-   // Convert exclusive end to inclusive by subtracting 1, but only for positive indices.
-   // Negative indices already reference positions from the end, so no adjustment needed.
-   if (end_val > 0) end_val--;
-   setintV(L->base + 2, end_val);
+   if (not lua_isnoneornil(L, 3)) lj_lib_checkint(L, 3);
    return FFH_RETRY;
 }
 
@@ -744,7 +742,7 @@ LJLIB_CF(string_find)      LJLIB_REC(.)
 
    if (auto q = lj_str_findsv({strdata(s) + st, s->len - st}, {strdata(p), p->len})) {
       setintV(L->top - 2, (int32_t)(q - strdata(s)));  // 0-based start
-      setintV(L->top - 1, (int32_t)(q - strdata(s)) + (int32_t)p->len - 1);  // 0-based end (inclusive)
+      setintV(L->top - 1, (int32_t)(q - strdata(s)) + (int32_t)p->len);  // 0-based stop (exclusive)
       return 2;
    }
 
@@ -831,6 +829,10 @@ extern int luaopen_string(lua_State *L)
    LJ_LIB_REG(L, "string", string);
    // At this point, L->top - 1 has the string library table on the Lua stack
 
+   // `sub()` is the canonical spelling.  Keep `substr()` as a deprecated compatibility alias.
+   lua_getfield(L, -1, "sub");
+   lua_setfield(L, -2, "substr");
+
    GCtab *mt = lj_tab_new(L, 0, 1);
 
    // NOBARRIER: basemt is a GC root.
@@ -911,6 +913,8 @@ extern int luaopen_string(lua_State *L)
       { TiriType::Bool }, { TiriType::Str, TiriType::Str }, FProtoFlags::ContextIndependent);
    reg_iface_method(L, "string", "sub", TiriType::Str, builtin_callable_id(FastFunc::string_sub),
       { TiriType::Str }, { TiriType::Str, TiriType::Num, TiriType::Num });
+   reg_iface_method(L, "string", "substr", TiriType::Str, builtin_callable_id(FastFunc::string_sub),
+      { TiriType::Str }, { TiriType::Str, TiriType::Num, TiriType::Num }, FProtoFlags::None, true);
    reg_iface_method(L, "string", "trim", TiriType::Str, builtin_callable_id(FastFunc::string_trim),
       { TiriType::Str }, { TiriType::Str }, FProtoFlags::ContextIndependent);
    reg_iface_method(L, "string", "unescapeXML", TiriType::Str,

--- a/src/tiri/jit/src/lib/lib_table.cpp
+++ b/src/tiri/jit/src/lib/lib_table.cpp
@@ -103,7 +103,7 @@ LJLIB_CF(table_move)
 {
    GCtab *a1 = lj_lib_checktab(L, 1);
    int32_t f = lj_lib_checkint(L, 2);  // Start index
-   int32_t e = lj_lib_checkint(L, 3);  // End index
+   int32_t e = lj_lib_checkint(L, 3);  // Exclusive stop index
    int32_t t = lj_lib_checkint(L, 4);  // Target index
 
    // If a2 is nil, use a1 as destination
@@ -117,19 +117,19 @@ LJLIB_CF(table_move)
       lua_pushvalue(L, 5);  // Push a2 as return value
    }
 
-   if (e >= f) {
+   if (e > f) {
       int32_t d = t - f;
       // Choose iteration direction to handle overlapping regions correctly
-      if (t > e or t <= f or a2 != a1) {
+      if (t >= e or t <= f or a2 != a1) {
          // Forward iteration: no overlap or different tables
-         for (int32_t i = f; i <= e; i++) {
+         for (int32_t i = f; i < e; i++) {
             lua_rawgeti(L, 1, i);  // Get a1[i]
             lua_rawseti(L, (a2 IS a1) ? 1 : 5, i + d);  // Set a2[i+d]
          }
       }
       else {
          // Backward iteration: overlapping region requires reverse copy
-         for (int32_t i = e; i >= f; i--) {
+         for (int32_t i = e - 1; i >= f; i--) {
             lua_rawgeti(L, 1, i);  // Get a1[i]
             lua_rawseti(L, 1, i + d);  // Set a1[i+d] (same table)
          }
@@ -145,11 +145,12 @@ LJLIB_CF(table_concat) LJLIB_REC(.)
 {
    // An explicit end index supplies the numerical domain, so any classification is acceptable.  Without one the
    // boundary is inferred from lj_tab_len(), which requires a sequence.
-   const int explicit_end = (L->base + 3 < L->top and !tvisnil(L->base + 3));
-   GCtab* t = explicit_end ? lj_lib_checktab(L, 1) : lj_lib_checksequence(L, 1, "concat");
+   const int explicit_stop = (L->base + 3 < L->top and !tvisnil(L->base + 3));
+   GCtab* t = explicit_stop ? lj_lib_checktab(L, 1) : lj_lib_checksequence(L, 1, "concat");
    GCstr* sep = lj_lib_optstr(L, 2);
    int32_t i = lj_lib_optint(L, 3, 0);  // 0-based: default start
-   int32_t e = explicit_end ? lj_lib_checkint(L, 4) : (int32_t)lj_tab_len(t) - 1;  // 0-based: last index = len-1
+   int32_t stop = explicit_stop ? lj_lib_checkint(L, 4) : (int32_t)lj_tab_len(t);
+   int32_t e = stop > INT32_MIN ? stop - 1 : INT32_MIN;  // lj_buf_puttab() uses an inclusive endpoint.
 
    SBuf* sb = lj_buf_tmp_(L);
    SBuf* sbx = lj_buf_puttab(sb, t, sep, i, e);

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -1405,6 +1405,11 @@ static void recff_string_range(jit_State* J, RecordFFData* rd)
             J->base[0] = lj_ir_kstr(J, &J2G(J)->strempty);
             return;
          }
+         if (end IS INT32_MIN) {
+            emitir(IRTGI(IR_EQ), trend, lj_ir_kint(J, INT32_MIN));
+            J->base[0] = lj_ir_kstr(J, &J2G(J)->strempty);
+            return;
+         }
          // The recorder uses an inclusive endpoint internally.  Convert every non-zero exclusive stop.
          end--;
          trend = emitir(IRTI(IR_ADD), trend, lj_ir_kint(J, -1));
@@ -1424,6 +1429,11 @@ static void recff_string_range(jit_State* J, RecordFFData* rd)
          trend = lj_opt_narrow_toint(J, J->base[2]);
          end = argv2int(J, &rd->argv[2]);
          if (end IS 0) {
+            rd->nres = 0;
+            return;
+         }
+         if (end IS INT32_MIN) {
+            emitir(IRTGI(IR_EQ), trend, lj_ir_kint(J, INT32_MIN));
             rd->nres = 0;
             return;
          }

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -1377,7 +1377,7 @@ static TRef recff_string_start(jit_State* J, GCstr* s, int32_t* st, TRef tr, TRe
 }
 
 //********************************************************************************************************************
-// Handle string.byte (rd->data = 0) and string.sub (rd->data = 1).
+// Handle string.byte (rd->data = 0) and string.sub/string.substr (rd->data = 1).
 
 static void recff_string_range(jit_State* J, RecordFFData* rd)
 {
@@ -1390,7 +1390,7 @@ static void recff_string_range(jit_State* J, RecordFFData* rd)
    TRef trstart, trend;
    GCstr* str = argv2str(J, &rd->argv[0]);
    int32_t start, end;
-   if (rd->data) {  // string.sub(str, start [,end]) - end is exclusive
+   if (rd->data) {  // string.sub(str, start [,stop]) - stop is exclusive
       start = argv2int(J, &rd->argv[1]);
       trstart = lj_opt_narrow_toint(J, J->base[1]);
       trend = J->base[2];
@@ -1401,14 +1401,16 @@ static void recff_string_range(jit_State* J, RecordFFData* rd)
       else {
          trend = lj_opt_narrow_toint(J, trend);
          end = argv2int(J, &rd->argv[2]);
-         // Convert exclusive end to inclusive (only for positive values)
-         if (end > 0) {
-            end--;
-            trend = emitir(IRTI(IR_ADD), trend, lj_ir_kint(J, -1));
+         if (end IS 0) {
+            J->base[0] = lj_ir_kstr(J, &J2G(J)->strempty);
+            return;
          }
+         // The recorder uses an inclusive endpoint internally.  Convert every non-zero exclusive stop.
+         end--;
+         trend = emitir(IRTI(IR_ADD), trend, lj_ir_kint(J, -1));
       }
    }
-   else {  // string.byte(str, [,start [,end]])
+   else {  // string.byte(str, [,start [,stop]])
       if (tref_isnil(J->base[1])) {
          start = 0;  // 0-based: default start is 0
          trstart = lj_ir_kint(J, 0);
@@ -1421,6 +1423,12 @@ static void recff_string_range(jit_State* J, RecordFFData* rd)
       if (J->base[1] and !tref_isnil(J->base[2])) {
          trend = lj_opt_narrow_toint(J, J->base[2]);
          end = argv2int(J, &rd->argv[2]);
+         if (end IS 0) {
+            rd->nres = 0;
+            return;
+         }
+         end--;
+         trend = emitir(IRTI(IR_ADD), trend, lj_ir_kint(J, -1));
       }
       else {
          trend = trstart;
@@ -1434,7 +1442,7 @@ static void recff_string_range(jit_State* J, RecordFFData* rd)
       end = end + (int32_t)str->len;
    }
    else {
-      // 0-based: end is inclusive, max valid is len-1
+      // The recorder uses an inclusive endpoint internally, whose maximum valid value is len-1.
       TRef trmax = emitir(IRTI(IR_ADD), trlen, lj_ir_kint(J, -1));
       if ((MSize)end < str->len) {
          emitir(IRTGI(IR_ULE), trend, trmax);
@@ -1446,7 +1454,7 @@ static void recff_string_range(jit_State* J, RecordFFData* rd)
       }
    }
    trstart = recff_string_start(J, str, &start, trstart, trlen, tr0);
-   if (rd->data) {  // Return string.sub result.
+   if (rd->data) {  // Return string.sub/string.substr result.
       if (end - start >= 0) {
          // 0-based inclusive: length = end - start + 1
          TRef trptr, trslen = emitir(IRTI(IR_SUB), trend, trstart);
@@ -1587,10 +1595,9 @@ static void recff_string_find(jit_State* J, RecordFFData* rd)
          emitir(IRTG(IR_NE, IRT_PGC), tr, trp0);
          // Recompute offset. trsptr may not point into trstr after folding.
          pos = emitir(IRTI(IR_ADD), emitir(IRTI(IR_SUB), tr, trsptr), trstart);
-         // 0-based: return start position and inclusive end position
+         // 0-based: return a half-open span.
          J->base[0] = pos;
-         J->base[1] = emitir(IRTI(IR_ADD), pos,
-            emitir(IRTI(IR_ADD), trplen, lj_ir_kint(J, -1)));
+         J->base[1] = emitir(IRTI(IR_ADD), pos, trplen);
          rd->nres = 2;
       }
       else {
@@ -1739,12 +1746,12 @@ static void recff_table_concat(jit_State* J, RecordFFData* rd)
 {
    TRef tab = J->base[0];
    if (tref_istab(tab)) {
-      const bool explicit_end = J->base[1] and J->base[2] and not tref_isnil(J->base[3]);
-      if (not explicit_end and not recff_guard_sequence(J, rd, tab, tabV(&rd->argv[0]))) return;
+      const bool explicit_stop = J->base[1] and J->base[2] and not tref_isnil(J->base[3]);
+      if (not explicit_stop and not recff_guard_sequence(J, rd, tab, tabV(&rd->argv[0]))) return;
       TRef sep = !tref_isnil(J->base[1]) ? lj_ir_tostr(J, J->base[1]) : lj_ir_knull(J, IRT_STR);
       TRef tri = (J->base[1] and !tref_isnil(J->base[2])) ? lj_opt_narrow_toint(J, J->base[2]) : lj_ir_kint(J, 0);  // 0-based: default start
-      TRef tre = explicit_end ?
-         lj_opt_narrow_toint(J, J->base[3]) : emitir(IRTI(IR_ADD), emitir(IRTI(IR_ALEN), tab, TREF_NIL), lj_ir_kint(J, -1));  // 0-based: end = len - 1
+      TRef tre = explicit_stop ? emitir(IRTI(IR_SUB), lj_opt_narrow_toint(J, J->base[3]), lj_ir_kint(J, 1)) :
+         emitir(IRTI(IR_ADD), emitir(IRTI(IR_ALEN), tab, TREF_NIL), lj_ir_kint(J, -1));  // Internal endpoint is inclusive.
       TRef hdr = recff_bufhdr(J);
       TRef tr = lj_ir_call(J, IRCALL_lj_buf_puttab, hdr, tab, sep, tri, tre);
       emitir(IRTG(IR_NE, IRT_PTR), tr, lj_ir_kptr(J, nullptr));

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -7618,7 +7618,7 @@ static bool test_builtin_callable_bytecode(kt::Log &Log)
 
    BuiltinCallableID byte_id = builtin_callable_id(FastFunc::string_byte);
    if (not run_patched_call(
-       "local f = string.byte\nlocal first, second = f('AB', 0, 1)\nreturn first, second\n",
+       "local f = string.byte\nlocal first, second = f('AB', 0, 2)\nreturn first, second\n",
        byte_id, 2, BC_CALL) or lua_tointeger(first, -2) != 65 or lua_tointeger(first, -1) != 66) {
       Log.error("BC_BFUNC multi-result call did not preserve string.byte results");
       return false;

--- a/src/tiri/jit/src/runtime/lj_proto_registry.cpp
+++ b/src/tiri/jit/src/runtime/lj_proto_registry.cpp
@@ -191,7 +191,7 @@ static cTValue * exported_interface_member(
 }
 
 static ERR validate_method_state(lua_State *L, std::string_view Interface, std::string_view Method,
-   BuiltinCallableID Callable, bool RequireExportedMember)
+   BuiltinCallableID Callable, bool RequireExportedMember, bool AllowAlias)
 {
    if (not L or not builtin_callable_valid(Callable)) return ERR::InvalidValue;
    const char *canonical_name = builtin_callable_name(Callable);
@@ -202,7 +202,7 @@ static ERR validate_method_state(lua_State *L, std::string_view Interface, std::
    if (expected_name != canonical_name) {
       std::string object_alias("object.");
       object_alias.append(Method);
-      if (Interface != "obj" or object_alias != canonical_name) return ERR::Mismatch;
+      if (not AllowAlias and (Interface != "obj" or object_alias != canonical_name)) return ERR::Mismatch;
    }
 
    GCfunc *canonical = lj_builtin_callable(L, Callable);
@@ -280,14 +280,14 @@ ERR reg_iface_prototype(std::string_view Interface, std::string_view Method, std
 
 ERR reg_iface_method(lua_State *L, std::string_view Interface, std::string_view Method, TiriType ReceiverType,
    BuiltinCallableID Callable, std::initializer_list<TiriType> ResultTypes,
-   std::initializer_list<TiriType> ParamTypes, FProtoFlags Flags)
+   std::initializer_list<TiriType> ParamTypes, FProtoFlags Flags, bool AllowAlias)
 {
    if (Interface.empty() or Method.empty() or ReceiverType IS TiriType::Any or
        ReceiverType IS TiriType::Unknown or ReceiverType IS TiriType::Nil or
        ParamTypes.size() IS 0 or *ParamTypes.begin() != ReceiverType) return ERR::InvalidValue;
    ERR limits = validate_prototype_limits(ResultTypes, ParamTypes);
    if (limits != ERR::Okay) return limits;
-   ERR state_validation = validate_method_state(L, Interface, Method, Callable, true);
+   ERR state_validation = validate_method_state(L, Interface, Method, Callable, true, AllowAlias);
    if (state_validation != ERR::Okay) return state_validation;
    if ((Flags & FProtoFlags::ContextIndependent) != FProtoFlags::None) {
       lj_builtin_set_context_independent(L, Callable);
@@ -351,7 +351,7 @@ ERR reg_intrinsic_method(lua_State *L, std::string_view Interface, std::string_v
        *ParamTypes.begin() != ReceiverType) return ERR::InvalidValue;
    ERR limits = validate_prototype_limits(ResultTypes, ParamTypes);
    if (limits != ERR::Okay) return limits;
-   ERR state_validation = validate_method_state(L, Interface, Method, Callable, false);
+   ERR state_validation = validate_method_state(L, Interface, Method, Callable, false, false);
    if (state_validation != ERR::Okay) return state_validation;
    if ((Flags & FProtoFlags::ContextIndependent) != FProtoFlags::None) {
       lj_builtin_set_context_independent(L, Callable);

--- a/src/tiri/jit/src/runtime/lj_proto_registry.h
+++ b/src/tiri/jit/src/runtime/lj_proto_registry.h
@@ -36,7 +36,7 @@ ERR reg_iface_prototype(std::string_view Interface, std::string_view Method,
 
 ERR reg_iface_method(lua_State *L, std::string_view Interface, std::string_view Method, TiriType ReceiverType,
    BuiltinCallableID Callable, std::initializer_list<TiriType> ResultTypes,
-   std::initializer_list<TiriType> ParamTypes, FProtoFlags Flags = FProtoFlags::None);
+   std::initializer_list<TiriType> ParamTypes, FProtoFlags Flags = FProtoFlags::None, bool AllowAlias = false);
 
 // Register a hidden instance method.  Unlike reg_iface_method(), this does not require a matching public interface
 // field and stores only the receiver/member prototype entry.

--- a/src/tiri/jit/src/runtime/unit_test_vm_asm.cpp
+++ b/src/tiri/jit/src/runtime/unit_test_vm_asm.cpp
@@ -1432,7 +1432,7 @@ static bool test_asm_string_sub_negative_start(kt::Log& Log)
    return false;
 }
 
-// Tests negative end index (assembly handles via label 5)
+// Tests negative exclusive stop index (assembly handles via label 5)
 static bool test_asm_string_sub_negative_end(kt::Log& Log)
 {
    LuaStateHolder Holder;
@@ -1456,9 +1456,9 @@ static bool test_asm_string_sub_negative_end(kt::Log& Log)
 #endif
 
    const char* Result = lua_tostring(L, -1);
-   if (Result and std::string_view(Result) IS std::string_view("ABCD")) return true;
+   if (Result and std::string_view(Result) IS std::string_view("ABC")) return true;
 
-   Log.error("expected 'ABCD', got '%s'", Result ? Result : "(nil)");
+   Log.error("expected 'ABC', got '%s'", Result ? Result : "(nil)");
    return false;
 }
 
@@ -1605,9 +1605,9 @@ static bool test_asm_string_sub_both_negative(kt::Log& Log)
 #endif
 
    const char* Result = lua_tostring(L, -1);
-   if (Result and std::string_view(Result) IS std::string_view("BCD")) return true;
+   if (Result and std::string_view(Result) IS std::string_view("BC")) return true;
 
-   Log.error("expected 'BCD', got '%s'", Result ? Result : "(nil)");
+   Log.error("expected 'BC', got '%s'", Result ? Result : "(nil)");
    return false;
 }
 

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -736,6 +736,10 @@ end
    -- Find with start index
    assert(arr.find(50, 5) is 5, "find(50, 5) should return 5")
    assert(arr.find(50, 6) is nil, "find(50, 6) should return nil")
+   assert(arr.find(50, 0, 5) is nil, "an exclusive stop should exclude index 5")
+   assert(arr.find(50, 0, 6) is 5, "an exclusive stop should include index 5")
+   assert(arr.find(90, 9, #arr) is 9, "a stop equal to array length should be valid")
+   assert(arr.find(50, 5, 5) is nil, "an empty span should not find a value")
 end
 
 @Test function ArrayFindFloat()
@@ -1761,32 +1765,32 @@ end
 
 @Test function ArrayConcatRangeString()
    arr = array<str> { 'a', 'b', 'c', 'd' }
-   result = arr.concat(',', nil, 1, 2)
+   result = arr.concat(',', nil, 1, 3)
    assert(result is 'b,c', "concat with indexes 1 to 2 should return 'b,c', got '" .. result .. "'")
 end
 
 @Test function ArrayConcatRangeIntFormat()
    arr = array<int> { 1, 2, 3, 4 }
-   result = arr.concat('-', '%02d', 1, 3)
+   result = arr.concat('-', '%02d', 1, 4)
    assert(result is '02-03-04', "formatted concat with indexes 1 to 3 should return '02-03-04', got '" .. result .. "'")
 end
 
 @Test function ArrayConcatRangeNilSeparator()
    arr = array<int> { 1, 2, 3, 4 }
-   result = arr.concat(nil, '%d', 1, 3)
+   result = arr.concat(nil, '%d', 1, 4)
    assert(result is '234', "concat with nil separator and indexes 1 to 3 should return '234', got '" .. result .. "'")
 end
 
 @Test function ArrayConcatRangeSingleElement()
    arr = array<str> { 'zero', 'one', 'two' }
-   result = arr.concat(', ', nil, 1, 1)
+   result = arr.concat(', ', nil, 1, 2)
    assert(result is 'one', "single-element concat range should return only that element, got '" .. result .. "'")
 end
 
 @Test function ArrayConcatRangeEmptySpan()
    arr = array<str> { 'zero', 'one', 'two' }
    result = arr.concat(', ', nil, 2, 1)
-   assert(result is '', "concat range with End before Start should return an empty string, got '" .. result .. "'")
+   assert(result is '', "concat range with Stop before Start should return an empty string, got '" .. result .. "'")
 end
 
 @Test function ArrayConcatRangeOmittedIndexes()
@@ -1810,24 +1814,11 @@ end
       error('concat should reject negative End indexes')
    end
 
-   try
-      arr.concat(',', nil, 3, 3)
-   success
-      error('concat should reject Start indexes beyond the array length')
-   end
-
-   try
-      arr.concat(',', nil, 0, 3)
-   success
-      error('concat should reject End indexes beyond the array length')
-   end
+   assert(arr.concat(',', nil, 3, 3) is '', 'an empty span at the array end should be valid')
+   assert(arr.concat(',', nil, 0, 3) is 'a,b,c', 'a stop equal to array length should be valid')
 
    empty = array<str>
-   try
-      empty.concat(',', nil, 0, 0)
-   success
-      error('concat should reject explicit ranges on empty arrays')
-   end
+   assert(empty.concat(',', nil, 0, 0) is '', 'an empty span on an empty array should be valid')
 end
 
 @Test function ArrayConcatFloat()

--- a/src/tiri/tests/test_builtin_methods.tiri
+++ b/src/tiri/tests/test_builtin_methods.tiri
@@ -26,7 +26,7 @@ end
    assert(text.upper() is 'HELLO WORLD', 'String transformations should use dot calls')
    assert(text.contains('World') and text.startsWith('Hello'), 'String query methods should use dot calls')
 
-   local first, second = 'AB'.byte(0, 1)
+   local first, second = 'AB'.byte(0, 2)
    assert(first is 65 and second is 66, 'Variadic string methods should preserve multiple results')
    local parts = 'a,b,c'.split(',')
    assert(#parts is 3 and parts[1] is 'b', 'String array results should retain their inferred type')
@@ -76,7 +76,7 @@ end
       record=struct<BuiltinMethodRecord> { Value=9 },
       file=obj.new('file')
    }
-   local first, second = holder.text.byte(0, 1)
+   local first, second = holder.text.byte(0, 2)
    holder.values.push(2)
    local clone = holder.record.clone()
    assert(first is 65 and second is 66 and holder.values[1] is 2 and holder.sequence.contains(2) and

--- a/src/tiri/tests/test_contextual_designation.tiri
+++ b/src/tiri/tests/test_contextual_designation.tiri
@@ -246,11 +246,11 @@ end
    -- table.move() does not create its destination, so a caller-supplied ordinary destination stays ordinary and a
    -- contextual destination stays contextual because the flag is permanent.
    local ordinary_destination = { name = 'destination', read = probe_name }
-   table.move(designated, 0, 0, 0, ordinary_destination)
+   table.move(designated, 0, 1, 0, ordinary_destination)
    assert(ordinary_destination.read() is nil, 'table.move() should not promote a caller-supplied destination')
 
    local contextual_destination = entity { name = 'contextual destination', read = probe_name }
-   table.move({ 1 }, 0, 0, 0, contextual_destination)
+   table.move({ 1 }, 0, 1, 0, contextual_destination)
    assert(contextual_destination.read() is 'contextual destination',
       'A contextual destination should remain contextual after table.move()')
 end

--- a/src/tiri/tests/test_if_empty.tiri
+++ b/src/tiri/tests/test_if_empty.tiri
@@ -267,9 +267,9 @@ end
 @Test function IfEmptyStringFindError()
    local function_value = { status = 'Hello' }
 
-   start_index, end_index = (function_value.status ?? 'then').find('e')
+   start_index, stop_index = (function_value.status ?? 'then').find('e')
    assert(start_index is 1, "Expected search to start at index 1, got '" .. tostring(start_index) .. "'")
-   assert(end_index is 1, "Expected search to end at index 1, got '" .. tostring(end_index) .. "'")
+   assert(stop_index is 2, "Expected search to stop at index 2, got '" .. tostring(stop_index) .. "'")
 end
 
 @Test function MethodCallInOptionalForm()

--- a/src/tiri/tests/test_regex.tiri
+++ b/src/tiri/tests/test_regex.tiri
@@ -130,6 +130,7 @@ end
    pos, stop = sample_regex.findFirst('abc123def', 0)
    assert(pos is 3, f'Expected position 3, got {pos}')
    assert(stop is 6, f'Expected stop 6, got {stop}')
+   assert('abc123def'.sub(pos, stop) is '123', 'findFirst positions should compose with sub')
 
    pos2, stop = sample_regex.findFirst('no digits here', 0)
    assert(pos2 is nil and stop is nil, 'Expected no match, got position ' .. tostring(pos2))
@@ -373,6 +374,8 @@ end
    assert(matches[0].pos is 3 and matches[0].stop is 6, 'First match at pos 3, stop 6')
    assert(matches[1].pos is 9 and matches[1].stop is 12, 'Second match at pos 9, stop 12')
    assert(matches[2].pos is 15 and matches[2].stop is 18, 'Third match at pos 15, stop 18')
+   assert('abc123def456ghi789'.sub(matches[1].pos, matches[1].stop) is '456',
+      'findAll positions should compose with sub')
 
    -- Test with starting position (pos 6 skips past '123' entirely)
    matches2 = {}

--- a/src/tiri/tests/test_strings.tiri
+++ b/src/tiri/tests/test_strings.tiri
@@ -462,6 +462,13 @@ end
       empty = s.sub(5, 5)
       assert(empty is "", "Expected empty string, got '" .. empty .. "'")
 
+      -- Stops before the beginning remain empty after negative-index resolution.
+      underflow = s.sub(0, -12)
+      assert(underflow is "", "Expected an underflowed stop to produce an empty string")
+
+      minimum = s.sub(0, -2147483648)
+      assert(minimum is "", "Expected the minimum integer stop to produce an empty string")
+
       -- Beyond string length
       beyond = s.sub(0, 100)
       assert(#beyond is #s, "Expected length to match original string length, got " .. #beyond)
@@ -504,6 +511,10 @@ end
       -- Empty range
       empty = string.byte("hello", 5, 3)
       assert(empty is nil, "Expected nil for empty range, got " .. tostring(empty))
+
+      -- Extreme negative stops return no results without overflowing the recorder.
+      minimum = string.byte("hello", 0, -2147483648)
+      assert(minimum is nil, "Expected the minimum integer stop to return no bytes")
 
       -- Single character at last position
       last = string.byte("hello", 4)

--- a/src/tiri/tests/test_strings.tiri
+++ b/src/tiri/tests/test_strings.tiri
@@ -429,9 +429,8 @@ end
    assert(ue is "<<>>", "Received string is incorrect: " .. tostring(ue))
 end
 
-@Test function SubStr()
-   -- string.sub() uses exclusive end index (like JavaScript substring/Python slicing)
-   -- s.sub(start, end) extracts chars from start to end-1
+@Test function Sub()
+   -- string.sub() uses an exclusive stop index (like JavaScript substring/Python slicing).
    s = "hello world"
 
    for i in {0 to 1000} do
@@ -443,9 +442,9 @@ end
       mid = s.sub(6, 11) -- Indices 6,7,8,9,10 (not 11)
       assert(mid is "world", "Expected 'world', got '" .. mid .. "'")
 
-      -- Negative indices (count from end)
+      -- Negative stops remain exclusive after they are resolved from the end.
       neg = s.sub(-5, -1)
-      assert(neg is "world", "Expected 'world' from negative indices, got '" .. neg .. "'")
+      assert(neg is "worl", "Expected 'worl' from negative indices, got '" .. neg .. "'")
 
       -- Negative start, positive end
       mixed = s.sub(-5, 11)
@@ -471,6 +470,9 @@ end
       -- Empty string
       emptyStr = "".sub(0, 0)
       assert(emptyStr is "", "Expected empty string, got '" .. emptyStr .. "'")
+
+      -- The deprecated spelling remains an exact behavioural alias.
+      assert(s.substr(0, 5) is s.sub(0, 5), "string.substr() should match string.sub()")
    end
 end
 
@@ -481,7 +483,7 @@ end
       assert(b is 104, "Expected 104 (h), got " .. b)
 
       -- Multiple characters
-      b1, b2, b3 = string.byte("abc", 0, 2)
+      b1, b2, b3 = string.byte("abc", 0, 3)
       assert(b1 is 97, "Expected 97 (a), got " .. b1)
       assert(b2 is 98, "Expected 98 (b), got " .. b2)
       assert(b3 is 99, "Expected 99 (c), got " .. b3)
@@ -495,7 +497,7 @@ end
       assert(neg is 111, "Expected 111 (o), got " .. neg)
 
       -- Range with negative end
-      b4, b5 = string.byte("hello", -2, -1)
+      b4, b5 = string.byte("hello", -2, 5)
       assert(b4 is 108, "Expected 108 (l), got " .. b4)
       assert(b5 is 111, "Expected 111 (o), got " .. b5)
 
@@ -506,6 +508,26 @@ end
       -- Single character at last position
       last = string.byte("hello", 4)
       assert(last is 111, "Expected 111 (o), got " .. last)
+   end
+end
+
+@Test function FindAndSubComposition()
+   text = 'prefix needle suffix needle'
+
+   for i in {0 to 1000} do
+      start, stop = text.find('needle')
+      assert(start is 7 and stop is 13, 'find should return the first half-open span')
+      assert(text.sub(start, stop) is 'needle', 'find results should compose directly with sub')
+
+      final_start, final_stop = text.find('needle', 14)
+      assert(final_start is 21 and final_stop is 27, 'find should return the final half-open span')
+      assert(text.sub(final_start, final_stop) is 'needle', 'the final match should slice without adjustment')
+
+      empty_start, empty_stop = 'abc'.find('')
+      assert(empty_start is 0 and empty_stop is 0, 'an empty match should be an empty half-open span')
+
+      missing_start, missing_stop = text.find('absent')
+      assert(missing_start is nil and missing_stop is nil, 'a missing literal should return nil results')
    end
 end
 
@@ -631,12 +653,12 @@ end
    s = "hello world"
    start, finish = s.find("world")
    assert(start is 6, "Expected start at 6, got " .. tostring(start))
-   assert(finish is 10, "Expected finish at 10, got " .. tostring(finish))
+   assert(finish is 11, "Expected stop at 11, got " .. tostring(finish))
 
    -- Find at beginning
    start2, finish2 = s.find("hello")
    assert(start2 is 0, "Expected start at 0, got " .. tostring(start2))
-   assert(finish2 is 4, "Expected finish at 4, got " .. tostring(finish2))
+   assert(finish2 is 5, "Expected stop at 5, got " .. tostring(finish2))
 
    -- Not found
    notFound = s.find("xyz")
@@ -645,7 +667,7 @@ end
    -- With start position
    start3, finish3 = s.find("o", 5)
    assert(start3 is 7, "Expected start at 7, got " .. tostring(start3))
-   assert(finish3 is 7, "Expected finish at 7, got " .. tostring(finish3))
+   assert(finish3 is 8, "Expected stop at 8, got " .. tostring(finish3))
 end
 
 @Test function Count()

--- a/src/tiri/tests/test_table.tiri
+++ b/src/tiri/tests/test_table.tiri
@@ -134,7 +134,7 @@ end
 @Test function MoveBasic()
    -- Test basic move within same table
    t = { 'a', 'b', 'c', 'd', 'e' }
-   result = t.move(0, 2, 3)  -- Move indices 0-2 to start at 3
+   result = t.move(0, 3, 3)  -- Move [0, 3) to start at 3
    assert(result is t, "move should return the target table")
    assert(t[3] is 'a', "t[3] should be 'a', got " .. tostring(t[3]))
    assert(t[4] is 'b', "t[4] should be 'b', got " .. tostring(t[4]))
@@ -145,7 +145,7 @@ end
    -- Test move to a different table
    src = { 10, 20, 30 }
    dst = {}
-   result = src.move(0, 2, 0, dst)
+   result = src.move(0, 3, 0, dst)
    assert(result is dst, "move should return destination table")
    assert(dst[0] is 10, "dst[0] should be 10")
    assert(dst[1] is 20, "dst[1] should be 20")
@@ -153,10 +153,10 @@ end
 end
 
 @Test function MoveEmptyRange()
-   -- Test move with empty range (e < f)
+   -- Test move with an empty half-open range.
    t = { 1, 2, 3 }
    original_len = #t
-   result = t.move(2, 1, 5)  -- Empty range, should do nothing
+   result = t.move(2, 2, 5)  -- Empty range, should do nothing
    assert(result is t, "move should return the table")
    assert(#t is original_len, "Table length should be unchanged")
 end
@@ -164,14 +164,14 @@ end
 @Test function MoveSingleElement()
    -- Test moving a single element
    t = { 'x', 'y', 'z' }
-   t.move(1, 1, 5)  -- Move t[1] to t[5]
+   t.move(1, 2, 5)  -- Move t[1] to t[5]
    assert(t[5] is 'y', "t[5] should be 'y', got " .. tostring(t[5]))
 end
 
 @Test function MoveOverlappingForward()
    -- Test overlapping move (shifting forward)
    t = { 1, 2, 3, 4, 5 }
-   t.move(0, 2, 1)  -- Move 0-2 to 1-3 (overlapping)
+   t.move(0, 3, 1)  -- Move [0, 3) to 1-3 (overlapping)
    assert(t[1] is 1, "t[1] should be 1, got " .. tostring(t[1]))
    assert(t[2] is 2, "t[2] should be 2, got " .. tostring(t[2]))
    assert(t[3] is 3, "t[3] should be 3, got " .. tostring(t[3]))
@@ -181,14 +181,14 @@ end
    -- Test that move returns the destination table
    src = { 1, 2, 3 }
    dst = { 'a', 'b' }
-   result = src.move(0, 2, 0, dst)
+   result = src.move(0, 3, 0, dst)
    assert(result is dst, "move should return destination table when provided")
 end
 
 @Test function MoveNoDestination()
    -- Test move without explicit destination (uses source)
    t = { 'a', 'b', 'c' }
-   result = t.move(0, 1, 5)
+   result = t.move(0, 2, 5)
    assert(result is t, "move should return source table when no destination")
    assert(t[5] is 'a', "t[5] should be 'a'")
    assert(t[6] is 'b', "t[6] should be 'b'")
@@ -325,10 +325,18 @@ end
 end
 
 @Test function ConcatWithRange()
-   -- Concatenation with start and end indices
+   -- Concatenation with a half-open start/stop span.
    t = { 'a', 'b', 'c', 'd', 'e' }
    result = t.concat(',', 1, 3)
-   assert(result is 'b,c,d', "concat with range failed, got '" .. result .. "'")
+   assert(result is 'b,c', "concat with range failed, got '" .. result .. "'")
+end
+
+@Test function ConcatSpanBoundaries()
+   t = { 'a', 'b', 'c' }
+   assert(t.concat(',', 0, #t) is 'a,b,c', 'stop equal to table length should include the full table')
+   assert(t.concat(',', 1, 2) is 'b', 'a one-element span should contain one element')
+   assert(t.concat(',', 2, 2) is '', 'an empty span should concatenate to an empty string')
+   assert(t.concat(',', 2, 1) is '', 'a reversed span should concatenate to an empty string')
 end
 
 @Test function ConcatSingleElement()
@@ -789,7 +797,7 @@ end
    -- Explicitly bounded operations work on the caller-supplied domain, so they accept any classification.
    t = { 'a', 'b', 'c' }
    t.name = 'x'
-   assert(t.concat(',', 0, 2) is 'a,b,c', "Explicitly bounded concat should be permitted")
+   assert(t.concat(',', 0, 3) is 'a,b,c', "Explicitly bounded concat should be permitted")
 
    -- Omitting the end index infers the boundary and is therefore rejected.
    local rejected = false

--- a/src/tiri/tiri_regex.cpp
+++ b/src/tiri/tiri_regex.cpp
@@ -278,9 +278,9 @@ static int regex_extract(lua_State *Lua)
 }
 
 //********************************************************************************************************************
-// Method: regex.findFirst(text, [pos], [flags]) -> start, end, [captures]
+// Method: regex.findFirst(text, [pos], [flags]) -> start, stop, [captures]
 // This is the fastest available means for searching for the position of a match.
-// Returns nil on failure, or the start and end of the first match/capture.
+// Returns nil on failure, or the half-open start and stop of the first match/capture.
 
 static int regex_findFirst(lua_State *Lua)
 {
@@ -351,7 +351,7 @@ static int regex_findAll_iter(lua_State *Lua)
 //********************************************************************************************************************
 // Method: regex.findAll(text, [pos], [flags]) -> iterator
 // Returns an iterator function for use in for loops:
-//    for start, end, cap in rx.findAll(text) do ... end
+//    for start, stop, cap in rx.findAll(text) do ... end
 
 static int regex_findAll(lua_State *Lua)
 {

--- a/tools/benchmark/benchmark_string.tiri
+++ b/tools/benchmark/benchmark_string.tiri
@@ -215,7 +215,7 @@ end
       local last_part = text.sub(-10)
 
       -- Extract with negative indices
-      local from_end = text.sub(-20, -11)
+      local from_end = text.sub(-20, -10)
 
       -- Variable position extraction
       local pos = (i % 40) + 1
@@ -482,7 +482,7 @@ end
       -- Get character at specific position using string.sub
       local char1 = text.sub(1, 1)   -- 'H'
       local char2 = text.sub(7, 7)   -- ' '
-      local char3 = text.sub(-1, -1) -- '!'
+      local char3 = text.sub(-1)     -- '!'
 
       -- Get character code (byte value)
       local code1 = text.byte(1)     -- 72 ('H')

--- a/tools/idl/idl-c.tiri
+++ b/tools/idl/idl-c.tiri
@@ -268,7 +268,7 @@ global function idlFunction(Name:str, Category:str, Comment:str, Status:str, Des
       jumpArgs = Def.ext_proto
       argSeq   = Def.ext_proto
       if argSeq.sub(-3) is '...' then
-         argSeq = argSeq.sub(0, -4) .. 'Args... Tags'
+         argSeq = argSeq.sub(0, -3) .. 'Args... Tags'
       end
    elseif not jumpArgs then
       jumpArgs = argSeq

--- a/tools/idl/include/client_functions.tiri
+++ b/tools/idl/include/client_functions.tiri
@@ -1014,7 +1014,7 @@ global function klass(Name:str, Options:table, Spec:str, Private:str, Custom:str
             return 'const std::string_view &'
          elseif Param.resultValue and Param.mutable and Param.type.endsWith('*') then
             Param.byRef = true
-            return Param.type.sub(0,-2) .. '&'
+            return Param.type.sub(0,-1) .. '&'
          elseif Param.isSpan then
             return Param.type .. ' '
          elseif Param.isComplex then

--- a/tools/idl/include/output.tiri
+++ b/tools/idl/include/output.tiri
@@ -114,7 +114,7 @@ end
 
 function fieldSetIDName(FieldName:str):str
    local id = FieldName.sub(-3)
-   if rx_lowercase_id.test(id) then return FieldName.sub(0, -3) end
+   if rx_lowercase_id.test(id) then return FieldName.sub(0, -2) end
 
    return FieldName
 end
@@ -166,8 +166,8 @@ end
 function fieldArrayElementType(Field:table):str
    local field_type = Field.innerType ?? Field.type
 
-   if field_type.endsWith('[]') then return field_type.sub(0, -3).trim() end
-   if field_type.endsWith('*') then return field_type.sub(0, -2).trim() end
+   if field_type.endsWith('[]') then return field_type.sub(0, -2).trim() end
+   if field_type.endsWith('*') then return field_type.sub(0, -1).trim() end
 
    return field_type
 end
@@ -460,7 +460,7 @@ function outputFieldSetterSignature(Field:table, FidName:str, FieldType:str)
          output(f'   inline ERR set{FidName}(std::span<{fieldArraySetterElementType(Field)}> Value) noexcept {{')
       end
    elseif FieldType.endsWith('[]') then
-      local array_type = FieldType.sub(0,-3).trim()
+      local array_type = FieldType.sub(0,-2).trim()
       output(f'   inline ERR set{FidName}(std::span<{array_type}> Value) noexcept {{')
    elseif Field.flags has FD_STRING then -- std::string internally, accessed as std::string_view.
       output(f'   inline ERR set{FidName}(const std::string_view &Value) noexcept {{')
@@ -866,7 +866,7 @@ global function saveOutput()
       end
    end
 
-   if content.endsWith('\n\n') then content = content.sub(0, -3) end
+   if content.endsWith('\n\n') then content = content.sub(0, -2) end
 
    local offset_output = prepareClassOffsetOutput()
    if offset_output then


### PR DESCRIPTION
* Reworked string.byte/sub, array.concat/find and table.move/concat to interpret stop indexes as exclusive
* Updated the JIT recorder and x64/arm64/ppc VM stubs for string.byte/sub to convert the exclusive stop and short-circuit on an empty span
* Adjusted regex.findFirst/findAll to report matches as a half-open start/stop pair
* Added a deprecated string.substr alias for sub, threaded through reg_iface_method() via a new AllowAlias flag
* Updated Tiri scripts, benchmarks, IDL tooling and unit tests for the new stop convention