### PR TITLE
[Tiri] Added the contextual type-test operator with a dedicated TYPETEST bytecode

### DIFF
--- a/apps/proximity.tiri
+++ b/apps/proximity.tiri
@@ -129,7 +129,7 @@ Examples:
    end
 
    glOptions.onError = function(Error:any!)
-      if type(Error) is 'table' then
+      if Error is <table> then
          print('[ERROR] ' .. (Error.message ?? Error.code ?? 'Proxy error'))
       else
          print('[ERROR] ' .. tostring(Error))

--- a/scripts/config.tiri
+++ b/scripts/config.tiri
@@ -27,7 +27,7 @@ function validate_text(Text:str!, Description:str!)
 end
 
 function validate_name(Name:any!, Description:str!):str
-   if type(Name) != 'string' then error(Description .. ' must be a string.') end
+   if Name != <str> then error(Description .. ' must be a string.') end
    if Name is '' then error(Description .. ' cannot be empty.') end
    validate_text(Name, Description)
    return Name
@@ -121,7 +121,7 @@ config.encode = function(Value:table!):str
 
    for group_name, group in Value.sortByKeys() do
       group_name = validate_group_name(group_name)
-      if type(group) != 'table' then error(f'Config group "{group_name}" must be a table.') end
+      if group != <table> then error(f'Config group "{group_name}" must be a table.') end
 
       if group_count > 0 then output.push('\n') end
       output.push('[', group_name, ']\n')

--- a/scripts/gui.tiri
+++ b/scripts/gui.tiri
@@ -415,7 +415,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 gui.rgbToIconTheme = function(Value:any!):str
-   if type(Value) is 'string' then
+   if Value is <str> then
       Value = gui.strToRGB(Value)
    end
 
@@ -516,9 +516,9 @@ gui.createIcon = function(Scene:obj!, Path:str!, Size:num, Theme:any!, Name:str)
    gui._counter++
    gname = 'icon_grd' .. gui._counter
 
-   if type(Theme) is 'table' then
+   if Theme is <table> then
       lGradient = Theme
-   elseif type(Theme) is 'string' then
+   elseif Theme is <str> then
       gname = f'icon_{Theme}'
       if gui.iconThemes[Theme] then
          lGradient = gui.iconThemes[Theme]
@@ -576,7 +576,7 @@ gui.separator = function(Viewport:obj!, Orientation:str!, Pos:any!, MarginA:any,
       options.xOffset = MarginB ?? 0
       options.height  = gui.sizing.widget.strokeWidth
 
-      if type(Pos) is 'number' and (Pos < 0 or (Pos is 0 and (1/Pos) < 0)) then -- Include negative zero
+      if Pos is <num> and (Pos < 0 or (Pos is 0 and (1/Pos) < 0)) then -- Include negative zero
          options.yOffset = -Pos
          subvp = Viewport.new('VectorViewport', options)
          subvp.new('VectorRectangle', { fill=options.fill, width='100%', height='100%' })
@@ -588,7 +588,7 @@ gui.separator = function(Viewport:obj!, Orientation:str!, Pos:any!, MarginA:any,
       options.y       = MarginA ?? 0
       options.yOffset = MarginB ?? 0
       options.width   = gui.sizing.widget.strokeWidth
-      if type(Pos) is 'number' and (Pos < 0 or (Pos is 0 and (1/Pos) < 0)) then
+      if Pos is <num> and (Pos < 0 or (Pos is 0 and (1/Pos) < 0)) then
          options.xOffset = -Pos
          subvp = Viewport.new('VectorViewport', options)
          subvp.new('VectorRectangle', { fill=options.fill, width='100%', height='100%' })

--- a/scripts/gui/colourdialog.tiri
+++ b/scripts/gui/colourdialog.tiri
@@ -501,15 +501,15 @@ function loadColours(self)
       js = io.readAll('user:config/colours.json')
       if js?? then
          self._userColours = json.decode(js)
-         if type(self._userColours) != 'array' then
+         if self._userColours != <array> then
             print('Invalid user:config/colours.json file detected.')
             self._userColours = array<table>
          end
 
          for i, col in self._userColours do
-            if type(col) is 'table' then -- Legacy format; remove in 2027
+            if col is <table> then -- Legacy format; remove in 2027
                self._userColours[i] = gui.srgb(col.r, col.g, col.b)
-            elseif type(col) is 'string' then
+            elseif col is <str> then
                self._userColours[i] = gui.strToRGB(col)
             end
          end

--- a/scripts/gui/columnview.tiri
+++ b/scripts/gui/columnview.tiri
@@ -30,7 +30,7 @@ lColours = {
 ----------------------------------------------------------------------------------------------------------------------
 
 function columnText(Value:any, Type:str):any
-   if type(Value) is 'table' then
+   if Value is <table> then
       Value = Value.value
    end
 
@@ -671,21 +671,21 @@ gui.columnView = function(Options):table
    -- NB: Attrib values that evaluate to nil are not permitted/supported.
 
    vw.sortColumn = function(View:table!, Column:any!, Ascending:bool!)
-      if type(Column) is 'string' then
+      if Column is <str> then
          for col in values(View.columns) do
             if col['attrib'] is Column then
                Column = col
                break
             end
          end
-      elseif type(Column) is 'number' then
+      elseif Column is <num> then
          Column = View.columns[Column]
       end
 
-      if type(Column) is 'table' then
+      if Column is <table> then
          if #View.items > 0 then
             attrib = Column['attrib']
-            if type(View.items[0][attrib]) is 'table' then
+            if View.items[0][attrib] is <table> then
                if View.items[0][attrib]['sort'] then
                   View.items.sort(function(a,b)
                      return Ascending ? a[attrib].sort < b[attrib].sort : a[attrib].sort > b[attrib].sort

--- a/scripts/gui/dialog.tiri
+++ b/scripts/gui/dialog.tiri
@@ -112,7 +112,7 @@ gui.dialog.message = function(Options)
 
       -- At minimum, there must be an OK option.
 
-      if not ((type(self.options) is 'table') and (#self.options > 0)) then
+      if not ((self.options is <table>) and (#self.options > 0)) then
          self.options = { { id=1, text='Close Dialog', icon='items/cancel' } }
       end
 
@@ -168,7 +168,7 @@ gui.dialog.message = function(Options)
          inputOptions = ''
          if Options.secret then inputOptions = 'secret="true"' end
 
-         msg = type(Options.userInput) is 'string' ? Options.userInput : ''
+         msg = Options.userInput is <str> ? Options.userInput : ''
 
          doc ..= f'<p><input name="input" {inputOptions} width="16em" value="{msg}"/></p>\n'
       end

--- a/scripts/gui/fileview.tiri
+++ b/scripts/gui/fileview.tiri
@@ -248,7 +248,7 @@ function getFilters(self):array<str>
    if self.filterList then
       for filter in values(self.filterList) do
          if filter.selected then
-            if type(filter.ext) is 'table' or type(filter.ext) is 'array' then
+            if filter.ext is <table> or filter.ext is <array> then
                for ext in values(filter.ext) do
                   self._filters.push(ext)
                end
@@ -1418,7 +1418,7 @@ gui.fileview = function(Options)
          local tbo
          if (Options.toolBar is true) or (Options.toolBar is 'all') then
             tbo = { navigation=true, clipboard=true, actions=true, views=true }
-         elseif type(Options.toolBar) is 'table' then
+         elseif Options.toolBar is <table> then
             tbo = Options.toolBar
          else
             error('Invalid value passed to fileview.toolBar')

--- a/scripts/gui/libview.tiri
+++ b/scripts/gui/libview.tiri
@@ -543,7 +543,7 @@ gui.initView = function(Options:table!, BuildUI, NewItems)
 
       if #vw.items <= 1 then return end
 
-      if type(vw.items[0][Attrib]) is 'table' then
+      if vw.items[0][Attrib] is <table> then
          if vw.items[0][Attrib]['sort'] then
             vw.items.sort(function(a,b)
                return Ascending ? (a[Attrib].sort < b[Attrib].sort) : (a[Attrib].sort > b[Attrib].sort)
@@ -553,7 +553,7 @@ gui.initView = function(Options:table!, BuildUI, NewItems)
                return Ascending ? (a[Attrib].value < b[Attrib].value) : (a[Attrib].value > b[Attrib].value)
             end)
          end
-      elseif type(vw.items[1][Attrib]) is 'string' then
+      elseif vw.items[1][Attrib] is <str> then
          vw.items.sort(function(a,b)
             return Ascending ? (string.lower(a[Attrib]) < string.lower(b[Attrib])) :
                (string.lower(a[Attrib]) > string.lower(b[Attrib]))

--- a/scripts/gui/listview.tiri
+++ b/scripts/gui/listview.tiri
@@ -177,7 +177,7 @@ gui.listView = function(Options:table!):table
 
             item._vectors.text.x = MARGIN + ICON_MARGIN
             item._vectors.text.y = LINE_OFFSET
-            if type(item_name) is 'table' then
+            if item_name is <table> then
                item._vectors.text.string = item_name.value
             else
                item._vectors.text.string = item_name

--- a/scripts/gui/toolbar.tiri
+++ b/scripts/gui/toolbar.tiri
@@ -436,7 +436,7 @@ gui.toolbar = function(Options)
       end
 
       if Content then
-         if type(Content) is 'number' then
+         if Content is <num> then
             if Content > 9 then
                size = math.floor(self._iconSize * 0.33)
                gui.createIcon(self.viewport.scene, 'items/add', size, 'pearl', 'sticker_plus')
@@ -449,7 +449,7 @@ gui.toolbar = function(Options)
             end
          end
 
-         if type(Content) is 'string' then
+         if Content is <str> then
             if #Content > 1 then Content = Content.sub(0,1) end
          end
 

--- a/scripts/io/filemgr.tiri
+++ b/scripts/io/filemgr.tiri
@@ -95,8 +95,8 @@ end
 -- NB: This call can block if it needs a response from the user.  It does not return until the copy is complete.
 
 io.ui.copy = function(Source:any!, Dest:str!, Move:bool!)
-   if type(Source) is 'string' then Source = { Source } end
-   if type(Source) != 'table' then error('Provided Source is not a table') end
+   if Source is <str> then Source = { Source } end
+   if Source != <table> then error('Provided Source is not a table') end
 
    -- Scan the file list and move or copy each file to the Dest folder
 
@@ -209,8 +209,8 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 io.ui.delete = function(Paths)
-   if type(Paths) is 'string' then Paths = { Paths } end
-   if type(Paths) != 'table' then error('Path must be a string or string list.') end
+   if Paths is <str> then Paths = { Paths } end
+   if Paths != <table> then error('Path must be a string or string list.') end
 
    for path in values(Paths) do
       mSys.DeleteFile(path, function(Feedback)

--- a/scripts/io/filesearch.tiri
+++ b/scripts/io/filesearch.tiri
@@ -209,7 +209,7 @@ io.search = function(Path:str!, Options:table!)
 
    -- Entry point for the search
 
-   if lOptions.nameFilter and type(lOptions.nameFilter) != 'string' then
+   if lOptions.nameFilter and lOptions.nameFilter != <str> then
       -- Check if it's a regex object by testing for regex methods
       if lOptions.nameFilter.test and lOptions.nameFilter.match then
          isRegexFilter = true
@@ -224,7 +224,7 @@ io.search = function(Path:str!, Options:table!)
       lOptions.minDateSet = true
    end
 
-   if type(Path) is 'table' or type(Path) is 'array' then
+   if Path is <table> or Path is <array> then
       for v in values(Path) do
          processPath(v)
       end

--- a/scripts/json.tiri
+++ b/scripts/json.tiri
@@ -97,9 +97,8 @@ ErrorCallback: Optional callback invoked when the value cannot be encoded
 string: JSON text
 ]])
 json.encode = function(Value:any, ErrorCallback:func, AsKey:bool):str
-   local kind = type(Value)
    ErrorCallback ?= error
-   if kind is 'array' then
+   if Value is <array> then
       s = array<str>
       if AsKey then
          ErrorCallback('Can\'t encode array as key.')
@@ -112,7 +111,7 @@ json.encode = function(Value:any, ErrorCallback:func, AsKey:bool):str
          s.push(']')
       end
       return s.concat()
-   elseif kind is 'table' then
+   elseif Value is <table> then
       s = array<str>
       if AsKey then
          ErrorCallback('Can\'t encode table as key.')
@@ -125,19 +124,19 @@ json.encode = function(Value:any, ErrorCallback:func, AsKey:bool):str
          s.push('}')
       end
       return s.concat()
-   elseif kind is 'string' then
+   elseif Value is <str> then
       return '"' .. escape_str(Value) .. '"'
-   elseif kind is 'number' then
+   elseif Value is <num> then
       if AsKey then return '"' .. tostring(Value) .. '"' end
       return tostring(Value)
-   elseif kind is 'bool' then
+   elseif Value is <bool> then
       return tostring(Value)
-   elseif kind is 'nil' then
+   elseif Value is <nil> then
       return 'null'
-   elseif kind is 'function' then
+   elseif Value is <func> then
       return 'function'
    else
-      ErrorCallback('Unsupported type: ' .. kind .. '.')
+      ErrorCallback('Unsupported type: ' .. type(Value) .. '.')
       return ''
    end
 end

--- a/scripts/net/httpserver.tiri
+++ b/scripts/net/httpserver.tiri
@@ -467,7 +467,7 @@ function parseQueryString(QueryString:str):table
          value = urlDecode(value)
          if query[key] then
             -- Handle multiple values for same key by converting to array
-            if type(query[key]) != 'table' then
+            if query[key] != <table> then
                query[key] = { query[key] }
             end
             query[key].insert(value)
@@ -701,7 +701,7 @@ function sendHttpResponse(self, Client, statusCode, statusText, headers, body, C
    end
 
    for name, value in pairs(headers) do
-      if type(value) is 'table' then
+      if value is <table> then
          for header_value in values(value) do
             response ..= name .. ": " .. tostring(header_value) .. "\r\n"
          end
@@ -792,7 +792,7 @@ function createResponseObject(self, Client)
       -- Handle multiple cookies by making set-cookie an array
       existing = res._headers['set-cookie']
       if existing then
-         if type(existing) != 'table' then
+         if existing != <table> then
             existing = { existing }
          end
          existing.insert(cookieStr)
@@ -807,7 +807,7 @@ function createResponseObject(self, Client)
    res.json = function(data)
       assert(not res._sent, 'Response already sent')
 
-      jsonStr = type(data) is 'string' ? data : json.encode(data)
+      jsonStr = data is <str> ? data : json.encode(data)
 
       res._headers['content-type'] = 'application/json'
       sendHttpResponse(res._self, res._client, res._statusCode, res._statusText, res._headers, jsonStr)
@@ -1332,11 +1332,11 @@ function addRoute(self:table, route:table)
 
       if not self._routes[method] then self._routes[method] = {} end
 
-      if type(route.handler) is 'function' then
+      if route.handler is <func> then
          -- Validate route-specific middleware
-         if type(route.middleware) is 'table' then
+         if route.middleware is <table> then
             for j, mw in ipairs(route.middleware) do
-               if type(mw) != 'function' then
+               if mw != <func> then
                   error('Invalid middleware for route ' .. method .. ' ' .. pattern .. ' at index ' .. j .. ' - must be a function')
                end
             end
@@ -1662,7 +1662,7 @@ function serverIncoming(self, ClientSocket)
                sendHttpResponse(self, ClientSocket, 400, "Bad Request", { ['content-type'] = 'text/html' }, errorBody)
                state.invalid_header = true
                state.phase = 'CANCELLED'
-            elseif type(vres) is 'table' and vres.status then
+            elseif vres is <table> and vres.status then
                -- Custom error response from validateHeader
                statusCode = vres.status or 400
                statusText = vres.statusText or 'Bad Request'
@@ -1955,7 +1955,7 @@ hslib.start = function(Options)
    self.folder ?? error('The folder option is required')
 
    if Options.verbose then
-      if type(Options.verbose) is 'bool' then
+      if Options.verbose is <bool> then
          self.verbose = Options.verbose
       else
          verbose = tostring(Options.verbose).lower()
@@ -1991,7 +1991,7 @@ hslib.start = function(Options)
    end
 
    if Options.autoIndex then
-      if type(Options.autoIndex) is 'bool' then
+      if Options.autoIndex is <bool> then
          self.autoIndex = Options.autoIndex
       else
          autoindex = tostring(Options.autoIndex).lower()
@@ -2018,7 +2018,7 @@ hslib.start = function(Options)
    end
 
    if Options.logMessage then
-      if type(Options.logMessage) is 'function' then
+      if Options.logMessage is <func> then
          self.logMessage = Options.logMessage
       elseif Options.logMessage is true then
          self.logMessage = msg
@@ -2030,10 +2030,10 @@ hslib.start = function(Options)
    -- Process middleware configuration
    middlewareCount = 0
    if Options.middleware then
-      if type(Options.middleware) is 'table' or type(Options.middleware) is 'array' then
+      if Options.middleware is <table> or Options.middleware is <array> then
          self._middleware = array<any> {}
          for middleware in values(Options.middleware) do
-            if type(middleware) is 'function' then
+            if middleware is <func> then
                array.push(self._middleware, middleware)
                middlewareCount++
                logMessage(self, f'Global middleware configured at index {middlewareCount}')
@@ -2049,9 +2049,9 @@ hslib.start = function(Options)
    -- Process routes configuration
    routeCount = 0
    if Options.routes then
-      if type(Options.routes) is 'table' then
+      if Options.routes is <table> then
          for route in values(Options.routes) do
-            if type(route) is 'table' then
+            if route is <table> then
                addRoute(self, route)
                routeCount++
             end
@@ -2122,7 +2122,7 @@ hslib.start = function(Options)
    self.newMiddleware = function(middleware)
       self._middleware ?= {}
 
-      if type(middleware) is 'function' then
+      if middleware is <func> then
          self._middleware.insert(middleware)
          logMessage(self, 'Global middleware added')
       else

--- a/scripts/net/proxyserver.tiri
+++ b/scripts/net/proxyserver.tiri
@@ -94,7 +94,7 @@ function parseProxyAddress(Value:any):<table, str>
 end
 
 function exceptionMessage(Error:any):str
-   if type(Error) is 'table' and Error.message then return tostring(Error.message) end
+   if Error is <table> and Error.message then return tostring(Error.message) end
    return tostring(Error)
 end
 
@@ -279,11 +279,10 @@ function createFlowManager(self)
 
    manager.copyHeaders = function(Headers:table!):table
       local headers = {}
-      if type(Headers) != 'table' then return headers end
+      if Headers != <table> then return headers end
 
       for name, value in pairs(Headers) do
-         local value_type = type(value)
-         if value_type is 'string' or value_type is 'number' or value_type is 'bool' then
+         if value is <str> or value is <num> or value is <bool> then
             headers[tostring(name)] = value
          end
       end
@@ -292,7 +291,7 @@ function createFlowManager(self)
    end
 
    manager.copyMessage = function(Message:table!):any
-      if type(Message) != 'table' then return nil end
+      if Message != <table> then return nil end
 
       local copy = {
          method = Message.method,
@@ -305,7 +304,7 @@ function createFlowManager(self)
          raw = Message.raw
       }
 
-      if not copy.streamed and type(Message.body) is 'string' then
+      if not copy.streamed and Message.body is <str> then
          copy.body = Message.body
       end
 
@@ -326,15 +325,15 @@ function createFlowManager(self)
    end
 
    manager.normaliseFlow = function(Flow:table, Key:any!):any
-      if type(Flow) != 'table' then return nil end
+      if Flow != <table> then return nil end
 
       local id = tonumber(Flow.id) or tonumber(Key)
       if not id then return nil end
 
       return {
          id = id,
-         timestamp = type(Flow.timestamp) is 'string' and Flow.timestamp or timestamp(),
-         clientIP = type(Flow.clientIP) is 'string' and Flow.clientIP or 'unknown',
+         timestamp = Flow.timestamp is <str> and Flow.timestamp or timestamp(),
+         clientIP = Flow.clientIP is <str> and Flow.clientIP or 'unknown',
          request = manager.copyMessage(Flow.request),
          response = manager.copyMessage(Flow.response),
          duration = tonumber(Flow.duration) or 0,
@@ -400,7 +399,7 @@ function createFlowManager(self)
          return false
       end
 
-      if type(encoded) != 'string' then return false end
+      if encoded != <str> then return false end
 
       local fl:any = nil
       try
@@ -449,7 +448,7 @@ function createFlowManager(self)
          return false
       end
 
-      if type(decoded) != 'table' and type(decoded) != 'array' then return false end
+      if decoded != <table> and decoded != <array> then return false end
 
       local imported_flows = {}
       local max_id = 0
@@ -471,7 +470,7 @@ function createFlowManager(self)
    end
 
    manager.importTable = function(Flows:table!):bool
-      if type(Flows) != 'table' and type(Flows) != 'array' then return false end
+      if Flows != <table> and Flows != <array> then return false end
 
       local imported_flows = {}
       local max_id = 0
@@ -559,7 +558,7 @@ function createInterceptorEngine(self)
 
    -- Add request interceptor
    engine.addRequestInterceptor = function(interceptor)
-      if type(interceptor) is 'function' then
+      if interceptor is <func> then
          engine._requestInterceptors.insert(interceptor)
          logMessage(self, 'INFO', 'Request interceptor added')
       end
@@ -567,7 +566,7 @@ function createInterceptorEngine(self)
 
    -- Add response interceptor
    engine.addResponseInterceptor = function(interceptor)
-      if type(interceptor) is 'function' then
+      if interceptor is <func> then
          engine._responseInterceptors.insert(interceptor)
          logMessage(self, 'INFO', 'Response interceptor added')
       end

--- a/scripts/net/url.tiri
+++ b/scripts/net/url.tiri
@@ -158,7 +158,7 @@ url.parseQuery = function(Query:str):table
          value = url.decodePlus(value)
          if params[key] then
             -- Handle multiple values for same key
-            if type(params[key]) != 'table' then
+            if params[key] != <table> then
                params[key] = { params[key] }
             end
             params[key].insert(value)
@@ -215,7 +215,7 @@ url.buildQuery = function(Params:any):str
 
    parts = array<str>
 
-   if type(Params) is 'array' then
+   if Params is <array> then
       for param in values(Params) do
          parts.push(url.encodePlus(tostring(param.key)) .. '=' .. url.encodePlus(tostring(param.value or '')))
       end
@@ -223,7 +223,7 @@ url.buildQuery = function(Params:any):str
       -- Hash-like table
       for key, value in pairs(Params) do
          key = url.encodePlus(tostring(key))
-         if type(value) is 'table' then
+         if value is <table> then
             -- Handle multiple values for same key
             for _, v in ipairs(value) do
                encodedValue = url.encodePlus(tostring(v))

--- a/scripts/options.tiri
+++ b/scripts/options.tiri
@@ -113,7 +113,7 @@ end
 -- Verify that a parameter name is usable as a command-line token name.
 
 function validate_name(Name:any!)
-   if type(Name) != 'string' or Name is '' then
+   if Name != <str> or Name is '' then
       raise ERR_EmptyString, 'Parameter names must be non-empty strings.'
    end
 
@@ -235,11 +235,11 @@ end
 -- Convert a comma-separated string into an array of trimmed strings.
 
 function convert_csv(Value:any!, Param:table!):array<str>
-   if type(Value) is 'array' or type(Value) is 'table' then
+   if Value is <array> or Value is <table> then
       return string_array(Value)
    end
 
-   if type(Value) != 'string' then
+   if Value != <str> then
       raise ERR_WrongType, f"Parameter '{Param.name}' requires a comma-separated string."
    end
 
@@ -255,11 +255,11 @@ end
 -- Convert a raw value into an array of strings.
 
 function convert_array(Value:any!, Param:table!):array<str>
-   if type(Value) is 'array' or type(Value) is 'table' then
+   if Value is <array> or Value is <table> then
       return string_array(Value)
    end
 
-   if type(Value) != 'string' then
+   if Value != <str> then
       raise ERR_WrongType, f"Parameter '{Param.name}' requires an array value."
    end
 
@@ -275,7 +275,7 @@ end
 -- Split a string into a number and trailing unit suffix.
 
 function split_number_unit(Value:any!, Param:table!, Description:str!):<num, str>
-   if type(Value) != 'string' then
+   if Value != <str> then
       raise ERR_WrongType, f"Parameter '{Param.name}' requires {Description}."
    end
 
@@ -307,7 +307,7 @@ end
 -- Convert a duration string into seconds.
 
 function convert_duration(Value:any!, Param:table!):num
-   if type(Value) is 'number' then return Value end
+   if Value is <num> then return Value end
 
    number, unit = split_number_unit(Value, Param, "a duration with an ms, s, m, h, or d suffix")
    multiplier = duration_multipliers[unit]
@@ -323,7 +323,7 @@ end
 -- Convert a size string into bytes.
 
 function convert_size(Value:any!, Param:table!):num
-   if type(Value) is 'number' then return Value end
+   if Value is <num> then return Value end
 
    number, unit = split_number_unit(Value, Param, "a size with a b, kb, mb, gb, or tb suffix")
    multiplier = size_multipliers[unit]
@@ -339,7 +339,7 @@ end
 -- Convert a percent value into a normalised fraction.
 
 function convert_percent(Value:any!, Param:table!):num
-   if type(Value) is 'number' then return Value end
+   if Value is <num> then return Value end
 
    text = tostring(Value.trim())
    if text.endsWith('%') then
@@ -362,8 +362,8 @@ end
 -- Compile a regular expression parameter.
 
 function convert_regex(Value:any!, Param:table!):any
-   if type(Value) is 'userdata' then return Value end
-   if type(Value) != 'string' then
+   if Value is <userdata> then return Value end
+   if Value != <str> then
       raise ERR_WrongType, f"Parameter '{Param.name}' requires a regex pattern."
    end
 
@@ -379,7 +379,7 @@ end
 -- Decode a JSON parameter and reject trailing non-whitespace input.
 
 function convert_json(Value:any, Param:table!):any
-   if type(Value) != 'string' then return Value end
+   if Value != <str> then return Value end
 
    local param_name = Param.name
    try
@@ -398,7 +398,7 @@ end
 -- Validate an ISO date string in YYYY-MM-DD form.
 
 function convert_date(Value:any!, Param:table!):str
-   if type(Value) != 'string' then
+   if Value != <str> then
       raise ERR_WrongType, f"Parameter '{Param.name}' requires an ISO date in YYYY-MM-DD form."
    end
 
@@ -414,7 +414,7 @@ end
 -- Validate an ISO time string in HH:MM or HH:MM:SS form, with optional fractional seconds.
 
 function convert_time(Value:any!, Param:table!):str
-   if type(Value) != 'string' then
+   if Value != <str> then
       raise ERR_WrongType, f"Parameter '{Param.name}' requires an ISO time value."
    end
 
@@ -430,7 +430,7 @@ end
 -- Validate an ISO date-time string with an optional timezone offset.
 
 function convert_datetime(Value:any!, Param:table!):str
-   if type(Value) != 'string' then
+   if Value != <str> then
       raise ERR_WrongType, f"Parameter '{Param.name}' requires an ISO date-time value."
    end
 
@@ -446,7 +446,7 @@ end
 -- Validate supported CSS colour function syntax.
 
 function convert_colour(Value:any!, Param:table!):str
-   if type(Value) != 'string' then
+   if Value != <str> then
       raise ERR_WrongType, f"Parameter '{Param.name}' requires a supported CSS colour value."
    end
 
@@ -463,10 +463,10 @@ end
 
 function convert_builtin(TypeName:str!, Value:any!, Param:table!):any
    if TypeName is 'str' or TypeName is 'string' or TypeName is 'enum' then
-      if type(Value) is 'string' then return Value end
+      if Value is <str> then return Value end
       return tostring(Value)
    elseif TypeName is 'num' or TypeName is 'number' then
-      if type(Value) is 'number' then return Value end
+      if Value is <num> then return Value end
 
       number = tonumber(Value)
       if number is nil then
@@ -475,7 +475,7 @@ function convert_builtin(TypeName:str!, Value:any!, Param:table!):any
       return number
    elseif TypeName is 'int' then
       local number:any
-      if type(Value) is 'number' then
+      if Value is <num> then
          number = Value
       else
          number = tonumber(Value)
@@ -486,7 +486,7 @@ function convert_builtin(TypeName:str!, Value:any!, Param:table!):any
       end
       return number
    elseif TypeName is 'bool' then
-      if type(Value) is 'bool' then return Value end
+      if Value is <bool> then return Value end
 
       local text = tostring(Value).lower()
       if text is 'true' or text is '1' or text is 'yes' or text is 'on' then return true end
@@ -494,7 +494,7 @@ function convert_builtin(TypeName:str!, Value:any!, Param:table!):any
 
       raise ERR_WrongType, f"Parameter '{Param.name}' requires a boolean value."
    elseif TypeName is 'path' or TypeName is 'file' or TypeName is 'folder' then
-      if type(Value) is 'string' then return Value end
+      if Value is <str> then return Value end
       return tostring(Value)
    elseif TypeName is 'csv' then
       return convert_csv(Value, Param)
@@ -529,7 +529,7 @@ end
 function convert_value(Parser:table!, Param:table!, Value:any!):any
    converter = Param.type
 
-   if type(converter) is 'function' then
+   if converter is <func> then
       try
          return converter(Value, Param, Parser)
       except e
@@ -537,7 +537,7 @@ function convert_value(Parser:table!, Param:table!, Value:any!):any
       end
    end
 
-   assert(type(converter) is 'string', f"Parameter '{Param.name}' type must be a string or function.")
+   assert(converter is <str>, f"Parameter '{Param.name}' type must be a string or function.")
 
    return convert_builtin(converter, Value, Param)
 end
@@ -575,7 +575,7 @@ function set_source_result(Result:table, ArgNames:table, Presence:table, Param:t
    if Param.multiple then
       result_values = array<any>
 
-      if type(RawValue) is 'array' then
+      if RawValue is <array> then
          for value in values(RawValue) do
             result_values.push(value)
          end
@@ -599,7 +599,7 @@ end
 
 function add_observed_result(Result:table!, ArgNames:table!, Presence:table!, Param:table!, ArgName:str!,
    RawValue:any!):table
-   if Param.multiple and type(RawValue) is 'array' then
+   if Param.multiple and RawValue is <array> then
       for value in values(RawValue) do
          add_result_value(Result, ArgNames, Presence, Param, ArgName, value, true)
       end
@@ -730,7 +730,7 @@ function get_script_arguments(Parameters:array<str>!):array<str>
 
    while index < #Parameters do
       token = Parameters[index]
-      assert(type(token) is 'string', 'Task parameters must contain strings')
+      assert(token is <str>, 'Task parameters must contain strings')
 
       if not script_seen then
          if token.startsWith('--') then
@@ -759,7 +759,7 @@ end
 
 function get_task_parameters(Options:table):array<str>
    if Options and Options.taskParameters != nil then
-      assert(type(Options.taskParameters) is 'array', 'Options.taskParameters must be an array.')
+      assert(Options.taskParameters is <array>, 'Options.taskParameters must be an array.')
       return Options.taskParameters
    end
 
@@ -806,7 +806,7 @@ function parse_ordered_input(Parser:table!, Result:table!, ArgNames:table!, Pres
    pos_index = 0
    token_index = 0
    for token in values(Input) do
-      assert(type(token) is 'string', 'Command-line input must contain strings')
+      assert(token is <str>, 'Command-line input must contain strings')
       name = split_token(token)
       pos_index = parse_ordered_token(Parser, Result, ArgNames, Presence, token, pos_index)
       if token_index is 0 and name is Parser.helpArg and Result[Parser.helpArg] != nil then
@@ -866,7 +866,7 @@ function convert_result(Parser:table!, RawResult:table!, ArgNames:table!, Presen
       if raw_value != nil then
          try
             if param.multiple then
-               assert(type(raw_value) is 'array', f"Parameter '{param.name}' should contain an array of values.")
+               assert(raw_value is <array>, f"Parameter '{param.name}' should contain an array of values.")
 
                if converts_repeated_values(param) then
                   result[param.name] = convert_value(Parser, param, raw_value)
@@ -1265,7 +1265,7 @@ function build_param_help(Parser:table!, Topic:str!):str
    lines.push('')
    lines.push('Usage: ' .. param_invocation(param))
    lines.push('Kind: ' .. param.kind)
-   if type(param.type) is 'string' then
+   if param.type is <str> then
       lines.push('Type: ' .. param.type)
    else
       lines.push('Type: custom')
@@ -1411,7 +1411,7 @@ function convert_param_default(Parser:table!, Param:table!):<bool, any>
 
       result_values = array<any>
 
-      if type(Param.default) is 'array' then
+      if Param.default is <array> then
          for item in values(Param.default) do
             result_values.push(convert_value(Parser, Param, item))
          end
@@ -1474,7 +1474,7 @@ end
 
 function validate_scalar_value(Param:table!, Value:any!)
    if Param.choices then
-      assert(type(Param.choices) is 'array' or type(Param.choices) is 'table',
+      assert(Param.choices is <array> or Param.choices is <table>,
          f"Parameter '{Param.name}' choices must be an array or table.")
 
       if not contains_choice(Param.choices, Value) then
@@ -1486,7 +1486,7 @@ function validate_scalar_value(Param:table!, Value:any!)
       local pattern:any = Param._pattern
       if pattern is nil or Param._pattern_source != Param.pattern then
          pattern = Param.pattern
-         if type(pattern) is 'string' then
+         if pattern is <str> then
             pattern = regex.new(pattern)
          end
 
@@ -1494,7 +1494,7 @@ function validate_scalar_value(Param:table!, Value:any!)
          Param._pattern_source = Param.pattern
       end
 
-      assert(type(pattern) is 'userdata', f"Parameter '{Param.name}' pattern must be a regex or string.")
+      assert(pattern is <userdata>, f"Parameter '{Param.name}' pattern must be a regex or string.")
       if not pattern.test(tostring(Value)) then
          raise ERR_Args, f"Parameter '{Param.name}' does not match the required pattern."
       end
@@ -1508,7 +1508,7 @@ end
 
 function validate_param_value(Parser:table!, Param:table!, ArgName:str!, Value:any!)
    if Param.multiple then
-      assert(type(Value) is 'array', f"Parameter '{Param.name}' should contain an array of values.")
+      assert(Value is <array>, f"Parameter '{Param.name}' should contain an array of values.")
       for item in values(Value) do
          validate_scalar_value(Param, item)
       end
@@ -1517,7 +1517,7 @@ function validate_param_value(Parser:table!, Param:table!, ArgName:str!, Value:a
    end
 
    if Param.exec then
-      assert(type(Param.exec) is 'function', f"Parameter '{Param.name}' exec must be a function.")
+      assert(Param.exec is <func>, f"Parameter '{Param.name}' exec must be a function.")
       Param.exec(Parser, ArgName, Value, Param)
    end
 
@@ -1530,7 +1530,7 @@ end
 function relationship_names(Parser:table!, Param:table!, Field:str!, Value:any!):array<str>
    names = array<str>
 
-   if type(Value) is 'string' then
+   if Value is <str> then
       item = Parser._lookup[Value]
       if item is nil then
          raise ERR_ParameterUnknown, f"Parameter '{Param.name}' references unknown parameter '{Value}' in {Field}."
@@ -1539,7 +1539,7 @@ function relationship_names(Parser:table!, Param:table!, Field:str!, Value:any!)
       return names
    end
 
-   assert(type(Value) is 'array' or type(Value) is 'table',
+   assert(Value is <array> or Value is <table>,
       f"Parameter '{Param.name}' {Field} must be a string, array, or table.")
 
    for name in values(Value) do
@@ -1764,7 +1764,7 @@ function load_user_config_defaults(Parser:table!, RawResult:table!):table
       raise ERR_WrongType, f"User config '{config_path}' requires valid JSON."
    end
 
-   if type(defaults) != 'table' then
+   if defaults != <table> then
       raise ERR_WrongType, f"User config '{config_path}' requires a JSON object."
    end
 
@@ -1785,7 +1785,7 @@ function resolve_input_result(Parser:table!, InputResult:table!, InputArgNames:t
    function apply_default_table(Parser:table!, Result:table!, ArgNames:table!, Defaults:table):table
       if Defaults is nil then return nil end
 
-      assert(type(Defaults) is 'table', 'Parser defaults must be a table.')
+      assert(Defaults is <table>, 'Parser defaults must be a table.')
 
       for name, value in pairs(Defaults) do
          param = Parser._lookup[name]
@@ -1940,7 +1940,7 @@ function parse_command_ordered_input(Parser:table, Input:array<str>!):table
 
    while index < #Input do
       token = Input[index]
-      assert(type(token) is 'string', 'Command-line input must contain strings')
+      assert(token is <str>, 'Command-line input must contain strings')
       name, _, has_explicit_value = split_token(token)
 
       if not is_global_ordered_token(Parser, name, has_explicit_value) and not has_explicit_value and
@@ -1965,7 +1965,7 @@ function parse_command_ordered_input(Parser:table, Input:array<str>!):table
 
    while index < #Input do
       token = Input[index]
-      assert(type(token) is 'string', 'Command-line input must contain strings')
+      assert(token is <str>, 'Command-line input must contain strings')
       command_input.push(token)
       index++
    end
@@ -1994,8 +1994,8 @@ function parse_command_table_input(Parser:table!, Input:table!):table
    globals = Input.globals ?? {}
    args = Input.args ?? {}
 
-   assert(type(globals) is 'table', 'Command globals input must be a table.')
-   assert(type(args) is 'table', 'Command args input must be a table.')
+   assert(globals is <table>, 'Command globals input must be a table.')
+   assert(args is <table>, 'Command args input must be a table.')
 
    return {
       command = command.name,
@@ -2028,10 +2028,10 @@ function parse_input(Parser:table!, Input:any, Options:table):table
       else
          return make_help_result(Parser, nil)
       end
-   elseif type(Input) is 'array' then
+   elseif Input is <array> then
       if has_commands then return parse_command_ordered_input(Parser, Input) end
       parse_ordered_input(Parser, input_result, input_arg_names, input_presence, Input)
-   elseif type(Input) is 'table' then
+   elseif Input is <table> then
       if has_commands then return parse_command_table_input(Parser, Input) end
       parse_table_input(Parser, input_result, input_arg_names, input_presence, Input)
    else
@@ -2082,7 +2082,7 @@ end
 -- Validate, normalise, and register a parameter definition with a parser.
 
 function add_param(Parser:table!, Definition:table!):table
-   assert(type(Definition) is 'table', 'Parameter definition must be a table.')
+   assert(Definition is <table>, 'Parameter definition must be a table.')
 
    local param = clone_definition(Definition)
 
@@ -2121,7 +2121,7 @@ end
 -- Validate, normalise, and register a command definition with a parser.
 
 function add_command(Parser:table!, Definition:table!):table
-   assert(type(Definition) is 'table', 'Command definition must be a table.')
+   assert(Definition is <table>, 'Command definition must be a table.')
 
    command = clone_command_definition(Parser, Definition)
 
@@ -2142,7 +2142,7 @@ function add_command(Parser:table!, Definition:table!):table
    end
 
    if Definition.args then
-      assert(type(Definition.args) is 'array' or type(Definition.args) is 'table',
+      assert(Definition.args is <array> or Definition.args is <table>,
          'Command args must be an array of parameter definitions.')
 
       for param_definition in values(Definition.args) do
@@ -2180,7 +2180,7 @@ function definitions_have_name(Definitions:any, Name:str!):bool
    if Definitions is nil then return false end
 
    for definition in values(Definitions) do
-      assert(type(definition) is 'table', 'Parameter definition must be a table.')
+      assert(definition is <table>, 'Parameter definition must be a table.')
       if definition_has_name(definition, Name) then return true end
    end
 
@@ -2192,7 +2192,7 @@ end
 
 create_parser = function(Config:table):table
    Config ?= {}
-   assert(type(Config) is 'table', 'options() expects a configuration table.')
+   assert(Config is <table>, 'options() expects a configuration table.')
 
    local parser = {
       name        = Config.name,
@@ -2216,9 +2216,9 @@ create_parser = function(Config:table):table
    parser.autoHelp ?= true
    parser.helpArg  ?= 'help' -- In future, allow translations to user's locale
    validate_name(parser.helpArg)
-   assert(parser.userConfig is nil or (type(parser.userConfig) is 'string') or (type(parser.userConfig) is 'bool'), 'userConfig must be a string or boolean.')
-   assert(parser.onError is nil or type(parser.onError) is 'function', 'onError must be a function.')
-   assert(parser.onHelp is nil or type(parser.onHelp) is 'function', 'onHelp must be a function.')
+   assert(parser.userConfig is nil or (parser.userConfig is <str>) or (parser.userConfig is <bool>), 'userConfig must be a string or boolean.')
+   assert(parser.onError is nil or parser.onError is <func>, 'onError must be a function.')
+   assert(parser.onHelp is nil or parser.onHelp is <func>, 'onHelp must be a function.')
 
    parser._params         = array<table>
    parser._positionals    = array<table>
@@ -2317,7 +2317,7 @@ create_parser = function(Config:table):table
    table: This parser.
    ]])
    parser.setDefaults = function(Defaults:table):table
-      assert(Defaults is nil or type(Defaults) is 'table', 'setDefaults() expects a table or nil.')
+      assert(Defaults is nil or Defaults is <table>, 'setDefaults() expects a table or nil.')
       parser._set_defaults = Defaults
       return parser
    end
@@ -2340,7 +2340,7 @@ create_parser = function(Config:table):table
    table: Converted and validated argument table.
    ]])
    parser.validate = function(Args:table!):table
-      assert(type(Args) is 'table', 'validate() expects an argument table.')
+      assert(Args is <table>, 'validate() expects an argument table.')
 
       raw_result = {}
       arg_names = {}
@@ -2495,7 +2495,7 @@ create_parser = function(Config:table):table
    end
 
    if Config.args then
-      assert(type(Config.args) is 'array' or type(Config.args) is 'table',
+      assert(Config.args is <array> or Config.args is <table>,
          'Parser args must be an array of parameter definitions.')
    end
 
@@ -2524,7 +2524,7 @@ create_parser = function(Config:table):table
       end
 
       add_param(parser, {
-         name = 'config', type = 'path', default = type(parser.userConfig) is 'string' ? parser.userConfig : nil, group = 'Configuration',
+         name = 'config', type = 'path', default = parser.userConfig is <str> ? parser.userConfig : nil, group = 'Configuration',
          comment = 'JSON config file with option defaults.'
       })
    end
@@ -2536,7 +2536,7 @@ create_parser = function(Config:table):table
    end
 
    if Config.commands then
-      assert(type(Config.commands) is 'array' or type(Config.commands) is 'table',
+      assert(Config.commands is <array> or Config.commands is <table>,
          'Parser commands must be an array of command definitions.')
 
       for definition in values(Config.commands) do

--- a/scripts/tempus.tiri
+++ b/scripts/tempus.tiri
@@ -74,7 +74,7 @@ function require_type_name(TypeName:str!)
 end
 
 function tempus._typeOf(Value:any):any
-   if type(Value) != 'table' then return nil end
+   if Value != <table> then return nil end
 
    local state = value_storage[Value]
    if state is nil then return nil end
@@ -133,7 +133,7 @@ function tempus._makeValue(TypeName:str!, Fields:table!):table
 end
 
 function tempus._requireNumber(Name:str!, Value:any!):num
-   if type(Value) != 'number' then
+   if Value != <num> then
       raise ERR_InvalidValue, f"{Name} must be a number."
    end
    return Value
@@ -148,7 +148,7 @@ function tempus._requireInteger(Name:str!, Value:any!):num
 end
 
 function tempus._requireTable(Name:str!, Value:any!):table
-   if type(Value) != 'table' then
+   if Value != <table> then
       raise ERR_InvalidValue, f"{Name} must be a table."
    end
    return Value
@@ -352,7 +352,7 @@ function is_format_token_start(Text:str):bool
 end
 
 function format_temporal(Pattern:any!, Values:table!):str
-   if type(Pattern) != 'string' then raise ERR_InvalidValue, 'Format pattern must be a string.' end
+   if Pattern != <str> then raise ERR_InvalidValue, 'Format pattern must be a string.' end
 
    local result = ''
    local index = 0
@@ -714,7 +714,7 @@ function get_time_zone_info(ZoneID:any, StartYear:any!, EndYear:any!):table
 end
 
 function new_zone(ZoneID:any):table
-   if ZoneID != nil and type(ZoneID) != 'string' then raise ERR_InvalidValue, 'Zone ID must be a string.' end
+   if ZoneID != nil and ZoneID != <str> then raise ERR_InvalidValue, 'Zone ID must be a string.' end
 
    local info = get_time_zone_info(ZoneID, ZONE_PROBE_YEAR, ZONE_PROBE_YEAR)
    return tempus._makeValue('Zone', {
@@ -934,7 +934,7 @@ function offset_date_time_from_instant(Instant:table!, Offset:table!):table
 end
 
 function parse_date_text(Text:any!):<num, num, num>
-   if type(Text) != 'string' then raise ERR_Syntax, 'LocalDate text must be a string.' end
+   if Text != <str> then raise ERR_Syntax, 'LocalDate text must be a string.' end
 
    year_text, month_text, day_text = rx_date.extract(Text)
    if year_text is nil then raise ERR_Syntax, f"Invalid LocalDate string '{Text}'." end
@@ -943,7 +943,7 @@ function parse_date_text(Text:any!):<num, num, num>
 end
 
 function parse_time_text(Text:any!):<num, num, num, num>
-   if type(Text) != 'string' then raise ERR_Syntax, 'LocalTime text must be a string.' end
+   if Text != <str> then raise ERR_Syntax, 'LocalTime text must be a string.' end
 
    hour_text, minute_text, second_text, fraction_text = rx_time.extract(Text)
    if hour_text is nil then raise ERR_Syntax, f"Invalid LocalTime string '{Text}'." end
@@ -952,7 +952,7 @@ function parse_time_text(Text:any!):<num, num, num, num>
 end
 
 function parse_local_date_time_text(Text:any!):<table, table>
-   if type(Text) != 'string' then raise ERR_Syntax, 'LocalDateTime text must be a string.' end
+   if Text != <str> then raise ERR_Syntax, 'LocalDateTime text must be a string.' end
 
    date_text, time_text = rx_local_date_time.extract(Text)
    if date_text is nil then raise ERR_Syntax, f"Invalid LocalDateTime string '{Text}'." end
@@ -1062,7 +1062,7 @@ end
 @result Duration value
 ]])
 tempus.duration.parse = function(Text:str!):table
-   if type(Text) != 'string' then raise ERR_Syntax, 'Duration text must be a string.' end
+   if Text != <str> then raise ERR_Syntax, 'Duration text must be a string.' end
 
    sign_text, hours_text, minutes_text, seconds_text, fraction_text = rx_duration.extract(Text)
    if (hours_text is nil or hours_text is '') and (minutes_text is nil or minutes_text is '') and
@@ -1112,7 +1112,7 @@ end
 @result Offset value
 ]])
 tempus.offset.parse = function(Text:str!):table
-   if type(Text) != 'string' then raise ERR_Syntax, 'Offset text must be a string.' end
+   if Text != <str> then raise ERR_Syntax, 'Offset text must be a string.' end
 
    full_text, sign_text, hour_text, minute_text = rx_offset.extract(Text)
    if full_text is nil then raise ERR_Syntax, f"Invalid Offset string '{Text}'." end
@@ -1266,7 +1266,7 @@ end
 @result OffsetDateTime value
 ]])
 tempus.offsetDateTime.parse = function(Text:str!):table
-   if type(Text) != 'string' then raise ERR_Syntax, 'OffsetDateTime text must be a string.' end
+   if Text != <str> then raise ERR_Syntax, 'OffsetDateTime text must be a string.' end
 
    local_text, offset_text = rx_offset_date_time.extract(Text)
    if local_text is nil then raise ERR_Syntax, f"Invalid OffsetDateTime string '{Text}'." end
@@ -1327,7 +1327,7 @@ end
 @result Period value
 ]])
 tempus.period.parse = function(Text:str!):table
-   if type(Text) != 'string' then raise ERR_Syntax, 'Period text must be a string.' end
+   if Text != <str> then raise ERR_Syntax, 'Period text must be a string.' end
 
    sign_text, years_text, months_text, weeks_text, days_text = rx_period.extract(Text)
    if (years_text is nil or years_text is '') and (months_text is nil or months_text is '') and
@@ -2944,7 +2944,7 @@ end
 @result ZonedDateTime value
 ]])
 tempus.zonedDateTime.parse = function(Text:str!):table
-   if type(Text) != 'string' then raise ERR_Syntax, 'ZonedDateTime text must be a string.' end
+   if Text != <str> then raise ERR_Syntax, 'ZonedDateTime text must be a string.' end
 
    offset_text, zone_text = rx_zoned_date_time.extract(Text)
    if offset_text is nil then raise ERR_Syntax, f"Invalid ZonedDateTime string '{Text}'." end

--- a/scripts/vfx.tiri
+++ b/scripts/vfx.tiri
@@ -55,24 +55,24 @@ vfx.apply_easing = function(Value:num!, Easing):num
    if not Easing then return progress end
 
    local easing:func
-   if type(Easing) is 'string' then
+   if Easing is <str> then
       easing = vfx.ease[easing]
       if not easing then error(f"Unsupported VFX easing '{Easing}'") end
-   elseif type(Easing) is 'function' then
+   elseif Easing is <func> then
       easing = Easing
    else
       error('VFX easing must be a string or function')
    end
 
    eased = easing(progress)
-   assert(type(eased) is 'number', 'VFX easing function must return a number')
+   assert(eased is <num>, 'VFX easing function must return a number')
 
    return eased
 end
 
 vfx.effect_config = function(Options)
    Options ?= { }
-   assert(type(Options) is 'table', 'VFX effect options must be supplied as a table')
+   assert(Options is <table>, 'VFX effect options must be supplied as a table')
 
    return {
       seconds  = Options.seconds ?? 1.0,
@@ -97,10 +97,10 @@ end
 
 vfx.config_circle = function(State, Options)
    State.cx = 0.5 * State.v_width
-   if type(Options.cx) is 'number' then State.cx = Options.cx * State.v_width end
+   if Options.cx is <num> then State.cx = Options.cx * State.v_width end
 
    State.cy = 0.5 * State.v_height
-   if type(Options.cy) is 'number' then State.cy = Options.cy * State.v_height end
+   if Options.cy is <num> then State.cy = Options.cy * State.v_height end
 
    ex = State.cx <= 0.5 ? State.v_width : 0
    ey = State.cy <= 0.5 ? State.v_height : 0
@@ -139,7 +139,7 @@ end
 
 vfx.wipe = function(Viewport:obj!, Options:table)
    Options ?= { }
-   assert(type(Options) is 'table', 'VFX wipe options must be supplied as a table')
+   assert(Options is <table>, 'VFX wipe options must be supplied as a table')
 
    config = vfx.effect_config(Options)
    style = Options.style ?? 'shutter'
@@ -332,7 +332,7 @@ end
 
 vfx.shake = function(Viewport:obj!, Options:table)
    Options ?= { }
-   assert(type(Options) is 'table', 'VFX shake options must be supplied as a table')
+   assert(Options is <table>, 'VFX shake options must be supplied as a table')
 
    config = vfx.effect_config(Options)
    intensity = Options.intensity ?? 1.0

--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -870,7 +870,7 @@ set (TIRI_TESTS
    try_except import include_list processing metatables with thunk_table_index debug malformed_syntax numeric_limits return_types url tips tempus
    comparison_chaining reserved_keywords compile_if_import overflow protected_globals constant_shadowing config_library
    module_namespaces builtin_methods
-   object_pinning import_type_analysis global_types type_contracts thunk_contract_argument type_signature_dumps
+   object_pinning import_type_analysis global_types type_contracts type_tests thunk_contract_argument type_signature_dumps
    type_guided_emission type_guided_jit_signatures
    context_access contextual_member_calls contextual_designation context_blocks context_materialisation
    metamethod_context_dispatch stack_growth function_callback_context

--- a/src/tiri/jit/src/bytecode/lj_bc.h
+++ b/src/tiri/jit/src/bytecode/lj_bc.h
@@ -294,7 +294,9 @@ constexpr uint8_t  NO_REG = BCMAX_A;
   _(CTXBEGIN,  var,  ___, lit, ___) \
   _(CTXEND,    ___,  ___, lit, ___) \
   _(CLOSEARM,  var,  ___, ___, ___) \
-  _(CLOSE,     var,  ___, ___, ___)
+  _(CLOSE,     var,  ___, ___, ___) \
+  /* Boolean contextual type test. */ \
+  _(TYPETEST,  var,  ___, str, ___)
 
 // Bytecode opcode numbers.
 // Explicitly enumerated for debugger visibility and easy value lookup.
@@ -470,8 +472,9 @@ typedef enum {
    BC_CTXEND = 131,
    BC_CLOSEARM = 132,
    BC_CLOSE = 133,
+   BC_TYPETEST = 134,
 
-   BC__MAX   = 134
+   BC__MAX   = 135
 } BCOp;
 
 [[nodiscard]] inline constexpr bool bc_is_func_header(BCOp Op) noexcept

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -4872,6 +4872,17 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_next
     break;
 
+  case BC_TYPETEST:
+    |  ldr L, SAVE_L
+    |  str BASE, L->base
+    |  mov CARG1, L
+    |  mov CARG2, PC
+    |  str PC, SAVE_PC
+    |  bl extern lj_meta_type_test_pc
+    |  ldr BASE, L->base
+    |  ins_next
+    break;
+
   //  ----------------------------------------------------------------------
 
   default:

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -6938,6 +6938,17 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_next
     break;
 
+  case BC_TYPETEST:
+    |  lwz L, SAVE_L
+    |  stp BASE, L->base
+    |  mr CARG1, L
+    |  mr CARG2, PC
+    |  stw PC, SAVE_PC
+    |  bl extern lj_meta_type_test_pc
+    |  lp BASE, L->base
+    |  ins_next
+    break;
+
   //  ----------------------------------------------------------------------
 
   default:

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -5883,6 +5883,17 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_next
     break;
 
+  case BC_TYPETEST:
+    |  mov L:RB, SAVE_L
+    |  mov L:RB->base, BASE
+    |  mov CARG2, PC
+    |  mov L:CARG1, L:RB
+    |  mov SAVE_PC, PC
+    |  call extern lj_meta_type_test_pc
+    |  mov BASE, L:RB->base
+    |  ins_next
+    break;
+
   //  ----------------------------------------------------------------------
 
   default:

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -459,7 +459,7 @@ static RecordedContract rec_contract_guard_object(
    if (ExpectedClassId IS CLASSID::NIL) return RecordedContract::Basic;
 
    GCobject *object = objectV(Value);
-   if (not object->classptr or object->classptr->ClassID != ExpectedClassId) {
+   if (not lj_meta_object_class_matches(object, ExpectedClassId)) {
       return RecordedContract::Mismatch;
    }
 
@@ -580,6 +580,88 @@ static RecordedContract rec_contract_record(jit_State *J, BCREG Base, GCstr *Enc
       if (result != RecordedContract::Basic) return result;
    }
    return RecordedContract::Basic;
+}
+
+static TRef rec_type_test(jit_State *J, BCREG Slot, GCstr *Encoded)
+{
+   RuntimeContractDescriptor descriptor;
+   if (not decode_runtime_contract(Encoded, descriptor) or descriptor.contract_count != 1) return 0;
+
+   const RuntimeContractEntry &entry = descriptor.entries[0];
+   cTValue *value = J->L->base + Slot;
+   if (lj_is_thunk(value)) return 0;
+
+   TRef value_ref = getslot(J, Slot);
+   bool matched = false;
+   RecordedContract guard = RecordedContract::Basic;
+   if (tvisnil(value)) matched = entry.type IS TiriType::Any or entry.type IS TiriType::Nil;
+   else {
+      switch (entry.type) {
+         case TiriType::Any: matched = true; break;
+         case TiriType::Unknown: matched = true; break;
+         case TiriType::Nil: matched = false; break;
+         case TiriType::Bool: matched = tvisbool(value); break;
+         case TiriType::Num: matched = tvisnumber(value); break;
+         case TiriType::Str: matched = tvisstr(value); break;
+         case TiriType::Table: matched = tvistab(value); break;
+         case TiriType::Array:
+            guard = rec_contract_guard_array(J, value_ref, value, entry);
+            matched = guard IS RecordedContract::Basic;
+            break;
+         case TiriType::Func:
+            guard = rec_contract_guard_callable(J, value_ref, value);
+            matched = guard IS RecordedContract::Basic;
+            break;
+         case TiriType::Struct:
+            guard = rec_contract_guard_struct(J, value_ref, value, entry.constraint_name);
+            matched = guard IS RecordedContract::Basic;
+            break;
+         case TiriType::Object:
+            guard = rec_contract_guard_object(J, value_ref, value, entry.object_class_id);
+            matched = guard IS RecordedContract::Basic;
+            break;
+         case TiriType::Range:
+            guard = rec_contract_guard_range(J, value_ref, value, true);
+            matched = guard IS RecordedContract::Basic;
+            break;
+         case TiriType::Userdata:
+            guard = rec_contract_guard_userdata(J, value_ref, value);
+            matched = guard IS RecordedContract::Basic;
+            break;
+      }
+   }
+
+   // A failed constrained check needs a guard for the observed aggregate metadata, not merely its outer TValue tag.
+   if (not matched) {
+      if (tvisarray(value)) {
+         RuntimeContractEntry observed;
+         observed.type = TiriType::Array;
+         observed.array_element_type = arrayV(value)->elemtype;
+         if (arrayV(value)->elemtype IS AET::STRUCT and arrayV(value)->structdef) {
+            observed.constraint_name = arrayV(value)->structdef->Name;
+         }
+         if (rec_contract_guard_array(J, value_ref, value, observed) != RecordedContract::Basic) return 0;
+      }
+      else if (tvisobject(value)) {
+         GCobject *object = objectV(value);
+         if (not object->classptr or
+             rec_contract_guard_object(J, value_ref, value, object->classptr->ClassID) != RecordedContract::Basic) {
+            return 0;
+         }
+      }
+      else if (tvisstruct(value)) {
+         struct_record *definition = structV(value)->def;
+         if (not definition or
+             rec_contract_guard_struct(J, value_ref, value, definition->Name) != RecordedContract::Basic) return 0;
+      }
+      else if (tvisudata(value)) {
+         bool observed_range = rec_contract_is_range(J, value);
+         if (rec_contract_guard_range(J, value_ref, value, observed_range) != RecordedContract::Basic) return 0;
+      }
+   }
+
+   if ((entry.flags & contract_flag(ContractEntryFlag::Negated)) != 0) matched = not matched;
+   return matched ? TREF_TRUE : TREF_FALSE;
 }
 
 //********************************************************************************************************************
@@ -5144,6 +5226,18 @@ void lj_record_ins(jit_State *J)
       }
       setintV(&J->errinfo, int32_t(op));
       lj_trace_err_info(J, LJ_TRERR_NYIBC);
+      break;
+   }
+
+   case BC_TYPETEST:
+   {
+      TRef result = rec_type_test(J, bc_a(ins), strV(rcv));
+      if (not result) {
+         // Deferred tests may enter a protected call and resume in the interpreter without disabling the prototype.
+         lj_snap_add(J);
+         lj_record_stop(J, TraceLink::INTERP, 0);
+      }
+      J->base[bc_a(ins)] = result;
       break;
    }
 

--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -194,6 +194,7 @@ private:
    ParserResult<ParameterListResult> parse_parameter_list(bool);
    ParserResult<Token> parse_type_annotation(
       TiriType &Type, struct_record *&StructDef, ArrayElementDescriptor &ArrayElement, bool &Required);
+   ParserResult<TypeTestDescriptor> parse_type_test_descriptor();
    ParserResult<std::vector<TableField>> parse_table_fields(bool *);
    ParserResult<ExprNodeList> parse_call_arguments(bool *);
 

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -393,15 +393,46 @@ ParserResult<ExprNodePtr> AstBuilder::parse_expression(uint8_t precedence)
       // Handled here rather than in match_binary_operator() to avoid lookahead
       // side-effects that corrupt the token stream for f-strings with expressions.
 
+      if (next.kind() IS TokenKind::NotEqual) {
+         constexpr uint8_t not_equal_left = 3;
+         constexpr uint8_t not_equal_right = 3;
+         if (not_equal_left <= precedence) break;
+         this->ctx.tokens().advance(); // Consume '!='
+         if (this->ctx.check(TokenKind::Less)) {
+            auto descriptor = this->parse_type_test_descriptor();
+            if (not descriptor.ok()) return ParserResult<ExprNodePtr>::failure(descriptor.error_ref());
+            SourceSpan span = combine_spans(left.value_ref()->span, next.span());
+            left = ParserResult<ExprNodePtr>::success(make_type_test_expr(
+               span, std::move(left.value_ref()), descriptor.value_ref(), true));
+            continue;
+         }
+         auto right = this->parse_expression(not_equal_right);
+         if (not right.ok()) return right;
+         SourceSpan span = combine_spans(left.value_ref()->span, right.value_ref()->span);
+         left = ParserResult<ExprNodePtr>::success(make_binary_expr(
+            span, AstBinaryOperator::NotEqual, std::move(left.value_ref()), std::move(right.value_ref())));
+         continue;
+      }
+
       if (next.kind() IS TokenKind::IsToken) {
          constexpr uint8_t is_left = 3;
          constexpr uint8_t is_right = 3;
          if (is_left <= precedence) break;
          this->ctx.tokens().advance(); // Consume 'is'
          AstBinaryOperator is_op = AstBinaryOperator::Equal;
+         bool negated = false;
          if (this->ctx.tokens().current().kind() IS TokenKind::NotToken) {
             this->ctx.tokens().advance(); // Consume 'not'
             is_op = AstBinaryOperator::NotEqual;
+            negated = true;
+         }
+         if (this->ctx.check(TokenKind::Less)) {
+            auto descriptor = this->parse_type_test_descriptor();
+            if (not descriptor.ok()) return ParserResult<ExprNodePtr>::failure(descriptor.error_ref());
+            SourceSpan span = combine_spans(left.value_ref()->span, next.span());
+            left = ParserResult<ExprNodePtr>::success(make_type_test_expr(
+               span, std::move(left.value_ref()), descriptor.value_ref(), negated));
+            continue;
          }
          auto right = this->parse_expression(is_right);
          if (not right.ok()) return right;

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -296,6 +296,97 @@ ParserResult<Token> AstBuilder::parse_type_annotation(
    return finish_annotation();
 }
 
+//********************************************************************************************************************
+// Parses the contextual descriptor following `is` or `is not`.  Aggregate type tests permit an optional,
+// whitespace-separated inner name, unlike declaration annotations.
+
+ParserResult<TypeTestDescriptor> AstBuilder::parse_type_test_descriptor()
+{
+   auto opened = this->ctx.consume(TokenKind::Less, ParserErrorCode::ExpectedToken);
+   if (not opened.ok()) return ParserResult<TypeTestDescriptor>::failure(opened.error_ref());
+
+   Token type_token = this->ctx.tokens().current();
+   std::string_view type_name_view;
+   if (type_token.kind() IS TokenKind::Identifier) {
+      GCstr *symbol = type_token.identifier();
+      type_name_view = std::string_view(strdata(symbol), symbol->len);
+      this->ctx.tokens().advance();
+   }
+   else if (type_token.kind() IS TokenKind::Nil) {
+      type_name_view = "nil";
+      this->ctx.tokens().advance();
+   }
+   else {
+      return this->fail<TypeTestDescriptor>(ParserErrorCode::ExpectedTypeName, type_token,
+         "Type-test descriptor requires a Tiri type name");
+   }
+
+   TypeTestDescriptor descriptor;
+   descriptor.type = type_name_view IS "object" ? TiriType::Object : parse_type_name(type_name_view);
+   if (descriptor.type IS TiriType::Unknown) {
+      return this->fail<TypeTestDescriptor>(ParserErrorCode::UnknownTypeName, type_token,
+         std::format("Unknown type-test name '{}'; expected a Tiri type", type_name_view));
+   }
+
+   if (not this->ctx.check(TokenKind::Greater)) {
+      Token constraint_token = this->ctx.tokens().current();
+      if (descriptor.type != TiriType::Array and descriptor.type != TiriType::Object and
+          descriptor.type != TiriType::Struct) {
+         return this->fail<TypeTestDescriptor>(ParserErrorCode::UnexpectedToken, constraint_token,
+            std::format("Type-test descriptor '<{}>' does not accept an inner name", type_name_view));
+      }
+      if (constraint_token.kind() != TokenKind::Identifier) {
+         return this->fail<TypeTestDescriptor>(ParserErrorCode::ExpectedIdentifier, constraint_token,
+            "Expected one inner name in type-test descriptor");
+      }
+
+      GCstr *constraint_symbol = constraint_token.identifier();
+      std::string_view constraint_name(strdata(constraint_symbol), constraint_symbol->len);
+      this->ctx.tokens().advance();
+      descriptor.constrained = true;
+
+      if (descriptor.type IS TiriType::Array) {
+         auto element = describe_array_element(constraint_name IS "obj" ? "object" : constraint_name,
+            &this->ctx.lua());
+         if (element and element->storage != AET::PTR and
+             (element->storage != AET::STRUCT or element->struct_def)) descriptor.array_element = *element;
+         else if (struct_record *definition = find_struct(&this->ctx.lua(), constraint_name)) {
+            descriptor.array_element = { AET::STRUCT, TiriType::Struct, CLASSID::NIL, definition, true };
+         }
+         else {
+            return this->fail<TypeTestDescriptor>(ParserErrorCode::UnknownTypeName, constraint_token,
+               std::format("Unknown array element type '{}'", constraint_name));
+         }
+      }
+      else if (descriptor.type IS TiriType::Object) {
+         descriptor.object_class_id = ResolveClassName(constraint_name);
+         if (descriptor.object_class_id IS CLASSID::NIL) {
+            return this->fail<TypeTestDescriptor>(ParserErrorCode::UnknownTypeName, constraint_token,
+               std::format("Unknown Kōtuku class '{}'", constraint_name));
+         }
+      }
+      else {
+         descriptor.struct_def = find_struct(&this->ctx.lua(), constraint_name);
+         if (not descriptor.struct_def) {
+            return this->fail<TypeTestDescriptor>(ParserErrorCode::UnknownTypeName, constraint_token,
+               std::format("Unknown structure '{}'; declarations must precede use", constraint_name));
+         }
+      }
+
+      if (not this->ctx.check(TokenKind::Greater)) {
+         return this->fail<TypeTestDescriptor>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
+            "Type-test descriptors accept at most one inner name");
+      }
+   }
+
+   auto close = this->ctx.consume(TokenKind::Greater, ParserErrorCode::ExpectedToken);
+   if (not close.ok()) {
+      return this->fail<TypeTestDescriptor>(ParserErrorCode::ExpectedToken, this->ctx.tokens().current(),
+         "Type-test descriptor is missing '>'");
+   }
+   return ParserResult<TypeTestDescriptor>::success(descriptor);
+}
+
 ParserResult<std::vector<Identifier>> AstBuilder::parse_name_list()
 {
    std::vector<Identifier> names;

--- a/src/tiri/jit/src/parser/ast/nodes.cpp
+++ b/src/tiri/jit/src/parser/ast/nodes.cpp
@@ -108,6 +108,9 @@ TiriType infer_expression_type(const ExprNode &Expr)
          break;
       }
 
+      case AstNodeKind::TypeTestExpr:
+         return TiriType::Bool;
+
       case AstNodeKind::ComparisonChainExpr:
          return TiriType::Bool;
 
@@ -271,6 +274,10 @@ struct ExpressionChildCounter {
 
    [[nodiscard]] inline size_t operator()(const UpdateExprPayload &Payload) const {
       return Payload.target ? 1 : 0;
+   }
+
+   [[nodiscard]] inline size_t operator()(const TypeTestExprPayload &Payload) const {
+      return Payload.value ? 1 : 0;
    }
 
    [[nodiscard]] inline size_t operator()(const BinaryExprPayload &Payload) const {
@@ -528,6 +535,7 @@ struct StatementChildCounter {
 DirectCallTarget::~DirectCallTarget() = default;
 UnaryExprPayload::~UnaryExprPayload() = default;
 UpdateExprPayload::~UpdateExprPayload() = default;
+TypeTestExprPayload::~TypeTestExprPayload() = default;
 BinaryExprPayload::~BinaryExprPayload() = default;
 ComparisonChainExprPayload::~ComparisonChainExprPayload() = default;
 TernaryExprPayload::~TernaryExprPayload() = default;
@@ -647,6 +655,21 @@ ExprNodePtr make_binary_expr(SourceSpan Span, AstBinaryOperator op, ExprNodePtr 
    payload.right = std::move(right);
    ExprNodePtr node = std::make_unique<ExprNode>();
    node->kind = AstNodeKind::BinaryExpr;
+   node->span = Span;
+   node->data = std::move(payload);
+   return node;
+}
+
+ExprNodePtr make_type_test_expr(
+   SourceSpan Span, ExprNodePtr Value, TypeTestDescriptor Descriptor, bool Negated)
+{
+   assert_node(ensure_operand(Value), "type-test expression requires a value");
+   TypeTestExprPayload payload;
+   payload.value = std::move(Value);
+   payload.descriptor = Descriptor;
+   payload.negated = Negated;
+   ExprNodePtr node = std::make_unique<ExprNode>();
+   node->kind = AstNodeKind::TypeTestExpr;
    node->span = Span;
    node->data = std::move(payload);
    return node;

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -359,6 +359,26 @@ struct UpdateExprPayload {
    ~UpdateExprPayload();
 };
 
+struct TypeTestDescriptor {
+   TiriType type = TiriType::Unknown;
+   ArrayElementDescriptor array_element{};
+   CLASSID object_class_id = CLASSID::NIL;
+   struct_record *struct_def = nullptr;
+   bool constrained = false;
+};
+
+struct TypeTestExprPayload {
+   TypeTestExprPayload() = default;
+   TypeTestExprPayload(const TypeTestExprPayload&) = delete;
+   TypeTestExprPayload& operator=(const TypeTestExprPayload&) = delete;
+   TypeTestExprPayload(TypeTestExprPayload&&) noexcept = default;
+   TypeTestExprPayload& operator=(TypeTestExprPayload&&) noexcept = default;
+   ExprNodePtr value;
+   TypeTestDescriptor descriptor{};
+   bool negated = false;
+   ~TypeTestExprPayload();
+};
+
 struct BinaryExprPayload {
    BinaryExprPayload() = default;
    BinaryExprPayload(const BinaryExprPayload&) = delete;
@@ -673,7 +693,7 @@ struct ExprNode {
    mutable StaticValueHandle static_value = 0;
    mutable StaticResultSetHandle static_results = 0;
    std::variant<LiteralValue, NameRef, CurrentContextExprPayload, VarArgExprPayload, UnaryExprPayload,
-      UpdateExprPayload, BinaryExprPayload, ComparisonChainExprPayload, TernaryExprPayload,
+      UpdateExprPayload, TypeTestExprPayload, BinaryExprPayload, ComparisonChainExprPayload, TernaryExprPayload,
       PresenceExprPayload, PipeExprPayload, CallExprPayload, MemberExprPayload,
       IndexExprPayload, SafeMemberExprPayload, SafeIndexExprPayload,
       ResultFilterPayload, TableExprPayload, FunctionExprPayload, DeferredExprPayload,
@@ -1132,6 +1152,8 @@ ExprNodePtr make_current_context_expr(SourceSpan span);
 ExprNodePtr make_vararg_expr(SourceSpan span);
 ExprNodePtr make_unary_expr(SourceSpan span, AstUnaryOperator op, ExprNodePtr operand);
 ExprNodePtr make_update_expr(SourceSpan span, AstUpdateOperator op, bool is_postfix, ExprNodePtr target);
+ExprNodePtr make_type_test_expr(
+   SourceSpan span, ExprNodePtr value, TypeTestDescriptor descriptor, bool negated);
 ExprNodePtr make_binary_expr(SourceSpan span, AstBinaryOperator op, ExprNodePtr left, ExprNodePtr right);
 ExprNodePtr make_comparison_chain_expr(SourceSpan span, std::vector<AstBinaryOperator> operators,
    ExprNodeList operands);

--- a/src/tiri/jit/src/parser/constant_evaluator.cpp
+++ b/src/tiri/jit/src/parser/constant_evaluator.cpp
@@ -173,6 +173,22 @@ std::optional<CompileTimeValue> ConstantEvaluator::evaluate(const ExprNode &Expr
          return std::nullopt;
       case AstNodeKind::UnaryExpr:
          return this->evaluate_unary(std::get<UnaryExprPayload>(Expression.data));
+      case AstNodeKind::TypeTestExpr: {
+         const auto &payload = std::get<TypeTestExprPayload>(Expression.data);
+         if (not payload.value) return std::nullopt;
+         auto value = this->evaluate(*payload.value);
+         if (not value) return std::nullopt;
+         TiriType actual = TiriType::Unknown;
+         switch (value->kind) {
+            case LiteralKind::Nil: actual = TiriType::Nil; break;
+            case LiteralKind::Boolean: actual = TiriType::Bool; break;
+            case LiteralKind::Number: actual = TiriType::Num; break;
+            case LiteralKind::String: actual = TiriType::Str; break;
+         }
+         bool matched = payload.descriptor.type IS TiriType::Any or payload.descriptor.type IS actual;
+         if (payload.negated) matched = not matched;
+         return CompileTimeValue::from_literal(LiteralValue::boolean(matched));
+      }
       case AstNodeKind::BinaryExpr:
          return this->evaluate_binary(std::get<BinaryExprPayload>(Expression.data));
       case AstNodeKind::TernaryExpr:

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -257,6 +257,8 @@ private:
             return this->expression_uses_context_ptr(std::get<UnaryExprPayload>(Expression.data).operand);
          case AstNodeKind::UpdateExpr:
             return this->expression_uses_context_ptr(std::get<UpdateExprPayload>(Expression.data).target);
+         case AstNodeKind::TypeTestExpr:
+            return this->expression_uses_context_ptr(std::get<TypeTestExprPayload>(Expression.data).value);
          case AstNodeKind::BinaryExpr: {
             const auto &payload = std::get<BinaryExprPayload>(Expression.data);
             return this->expression_uses_context_ptr(payload.left) or this->expression_uses_context_ptr(payload.right);
@@ -860,6 +862,7 @@ static UnsupportedNodeRecorder glUnsupportedNodes;
       case AstNodeKind::IdentifierExpr: return "IdentifierExpr";
       case AstNodeKind::VarArgExpr:     return "VarArgExpr";
       case AstNodeKind::UnaryExpr:      return "UnaryExpr";
+      case AstNodeKind::TypeTestExpr:   return "TypeTestExpr";
       case AstNodeKind::BinaryExpr:     return "BinaryExpr";
       case AstNodeKind::ComparisonChainExpr: return "ComparisonChainExpr";
       case AstNodeKind::UpdateExpr:     return "UpdateExpr";
@@ -2075,6 +2078,11 @@ bool IrEmitter::can_elide_expression(const ExprNode &Expression) const
          return payload.operand and this->can_elide_expression(*payload.operand);
       }
 
+      case AstNodeKind::TypeTestExpr: {
+         const auto &payload = std::get<TypeTestExprPayload>(Expression.data);
+         return payload.value and this->can_elide_expression(*payload.value);
+      }
+
       case AstNodeKind::BinaryExpr: {
          const auto &payload = std::get<BinaryExprPayload>(Expression.data);
          return payload.left and payload.right and
@@ -3116,6 +3124,9 @@ ParserResult<ExpDesc> IrEmitter::emit_expression(const ExprNode& expr)
       case AstNodeKind::UpdateExpr:
          result = this->emit_update_expr(std::get<UpdateExprPayload>(expr.data));
          break;
+      case AstNodeKind::TypeTestExpr:
+         result = this->emit_type_test_expr(std::get<TypeTestExprPayload>(expr.data));
+         break;
       case AstNodeKind::BinaryExpr:
          result = this->emit_binary_expr(std::get<BinaryExprPayload>(expr.data));
          break;
@@ -3427,6 +3438,88 @@ ParserResult<ExpDesc> IrEmitter::emit_update_expr(const UpdateExprPayload &Paylo
    }
 
    return ParserResult<ExpDesc>::success(infix);
+}
+
+//********************************************************************************************************************
+// Emits a boolean type test using the portable runtime-contract descriptor representation.  The VM replaces the
+// tested register with a canonical boolean, so the left operand is evaluated exactly once.
+
+ParserResult<ExpDesc> IrEmitter::emit_type_test_expr(const TypeTestExprPayload &Payload)
+{
+   if (not Payload.value) return this->unsupported_expr(AstNodeKind::TypeTestExpr, SourceSpan{});
+   auto value_result = this->emit_expression(*Payload.value);
+   if (not value_result.ok()) return value_result;
+
+   ExpDesc value = value_result.value_ref();
+   RegisterAllocator allocator(&this->func_state);
+   allocator.discharge_to_next_register(value);
+   BCReg value_reg(value.u.s.info);
+
+   auto append_uleb32 = [](std::string &Output, uint32_t Value) {
+      do {
+         uint8_t byte = uint8_t(Value & 0x7f);
+         Value >>= 7;
+         if (Value) byte |= 0x80;
+         Output.push_back(char(byte));
+      } while (Value);
+   };
+   auto append_text = [](std::string &Output, std::string_view Text) {
+      Output.push_back(char(uint8_t(Text.size())));
+      Output.append(Text);
+   };
+
+   const TypeTestDescriptor &type_test = Payload.descriptor;
+   std::string descriptor;
+   descriptor.reserve(24);
+   descriptor.push_back(char(uint8_t(ContractBoundary::Local)));
+   descriptor.push_back(char(0));
+   descriptor.push_back(char(1));
+   descriptor.push_back(char(1));
+   descriptor.push_back(char(uint8_t(type_test.type)));
+
+   uint8_t entry_flags = 0;
+   if (type_test.type IS TiriType::Any or type_test.type IS TiriType::Nil) {
+      entry_flags |= contract_flag(ContractEntryFlag::Nullable);
+   }
+   if (Payload.negated) entry_flags |= contract_flag(ContractEntryFlag::Negated);
+   descriptor.push_back(char(entry_flags));
+   descriptor.push_back(char(1));
+
+   CLASSID class_id = type_test.type IS TiriType::Object ? type_test.object_class_id : CLASSID::NIL;
+   append_uleb32(descriptor, uint32_t(class_id));
+
+   std::string_view struct_name;
+   if (type_test.type IS TiriType::Struct and type_test.struct_def) struct_name = type_test.struct_def->Name;
+   if (struct_name.size() > UINT8_MAX) {
+      return ParserResult<ExpDesc>::failure(this->make_error(
+         ParserErrorCode::UnexpectedToken, "Type-test structure name is too long"));
+   }
+   append_text(descriptor, struct_name);
+
+   if (type_test.type IS TiriType::Array) {
+      AET element_type = type_test.constrained ? type_test.array_element.storage : AET::ANY;
+      descriptor.push_back(char(uint8_t(element_type)));
+      std::string_view element_struct_name;
+      if (element_type IS AET::STRUCT and type_test.array_element.struct_def) {
+         element_struct_name = type_test.array_element.struct_def->Name;
+      }
+      if (element_struct_name.size() > UINT8_MAX) {
+         return ParserResult<ExpDesc>::failure(this->make_error(
+            ParserErrorCode::UnexpectedToken, "Type-test array structure name is too long"));
+      }
+      append_text(descriptor, element_struct_name);
+   }
+   append_text(descriptor, {});
+
+   GCstr *encoded = this->lex_state.keepstr(std::string_view(descriptor.data(), descriptor.size()));
+   ExpDesc constant(encoded);
+   bcemit_AD(&this->func_state, BC_TYPETEST, value_reg.raw(), const_str(&this->func_state, &constant));
+
+   value.init(ExpKind::NonReloc, value_reg.raw());
+   value.result_type = TiriType::Bool;
+   value.object_class_id = CLASSID::NIL;
+   value.struct_def = nullptr;
+   return ParserResult<ExpDesc>::success(value);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
@@ -232,6 +232,7 @@ private:
    ParserResult<ExpDesc> emit_vararg_expr();
    ParserResult<ExpDesc> emit_unary_expr(const UnaryExprPayload& payload);
    ParserResult<ExpDesc> emit_update_expr(const UpdateExprPayload& payload);
+   ParserResult<ExpDesc> emit_type_test_expr(const TypeTestExprPayload& payload);
    ParserResult<ExpDesc> emit_binary_expr(const BinaryExprPayload& payload);
    ParserResult<ExpDesc> emit_comparison_chain_expr(const ComparisonChainExprPayload& payload);
    ParserResult<ExpDesc> emit_ternary_expr(const TernaryExprPayload& payload);

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -336,6 +336,46 @@ static bool test_literal_binary_expr(kt::Log &log)
 }
 
 //********************************************************************************************************************
+
+static bool test_type_test_ast(kt::Log &Log)
+{
+   auto ast = build_ast_from_source(
+      "local value:any = 1\nreturn value is <num>, value is not <array int>, value != <str>");
+   if (not ast.chunk.ok()) {
+      Log.error("failed to parse type-test expressions");
+      log_diagnostics(ast.diagnostics, Log);
+      return false;
+   }
+
+   StatementListView statements = ast.chunk.value_ref()->view();
+   if (statements.size() != 2 or statements[1].kind != AstNodeKind::ReturnStmt) {
+      Log.error("type-test fixture did not produce the expected return statement");
+      return false;
+   }
+   const auto *returned = std::get_if<ReturnStmtPayload>(&statements[1].data);
+   if (not returned or returned->values.size() != 3) {
+      Log.error("type-test fixture returned the wrong arity");
+      return false;
+   }
+
+   const auto *primitive = std::get_if<TypeTestExprPayload>(&returned->values[0]->data);
+   const auto *array = std::get_if<TypeTestExprPayload>(&returned->values[1]->data);
+   const auto *not_equal = std::get_if<TypeTestExprPayload>(&returned->values[2]->data);
+   if (returned->values[0]->kind != AstNodeKind::TypeTestExpr or not primitive or
+       primitive->descriptor.type != TiriType::Num or primitive->negated or
+       returned->values[1]->kind != AstNodeKind::TypeTestExpr or not array or
+       array->descriptor.type != TiriType::Array or not array->descriptor.constrained or not array->negated or
+       array->descriptor.array_element.storage != AET::INT32 or
+       returned->values[2]->kind != AstNodeKind::TypeTestExpr or not not_equal or
+       not_equal->descriptor.type != TiriType::Str or not not_equal->negated) {
+      Log.error("type-test AST descriptors lost their resolved type metadata");
+      return false;
+   }
+
+   return true;
+}
+
+//********************************************************************************************************************
 // Expression parsing entry point tests.
 
 static bool test_expression_entry_point(kt::Log &log)
@@ -8476,10 +8516,11 @@ static bool test_contextual_designation_ownership(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 79> tests = { {
+   constexpr std::array<TestCase, 80> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
+      { "type_test_ast", test_type_test_ast },
       { "expression_entry_point", test_expression_entry_point },
       { "expression_list_entry_point", test_expression_list_entry_point },
       { "empty_comment_appended_to_variable", test_empty_comment_appended_to_variable },

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -138,6 +138,11 @@ private:
             if (payload.target) this->discover_expression(*payload.target, true);
             break;
          }
+         case AstNodeKind::TypeTestExpr: {
+            auto &payload = std::get<TypeTestExprPayload>(Expression.data);
+            if (payload.value) this->discover_expression(*payload.value);
+            break;
+         }
          case AstNodeKind::BinaryExpr: {
             auto &payload = std::get<BinaryExprPayload>(Expression.data);
             if (payload.left) this->discover_expression(*payload.left);
@@ -1522,6 +1527,11 @@ private:
             this->propagate_function(function);
             break;
          }
+         case AstNodeKind::TypeTestExpr:
+            value.primary = TiriType::Bool;
+            value.proof = StaticProof::Closed;
+            value.nullable = false;
+            break;
          case AstNodeKind::CallExpr:
          case AstNodeKind::SafeCallExpr: {
             auto &call = std::get<CallExprPayload>(Expression.data);
@@ -2104,6 +2114,7 @@ private:
       switch (Expression.kind) {
          case AstNodeKind::UnaryExpr: visit(std::get<UnaryExprPayload>(Expression.data).operand); break;
          case AstNodeKind::UpdateExpr: visit(std::get<UpdateExprPayload>(Expression.data).target); break;
+         case AstNodeKind::TypeTestExpr: visit(std::get<TypeTestExprPayload>(Expression.data).value); break;
          case AstNodeKind::BinaryExpr: {
             auto &p = std::get<BinaryExprPayload>(Expression.data); visit(p.left); visit(p.right); break;
          }

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -872,6 +872,9 @@ void TypeAnalyser::lower_unanalysed_expression(ExprNode &Expression)
       case AstNodeKind::UpdateExpr:
          lower(std::get<UpdateExprPayload>(Expression.data).target);
          break;
+      case AstNodeKind::TypeTestExpr:
+         lower(std::get<TypeTestExprPayload>(Expression.data).value);
+         break;
       case AstNodeKind::BinaryExpr: {
          auto &payload = std::get<BinaryExprPayload>(Expression.data);
          lower(payload.left);
@@ -2195,6 +2198,11 @@ void TypeAnalyser::analyse_expression(const ExprNode &Expression)
          if (payload and payload->target) this->analyse_expression(*payload->target);
          break;
       }
+      case AstNodeKind::TypeTestExpr: {
+         auto *payload = std::get_if<TypeTestExprPayload>(&Expression.data);
+         if (payload and payload->value) this->analyse_expression(*payload->value);
+         break;
+      }
       case AstNodeKind::BinaryExpr: {
          auto *payload = std::get_if<BinaryExprPayload>(&Expression.data);
          if (payload) {
@@ -2571,6 +2579,10 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
    InferredType result;
 
    switch (Expr.kind) {
+      case AstNodeKind::TypeTestExpr:
+         result.primary = TiriType::Bool;
+         result.is_nullable = false;
+         return result;
       case AstNodeKind::CurrentContextExpr:
          result.primary = TiriType::Table;
          result.is_nullable = false;
@@ -3753,6 +3765,10 @@ bool TypeAnalyser::expression_contains_call_to(const ExprNode& Expr, GCstr *Name
             return this->expression_contains_call_to(*payload->operand, Name);
          }
          break;
+      }
+      case AstNodeKind::TypeTestExpr: {
+         auto *payload = std::get_if<TypeTestExprPayload>(&Expr.data);
+         return payload and payload->value and this->expression_contains_call_to(*payload->value, Name);
       }
       case AstNodeKind::TernaryExpr: {
          auto *payload = std::get_if<TernaryExprPayload>(&Expr.data);

--- a/src/tiri/jit/src/runtime/lj_contract.h
+++ b/src/tiri/jit/src/runtime/lj_contract.h
@@ -30,7 +30,8 @@ enum class ContractEntryFlag : uint8_t {
    Required = 1 << 1,
    Const = 1 << 2,
    Initialising = 1 << 3,
-   GlobalHint = 1 << 4
+   GlobalHint = 1 << 4,
+   Negated = 1 << 5
 };
 
 [[nodiscard]] constexpr inline uint8_t contract_flag(ContractDescriptorFlag Flag) noexcept
@@ -303,6 +304,7 @@ private:
       uint8_t allowed_entry_flags = contract_flag(ContractEntryFlag::Nullable) |
          contract_flag(ContractEntryFlag::Required) | contract_flag(ContractEntryFlag::Const) |
          contract_flag(ContractEntryFlag::Initialising) | contract_flag(ContractEntryFlag::GlobalHint);
+      allowed_entry_flags |= contract_flag(ContractEntryFlag::Negated);
       if (not reader.read_byte(type) or type > uint8_t(TiriType::Unknown) or
           not reader.read_byte(entry.flags) or
           (entry.flags & ~allowed_entry_flags) != 0 or

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -762,6 +762,13 @@ void lj_meta_istype(lua_State *L, BCREG ra, BCREG tp)
 //              struct_name_length, struct_name_bytes, optional array member and structure name,
 //              label_length, label_bytes }
 
+bool lj_meta_object_class_matches(const GCobject *Object, CLASSID ExpectedClassId) noexcept
+{
+   if (not Object or not Object->classptr) return false;
+   return ExpectedClassId IS CLASSID::NIL or Object->classptr->ClassID IS ExpectedClassId or
+      Object->classptr->BaseClassID IS ExpectedClassId;
+}
+
 namespace {
 
 [[nodiscard]] static bool contract_is_range(lua_State *L, cTValue *Value)
@@ -827,9 +834,7 @@ namespace {
       }
       case TiriType::Object: {
          if (not tvisobject(Value)) return false;
-         if (Entry.object_class_id IS CLASSID::NIL) return true;
-         GCobject *object = objectV(Value);
-         return object->classptr and object->classptr->ClassID IS Entry.object_class_id;
+         return lj_meta_object_class_matches(objectV(Value), Entry.object_class_id);
       }
       case TiriType::Range:    return contract_is_range(L, Value);
       case TiriType::Userdata: return contract_is_userdata(L, Value);
@@ -1064,6 +1069,40 @@ static void apply_cached_contract(lua_State *L, TValue *Base, uint32_t DynamicCo
 }
 
 } // namespace
+
+extern "C" void lj_meta_type_test_pc(lua_State *L, const BCIns *PC)
+{
+   GCproto *prototype = funcproto(curr_func(L));
+   BCIns instruction = PC[-1];
+   if (bc_op(instruction) != BC_TYPETEST) lj_err_callermsg(L, "invalid type-test resume point");
+
+   GCstr *encoded = gco_to_string(proto_kgc(prototype, ~(ptrdiff_t)bc_d(instruction)));
+   RuntimeContractDescriptor descriptor;
+   decode_contract_or_error(L, encoded, descriptor);
+   if (descriptor.contract_count != 1) lj_err_callermsg(L, "invalid type-test descriptor");
+
+   RuntimeContractEntry &entry = descriptor.entries[0];
+   TValue *value = L->base + bc_a(instruction);
+   bool matched;
+   if (lj_is_thunk(value)) {
+      ThunkPayload *payload = thunk_payload(udataV(value));
+      if (entry.type IS TiriType::Any) matched = true;
+      else if (payload->resolved) matched = contract_matches(L, &payload->cached_value, entry);
+      else if (payload->expected_type != 0xff and
+          entry.object_class_id IS CLASSID::NIL and entry.constraint_name.empty() and
+          (entry.type != TiriType::Array or entry.array_element_type IS AET::ANY)) {
+         matched = entry.type IS TiriType(payload->expected_type);
+      }
+      else {
+         TValue *resolved = lj_thunk_resolve(L, udataV(value));
+         value = L->base + bc_a(instruction);
+         matched = contract_matches(L, resolved, entry);
+      }
+   }
+   else matched = contract_matches(L, value, entry);
+   if ((entry.flags & contract_flag(ContractEntryFlag::Negated)) != 0) matched = not matched;
+   setboolV(value, matched);
+}
 
 void lj_contract_build_cache(lua_State *L, GCproto *Prototype)
 {

--- a/src/tiri/jit/src/runtime/lj_meta.h
+++ b/src/tiri/jit/src/runtime/lj_meta.h
@@ -36,6 +36,8 @@ extern "C" [[nodiscard]] TValue* lj_meta_comp(lua_State* L, cTValue* o1, cTValue
 extern "C" void lj_meta_istype(lua_State* L, BCREG ra, BCREG tp);
 extern "C" void lj_meta_contract(lua_State *, TValue *, uint32_t, GCstr *);
 extern "C" void lj_meta_contract_pc(lua_State *, const BCIns *, uint32_t);
+extern "C" void lj_meta_type_test_pc(lua_State *, const BCIns *);
+[[nodiscard]] bool lj_meta_object_class_matches(const GCobject *, CLASSID) noexcept;
 LJ_FUNC void lj_contract_build_cache(lua_State *, GCproto *);
 extern "C" void lj_env_check(lua_State *, GCtab *, GCstr *, cTValue *);
 extern "C" void lj_env_check_override(lua_State *, GCtab *, GCstr *, cTValue *, GCstr *);

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -86,6 +86,7 @@ enum class AstNodeKind : uint16_t {
    CurrentContextExpr,
    VarArgExpr,
    UnaryExpr,
+   TypeTestExpr,
    BinaryExpr,
    ComparisonChainExpr,
    UpdateExpr,

--- a/src/tiri/tests/test_type_tests.tiri
+++ b/src/tiri/tests/test_type_tests.tiri
@@ -1,0 +1,145 @@
+-- Boolean type-test expressions for primitive and constrained runtime types.
+
+include 'vector'
+
+@BeforeEach(hotpath=true)
+function enforce_hotpath() end
+
+struct TypeTestAlpha
+   Value: int
+end
+
+struct TypeTestBravo
+   Value: int
+end
+
+function dynamic_value(Value):any
+   return Value
+end
+
+@Test function PrimitiveDescriptors()
+   assert(nil is <nil>, 'nil should match <nil>')
+   assert(nil is <any>, '<any> should include nil')
+   assert(true is <bool>, 'boolean should match <bool>')
+   assert(12.5 is <num>, 'number should match <num>')
+   assert('text' is <str>, 'string should match <str>')
+   assert({} is <table>, 'table should match <table>')
+   assert((function() end) is <func>, 'function should match <func>')
+   assert({0 to 2} is <range>, 'range should match <range>')
+   assert(newproxy(true) is <userdata>, 'full userdata should match <userdata>')
+
+   assert(1 is not <str>, 'negated mismatch should be true')
+   assert(not (1 is not <num>), 'negated match should be false')
+   assert(1 != <str>, 'symbolic negated mismatch should be true')
+   assert(not (1 != <num>), 'symbolic negated match should be false')
+   assert(dynamic_value(1) is <num>, 'dynamic values should be tested at runtime')
+end
+
+@Test function EqualityRemainsUnchanged()
+   local left = 4
+   local right = 4
+   assert(left is right, 'ordinary is should remain equality')
+   assert(left is not 5, 'ordinary is not should remain inequality')
+   assert(left != 5, 'ordinary != should remain inequality')
+end
+
+@Test function AggregateDescriptors()
+   local ints = array<int> { 1, 2 }
+   local words = array<str> { 'one', 'two' }
+   local table_value = { 1, 2 }
+
+   assert(ints is <array>, 'unconstrained array should match every native array')
+   assert(ints is <array int>, 'array member identity should match')
+   assert(ints is not <array str>, 'array member identity should reject a mismatch')
+   assert(words is <array str>, 'string arrays should match their public storage identity')
+   assert(table_value is not <array>, 'tables are not native arrays')
+
+   local alpha = struct<TypeTestAlpha> { Value=1 }
+   local bravo = struct<TypeTestBravo> { Value=2 }
+   local alpha_array = array<struct<TypeTestAlpha>> { alpha }
+   assert(alpha is <struct>, 'unconstrained struct should match')
+   assert(alpha is <struct TypeTestAlpha>, 'named structure identity should match')
+   assert(bravo is not <struct TypeTestAlpha>, 'different structure definitions should not match')
+   assert(alpha_array is <array TypeTestAlpha>, 'structure-array identity should match')
+end
+
+@Test function ObjectDescriptorsAndInheritance()
+   local time_value = obj.new('Time')
+   local rectangle = obj.new('VectorRectangle')
+
+   assert(time_value is <obj>, 'unconstrained obj should match every object wrapper')
+   assert(time_value is <object Time>, 'object alias should be accepted')
+   assert(time_value is not <obj File>, 'unrelated object classes should not match')
+   assert(rectangle is <obj Vector>, 'derived objects should match their base class')
+   assert(nil is not <obj>, 'nil should not match obj')
+end
+
+@Test function LeftOperandRunsOnce()
+   local count = 0
+   function next_value():any
+      count++
+      return 10, 'ignored'
+   end
+
+   assert(next_value() is <num>, 'only the first result should be tested')
+   assert(count is 1, 'the left operand should execute exactly once')
+end
+
+@Test function DeferredDeclaredTypes()
+   local executed = false
+   thunk deferred_number():num
+      executed = true
+      return 42
+   end
+
+   local value = deferred_number()
+   assert(value is <num>, 'a declared deferred type should be tested without forcing its body')
+   assert(executed is false, 'an unconstrained declared deferred test should not force evaluation')
+end
+
+@Test function BytecodeContainsTypeTest()
+   local script = obj.find('self')
+   local _, disassembly = script.mtDebugLog('disasm')
+   assert(disassembly.find('TYPETEST') != nil, 'dynamic type tests should emit TYPETEST bytecode')
+end
+
+@Test function BytecodeRoundTrip()
+   function factory():func
+      return function(Value:any):bool
+         return Value is <array int>
+      end
+   end
+
+   local restored_test = exec(string.dump(factory, true))
+   assert(restored_test(array<int> { 1 }), 'reloaded bytecode should preserve a matching descriptor')
+   assert(not restored_test(array<str> { 'one' }), 'reloaded bytecode should preserve a mismatching descriptor')
+end
+
+@Test function InterpreterAndJitParity()
+   local matches = 0
+   local value:any
+   for index in {0 to 1000} do
+      if index % 2 is 0 then value = index
+      else value = tostring(index) end
+      if value is <num> then matches++ end
+   end
+   assert(matches is 500, 'hot type tests should preserve matching and non-matching paths')
+end
+
+@Test function MalformedDescriptorDiagnostics()
+   local failed = false
+   try
+      exec([[return 1 is <integer>]])
+   except error_value
+      failed = error_value.message.find("Unknown type-test name 'integer'") != nil
+   end
+   assert(failed, 'unknown type-test names should have a focused diagnostic')
+
+   failed = false
+   try
+      exec([[return 1 is <array int str>]])
+   except error_value
+      failed = error_value.message.find('at most one inner name') != nil
+   end
+   assert(failed, 'surplus descriptor names should have a focused diagnostic')
+end


### PR DESCRIPTION
* Introduced the `value is <Type>`, `is not <Type>` and `!= <Type>` type-test syntax with optional inner constraints for array elements, object classes and structures
* Added the TypeTestExpr AST node, parser descriptor handling, IR emission, JIT recording and constant/type/static-descriptor analysis
* Implemented lj_meta_type_test_pc runtime evaluation with thunk-aware fast paths and Negated contract entry support
* Extended object class matching to accept base-class identifiers via lj_meta_object_class_matches
* [Script] Migrated GUI, IO, net, json, options and other scripts from string-based type() checks to the new type-test operator