### PR TITLE
[Tiri] Added LSP and syntax highlighting for the contextual type-test operator

### DIFF
--- a/src/tiri/jit/BYTECODE.md
+++ b/src/tiri/jit/BYTECODE.md
@@ -346,6 +346,11 @@ targets `FORL`, while a `break` targets `loop_exit`.  This keeps range preparati
 | `CHECK` | A D | Check error code in R(A), raise if >= threshold |
 | `RAISE` | A D | Raise exception with error code R(A) and message R(D) |
 
+#### Type Test Op
+| Opcode | Format | Description |
+|--------|--------|-------------|
+| `TYPETEST` | A D | R(A) = boolean result of testing R(A) against the single-entry contract descriptor at str(D) |
+
 ### 3.3 Resources and Cross-References
 - Opcode definitions and metadata (including the `BCDEF` macro): `src/tiri/jit/src/bytecode/lj_bc.h`.
 - Parser emission sites: `src/tiri/jit/src/parser/ir_emitter/operator_emitter.cpp` (operator lowering and bytecode emission), `src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp` (control-flow and expression emission).
@@ -821,6 +826,50 @@ callback's duration. Synchronous `lua_call()` and `lua_pcall()` re-entry does no
 active context. Fixed-argument contextual tail calls use `CTXCALLT`; direct and variable-argument calls preserve their
 existing tail or call-and-return paths respectively.
 
+### 10.5 Contextual Type Test (`BC_TYPETEST`)
+
+`TYPETEST` implements the `value is <Type>`, `value is not <Type>` and `value != <Type>` operators.  It is an AD-format
+instruction: `A` is the register holding the already-evaluated left operand and `D` is a string constant holding a
+portable runtime-contract descriptor.  The instruction tests `R(A)` against that descriptor and overwrites `R(A)` with
+a canonical boolean, so the left operand is evaluated exactly once and its slot is reused for the result.  There is no
+following `JMP`; unlike the `IS*` comparison family, `TYPETEST` produces a value rather than steering control flow.
+
+The descriptor is the same encoding consumed by `CONTRACT` (section 10.3), but always contains exactly one entry.  The
+emitter (`IrEmitter::emit_type_test_expr`) writes a `ContractBoundary::Local` descriptor with one fixed slot and one
+entry carrying the tested `TiriType`, its inner constraint, and entry flags:
+
+- `ContractEntryFlag::Nullable` is set for `any` and `nil` tests.
+- `ContractEntryFlag::Negated` (`1 << 5`) is set for the `is not` / `!=` forms, and inverts the final match result.
+- An `Object` test embeds the expected `CLASSID`; a `Struct` test embeds the structure name; an `Array` test embeds the
+  constrained element type (`AET`) and, for a struct element, the element structure name.  An unconstrained aggregate
+  test embeds `CLASSID::NIL`, an empty structure name or `AET::ANY` respectively.
+
+**Interpreter semantics** — the x64, ARM64 and PowerPC handlers all call `lj_meta_type_test_pc(L, PC)`.  It decodes the
+descriptor from `PC[-1]`, requires exactly one entry, and evaluates the match:
+
+- A non-thunk value is matched directly with `contract_matches`.
+- A thunk short-circuits when the test type is `any`; uses its cached value when already resolved; matches against the
+  thunk's declared `expected_type` when the test is a plain tag with no class, structure-name or array-element
+  constraint; and otherwise forces resolution before matching.
+- The `Negated` flag inverts the result, which is then written back to `R(A)` as a boolean.
+
+Object class matching is widened by `lj_meta_object_class_matches`: an object satisfies an `Object` test when the
+expected `CLASSID` is `NIL`, matches the object's own `ClassID`, or matches its `BaseClassID`.  This base-class
+acceptance is shared by the interpreter, the JIT recorder and ordinary contract checking.
+
+**JIT recording** — `rec_type_test` records the test without a runtime helper call whenever the observed value is not a
+thunk.  It emits the same aggregate guards as contract recording (`rec_contract_guard_array`, `_object`, `_struct`,
+`_range`, `_callable`, `_userdata`) so the trace stays specialised to the observed shape, then folds the boolean result
+(`TREF_TRUE`/`TREF_FALSE`) and applies the `Negated` flag.  A failing constrained match still guards the observed
+aggregate metadata (element type, class, struct definition, range-ness) so the trace cannot silently accept a differently
+shaped value.  A thunk operand, or any descriptor the recorder cannot fold, adds a snapshot and stops the trace with an
+interpreter link (`TraceLink::INTERP`) so the deferred test resumes safely in the interpreter without disabling the
+prototype.
+
+**Constant folding** — `ConstantEvaluator` folds a `TYPETEST` whose operand is a compile-time literal, comparing the
+literal's category against the tested type (honouring `any` and `Negated`) and yielding a boolean constant.  Type and
+static-descriptor analysis classify the expression's result as a non-nullable `Bool`.
+
 ## 11. Testing, Debugging, and Tooling
 
 ### 11.1 Using Flute and Tiri Tests
@@ -916,6 +965,9 @@ existing tail or call-and-return paths respectively.
 - `CONTRACT A, D`: validates values starting at register `A` using the portable descriptor string at constant `D`.
   Descriptors encode the boundary, exact Tiri types, nullable/required flags, labels, named-structure identity and
   fixed or dynamic result shape.
+- `TYPETEST A, D`: tests `R(A)` against the single-entry contract descriptor at constant `D` and overwrites `R(A)` with
+  a boolean. Implements `value is <Type>`, `is not <Type>` and `!= <Type>`; the `ContractEntryFlag::Negated` (`1 << 5`)
+  flag inverts the result. See section 10.5.
 - `MRSAVE A` / `MRRESTORE A`: preserve the VM multi-result count and returned values in a state-owned nested save stack
   while return-path `<close>` and `defer` handlers execute. Restored values begin at `R(A+1)`.
 - Basic tag contracts use trace slot specialisation. Prototypes needing structure identity, range metatable,

--- a/tools/tiri_lsp/include/lsp_parsing.tiri
+++ b/tools/tiri_lsp/include/lsp_parsing.tiri
@@ -433,9 +433,30 @@ global function tokenizeTiri(Source:str, ModulePrefixes:table):array<table>
          MULTIBYTE_OPERATORS[Source.sub(pos, pos + 2)]) or nil
 
       if op_bytes then
+         is_not_equal = Source.sub(pos, pos + op_bytes) is '≠'
          addToken(line, col, op_bytes, 1, 0)  -- operator
          pos += op_bytes
          col += op_bytes
+
+         if is_not_equal then
+            -- The Unicode not-equal operator is equivalent to `!=`, including when it introduces a type-test
+            -- descriptor.  Probe the descriptor before the generic identifier and struct-declaration branches.
+            probe_pos = pos
+            probe_col = col
+            probe_line = line
+            skipWhitespace()
+            if line is probe_line and pos < len and Source.sub(pos, pos + 1) is '<' then
+               if not tokenizeTypeTest(nil, nil) then
+                  pos = probe_pos
+                  col = probe_col
+                  line = probe_line
+               end
+            else
+               pos = probe_pos
+               col = probe_col
+               line = probe_line
+            end
+         end
 
       -- Line comment: --
       elseif c is '-' and pos + 1 < len and Source.sub(pos + 1, pos + 2) is '-' then

--- a/tools/tiri_lsp/include/lsp_parsing.tiri
+++ b/tools/tiri_lsp/include/lsp_parsing.tiri
@@ -167,6 +167,113 @@ global function tokenizeTiri(Source:str, ModulePrefixes:table):array<table>
       return Pos
    end
 
+   -- A type-test primary word may carry an inner constraint name: `<array int>`, `<obj Vector>` and
+   -- `<struct Point>`.  The remaining primaries (`num`, `str`, `nil`, `range`, ...) are unconstrained.
+   type_test_types = {
+      ['any'] = true, ['nil'] = true, ['bool'] = true, ['num'] = true, ['str'] = true, ['table'] = true,
+      ['array'] = true, ['func'] = true, ['struct'] = true, ['obj'] = true, ['object'] = true, ['range'] = true,
+      ['userdata'] = true
+   }
+   type_test_constrainable = {
+      ['array'] = true, ['obj'] = true, ['object'] = true, ['struct'] = true
+   }
+
+   -- Tokenise a contextual `is <...>` / `is not <...>` type-test descriptor beginning at the current position, which
+   -- must sit on the '<' (leading spaces are skipped first).  On success the '<' and '>' become operator tokens, the
+   -- primary word a 'type' token and any inner constraint name a 'class' token, and the function returns true with
+   -- pos/col advanced past '>'.  A malformed or absent descriptor leaves pos/col untouched and returns false so the
+   -- caller continues tokenising the '<' as an ordinary less-than operator.  Descriptors do not span line breaks.
+   function tokenizeTypeTest(NotLine:num, NotCol:num):bool
+      save_pos = pos
+      save_col = col
+
+      while pos < len and (Source.sub(pos, pos + 1) is ' ' or Source.sub(pos, pos + 1) is '\t') do
+         pos++
+         col++
+      end
+
+      if pos >= len or Source.sub(pos, pos + 1) != '<' then
+         pos = save_pos
+         col = save_col
+         return false
+      end
+
+      open_col = col
+      pos++
+      col++
+
+      while pos < len and (Source.sub(pos, pos + 1) is ' ' or Source.sub(pos, pos + 1) is '\t') do
+         pos++
+         col++
+      end
+
+      if pos >= len or not isIdentStart(Source.sub(pos, pos + 1)) then
+         pos = save_pos
+         col = save_col
+         return false
+      end
+
+      primary_col = col
+      primary_pos = pos
+      while pos < len and isIdentChar(Source.sub(pos, pos + 1)) do
+         pos++
+         col++
+      end
+      primary = Source.sub(primary_pos, pos)
+      primary_len = col - primary_col
+      if not type_test_types[primary] then
+         pos = save_pos
+         col = save_col
+         return false
+      end
+
+      inner_col = nil
+      inner_len = 0
+      if type_test_constrainable[primary] then
+         mark_pos = pos
+         mark_col = col
+         while pos < len and (Source.sub(pos, pos + 1) is ' ' or Source.sub(pos, pos + 1) is '\t') do
+            pos++
+            col++
+         end
+         if pos < len and isIdentStart(Source.sub(pos, pos + 1)) then
+            inner_col = col
+            while pos < len and isIdentChar(Source.sub(pos, pos + 1)) do
+               pos++
+               col++
+            end
+            inner_len = col - inner_col
+         else
+            pos = mark_pos
+            col = mark_col
+         end
+      end
+
+      while pos < len and (Source.sub(pos, pos + 1) is ' ' or Source.sub(pos, pos + 1) is '\t') do
+         pos++
+         col++
+      end
+
+      if pos >= len or Source.sub(pos, pos + 1) != '>' then
+         pos = save_pos
+         col = save_col
+         return false
+      end
+
+      close_col = col
+      pos++
+      col++
+
+      if NotCol then addToken(NotLine, NotCol, 3, 1, 0) end  -- 'not' operator
+      addToken(line, open_col, 1, 1, 0)                    -- '<' operator
+      addToken(line, primary_col, primary_len, 7, 0)       -- descriptor primary: type
+      if inner_col then
+         addToken(line, inner_col, inner_len, 11, 0)       -- inner constraint name: class
+      end
+      addToken(line, close_col, 1, 1, 0)                   -- '>' operator
+      return true
+   end
+
    function isRangeOperator(StartPos, StopPos, Ident)
       if not (isRangeWord(Ident) or Ident is 'by') then return false end
 
@@ -596,6 +703,43 @@ global function tokenizeTiri(Source:str, ModulePrefixes:table):array<table>
             pos = save_pos
             col = save_col
             line = save_line
+         elseif ident is 'is' then
+            -- `is` is ordinarily an equality operator, but `is <...>` / `is not <...>` (contextually recognised by a
+            -- following '<') is a boolean type test.  Emit the operator, then consume the optional `not` and the
+            -- angle-bracket descriptor so its primary and inner names highlight as types rather than falling through
+            -- to the generic identifier, range and 'struct'-declaration branches below.
+            addToken(line, ident_start, ident_len, 1, 0)  -- 'is' operator
+
+            probe_pos = pos
+            probe_col = col
+            probe_line = line
+            skipWhitespace()
+            not_present = false
+            not_col = nil
+            if line is probe_line and pos + 2 <= len and Source.sub(pos, pos + 3) is 'not' and
+                  (pos + 3 >= len or not isIdentChar(Source.sub(pos + 3, pos + 4))) then
+               not_present = true
+               not_col = col
+               pos += 3
+               col += 3
+               skipWhitespace()
+            end
+
+            if line is probe_line and pos < len and Source.sub(pos, pos + 1) is '<' then
+               not_line = nil
+               if not_present then not_line = probe_line end
+               if not tokenizeTypeTest(not_line, not_col) then
+                  -- Malformed descriptor: rewind to just after 'is' so the stray 'not'/'<' tokenise normally.
+                  pos = probe_pos
+                  col = probe_col
+                  line = probe_line
+               end
+            else
+               -- Not a type-test descriptor; rewind so a trailing `not`, expression or newline tokenises normally.
+               pos = probe_pos
+               col = probe_col
+               line = probe_line
+            end
          elseif FLUID_KEYWORDS[ident] then
             addToken(line, ident_start, ident_len, 0, 0)  -- keyword
          elseif FLUID_OPERATORS[ident] then
@@ -866,10 +1010,28 @@ global function tokenizeTiri(Source:str, ModulePrefixes:table):array<table>
       elseif c is '!' then
          op_start = col
          if pos + 1 < len and Source.sub(pos + 1, pos + 2) is '=' then
-            -- != not equal
+            -- != not equal.  Like `is`, `!= <...>` is a negated boolean type test; consume any descriptor that
+            -- follows so its primary and inner names highlight as types rather than falling through to the generic
+            -- identifier, range and 'struct'-declaration branches.
             addToken(line, op_start, 2, 1, 0)
             pos += 2
             col += 2
+
+            probe_pos = pos
+            probe_col = col
+            probe_line = line
+            skipWhitespace()
+            if line is probe_line and pos < len and Source.sub(pos, pos + 1) is '<' then
+               if not tokenizeTypeTest(nil, nil) then
+                  pos = probe_pos
+                  col = probe_col
+                  line = probe_line
+               end
+            else
+               pos = probe_pos
+               col = probe_col
+               line = probe_line
+            end
          else -- ! (used in flags like '!READ')
             pos++
             col++

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -558,6 +558,34 @@ end
    assert(inner.modifiers is 0, 'A != struct type-test name must not carry the declaration modifier.')
 end
 
+@Test function UnicodeNotEqualTypeTestReceivesTypeToken()
+   source = 'flag = x ≠ <num>\n'
+
+   tokens = tokenizeTiri(source)
+
+   not_equal = nil
+   for token in values(tokens) do
+      if token.line is 0 and token.char is 9 and token.length is 1 then not_equal = token end
+   end
+   primary = findToken(tokens, 0, 12, 'num')
+
+   assert(not_equal and not_equal.type is 1, '≠ should remain an operator token in a type test.')
+   assert(primary and primary.type is 7, 'A ≠ descriptor primary should be a type token.')
+end
+
+@Test function UnicodeNotEqualStructTypeTestIsNotAStructDeclaration()
+   source = 'ok = shape ≠ <struct Point>\n'
+
+   tokens = tokenizeTiri(source)
+
+   primary = findToken(tokens, 0, 14, 'struct')
+   inner = findToken(tokens, 0, 21, 'Point')
+
+   assert(primary and primary.type is 7, 'A ≠ struct type-test primary should be a type token, not a keyword.')
+   assert(inner and inner.type is 11, 'The struct name in a ≠ type test should be a class token.')
+   assert(inner.modifiers is 0, 'A ≠ struct type-test name must not carry the declaration modifier.')
+end
+
 @Test function OrdinaryNotEqualIsUnchanged()
    -- Without a following '<', `!=` remains a plain comparison operator with no descriptor tokens.
    source = 'flag = left != right\n'

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -462,3 +462,165 @@ end
    enum_keyword = findToken(tokens, 0, 0, 'enum')
    assert(enum_keyword and enum_keyword.type is 0, 'enum should be highlighted as a keyword.')
 end
+
+@Test function SimpleTypeTestDescriptorReceivesTypeToken()
+   source = 'if value is <num> then end\n'
+
+   tokens = tokenizeTiri(source)
+
+   is_op = findToken(tokens, 0, 9, 'is')
+   open = findToken(tokens, 0, 12, '<')
+   primary = findToken(tokens, 0, 13, 'num')
+   close = findToken(tokens, 0, 16, '>')
+
+   assert(is_op and is_op.type is 1, 'is should remain an operator token in a type test.')
+   assert(open and open.type is 1, 'The descriptor opening < should be an operator token.')
+   assert(primary and primary.type is 7, 'A simple type-test descriptor should be a type token.')
+   assert(close and close.type is 1, 'The descriptor closing > should be an operator token.')
+end
+
+@Test function NegatedTypeTestEmitsNotAndDescriptor()
+   source = 'flag = value is not <str>\n'
+
+   tokens = tokenizeTiri(source)
+
+   is_op = findToken(tokens, 0, 13, 'is')
+   not_op = findToken(tokens, 0, 16, 'not')
+   primary = findToken(tokens, 0, 21, 'str')
+
+   assert(is_op and is_op.type is 1, 'is should remain an operator token in a negated type test.')
+   assert(not_op and not_op.type is 1, 'not should be an operator token between is and the descriptor.')
+   assert(primary and primary.type is 7, 'The negated descriptor primary should be a type token.')
+end
+
+@Test function ConstrainedObjectTypeTestReceivesClassToken()
+   source = 'if node is <obj Vector> then end\n'
+
+   tokens = tokenizeTiri(source)
+
+   primary = findToken(tokens, 0, 12, 'obj')
+   inner = findToken(tokens, 0, 16, 'Vector')
+
+   assert(primary and primary.type is 7, 'The obj descriptor primary should be a type token.')
+   assert(inner and inner.type is 11, 'A constrained object class name should be a class token.')
+end
+
+@Test function ConstrainedArrayTypeTestReceivesClassToken()
+   source = 'ok = buffer is <array int>\n'
+
+   tokens = tokenizeTiri(source)
+
+   primary = findToken(tokens, 0, 16, 'array')
+   inner = findToken(tokens, 0, 22, 'int')
+
+   assert(primary and primary.type is 7, 'The array descriptor primary should be a type token.')
+   assert(inner and inner.type is 11, 'A constrained array element name should be a class token.')
+end
+
+@Test function StructTypeTestIsNotAStructDeclaration()
+   -- A mid-line `<struct Name>` type test must not trip the struct-declaration branch, which would emit the name
+   -- with a declaration modifier and mislead go-to-definition and document symbols.
+   source = 'ok = shape is <struct Point>\n'
+
+   tokens = tokenizeTiri(source)
+
+   primary = findToken(tokens, 0, 15, 'struct')
+   inner = findToken(tokens, 0, 22, 'Point')
+
+   assert(primary and primary.type is 7, 'A struct type-test primary should be a type token, not a keyword.')
+   assert(inner and inner.type is 11, 'The struct name in a type test should be a class token.')
+   assert(inner.modifiers is 0, 'A struct type-test name must not carry the declaration modifier.')
+end
+
+@Test function NotEqualTypeTestReceivesTypeToken()
+   -- `!= <...>` is the symbolic equivalent of `is not <...>` and must highlight its descriptor the same way.
+   source = 'flag = x != <num>\n'
+
+   tokens = tokenizeTiri(source)
+
+   not_equal = findToken(tokens, 0, 9, '!=')
+   primary = findToken(tokens, 0, 13, 'num')
+
+   assert(not_equal and not_equal.type is 1, '!= should remain an operator token in a type test.')
+   assert(primary and primary.type is 7, 'A != descriptor primary should be a type token.')
+end
+
+@Test function NotEqualStructTypeTestIsNotAStructDeclaration()
+   source = 'ok = shape != <struct Point>\n'
+
+   tokens = tokenizeTiri(source)
+
+   primary = findToken(tokens, 0, 15, 'struct')
+   inner = findToken(tokens, 0, 22, 'Point')
+
+   assert(primary and primary.type is 7, 'A != struct type-test primary should be a type token, not a keyword.')
+   assert(inner and inner.type is 11, 'The struct name in a != type test should be a class token.')
+   assert(inner.modifiers is 0, 'A != struct type-test name must not carry the declaration modifier.')
+end
+
+@Test function OrdinaryNotEqualIsUnchanged()
+   -- Without a following '<', `!=` remains a plain comparison operator with no descriptor tokens.
+   source = 'flag = left != right\n'
+
+   tokens = tokenizeTiri(source)
+
+   not_equal = findToken(tokens, 0, 12, '!=')
+   assert(not_equal and not_equal.type is 1, 'Ordinary != comparison should remain an operator token.')
+   assertNoToken(tokens, 0, 15, 'right', 'Ordinary != right operand should not become a descriptor type token.')
+end
+
+@Test function OrdinaryIsEqualityIsUnchanged()
+   -- Without a following '<', `is` and `is not` remain plain equality operators with no descriptor tokens.
+   source = 'a = (left is right)\n' ..
+      'b = left is not right\n'
+
+   tokens = tokenizeTiri(source)
+
+   is_op = findToken(tokens, 0, 10, 'is')
+   assert(is_op and is_op.type is 1, 'Ordinary is equality should remain an operator token.')
+   assertNoToken(tokens, 0, 13, 'right', 'Ordinary equality right operand should not become a descriptor type token.')
+
+   is_not_op = findToken(tokens, 1, 9, 'is')
+   not_op = findToken(tokens, 1, 12, 'not')
+   assert(is_not_op and is_not_op.type is 1, 'Ordinary is-not equality should remain an operator token.')
+   assert(not_op and not_op.type is 1, 'not in ordinary equality should remain an operator token.')
+end
+
+@Test function MalformedTypeTestFallsBackToLessThan()
+   -- An opening '<' with no valid descriptor must not be consumed as a type test; the '<' stays a comparison
+   -- operator so the surrounding expression still tokenises.
+   source = 'flag = count is < limit\n'
+
+   tokens = tokenizeTiri(source)
+
+   is_op = findToken(tokens, 0, 13, 'is')
+   less_than = findToken(tokens, 0, 16, '<')
+
+   assert(is_op and is_op.type is 1, 'is preceding a bare < should remain an operator token.')
+   assert(less_than and less_than.type is 1, 'A bare < after is should tokenise as a less-than operator.')
+end
+
+@Test function MalformedNegatedTypeTestDoesNotDuplicateNotToken()
+   source = 'flag = count is not < limit\n'
+
+   tokens = tokenizeTiri(source)
+
+   matching_not_tokens = 0
+   for token in values(tokens) do
+      if token.line is 0 and token.char is 16 and token.length is 3 then matching_not_tokens++ end
+   end
+
+   assert(matching_not_tokens is 1, 'A malformed is-not type test should emit exactly one not token.')
+   less_than = findToken(tokens, 0, 20, '<')
+   assert(less_than and less_than.type is 1, 'A malformed negated descriptor should retain its less-than token.')
+end
+
+@Test function UnknownTypeTestNameFallsBackToOrdinaryTokens()
+   source = 'flag = value is <integer>\n'
+
+   tokens = tokenizeTiri(source)
+
+   less_than = findToken(tokens, 0, 16, '<')
+   assert(less_than and less_than.type is 1, 'An unknown descriptor should retain its less-than token.')
+   assertNoToken(tokens, 0, 17, 'integer', 'An unknown descriptor name should not receive a type token.')
+end

--- a/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
+++ b/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
@@ -57,8 +57,8 @@
             },
             {
                "name": "meta.type-test.tiri",
-               "comment": "Constrained `!= <aggregate Name>` boolean type test.",
-               "match": "(!=)\\s*(<)\\s*(array|struct|obj|object)\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*(>)",
+               "comment": "Constrained `!= <aggregate Name>` or `≠ <aggregate Name>` boolean type test.",
+               "match": "(!=|≠)\\s*(<)\\s*(array|struct|obj|object)\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*(>)",
                "captures": {
                   "1": { "name": "keyword.operator.comparison.tiri" },
                   "2": { "name": "punctuation.definition.type-test.begin.tiri" },
@@ -69,8 +69,8 @@
             },
             {
                "name": "meta.type-test.tiri",
-               "comment": "Unconstrained `!= <type>` boolean type test.",
-               "match": "(!=)\\s*(<)\\s*(any|nil|bool|num|str|table|array|func|struct|obj|object|range|userdata)\\s*(>)",
+               "comment": "Unconstrained `!= <type>` or `≠ <type>` boolean type test.",
+               "match": "(!=|≠)\\s*(<)\\s*(any|nil|bool|num|str|table|array|func|struct|obj|object|range|userdata)\\s*(>)",
                "captures": {
                   "1": { "name": "keyword.operator.comparison.tiri" },
                   "2": { "name": "punctuation.definition.type-test.begin.tiri" },

--- a/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
+++ b/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
@@ -6,6 +6,7 @@
       { "include": "#comments" },
       { "include": "#strings" },
       { "include": "#annotations" },
+      { "include": "#typetests" },
       { "include": "#functions" },
       { "include": "#keywords" },
       { "include": "#operators" },
@@ -24,6 +25,58 @@
             {
                "name": "comment.line.double-dash.tiri",
                "match": "--.*$"
+            }
+         ]
+      },
+      "typetests": {
+         "patterns": [
+            {
+               "name": "meta.type-test.tiri",
+               "comment": "Contextual constrained `is [not] <aggregate Name>` boolean type test.",
+               "match": "\\b(is)\\b(?:\\s+(not))?\\s*(<)\\s*(array|struct|obj|object)\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*(>)",
+               "captures": {
+                  "1": { "name": "keyword.operator.logical.tiri" },
+                  "2": { "name": "keyword.operator.logical.tiri" },
+                  "3": { "name": "punctuation.definition.type-test.begin.tiri" },
+                  "4": { "name": "support.type.primitive.tiri" },
+                  "5": { "name": "entity.name.type.tiri" },
+                  "6": { "name": "punctuation.definition.type-test.end.tiri" }
+               }
+            },
+            {
+               "name": "meta.type-test.tiri",
+               "comment": "Contextual unconstrained `is [not] <type>` boolean type test.",
+               "match": "\\b(is)\\b(?:\\s+(not))?\\s*(<)\\s*(any|nil|bool|num|str|table|array|func|struct|obj|object|range|userdata)\\s*(>)",
+               "captures": {
+                  "1": { "name": "keyword.operator.logical.tiri" },
+                  "2": { "name": "keyword.operator.logical.tiri" },
+                  "3": { "name": "punctuation.definition.type-test.begin.tiri" },
+                  "4": { "name": "support.type.primitive.tiri" },
+                  "5": { "name": "punctuation.definition.type-test.end.tiri" }
+               }
+            },
+            {
+               "name": "meta.type-test.tiri",
+               "comment": "Constrained `!= <aggregate Name>` boolean type test.",
+               "match": "(!=)\\s*(<)\\s*(array|struct|obj|object)\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*(>)",
+               "captures": {
+                  "1": { "name": "keyword.operator.comparison.tiri" },
+                  "2": { "name": "punctuation.definition.type-test.begin.tiri" },
+                  "3": { "name": "support.type.primitive.tiri" },
+                  "4": { "name": "entity.name.type.tiri" },
+                  "5": { "name": "punctuation.definition.type-test.end.tiri" }
+               }
+            },
+            {
+               "name": "meta.type-test.tiri",
+               "comment": "Unconstrained `!= <type>` boolean type test.",
+               "match": "(!=)\\s*(<)\\s*(any|nil|bool|num|str|table|array|func|struct|obj|object|range|userdata)\\s*(>)",
+               "captures": {
+                  "1": { "name": "keyword.operator.comparison.tiri" },
+                  "2": { "name": "punctuation.definition.type-test.begin.tiri" },
+                  "3": { "name": "support.type.primitive.tiri" },
+                  "4": { "name": "punctuation.definition.type-test.end.tiri" }
+               }
             }
          ]
       },


### PR DESCRIPTION
* Tokenised `is <Type>`, `is not <Type>` and `!= <Type>` descriptors in the LSP semantic tokeniser, emitting type tokens for the primary and class tokens for constrained obj/array/struct names
* Recognised type-test descriptors contextually so a mid-line `<struct Name>` test no longer trips the struct-declaration branch, and malformed or unknown descriptors fall back to ordinary less-than tokenisation
* Added TextMate grammar rules for constrained and unconstrained type-test descriptors in the VS Code plugin
* [Doc] Documented the TYPETEST bytecode instruction and its interpreter, JIT recording and constant-folding semantics in BYTECODE.md