### PR TITLE
[Tiri] Fixed multi-result table field expansion to patch the correct call instruction

### DIFF
--- a/src/tiri/jit/src/parser/ir_emitter/emit_table.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_table.cpp
@@ -10,6 +10,7 @@ ParserResult<ExpDesc> IrEmitter::emit_table_expr(const TableExprPayload &Payload
    FuncState* fs = &this->func_state;
    GCtab* template_table = nullptr;
    int vcall = 0;
+   BCPOS vcall_primary = NO_JMP;
    BCPOS vcall_alternate = NO_JMP;
    int needarr = 0;
    int fixt = 0;
@@ -74,6 +75,7 @@ ParserResult<ExpDesc> IrEmitter::emit_table_expr(const TableExprPayload &Payload
       if (not value_result.ok()) return value_result;
 
       ExpDesc val = value_result.value_ref();
+      vcall_primary = val.k IS ExpKind::Call ? val.u.s.info : NO_JMP;
       vcall_alternate = val.alternate_call;
 
       bool emit_constant = key.is_constant() and key.k != ExpKind::Nil and (key.k IS ExpKind::Str or val.is_constant_nojump());
@@ -125,7 +127,8 @@ ParserResult<ExpDesc> IrEmitter::emit_table_expr(const TableExprPayload &Payload
          ilp--;
       }
       ilp->ins = BCINS_AD(BC_TSETM, freg, const_num(fs, &en));
-      setbc_b(&ilp[-1].ins, 0);
+      fs_check_assert(fs, vcall_primary != NO_JMP, "multi-result table field has no call instruction");
+      setbc_b(&fs->bcbase[vcall_primary].ins, 0);
       if (vcall_alternate != NO_JMP) setbc_b(&fs->bcbase[vcall_alternate].ins, 0);
    }
 

--- a/src/tiri/tests/test_strings.tiri
+++ b/src/tiri/tests/test_strings.tiri
@@ -495,6 +495,12 @@ end
       assert(b2 is 98, "Expected 98 (b), got " .. b2)
       assert(b3 is 99, "Expected 99 (c), got " .. b3)
 
+      -- A final multi-result call expands into successive table elements.
+      captured = { string.byte("ABC", 0, 3) }
+      assert(#captured is 3, "Expected three captured bytes, got " .. tostring(#captured))
+      assert(captured[0] is 65 and captured[1] is 66 and captured[2] is 67,
+         "Expected captured bytes 65, 66, 67")
+
       -- Default range (single character at index 0)
       def = string.byte("hello")
       assert(def is 104, "Expected 104 (h) as default, got " .. def)


### PR DESCRIPTION
* Tracked the primary call instruction position (vcall_primary) so BC_TSETM patches the multi-result call rather than the instruction preceding it
* Added an assertion guarding against a multi-result table field with no associated call instruction
* [Test] Added coverage for a trailing multi-result call expanding into successive table elements