### PR TITLE
[Tiri] Added the <view> declaration attribute for array views

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -861,7 +861,7 @@ endif ()
 
 set (TIRI_TESTS
    defer debuglog io object regex struct async async_actions async_wait xml strings math array array_any array_manip
-   array_element_validation
+   array_element_validation array_view
    array_functional array_typed_syntax bitshift bitwise has_operator approx if_empty if_empty_guard presence blank ternary table stress unit_tests
    jitoptions fstring const const_optimisation import_scope unicode ellipsis safe_nav close type_annotations type_fixing
    type_inference jit jit_try_regex pipe pipe_iteration arrow_functions result_filter thunks deferred_expr shadow_assert

--- a/src/tiri/jit/src/bytecode/lj_bc.h
+++ b/src/tiri/jit/src/bytecode/lj_bc.h
@@ -296,7 +296,9 @@ constexpr uint8_t  NO_REG = BCMAX_A;
   _(CLOSEARM,  var,  ___, ___, ___) \
   _(CLOSE,     var,  ___, ___, ___) \
   /* Boolean contextual type test. */ \
-  _(TYPETEST,  var,  ___, str, ___)
+  _(TYPETEST,  var,  ___, str, ___) \
+  /* Arm or clear the one-shot object array view read mode. */ \
+  _(VIEW,      ___,  ___, lit, ___)
 
 // Bytecode opcode numbers.
 // Explicitly enumerated for debugger visibility and easy value lookup.
@@ -473,8 +475,9 @@ typedef enum {
    BC_CLOSEARM = 132,
    BC_CLOSE = 133,
    BC_TYPETEST = 134,
+   BC_VIEW = 135,
 
-   BC__MAX   = 135
+   BC__MAX   = 136
 } BCOp;
 
 [[nodiscard]] inline constexpr bool bc_is_func_header(BCOp Op) noexcept

--- a/src/tiri/jit/src/bytecode/lj_bcread.cpp
+++ b/src/tiri/jit/src/bytecode/lj_bcread.cpp
@@ -342,6 +342,9 @@ static void bcread_bytecode(LexState *State, GCproto *pt, MSize sizebc)
          BCREG slot = bc_a(bc[i]);
          if (slot >= pt->framesize or slot >= 64) bcread_error(State, ErrMsg::BCBAD);
       }
+      else if (op IS BC_VIEW) {
+         if (bc_a(bc[i]) != 0 or bc_d(bc[i]) > 1) bcread_error(State, ErrMsg::BCBAD);
+      }
       else if (op IS BC_CTXENTER or op IS BC_CTXCALL or op IS BC_CTXCALLM or op IS BC_CTXLEAVE or
                op IS BC_CTXCALLT) {
          BCREG call_base = bc_a(bc[i]);

--- a/src/tiri/jit/src/debug/lj_err.cpp
+++ b/src/tiri/jit/src/debug/lj_err.cpp
@@ -593,6 +593,8 @@ extern "C" void setup_try_handler(lua_State *L)
 
    L->base = restorestack(L, try_frame->frame_base);
    L->top = restorestack(L, try_frame->saved_top);
+   L->array_view_scopes = try_frame->array_view_scopes;
+   L->array_view_depth = try_frame->array_view_depth;
    L->try_stack.depth--; // Pop try frame
 
    // Build exception table and place in handler's register (pass pending_trace, which may be null)
@@ -1118,6 +1120,8 @@ static void err_raise_ext(global_State* g, int errcode)
 
 LJ_NOINLINE void lj_err_throw(lua_State *L, int errcode)
 {
+   L->array_view_scopes = 0;
+   L->array_view_depth = 0;
    global_State* g = G(L);
 
    auto J = G2J(g);

--- a/src/tiri/jit/src/debug/try_except.cpp
+++ b/src/tiri/jit/src/debug/try_except.cpp
@@ -254,6 +254,8 @@ extern "C" void lj_try_enter(lua_State *L, GCfunc *Func, TValue *Base, uint16_t 
    try_frame->flags           = block_desc->flags;
    try_frame->context_depth   = L->context_stack.size();
    try_frame->context_floor   = L->context_root_floors.empty() ? 0 : L->context_root_floors.back();
+   try_frame->array_view_scopes = L->array_view_scopes;
+   try_frame->array_view_depth  = L->array_view_depth;
    lj_assertL(try_frame->context_depth >= try_frame->context_floor,
       "try context depth is below the active asynchronous root floor");
 }

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -2725,7 +2725,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  cmn ITYPE, #-LJ_TUDATA
     |  beq >7
     |  cmn ITYPE, #-LJ_TARRAY
-    |  beq >5
+    |  beq >7
     |  cmn ITYPE, #-LJ_TTAB
     |  bne >1
     |  tst RCw, #ISFALSEY_EMPTY_COLL
@@ -2758,13 +2758,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ldr TMP0w, STR:CARG1->len
     |  cbz TMP0w, >9
     |  b >1
-    |5:
-    |  tst RCw, #ISFALSEY_EMPTY_COLL
-    |  beq >1
-    |  and CARG1, CARG1, #LJ_GCVMASK
-    |  ldr TMP0w, ARRAY:CARG1->len
-    |  cbnz TMP0w, >1
-    |  b >9
     |7:
     |  str BASE, L->base
     |  mov CARG1, L
@@ -2848,7 +2841,13 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |4:  // Check for array type.
     |  cmn ITYPE, #-LJ_TARRAY
     |  bne ->vmeta_len
-    |  ldr CARG1w, ARRAY:CARG1->len
+    |  mov CARG2, CARG1
+    |  ldr L, SAVE_L
+    |  str BASE, L->base
+    |  mov CARG1, L
+    |  str PC, SAVE_PC
+    |  bl extern lj_array_length
+    |  ldr BASE, L->base
     |  b <1
     |
     |8:  // String-keyed table: the length operator yields nil.
@@ -4868,6 +4867,17 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mov CARG1, L
     |  mov CARG2w, RAw
     |  bl extern lj_close_consume
+    |  ldr BASE, L->base
+    |  ins_next
+    break;
+
+  case BC_VIEW:
+    |  ldr L, SAVE_L
+    |  str BASE, L->base
+    |  mov CARG1, L
+    |  mov CARG2w, RDw
+    |  str PC, SAVE_PC
+    |  bl extern lj_array_view_mode
     |  ldr BASE, L->base
     |  ins_next
     break;

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -3938,7 +3938,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  cmpwi TMP0, LJ_TUDATA
     |  beq >7
     |  checkarray TMP0
-    |  beq >5
+    |  beq >7
     |  checktab TMP0
     |  bne >1
     |  andi. TMP1, RC, ISFALSEY_EMPTY_COLL
@@ -4001,20 +4001,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  cmpwi TMP2, 0
     |  beq >9
     |  b >1
-    |5:
-    |  andi. TMP1, RC, ISFALSEY_EMPTY_COLL
-    |  beq >1
-|.if GPR64
-    |  ldx TMP1, BASE, RA		// Load full value for pointer
-    |  clrldi TMP1, TMP1, 17		// Clear type tag bits
-|.else
-    |  add TMP1, BASE, RA
-    |  lwz TMP1, 4(TMP1)		// Load pointer (lo word)
-    |.endif
-    |  lwz TMP2, ARRAY:TMP1->len
-    |  cmpwi TMP2, 0
-    |  bne >1
-    |  b >9
     |7:
     |  mr SAVE0, INS
     |  ld CARG2, -16(PC)
@@ -4139,7 +4125,13 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  b <1
     |4:  // Check for array type.
     |  checkarray TMP0; bne ->vmeta_len
-    |  lwz CRET1, ARRAY:CARG1->len
+    |  mr CARG2, CARG1
+    |  lwz L, SAVE_L
+    |  stp BASE, L->base
+    |  mr CARG1, L
+    |  stw PC, SAVE_PC
+    |  bl extern lj_array_length
+    |  lp BASE, L->base
     |  b <1
     |8:  // String-keyed table: the length operator yields nil.
     |  ins_next1
@@ -6934,6 +6926,17 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mr CARG1, L
     |  srwi CARG2, RA, 3
     |  bl extern lj_close_consume
+    |  lp BASE, L->base
+    |  ins_next
+    break;
+
+  case BC_VIEW:
+    |  lwz L, SAVE_L
+    |  stp BASE, L->base
+    |  mr CARG1, L
+    |  mr CARG2, RD
+    |  stw PC, SAVE_PC
+    |  bl extern lj_array_view_mode
     |  lp BASE, L->base
     |  ins_next
     break;

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -3380,7 +3380,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  cmp ITYPEd, LJ_TUDATA
     |  je >7
     |  cmp ITYPEd, LJ_TARRAY
-    |  je >5
+    |  je >7
     |  cmp ITYPEd, LJ_TTAB
     |  jne >1
     |  test RCd, ISFALSEY_EMPTY_COLL
@@ -3418,13 +3418,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  cmp dword STR:RB->len, 0
     |  je >9
     |  jmp >1
-    |5:
-    |  test RCd, ISFALSEY_EMPTY_COLL
-    |  jz >1
-    |  cleartp RB
-    |  cmp dword ARRAY:RB->len, 0
-    |  jne >1
-    |  jmp >9
     |7:
     |  mov L:RB, SAVE_L
     |  mov L:RB->base, BASE
@@ -3532,12 +3525,18 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  jmp <1
     |4:  // Check for array type.
     |  cmp ITYPEd, LJ_TARRAY; jne ->vmeta_len
+    |  mov L:RB, SAVE_L
+    |  mov L:RB->base, BASE
+    |  mov CARG2, RD
+    |  mov L:CARG1, L:RB
+    |  mov SAVE_PC, PC
+    |  call extern lj_array_length
+    |  mov BASE, L:RB->base
+    |  movzx RAd, PC_RA
     |.if DUALNUM
-    |  mov RDd, dword ARRAY:RD->len
     |  jmp <1
     |.else
-    |  xorps xmm0, xmm0
-    |  cvtsi2sd xmm0, dword ARRAY:RD->len
+    |  cvtsi2sd xmm0, RDd
     |  jmp <1
     |.endif
     |8:  // String-keyed table: the length operator yields nil.
@@ -5879,6 +5878,18 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mov CARG2d, RAd
     |  mov L:CARG1, L:RB
     |  call extern lj_close_consume
+    |  mov BASE, L:RB->base
+    |  ins_next
+    break;
+
+  case BC_VIEW:
+    |  ins_AD
+    |  mov L:RB, SAVE_L
+    |  mov L:RB->base, BASE
+    |  mov CARG2d, RDd
+    |  mov L:CARG1, L:RB
+    |  mov SAVE_PC, PC
+    |  call extern lj_array_view_mode
     |  mov BASE, L:RB->base
     |  ins_next
     break;

--- a/src/tiri/jit/src/lib/lib.cpp
+++ b/src/tiri/jit/src/lib/lib.cpp
@@ -23,6 +23,7 @@
 #include "lj_bcdump.h"
 #include "lib.h"
 #include "runtime/lj_thunk.h"
+#include "runtime/lj_array.h"
 
 //********************************************************************************************************************
 // Library initialization
@@ -404,7 +405,11 @@ GCarray * lj_lib_checkarray(lua_State *L, int Arg, bool Required)
          copyTV(L, o, resolved); // Replace thunk with resolved value
       }
 
-      if (tvisarray(o)) [[likely]] return arrayV(o);
+      if (tvisarray(o)) [[likely]] {
+         GCarray *array = arrayV(o);
+         if (array->flags & ARRAY_LIFECYCLE) lj_array_check_lifecycle(L, array);
+         return array;
+      }
    }
 
    if (Required) lj_err_argt(L, Arg, LUA_TARRAY);

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -2603,7 +2603,7 @@ static void array_append_push_piece(lua_State *L, cTValue *Value, ArrayAppendPie
    }
 
    if (tvisarray(Value)) {
-      GCarray *source = arrayV(Value);
+      GCarray *source = lj_array_checked(L, Value);
       if (source->elemtype IS AET::BYTE) {
          array_append_store_piece(Pieces, PieceCount, { ArrayAppendPiece::Kind::ByteArray, nullptr, source, 0,
             source->len });
@@ -2673,7 +2673,7 @@ LJLIB_INTRINSIC LJLIB_CF(array_append)      LJLIB_REC(.)
    if (piece_count < 1) lj_err_argv(L, 2, ErrMsg::NOVAL);
 
    if (tvisarray(left)) {
-      GCarray *arr = arrayV(left);
+      GCarray *arr = lj_array_checked(L, left);
       if (arr->elemtype IS AET::BYTE) {
          array_append_byte_pieces(L, arr, piece_count);
          setarrayV(L, L->base, arr);
@@ -2720,7 +2720,7 @@ static GCstr * array_concat_value(lua_State *L, cTValue *Value)
    if (tvisnumber(Value)) return lj_strfmt_number(L, Value);
 
    if (tvisarray(Value)) {
-      GCarray *arr = arrayV(Value);
+      GCarray *arr = lj_array_checked(L, Value);
       if (arr->elemtype IS AET::BYTE) return lj_str_new(L, arr->get<const char>(), arr->len);
    }
 

--- a/src/tiri/jit/src/lib/lib_range.cpp
+++ b/src/tiri/jit/src/lib/lib_range.cpp
@@ -910,7 +910,7 @@ static int range_slice_impl(lua_State *L)
 
    // Array slicing
    if (tvisarray(o)) {
-      GCarray *arr = arrayV(o);
+      GCarray *arr = lj_array_checked(L, o);
       int32_t len = int32_t(arr->len);
       tiri_index_range index_range;
       range_check_index(L, r, &index_range);

--- a/src/tiri/jit/src/lj_api.cpp
+++ b/src/tiri/jit/src/lj_api.cpp
@@ -643,7 +643,7 @@ extern int lua_toboolean(lua_State *L, int idx)
 extern GCarray * lua_toarray(lua_State *L, int Arg)
 {
    TValue *o = (Arg > LUA_REGISTRYINDEX) ? resolve_index(L, Arg) : index2adr(L, Arg);
-   if (tvisarray(o)) return &gcval(o)->arr;
+   if (tvisarray(o)) return lj_array_checked(L, o);
    lj_err_argt(L, Arg, LUA_TARRAY);
 }
 

--- a/src/tiri/jit/src/lj_api.cpp
+++ b/src/tiri/jit/src/lj_api.cpp
@@ -790,7 +790,7 @@ extern size_t lua_objlen(lua_State *L, int idx)
    TValue *o = index2adr(L, idx);
    if (tvisstr(o)) return strV(o)->len;
    else if (tvistab(o)) return (size_t)lj_tab_len(tabV(o));
-   else if (tvisarray(o)) return arrayV(o)->len;
+   else if (tvisarray(o)) return lj_array_length(L, arrayV(o));
    else if (tvisudata(o)) return udataV(o)->len;
    else if (tvisnumber(o)) {
       GCstr *s = lj_strfmt_number(L, o);

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -2202,6 +2202,7 @@ static TRef rec_mm_len(jit_State *J, TRef tr, TValue* tv)
          return ir.emit_int(IR_ALEN, tr, TREF_NIL); //equiv to: rc = emitir(IRTI(IR_ALEN), rc, TREF_NIL);
       }
       else if (tref_isarray(tr)) {
+         if (arrayV(tv)->flags & ARRAY_LIFECYCLE) lj_trace_err_info(J, LJ_TRERR_NYIBC);
          IRBuilder ir(J);
          return ir.emit_int(IR_FLOAD, tr, IRFL_ARRAY_LEN); //equiv to: rc = emitir(IRTI(IR_FLOAD), rc, IRFL_ARRAY_LEN);
       }
@@ -3549,6 +3550,7 @@ static TRef rec_arith_op(jit_State *J, RecordOps *ops)
 
 static TRef rec_array_xload(jit_State *J, TRef ArrayRef, TRef IdxRef, GCarray *Arr, int32_t IdxInt)
 {
+   if (Arr->flags & ARRAY_LIFECYCLE) return 0;
    IRBuilder ir(J);
    AET et = Arr->elemtype;
    int shift;
@@ -3580,6 +3582,8 @@ static TRef rec_array_xload(jit_State *J, TRef ArrayRef, TRef IdxRef, GCarray *A
    // Guard: elemtype matches recorded value (CSE'd across accesses to the same array)
    TRef et_ref = ir.fload(ArrayRef, IRFL_ARRAY_ELEMTYPE, IRT_U8);
    ir.guard_eq_int(et_ref, ir.kint(int32_t(et)));
+   TRef flags_ref = ir.fload(ArrayRef, IRFL_ARRAY_FLAGS, IRT_U8);
+   ir.guard_eq_int(flags_ref, ir.kint(int32_t(Arr->flags)));
 
    // Load storage pointer
    TRef storage_ref = ir.fload_ptr(ArrayRef, IRFL_ARRAY_STORAGE);
@@ -3671,6 +3675,7 @@ static TRef rec_array_xload(jit_State *J, TRef ArrayRef, TRef IdxRef, GCarray *A
 
 static bool rec_array_xstore(jit_State *J, TRef ArrayRef, TRef IdxRef, TRef ValRef, GCarray *Arr)
 {
+   if (Arr->flags & ARRAY_LIFECYCLE) return false;
    IRBuilder ir(J);
    AET et = Arr->elemtype;
    int shift;
@@ -3723,6 +3728,8 @@ static bool rec_array_xstore(jit_State *J, TRef ArrayRef, TRef IdxRef, TRef ValR
    // Guard: elemtype matches recorded value (CSE'd across accesses to the same array)
    TRef et_ref = ir.fload(ArrayRef, IRFL_ARRAY_ELEMTYPE, IRT_U8);
    ir.guard_eq_int(et_ref, ir.kint(int32_t(et)));
+   TRef flags_ref = ir.fload(ArrayRef, IRFL_ARRAY_FLAGS, IRT_U8);
+   ir.guard_eq_int(flags_ref, ir.kint(int32_t(Arr->flags)));
 
    // Load storage pointer
    TRef storage_ref = ir.fload_ptr(ArrayRef, IRFL_ARRAY_STORAGE);
@@ -4808,6 +4815,7 @@ void lj_record_ins(jit_State *J)
          rec_comp_fixup(J, J->pc, not is_falsey);
       }
       else if (tref_isarray(ra) and (rc & ISFALSEY_EMPTY_COLL)) {
+         if (arrayV(rav)->flags & ARRAY_LIFECYCLE) lj_trace_err_info(J, LJ_TRERR_NYIBC);
          TRef length = emitir(IRTI(IR_FLOAD), ra, IRFL_ARRAY_LEN);
          is_falsey = arrayV(rav)->len IS 0;
          rec_comp_prep(J);
@@ -5084,6 +5092,7 @@ void lj_record_ins(jit_State *J)
 
    case BC_CLOSEARM:
    case BC_CLOSE:
+   case BC_VIEW:
       lj_trace_err_info(J, LJ_TRERR_NYIBC);
       break;
 

--- a/src/tiri/jit/src/parser/ast/builder.cpp
+++ b/src/tiri/jit/src/parser/ast/builder.cpp
@@ -809,7 +809,7 @@ ParserResult<std::unique_ptr<BlockStmt>> AstBuilder::parse_block(std::span<const
 }
 
 //********************************************************************************************************************
-// Check if an identifier is followed by a <const> or <close> attribute.  Due to lexer lookahead buffer complexities,
+// Check if an identifier is followed by a recognised declaration attribute.  Due to lexer lookahead complexities,
 // we access the lexer's buffered_tokens directly when the special '<identifier' handling has been triggered.
 //
 // Patterns: `name <attr>`, `name:type <attr>`
@@ -830,7 +830,7 @@ static bool is_implicit_local_with_attribute(TokenStreamAdapter& Tokens)
    // - peek(2): <
    // - peek(3): >
    //
-   // We need to detect: identifier (current) followed by 'const'/'close' then '<' then '>'
+   // We need to detect: identifier (current) followed by the attribute name, '<', then '>'.
 
    size_t pos = 1;
    Token next = Tokens.peek(pos);
@@ -847,14 +847,14 @@ static bool is_implicit_local_with_attribute(TokenStreamAdapter& Tokens)
       next = Tokens.peek(pos);
    }
 
-   // Next should be 'const' or 'close' (the buffered identifier from '<identifier' handling)
+   // Next should be a recognised attribute (the buffered identifier from '<identifier' handling)
    if (next.kind() != TokenKind::Identifier) return false;
 
    GCstr* attr_name = next.identifier();
    if (!attr_name) return false;
 
    std::string_view attr_str(strdata(attr_name), attr_name->len);
-   if (attr_str != "const" and attr_str != "close") return false;
+   if (attr_str != "const" and attr_str != "close" and attr_str != "view") return false;
 
    // After the attribute name, we should see '<' (which was returned by the lexer)
    Token angle_open = Tokens.peek(pos + 1);
@@ -937,7 +937,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_statement()
             }
          }
 
-         // Check for implicit local declaration with <const> or <close> attribute
+         // Check for an implicit local declaration carrying an attribute.
          if (is_implicit_local_with_attribute(this->ctx.tokens())) {
             return this->parse_local();
          }

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -415,7 +415,7 @@ ParserResult<std::vector<Identifier>> AstBuilder::parse_name_list()
          }
       }
 
-      // Check for attribute: either '<' (normal case) or 'const'/'close' followed by '<' (buffered case)
+      // Check for attribute: either '<' (normal case) or its buffered identifier followed by '<'.
       // The buffered case occurs when the lexer's '<identifier' handling put the identifier in the buffer
       // before the '<', and then when we advanced past the variable name, we got the buffered identifier.
       bool is_buffered_attribute = false;
@@ -423,7 +423,8 @@ ParserResult<std::vector<Identifier>> AstBuilder::parse_name_list()
          GCstr *maybe_attr = this->ctx.tokens().current().identifier();
          if (maybe_attr) {
             std::string_view attr_view(strdata(maybe_attr), maybe_attr->len);
-            if ((attr_view IS "const" or attr_view IS "close") and this->ctx.tokens().peek(1).raw() IS '<') {
+            if ((attr_view IS "const" or attr_view IS "close" or attr_view IS "view") and
+                  this->ctx.tokens().peek(1).raw() IS '<') {
                is_buffered_attribute = true;
             }
          }
@@ -432,15 +433,17 @@ ParserResult<std::vector<Identifier>> AstBuilder::parse_name_list()
       if (this->ctx.tokens().current().raw() IS '<' or is_buffered_attribute) {
          bool is_close_attribute = false;
          bool is_const_attribute = false;
+         bool is_view_attribute = false;
 
          if (is_buffered_attribute) {
-            // Current token is already the attribute name ('const' or 'close')
+            // Current token is already the attribute name.
             GCstr *attr_name = this->ctx.tokens().current().identifier();
             std::string_view view(strdata(attr_name), attr_name->len);
             if (view IS "close") is_close_attribute = true;
             else if (view IS "const") is_const_attribute = true;
+            else if (view IS "view") is_view_attribute = true;
 
-            this->ctx.tokens().advance();  // Advance past 'const'/'close'
+            this->ctx.tokens().advance();  // Advance past the attribute name
             this->ctx.tokens().advance();  // Advance past '<'
          }
          else {
@@ -454,6 +457,7 @@ ParserResult<std::vector<Identifier>> AstBuilder::parse_name_list()
                std::string_view view(strdata(attr_name), attr_name->len);
                if (view IS std::string_view("close")) is_close_attribute = true;
                else if (view IS std::string_view("const")) is_const_attribute = true;
+               else if (view IS std::string_view("view")) is_view_attribute = true;
             }
          }
 
@@ -466,6 +470,7 @@ ParserResult<std::vector<Identifier>> AstBuilder::parse_name_list()
 
          if (is_close_attribute) identifier.has_close = true;
          else if (is_const_attribute) identifier.has_const = true;
+         else if (is_view_attribute) identifier.has_view = true;
          else {
             this->ctx.emit_error(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(), "unknown attribute");
          }

--- a/src/tiri/jit/src/parser/ast/nodes.cpp
+++ b/src/tiri/jit/src/parser/ast/nodes.cpp
@@ -1069,6 +1069,7 @@ size_t ast_expression_child_count(const ExprNode &Node)
 // Constructor for Identifier that creates an identifier from a string.
 
 Identifier::Identifier(lua_State* L, const char* Name, SourceSpan Span)
-   : symbol(lj_str_new(L, Name, std::strlen(Name))), span(Span), is_blank(false), has_close(false), type(TiriType::Unknown)
+   : symbol(lj_str_new(L, Name, std::strlen(Name))), span(Span), is_blank(false), has_close(false), has_const(false),
+     has_view(false), type(TiriType::Unknown)
 {
 }

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -235,6 +235,7 @@ struct Identifier {
    bool is_blank = false;
    bool has_close = false;
    bool has_const = false;  // Const attribute flag - variable cannot be reassigned
+   bool has_view = false;   // View attribute flag - first object array read is non-owning
    bool is_future_reserved = false;  // True when parsed from a keyword reserved for future syntax
    TiriType type = TiriType::Unknown;  // Explicit type annotation (Unknown = no annotation)
    struct_record *struct_def = nullptr; // Resolved layout for struct<Name> annotations
@@ -263,6 +264,7 @@ struct Identifier {
       id.is_blank = false;
       id.has_close = false;
       id.has_const = false;
+      id.has_view = false;
       id.is_future_reserved = false;
       return id;
    }

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -11,7 +11,7 @@
 
 //********************************************************************************************************************
 // Parses local variable declarations, local function statements and local thunk function statements.
-// Supports both explicit 'local' keyword and implicit local declarations with <const>/<close> attributes.
+// Supports both explicit 'local' keyword and implicit local declarations with declaration attributes.
 
 ParserResult<StmtNodePtr> AstBuilder::parse_local()
 {
@@ -109,6 +109,27 @@ ParserResult<StmtNodePtr> AstBuilder::parse_local()
       values.resize(name_count);
    }
 
+   auto view = std::find_if(name_list.begin(), name_list.end(), [](const Identifier &Identifier) {
+      return Identifier.has_view;
+   });
+   if (view != name_list.end()) {
+      if (name_list.size() != 1) {
+         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken,
+            Token::from_span(view->span, TokenKind::Identifier),
+            "A <view> declaration requires exactly one local name");
+      }
+      if (values.empty() or assign_op != AssignmentOperator::Plain) {
+         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken,
+            Token::from_span(view->span, TokenKind::Identifier),
+            "A <view> local requires an initialiser");
+      }
+      if (view->has_close or view->has_const) {
+         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken,
+            Token::from_span(view->span, TokenKind::Identifier),
+            "The <view> attribute cannot be combined with <close> or <const>");
+      }
+   }
+
    auto stmt = std::make_unique<StmtNode>(AstNodeKind::LocalDeclStmt, local_token.span());
    stmt->data.emplace<LocalDeclStmtPayload>(assign_op, std::move(name_list), std::move(values));
    return ParserResult<StmtNodePtr>::success(std::move(stmt));
@@ -169,6 +190,14 @@ ParserResult<StmtNodePtr> AstBuilder::parse_global()
 
    auto names = this->parse_name_list();
    if (not names.ok()) return ParserResult<StmtNodePtr>::failure(names.error_ref());
+
+   for (const Identifier &identifier : names.value_ref()) {
+      if (identifier.has_view) {
+         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken,
+            Token::from_span(identifier.span, TokenKind::Identifier),
+            "The <view> attribute is only valid on local declarations");
+      }
+   }
 
    ExprNodeList values;
    AssignmentOperator assign_op = AssignmentOperator::Plain;
@@ -272,7 +301,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_extern()
             Token::from_span(identifier.span, TokenKind::Identifier), "extern declarations require named symbols");
       }
 
-      if (identifier.type != TiriType::Unknown or identifier.has_const or identifier.has_close) {
+      if (identifier.type != TiriType::Unknown or identifier.has_const or identifier.has_close or identifier.has_view) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken,
             Token::from_span(identifier.span, TokenKind::Identifier),
             "Extern declarations cannot have type annotations or attributes");
@@ -682,7 +711,7 @@ static bool is_prefixed_attribute_token(TokenStreamAdapter &Tokens)
    if (not symbol) return false;
 
    std::string_view name(strdata(symbol), symbol->len);
-   if (name != "const" and name != "close") return false;
+   if (name != "const" and name != "close" and name != "view") return false;
    return Tokens.peek(1).raw() IS '<';
 }
 
@@ -746,7 +775,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_enum(const Token &StartToken)
 
    if (is_prefixed_attribute_token(this->ctx.tokens())) {
       return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-         "Enum prefixes cannot use <const> or <close> attributes");
+         "Enum prefixes cannot use declaration attributes");
    }
 
    auto open_brace = this->ctx.consume(TokenKind::LeftBrace, ParserErrorCode::ExpectedToken);

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1891,9 +1891,11 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
 
    ExpDesc tail;
    auto nexps = BCReg(0);
+   bool is_view = Payload.names.size() IS 1 and Payload.names[0].has_view;
    std::vector<std::optional<CompileTimeValue>> compile_time_values(Payload.names.size());
    if (Payload.values.empty()) tail = ExpDesc(ExpKind::Void);
    else {
+      if (is_view) bcemit_AD(&this->func_state, BC_VIEW, 0, 1);
       auto list = this->emit_expression_list(Payload.values, nexps);
       if (not list.ok()) return ParserResult<IrEmitUnit>::failure(list.error_ref());
       tail = list.value_ref();
@@ -1909,6 +1911,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
    }
 
    this->lex_state.assign_adjust(nvars.raw(), nexps.raw(), &tail);
+   if (is_view) bcemit_AD(&this->func_state, BC_VIEW, 0, 0);
    this->lex_state.var_add(nvars);
    auto base = BCReg(this->func_state.varmap.size() - nvars.raw());
 

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -406,6 +406,7 @@ void lj_array_store_new_values(lua_State *L, GCarray *Array, cTValue *Values, MS
 
 extern "C" void lj_arr_push1(lua_State *L, GCarray *Array, cTValue *Value)
 {
+   if (Array->flags & ARRAY_LIFECYCLE) lj_array_check_lifecycle(L, Array);
    if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
 
    if (Array->elemtype IS AET::BYTE and tvisstr(Value)) {
@@ -465,7 +466,7 @@ static void array_attach_basemt(lua_State *L, GCarray *Arr)
 // - The storage area stores CSTRING pointers into the vector
 
 extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Data, uint8_t Flags,
-   std::string_view StructName, struct_record *StructDef)
+   std::string_view StructName, struct_record *StructDef, Object *Lifecycle)
 {
    MSize elem_size;
    struct_record *sdef = nullptr;
@@ -485,12 +486,16 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
 
    lj_assertL(elem_size > 0, "invalid element size for array creation");
 
-   if (Data) {
+   if (Data or (Flags & ARRAY_EXTERNAL)) {
       if (Flags & ARRAY_EXTERNAL) {
          // External data - caller manages lifetime (no storage allocation needed)
          // External arrays have capacity = length and cannot grow
          auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-         arr->init(Data, Type, elem_size, Length, Length, Flags, sdef);
+         arr->init(Data, Type, elem_size, Length, Length, Flags, sdef, Lifecycle);
+         if (Lifecycle) {
+            Lifecycle->pinWeak();
+            arr->flags |= ARRAY_LIFECYCLE;
+         }
          array_attach_basemt(L, arr);
          return arr;
       }
@@ -662,8 +667,35 @@ void lj_array_free(global_State *g, GCarray *Array)
    if (storage_size > 0) {
       lj_mem_free(g, Array->storage, storage_size);
    }
+   if (Array->is_lifecycle_bound()) {
+      Array->lifecycle->unpinWeak();
+      Array->lifecycle = nullptr;
+   }
    Array->~GCarray(); // Call destructor (handles strcache cleanup)
    lj_mem_free(g, Array, sizeof(GCarray));
+}
+
+bool lj_array_stale(GCarray *Array)
+{
+   if (not Array->is_lifecycle_bound()) return false;
+   if (not Array->lifecycle->terminating()) return false;
+   Array->storage = nullptr;
+   Array->len = 0;
+   Array->capacity = 0;
+   return true;
+}
+
+void lj_array_check_lifecycle(lua_State *L, GCarray *Array)
+{
+   if (lj_array_stale(Array)) {
+      luaL_error(L, ERR::DoesNotExist, "Cannot access an array view; the source object has been destroyed.");
+   }
+}
+
+extern "C" uint32_t lj_array_length(lua_State *L, GCarray *Array)
+{
+   if (Array->flags & ARRAY_LIFECYCLE) lj_array_check_lifecycle(L, Array);
+   return Array->len;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_array.h
+++ b/src/tiri/jit/src/runtime/lj_array.h
@@ -36,3 +36,13 @@ extern void lj_array_store_new_values(lua_State *, GCarray *, cTValue *Values, M
 inline void * lj_array_index(GCarray *Array, uint32_t Idx) {
    return (int8_t*)Array->arraydata() + (Idx * Array->elemsize);
 }
+
+// Resolve a TValue known to hold an array, enforcing the lifecycle guard before any storage access.  This is the
+// mandatory entry point for operator, iterator and marshalling paths that resolve arrayV() on a raw value directly
+// (i.e. those that bypass lj_lib_checkarray()).  A stale view is emptied and raises before its freed storage can be
+// read.  The caller must have already confirmed tvisarray(O).
+inline GCarray * lj_array_checked(lua_State *L, cTValue *O) {
+   GCarray *arr = &gcval(O)->arr;
+   if (arr->flags & ARRAY_LIFECYCLE) lj_array_check_lifecycle(L, arr);
+   return arr;
+}

--- a/src/tiri/jit/src/runtime/lj_array.h
+++ b/src/tiri/jit/src/runtime/lj_array.h
@@ -6,8 +6,11 @@
 #include "lj_obj.h"
 
 extern GCarray * lj_array_new(lua_State *, uint32_t, AET, void *Data = nullptr, uint8_t Flags = 0,
-   std::string_view StructName = {}, struct_record *StructDef = nullptr);
+   std::string_view StructName = {}, struct_record *StructDef = nullptr, Object *Lifecycle = nullptr);
 extern void lj_array_free(global_State *, GCarray *);
+[[nodiscard]] extern bool lj_array_stale(GCarray *);
+extern void lj_array_check_lifecycle(lua_State *, GCarray *);
+extern "C" [[nodiscard]] uint32_t lj_array_length(lua_State *, GCarray *);
 [[nodiscard]] extern uint8_t lj_array_elemsize(AET);
 extern void lj_array_clear_range(GCarray *, MSize Start, MSize Count);
 extern void lj_array_copy(lua_State *, GCarray *, uint32_t dstidx, GCarray *, uint32_t srcidx, uint32_t count);

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -23,6 +23,7 @@
 #include "lj_strscan.h"
 #include "lj_strfmt.h"
 #include "lj_thunk.h"
+#include "lj_array.h"
 #include "lj_object.h"
 #include "lj_contract.h"
 #include "stack_helpers.h"
@@ -675,9 +676,7 @@ int lj_meta_isfalsey(lua_State *L, BCIns Ins)
    VMHelperGuard guard(L);
 
    cTValue *value = &L->base[bc_a(Ins)];
-   if (not lj_is_thunk(value)) return 0;
-
-   value = lj_thunk_resolve(L, udataV(value));
+   if (lj_is_thunk(value)) value = lj_thunk_resolve(L, udataV(value));
    uint32_t mask = bc_d(Ins);
 
    if (tvisnil(value)) return 1;
@@ -686,7 +685,7 @@ int lj_meta_isfalsey(lua_State *L, BCIns Ins)
       return (mask & ISFALSEY_ZERO) and (tvisint(value) ? intV(value) IS 0 : tviszero(value));
    }
    if (tvisstr(value)) return (mask & ISFALSEY_EMPTY_STR) and strV(value)->len IS 0;
-   if (tvisarray(value)) return (mask & ISFALSEY_EMPTY_COLL) and arrayV(value)->len IS 0;
+   if (tvisarray(value)) return (mask & ISFALSEY_EMPTY_COLL) and lj_array_length(L, arrayV(value)) IS 0;
    if (tvistab(value)) return (mask & ISFALSEY_EMPTY_COLL) and lj_tab_empty(tabV(value));
    return 0;
 }

--- a/src/tiri/jit/src/runtime/lj_obj.cpp
+++ b/src/tiri/jit/src/runtime/lj_obj.cpp
@@ -5,6 +5,7 @@
 #define LUA_CORE
 
 #include "lj_obj.h"
+#include "lj_array.h"
 #include <kotuku/main.h>
 
 //********************************************************************************************************************
@@ -40,7 +41,12 @@ const void * lj_obj_ptr(global_State *g, cTValue *o)
 {
    if (tvisudata(o)) return uddata(udataV(o));
    else if (tvislightud(o)) return lightudV(g, o);
-   else if (tvisarray(o)) return arrayV(o)->arraydata();
+   else if (tvisarray(o)) {
+      // Empty a stale view so identity/formatting observes a null pointer rather than freed storage.
+      GCarray *arr = arrayV(o);
+      if (arr->flags & ARRAY_LIFECYCLE) lj_array_stale(arr);
+      return arr->arraydata();
+   }
    else if (tvisgcv(o)) return gcV(o);
    else return nullptr;
 }

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -802,6 +802,8 @@ struct TryFrame {
    BCREG     saved_nactvar;    // Active slot count at try entry (first free register)
    size_t    context_depth;     // Absolute context-stack depth at try entry
    size_t    context_floor;     // Active asynchronous root floor at try entry
+   uint64_t  array_view_scopes; // Armed <view> scopes at try entry
+   uint8_t   array_view_depth;  // Active <view> scope depth at try entry
 };
 
 // Stack of try frames for exception unwinding
@@ -1286,6 +1288,7 @@ enum class AET : uint8_t {
 // Array flags
 inline constexpr uint8_t ARRAY_READONLY  = 0x01;  // Cannot modify elements
 inline constexpr uint8_t ARRAY_EXTERNAL  = 0x02;  // Data not owned by array (storage is raw pointer)
+inline constexpr uint8_t ARRAY_LIFECYCLE = 0x04;  // External data follows a Kotuku object's lifecycle
 inline constexpr uint8_t ARRAY_CACHED    = 0x00;  // Copy external data into owned storage (default, flag is 0)
 
 struct array_meta {
@@ -1314,6 +1317,7 @@ struct GCarray {
    MSize   elemsize;    // Size of each element in bytes
    struct struct_record *structdef;  // Optional: struct definition for struct arrays
    std::vector<char> *strcache; // Optional: cached string content for CSTRING/STRING_CPP arrays
+   Object  *lifecycle; // Weak-pinned owner for lifecycle-bound external views
 
 public:
    // Initialise the array structure. Storage must be pre-allocated by the caller using lj_mem_new()
@@ -1321,7 +1325,7 @@ public:
    // them! We avoid member initialiser lists to prevent GCC from zero-initializing the GCHeader
    // fields (nextgc, marked) that were set by lj_mem_newgco().
    void init(void *Data, AET Type, MSize ElemSize, MSize Length, MSize Capacity, uint8_t Flags,
-             struct struct_record *StructDef = nullptr) noexcept
+             struct struct_record *StructDef = nullptr, Object *Lifecycle = nullptr) noexcept
    {
       gct       = ~LJ_TARRAY;
       luatype   = glArrayConversion[size_t(Type)].type;
@@ -1337,6 +1341,7 @@ public:
       elemsize  = ElemSize;
       structdef = StructDef;
       strcache  = nullptr;
+      lifecycle = Lifecycle;
    }
 
    // Destructor only handles strcache. Storage is freed by lj_array_free() for proper GC tracking.
@@ -1367,6 +1372,7 @@ public:
    [[nodiscard]] inline MSize arraylen() const noexcept { return len; }
    [[nodiscard]] inline bool is_readonly() const noexcept { return (flags & ARRAY_READONLY) != 0; }
    [[nodiscard]] inline bool is_external() const noexcept { return (flags & ARRAY_EXTERNAL) != 0; }
+   [[nodiscard]] inline bool is_lifecycle_bound() const noexcept { return (flags & ARRAY_LIFECYCLE) != 0; }
    [[nodiscard]] int type_flags() const noexcept;
    [[nodiscard]] inline size_t alloc_size() const noexcept { return sizeof(GCarray); }
    [[nodiscard]] inline size_t storage_size() const noexcept { return is_external() ? 0 : size_t(capacity) * elemsize; }
@@ -1646,6 +1652,8 @@ struct lua_State {
    class extTiri *script;  // Back-reference to the script that owns this lua_State
    bool    sent_traceback;   // True if traceback has been sent for the current error
    uint8_t resolving_thunk;  // Flag to prevent recursive thunk resolution
+   uint64_t array_view_scopes = 0; // One armed bit per active <view> declaration initialiser
+   uint8_t array_view_depth = 0;   // Number of active <view> initialiser scopes
    ParserDiagnostics *parser_diagnostics; // Stores ParserDiagnostics* during parsing errors
    TipEmitter *parser_tips;               // Stores TipEmitter* during parsing for code hints
    ParserSymbolCollection *parser_symbols; // Stores parser symbol metadata for LSP/documentation tooling

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -448,6 +448,27 @@ extern "C" void lj_close_arm(lua_State *L, uint32_t Slot)
    state->armed_slots |= uint64_t(1) << Slot;
 }
 
+extern "C" void lj_array_view_mode(lua_State *L, uint32_t Enabled)
+{
+   if (Enabled) {
+      if (L->array_view_depth >= 64) lj_err_msg(L, ErrMsg::XNEST);
+      L->array_view_scopes |= uint64_t(1) << L->array_view_depth++;
+   }
+   else if (L->array_view_depth > 0) {
+      L->array_view_depth--;
+      L->array_view_scopes &= ~(uint64_t(1) << L->array_view_depth);
+   }
+}
+
+bool lj_array_take_view_mode(lua_State *L) noexcept
+{
+   if (L->array_view_depth IS 0) return false;
+   uint64_t scope = uint64_t(1) << (L->array_view_depth - 1);
+   bool armed = (L->array_view_scopes & scope) != 0;
+   L->array_view_scopes &= ~scope;
+   return armed;
+}
+
 uint64_t lj_close_take_armed(
    lua_State *L, const TValue *OwnerBase, uint32_t LowerSlot, uint32_t UpperSlot) noexcept
 {

--- a/src/tiri/jit/src/runtime/lj_state.h
+++ b/src/tiri/jit/src/runtime/lj_state.h
@@ -68,6 +68,8 @@ extern "C" LJ_FUNC void lj_context_end_block_jit(
    lua_State *L, TValue *OwnerBase, uint32_t BlockIndex) noexcept;
 extern "C" LJ_FUNC void lj_close_arm(lua_State *L, uint32_t Slot);
 extern "C" LJ_FUNC void lj_close_consume(lua_State *L, uint32_t Slot);
+extern "C" LJ_FUNC void lj_array_view_mode(lua_State *L, uint32_t Enabled);
+LJ_FUNC [[nodiscard]] bool lj_array_take_view_mode(lua_State *L) noexcept;
 LJ_FUNC uint64_t lj_close_take_armed(
    lua_State *L, const TValue *OwnerBase, uint32_t LowerSlot, uint32_t UpperSlot) noexcept;
 extern "C" LJ_FUNC void lj_context_enter_call(lua_State *L, uint32_t CallBase);

--- a/src/tiri/jit/src/runtime/lj_vmarray.cpp
+++ b/src/tiri/jit/src/runtime/lj_vmarray.cpp
@@ -137,6 +137,7 @@ extern "C" cTValue * lj_arr_get(lua_State *L, cTValue *O, cTValue *K)
    }
 
    GCarray *arr = arrayV(O);
+   if (arr->flags & ARRAY_LIFECYCLE) lj_array_check_lifecycle(L, arr);
 
    // Check if key is a string (method lookup like arr:concat())
 
@@ -200,6 +201,7 @@ extern "C" int lj_arr_set(lua_State *L, cTValue *O, cTValue *K, cTValue *V)
    }
 
    GCarray *arr = arrayV(O);
+   if (arr->flags & ARRAY_LIFECYCLE) lj_array_check_lifecycle(L, arr);
 
    if (arr->flags & ARRAY_READONLY) {
       lj_err_msg(L, ErrMsg::ARRRO);
@@ -232,6 +234,7 @@ extern "C" int lj_arr_set(lua_State *L, cTValue *O, cTValue *K, cTValue *V)
 
 extern "C" void lj_arr_getidx(lua_State *L, GCarray *Array, int32_t Idx, TValue *Result)
 {
+   if (Array->flags & ARRAY_LIFECYCLE) lj_array_check_lifecycle(L, Array);
    if (Idx < 0 or MSize(Idx) >= Array->len) lj_err_msgv(L, ErrMsg::ARROB, Idx, int(Array->len));
    arr_load_elem(L, Array, uint32_t(Idx), Result);
 }
@@ -242,6 +245,7 @@ extern "C" void lj_arr_getidx(lua_State *L, GCarray *Array, int32_t Idx, TValue 
 
 extern "C" void lj_arr_safe_getidx(lua_State *L, GCarray *Array, int32_t Idx, TValue *Result)
 {
+   if (Array->flags & ARRAY_LIFECYCLE) lj_array_check_lifecycle(L, Array);
    if (Idx < 0 or MSize(Idx) >= Array->len) {
       setnilV(Result);
       return;
@@ -254,6 +258,7 @@ extern "C" void lj_arr_safe_getidx(lua_State *L, GCarray *Array, int32_t Idx, TV
 
 extern "C" void lj_arr_setidx(lua_State *L, GCarray *Array, int32_t Idx, cTValue *Val)
 {
+   if (Array->flags & ARRAY_LIFECYCLE) lj_array_check_lifecycle(L, Array);
    if (Idx < 0 or MSize(Idx) >= Array->len) lj_err_msgv(L, ErrMsg::ARROB, Idx, int(Array->len));
    if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
    lj_array_store_checked(L, Array, uint32_t(Idx), Val);
@@ -263,6 +268,7 @@ extern "C" void lj_arr_setidx(lua_State *L, GCarray *Array, int32_t Idx, cTValue
 
 static void lj_arr_append_bytes(lua_State *L, GCarray *Array, const char *Data, MSize Len)
 {
+   if (Array->flags & ARRAY_LIFECYCLE) lj_array_check_lifecycle(L, Array);
    if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
    if (not (Array->elemtype IS AET::BYTE)) lj_err_msg(L, ErrMsg::ARRSTR);
    if (Len > (~MSize(0) - Array->len)) lj_err_msg(L, ErrMsg::ARREXT);
@@ -306,6 +312,7 @@ extern "C" void lj_arr_putnumtv(lua_State *L, GCarray *Array, cTValue *Value)
 
 extern "C" void lj_arr_clear(lua_State *L, GCarray *Array)
 {
+   if (Array->flags & ARRAY_LIFECYCLE) lj_array_check_lifecycle(L, Array);
    if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
 
    lj_array_clear_range(Array, 0, Array->len);
@@ -317,6 +324,7 @@ extern "C" void lj_arr_clear(lua_State *L, GCarray *Array)
 
 extern "C" int32_t lj_arr_resize(lua_State *L, GCarray *Array, int32_t NewSize)
 {
+   if (Array->flags & ARRAY_LIFECYCLE) lj_array_check_lifecycle(L, Array);
    if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
    if (NewSize < 0) lj_err_msgv(L, ErrMsg::NUMRNG, "non-negative", "negative");
 
@@ -349,6 +357,7 @@ extern "C" int32_t lj_arr_resize(lua_State *L, GCarray *Array, int32_t NewSize)
 
 extern "C" GCstr * lj_arr_getstring(lua_State *L, GCarray *Array, int32_t Start, int32_t Len)
 {
+   if (Array->flags & ARRAY_LIFECYCLE) lj_array_check_lifecycle(L, Array);
    if (not (Array->elemtype IS AET::BYTE)) lj_err_msg(L, ErrMsg::ARRSTR);
 
    int32_t count = Len;

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -475,6 +475,42 @@ static bool test_array_external(kt::Log &Log)
    return true;
 }
 
+static bool test_array_external_lifecycle(kt::Log &Log)
+{
+   LuaStateHolder holder;
+   lua_State *lua = holder.get();
+   if (not lua) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   OBJECTPTR owner = nullptr;
+   if (NewObject(CLASSID::TIME, &owner) != ERR::Okay) {
+      Log.error("failed to create lifecycle owner");
+      return false;
+   }
+
+   int32_t external_data[2] = { 10, 20 };
+   GCarray *array = lj_array_new(lua, 2, AET::INT32, external_data, ARRAY_EXTERNAL|ARRAY_READONLY, {}, nullptr,
+      owner);
+   if (not array->is_lifecycle_bound() or lj_array_stale(array)) {
+      Log.error("live lifecycle-bound array was reported stale");
+      FreeResource(owner);
+      return false;
+   }
+
+   FreeResource(owner);
+   if (not lj_array_stale(array)) {
+      Log.error("destroyed lifecycle owner did not stale its array view");
+      return false;
+   }
+   if (array->storage or array->len or array->capacity) {
+      Log.error("stale array view retained accessible storage");
+      return false;
+   }
+   return true;
+}
+
 //********************************************************************************************************************
 
 static bool test_array_element_contract(kt::Log &Log)
@@ -1296,7 +1332,7 @@ static bool test_lib_array_double_type(kt::Log &Log)
 
 void array_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 33> Tests = { {
+   constexpr std::array<TestCase, 34> Tests = { {
       // Core Data Structures
       { "array_creation_byte", test_array_creation_byte },
       { "array_creation_int32", test_array_creation_int32 },
@@ -1307,6 +1343,7 @@ void array_unit_tests(int &Passed, int &Total)
       { "array_index_access", test_array_index_access },
       { "array_elemsize", test_array_elemsize },
       { "array_external", test_array_external },
+      { "array_external_lifecycle", test_array_external_lifecycle },
       { "array_element_contract", test_array_element_contract },
       { "array_to_table", test_array_to_table },
       { "array_type_tag", test_array_type_tag },

--- a/src/tiri/tests/test_array_view.tiri
+++ b/src/tiri/tests/test_array_view.tiri
@@ -1,0 +1,169 @@
+-- Flute regression coverage for non-owning object array-field views.
+
+include 'display'
+
+function expect_failure(Action:func, Description:str)
+   local caught = false
+   try
+      Action()
+   except error_value
+      caught = true
+   end
+   assert(caught, Description)
+end
+
+function new_bitmap():obj
+   local bitmap = obj.new('bitmap', {
+      width=2, height=2, bitsPerPixel=32, bkgd='255,255,255,255'
+   })
+   bitmap.acClear()
+   return bitmap
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(display=true)
+function PrimitiveFieldViewIsLiveAndReadOnly()
+   local bitmap = new_bitmap()
+   local pixels <view> = bitmap.data
+
+   assert(array.readOnly(pixels), 'A field view must be read-only')
+   assert(pixels[0] is 255, 'The initial view should expose the bitmap storage')
+
+   bitmap.bkgd = '0,0,0,255'
+   bitmap.acClear()
+   assert(pixels[0] is 0, 'A view should observe native mutations without another field read')
+
+   expect_failure(() => do pixels[0] = 1 end, 'Element assignment through a view must fail')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(display=true)
+function DestroyedSourceStalesView()
+   local bitmap = new_bitmap()
+   local pixels <view> = bitmap.data
+   bitmap.free()
+
+   expect_failure(() => do local value = pixels[0] end,
+      'Access after explicit source destruction must raise a catchable error')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(display=true)
+function GarbageCollectedSourceStalesView()
+   local bitmap = new_bitmap()
+   local pixels <view> = bitmap.data
+   bitmap = nil
+   processing.collect()
+
+   expect_failure(() => do local value = pixels[0] end,
+      'A view must retain a testable weak-pinned source header after collection')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(display=true)
+function ViewModeIsOneShot()
+   local bitmap = new_bitmap()
+   local second
+
+   function read_twice(Bitmap:obj):array<any>
+      local first = Bitmap.data
+      second = Bitmap.data
+      return first
+   end
+
+   local first <view> = read_twice(bitmap)
+   assert(array.readOnly(first), 'The first object array read should consume view mode')
+   assert(not array.readOnly(second), 'A second object array read in the initialiser must remain a copy')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(display=true)
+function ErrorUnwindClearsViewMode()
+   expect_failure(() => do local failed <view> = error('expected failure') end,
+      'The failing view initialiser should be catchable')
+
+   local bitmap = new_bitmap()
+   local copied = bitmap.data
+   assert(not array.readOnly(copied), 'A failed view initialiser must not arm a later field read')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(display=true)
+function CaughtErrorPreservesOuterViewMode()
+   local bitmap = new_bitmap()
+
+   function read_after_error(Bitmap:obj):array<any>
+      try
+         error('expected failure')
+      except error_value
+      end
+      return Bitmap.data
+   end
+
+   local pixels <view> = read_after_error(bitmap)
+   assert(array.readOnly(pixels), 'A caught error inside the initialiser must preserve its active view scope')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(display=true)
+function NestedViewScopesAreIndependent()
+   local bitmap = new_bitmap()
+
+   function read_after_nested_view(Bitmap:obj):array<any>
+      local benign <view> = 42
+      return Bitmap.data
+   end
+
+   local pixels <view> = read_after_nested_view(bitmap)
+   assert(array.readOnly(pixels), 'A nested view declaration must not clear its outer view scope')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(display=true)
+function DestroyedSourceRejectsLengthAndFalseyChecks()
+   local bitmap = new_bitmap()
+   local pixels <view> = bitmap.data
+   bitmap.free()
+
+   expect_failure(() => do local length = #pixels end,
+      'The length operator must reject a stale view')
+   expect_failure(() => do local fallback = pixels ?? array<byte> end,
+      'Collection falsey checks must reject a stale view')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function UnsupportedAndBenignInitialisers()
+   local script = obj.new('script')
+   expect_failure(() => do local strings <view> = script.results end,
+      'String-array fields must reject view materialisation')
+
+   local number <view> = 42
+   assert(number is 42, 'A non-array view initialiser should be a benign no-op')
+
+   local existing = array<int> { 1, 2 }
+   local same <view> = existing
+   assert(same is existing and not array.readOnly(same),
+      'An existing array reference should pass through without changing its ownership or mutability')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function InvalidViewDeclarationsAreRejected()
+   expect_failure(() => exec('local first <view>, second = 1, 2'),
+      'A view declaration must reject multiple local names')
+   expect_failure(() => exec('local missing <view>'),
+      'A view declaration must require an initialiser')
+   expect_failure(() => exec('local combined <view><close> = 1'),
+      'A view declaration must reject another attribute on the same name')
+   expect_failure(() => exec('global invalid <view> = 1'),
+      'The view attribute must be local-only')
+end

--- a/src/tiri/tests/test_array_view.tiri
+++ b/src/tiri/tests/test_array_view.tiri
@@ -140,6 +140,22 @@ function DestroyedSourceRejectsLengthAndFalseyChecks()
 end
 
 -----------------------------------------------------------------------------------------------------------------------
+-- The lifecycle guard must cover operator paths that resolve the array directly, not just the array.* library
+-- functions.  Slicing and concatenation previously read freed storage instead of raising.
+
+@Test; @Requires(display=true)
+function DestroyedSourceRejectsOperatorAccess()
+   local bitmap = new_bitmap()
+   local pixels <view> = bitmap.data
+   bitmap.free()
+
+   expect_failure(() => do local slice = pixels[{0 to 1}] end,
+      'Range slicing must reject a stale view rather than copy freed storage')
+   expect_failure(() => do local joined = pixels .. 'x' end,
+      'Concatenation must reject a stale view rather than expose freed storage')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
 
 @Test function UnsupportedAndBenignInitialisers()
    local script = obj.new('script')

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -43,6 +43,7 @@ For more information on the Tiri syntax, please refer to the official Tiri Refer
 #include "lj_bc.h"
 #include "lj_array.h"
 #include "lj_gc.h"
+#include "lj_state.h"
 #include "lj_vm.h"
 
 JUMPTABLE_CORE

--- a/src/tiri/tiri_objects_indexes.cpp
+++ b/src/tiri/tiri_objects_indexes.cpp
@@ -678,8 +678,21 @@ template <class Callback> static int object_get_field(lua_State *Lua, const obj_
    return error != ERR::Okay ? 0 : 1;
 }
 
-static ERR make_object_field_array(lua_State *Lua, const Field *Field, size_t Elements, CPTR Values)
+static ERR make_object_field_array(lua_State *Lua, OBJECTPTR Object, const Field *Field, size_t Elements, CPTR Values,
+   bool View)
 {
+   if (View) {
+      if (Field->Flags & (FD_STRING|FD_OBJECT|FD_POINTER|FD_STRUCT)) return ERR::FieldTypeMismatch;
+      AET type = ff_to_aet(Field->Flags);
+      if (type IS AET::MAX) return ERR::FieldTypeMismatch;
+
+      GCarray *array = lj_array_new(Lua, Elements, type, (void *)Values, ARRAY_EXTERNAL|ARRAY_READONLY, {}, nullptr,
+         Object);
+      setarrayV(Lua, Lua->top++, array);
+      lj_gc_check(Lua);
+      return ERR::Okay;
+   }
+
    struct_record *struct_def = nullptr;
    std::string_view struct_name;
 
@@ -700,10 +713,12 @@ static ERR make_object_field_array(lua_State *Lua, const Field *Field, size_t El
 static int object_get_array(lua_State *Lua, const obj_read &Handle, GCobject *Def)
 {
    return object_get_field(Lua, Handle, Def, [Lua](OBJECTPTR Object, const Field *Field) -> ERR {
+      bool view = lj_array_take_view_mode(Lua);
       ERR error;
       std::span<int> span;
       if (Field->Flags & FD_VECTOR) { // kt::vector<>
          if (Field->Flags & FD_STRING) { // kt::vector<std::string>
+            if (view) return ERR::FieldTypeMismatch;
             std::span<std::string> values;
             if (!(error = Object->get(Field->FieldID, values))) {
                kt::vector<std::string> strings(values.data(), values.data() + values.size());
@@ -717,19 +732,21 @@ static int object_get_array(lua_State *Lua, const obj_read &Handle, GCobject *De
             // For kt::vector primitives we can just convert to a raw data array.
             std::span<int> values; // The type doesn't matter.
             if (!(error = Object->get(Field->FieldID, values, false))) {
-               error = make_object_field_array(Lua, Field, values.size(), values.data());
+               error = make_object_field_array(Lua, Object, Field, values.size(), values.data(), view);
             }
          }
       }
       else if (!(error = Object->get(Field->FieldID, span, false))) {
          if (Field->Flags & FD_STRING) {
+            if (view) return ERR::FieldTypeMismatch;
             make_array(Lua, AET::CSTR, span.size(), span.data());
          }
          else if (Field->Flags & FD_OBJECT) {
+            if (view) return ERR::FieldTypeMismatch;
             make_array(Lua, AET::OBJECT, span.size(), span.data());
          }
          else if (Field->Flags & (FD_INT|FD_INT64|FD_FLOAT|FD_DOUBLE|FD_POINTER|FD_BYTE|FD_WORD|FD_STRUCT)) {
-            error = make_object_field_array(Lua, Field, span.size(), span.data());
+            error = make_object_field_array(Lua, Object, Field, span.size(), span.data(), view);
          }
          else {
             kt::Log("object_get_array").warning("Invalid array type for '%s', flags: $%.8x", Field->Name,


### PR DESCRIPTION
* Introduced the <view> local attribute, parsed via a one-shot BC_VIEW bytecode that arms non-owning reads of an object's array field initialiser
* Added ARRAY_LIFECYCLE arrays that weak-pin the source Object and go stale (empty, storage cleared) once it terminates, with lj_array_check_lifecycle guarding every array access path
* Restricted <view> to a single local with a plain initialiser and primitive element types, rejecting string, object, pointer and struct fields
* Routed array length through lj_array_length and staleness checks so falsey tests and the length operator observe destroyed sources
* [JIT] Aborted trace recording on BC_VIEW and lifecycle-bound array loads, stores, length and falsey ops, guarding on array flags for recorded accesses
* Preserved and reset the armed view scopes across try-frame entry, handler setup and error throw