### PR TITLE
[Tiri] Return native struct arrays and enforce strict module-call argument typing

### DIFF
--- a/scripts/gui.tiri
+++ b/scripts/gui.tiri
@@ -362,7 +362,7 @@ end
 gui.getFontHeight = function(Font:table):<num,num>
    try<trace>
       if not Font.height then
-         err, handle = mVec.getFontHandle(Font.face, 'Regular', 0, Font.size)
+         err, handle = mVec.getFontHandle(Font.face, 'Regular', 0, tonumber(Font.size))
          metrics = struct.new('FontMetrics')
          mVec.getFontMetrics(handle, metrics)
          Font.height  = metrics.height

--- a/src/core/compression/class_compression.cpp
+++ b/src/core/compression/class_compression.cpp
@@ -17,7 +17,7 @@ The following examples demonstrate basic usage of compression objects in Tiri:
 <pre>
 // Create a new zip archive and compress two files.
 
-cmp = obj.new('compression', { path='temp:result.zip', flags='!NEW' } )
+cmp = obj.new('compression', { path='temp:result.zip', flags=CMF_NEW } )
 err = cmp.mtCompressFile('config:defs/compression.def', '')
 err = cmp.mtCompressFile('config:defs/core.def', '')
 

--- a/src/core/tests/test_messages.tiri
+++ b/src/core/tests/test_messages.tiri
@@ -6,12 +6,6 @@ local function new_message_id()
    return msg_id
 end
 
-local function free_handler(Handle)
-   if Handle then
-      mSys.FreeResource(Handle)
-   end
-end
-
 local function drain_messages()
    check mSys.ProcessMessages(0, 0)
 end
@@ -76,7 +70,6 @@ end
       return ERR_Okay
    end)
    assert(err is ERR_Okay, 'AddMsgHandler() failed: ' .. mSys.GetErrorMsg(err))
-   defer free_handler(handler) end
 
    check mSys.SendMessage(msg_id, 0, 'first')
    check mSys.SendMessage(msg_id, MSF_NO_DUPLICATE, 'second')
@@ -104,14 +97,12 @@ end
       return ERR_Okay
    end)
    assert(err is ERR_Okay, 'AddMsgHandler() for the calibration message failed: ' .. mSys.GetErrorMsg(err))
-   defer free_handler(calibrate_handler) end
 
    err, target_handler = mSys.AddMsgHandler(target_id, function(UID, Type, Data, Size)
       target_count++
       return ERR_Okay
    end)
    assert(err is ERR_Okay, 'AddMsgHandler() for the retargeted message failed: ' .. mSys.GetErrorMsg(err))
-   defer free_handler(target_handler) end
 
    check mSys.SendMessage(calibrate_id, 0)
    drain_messages()
@@ -144,7 +135,6 @@ end
       return ERR_Okay
    end)
    assert(err is ERR_Okay, 'AddMsgHandler() for the first message failed: ' .. mSys.GetErrorMsg(err))
-   defer free_handler(first_handler) end
 
    err, second_handler = mSys.AddMsgHandler(second_id, function(UID, Type, Data, Size)
       sequence ..= 'B'
@@ -152,7 +142,6 @@ end
       return ERR_Okay
    end)
    assert(err is ERR_Okay, 'AddMsgHandler() for the second message failed: ' .. mSys.GetErrorMsg(err))
-   defer free_handler(second_handler) end
 
    check mSys.SendMessage(first_id, 0, 'first')
    check mSys.SendMessage(second_id, 0, 'middle')

--- a/src/network/class_netlookup.cpp
+++ b/src/network/class_netlookup.cpp
@@ -561,7 +561,7 @@ static void resolve_callback(extNetLookup *Self, ERR Error, std::string_view Hos
       routine(Self, Error, HostName, Addresses, Self->Callback.Meta);
    }
    else if (Self->Callback.isScript()) {
-      // Tiri scripts can retrieve the host and addresses from the NetLookup object - it's a more optimal solution
+      // Tiri scripts can retrieve the host and addresses from NetLookup.Addresses, it's a more optimal solution
       sc::Call(Self->Callback, std::to_array<ScriptArg>({ { "NetLookup", Self, FDF_OBJECT }, { "Error", int(Error) } }));
    }
 }

--- a/src/network/tests/test_ipv6.tiri
+++ b/src/network/tests/test_ipv6.tiri
@@ -132,8 +132,10 @@ end
       callback = function(Lookup, Error)
          addresses = Lookup.addresses
          if (Error is ERR_Okay) and addresses then
+            assert(addresses is <array IPAddress>, 'NetLookup.addresses should be an IPAddress struct array')
             logOutput('[DNS] Resolved ' .. tostring(Lookup.hostName) .. ' to ' .. #addresses .. ' addresses:')
             for i, addr in ipairs(addresses) do
+               assert(type(addr) is 'struct', 'NetLookup.addresses should contain native structs')
                err, addr_str = mNet.AddressToStr(addr)
                check err
                type_str = (addr.type is IPADDR_V6) and 'IPv6' or 'IPv4'

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -125,12 +125,12 @@ static std::string_view array_struct_name(lua_State *L, int NArg)
 // garbage-collector ownership or managed-object lifetime tracking.  Embedded structures are safe only when every
 // nested field satisfies the same contract.
 
-static bool array_struct_is_trivial(const struct_record &Def)
+bool lj_array_struct_is_trivial(const struct_record &Def)
 {
    for (auto &field : Def.Fields) {
       if (field.Type & (FD_CPP|FD_VECTOR|FD_STRING|FD_FUNCTION|FD_OBJECT)) return false;
       if ((field.Type & FD_STRUCT) and (not (field.Type & FD_PTR))) {
-         if ((not field.StructDefinition) or (not array_struct_is_trivial(*field.StructDefinition))) return false;
+         if ((not field.StructDefinition) or (not lj_array_struct_is_trivial(*field.StructDefinition))) return false;
       }
    }
    return true;
@@ -327,7 +327,7 @@ LJLIB_CF(array_new)      LJLIB_REC(.)
          auto struct_name = array_struct_name(L, 2);
          if (struct_name.empty()) lj_err_argv(L, 2, ErrMsg::ARRTYPE);
          auto struct_def = find_struct(L, struct_name);
-         if ((not struct_def) or (not array_struct_is_trivial(*struct_def))) {
+         if ((not struct_def) or (not lj_array_struct_is_trivial(*struct_def))) {
             lj_err_argv(L, 2, ErrMsg::ARRTYPE);
          }
          arr = lj_array_new(L, uint32_t(size), elem_type, nullptr, 0, struct_name, struct_def);
@@ -368,7 +368,7 @@ LJLIB_CF(array_of)
       auto struct_name = array_struct_name(L, 1);
       if (struct_name.empty()) lj_err_argv(L, 1, ErrMsg::ARRTYPE);
       auto struct_def = find_struct(L, struct_name);
-      if ((not struct_def) or (not array_struct_is_trivial(*struct_def))) {
+      if ((not struct_def) or (not lj_array_struct_is_trivial(*struct_def))) {
          lj_err_argv(L, 1, ErrMsg::ARRTYPE);
       }
       arr = lj_array_new(L, uint32_t(num_values), elem_type, nullptr, 0, struct_name, struct_def);

--- a/src/tiri/jit/src/runtime/lj_array.h
+++ b/src/tiri/jit/src/runtime/lj_array.h
@@ -9,6 +9,7 @@ extern GCarray * lj_array_new(lua_State *, uint32_t, AET, void *Data = nullptr, 
    std::string_view StructName = {}, struct_record *StructDef = nullptr);
 extern void lj_array_free(global_State *, GCarray *);
 [[nodiscard]] extern uint8_t lj_array_elemsize(AET);
+[[nodiscard]] extern bool lj_array_struct_is_trivial(const struct_record &Def);
 extern void lj_array_clear_range(GCarray *, MSize Start, MSize Count);
 extern void lj_array_copy(lua_State *, GCarray *, uint32_t dstidx, GCarray *, uint32_t srcidx, uint32_t count);
 extern GCtab* lj_array_to_table(lua_State *, GCarray *);

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -722,13 +722,30 @@ void make_struct_array(lua_State *Lua, std::string_view StructName, int Elements
       luaL_error(Lua, ERR::Search, "Failed to find struct '%.*s'", int(StructName.size()), StructName.data());
    }
 
+   int struct_stride = (Stride > 0) ? Stride : sdef->Size;
+   if (lj_array_struct_is_trivial(*sdef)) {
+      GCarray *arr;
+      if (Input and (struct_stride IS sdef->Size)) {
+         arr = lj_array_new(Lua, Elements, AET::STRUCT, (void *)Input, ARRAY_CACHED, sdef->Name, sdef);
+      }
+      else {
+         arr = lj_array_new(Lua, Elements, AET::STRUCT, nullptr, 0, sdef->Name, sdef);
+         for (int i=0; Input and (i < Elements); i++) {
+            std::memcpy(lj_array_index(arr, i), Input, sdef->Size);
+            Input = (int8_t *)Input + struct_stride;
+         }
+      }
+      setarrayV(Lua, Lua->top++, arr);
+      lj_gc_check(Lua);
+      return;
+   }
+
    GCarray *arr = lj_array_new(Lua, Elements, AET::TABLE);
    setarrayV(Lua, Lua->top++, arr); // Push to stack immediately to protect from GC during loop
    int arr_idx = lua_gettop(Lua);
 
    if (Input) {
       std::vector<lua_ref> ref;
-      int struct_stride = (Stride > 0) ? Stride : sdef->Size;
 
       for (int i=0; i < Elements; i++) {
          if (!struct_to_table(Lua, ref, *sdef, Input)) {

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -80,21 +80,17 @@ struct ModuleBinding;
 // the call bridge construct only the elements a signature actually uses, and lets preparation reject a signature whose
 // demands would exceed a bounded store instead of discovering the overflow mid-call.
 //
-// Counts are upper bounds.  A conditional temporary, such as the structure conversion performed only when a script
-// passes a table, is counted for every argument that could require it.
-
 struct marshalling_profile {
    uint8_t Strings = 0;         // Mutable std::string temporaries (FD_STR|FD_CPP with FD_MUTABLE or FD_RESULT)
    uint8_t StringViews = 0;     // std::string_view temporaries (FD_STR|FD_CPP, read-only)
    uint8_t MutableStrings = 0;  // Copy-back records for mutable std::string arguments
-   uint8_t Structs = 0;         // Table-to-structure conversions
    uint8_t Arrays = 0;          // kt::vector<> results
    uint8_t Spans = 0;           // std::span wrappers
 
    // True when the signature needs no bridge-owned temporary at all.  Scalar-only and read-only C-string calls take
    // this path and perform no heap allocation of their own.
    [[nodiscard]] bool trivial_storage() const noexcept {
-      return not (Strings or StringViews or MutableStrings or Structs or Arrays or Spans);
+      return not (Strings or StringViews or MutableStrings or Arrays or Spans);
    }
 };
 
@@ -467,10 +463,6 @@ static void profile_arg(const FunctionField &Field, marshalling_profile &Profile
       return;
    }
 
-   // A pointer argument allocates a structure only when the script passes a table, which cannot be known until the
-   // call.  Counting it unconditionally keeps the bound safe for every input the argument accepts.
-
-   if ((argtype & FD_PTR) and (argtype & FD_STRUCT)) Profile.Structs++;
 }
 
 //********************************************************************************************************************
@@ -583,8 +575,8 @@ static void prepare_module_callables(ModuleBinding *Module, const Function *Func
 
       if (callable->valid()) {
          if ((profile.Strings > MAX_MODULE_ARGS) or (profile.StringViews > MAX_MODULE_ARGS) or
-             (profile.MutableStrings > MAX_MODULE_ARGS) or (profile.Structs > MAX_MODULE_ARGS) or
-             (profile.Arrays > MAX_MODULE_ARGS) or (profile.Spans > MAX_MODULE_ARGS)) {
+             (profile.MutableStrings > MAX_MODULE_ARGS) or (profile.Arrays > MAX_MODULE_ARGS) or
+             (profile.Spans > MAX_MODULE_ARGS)) {
             callable->invalidate();
             log.msg("Function '%s' exceeds the bounded temporary storage limit.", callable->Name);
          }
@@ -1207,12 +1199,14 @@ extern "C" void tiri_module_activate(lua_State *Lua, uint32_t Dependency)
 //
 // A breakdown of possible FD configurations follows.  Input values:
 //
-// STR          = CSTRING.  Read-only string pointer.  Tiri string/number/boolean are accepted; NULL permitted
-// STR|CPP      = const std::string_view &.  Read-only string view.  A real string value is required.
+// STR          = CSTRING.  Read-only string pointer.  Tiri string values are accepted; NULL is permitted.
+// STR|CPP      = const std::string_view &.  Read-only string view.  Tiri nil becomes a zero-length view with
+//                null data.
 // PTR          = APTR.  Raw pointer input.  Tiri strings, arrays, structs, objects and userdata can provide
 //                backing storage depending on the call.
-// PTR|STRUCT   = Struct *.  Accepts an existing Tiri struct or converts a Tiri table to a temporary struct.
+// PTR|STRUCT   = Struct *.  Requires an existing Tiri struct.
 // OBJECT|PTR   = OBJECTPTR.  Accepts a Tiri object and resolves it to an object pointer.
+// INT/DOUBLE/INT64 = Numeric values.  Tiri nil or a missing argument becomes zero.
 // ARRAY        = Unsupported.  Raw pointer-array marshalling has been removed.
 // ARRAY|CPP    = Unsupported as input.  kt::vector<> input marshalling is not implemented for module calls.
 // SPAN         = const std::span<T> &.  Accepts matching Tiri array or structure storage, byte strings or an empty value.
@@ -1269,51 +1263,6 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
    uint8_t buffer[BUFFER_SIZE]; // 16 bytes per argument accommodates output metadata such as sizes.
    int i;
 
-   // Track dynamically allocated objects for cleanup
-   struct allocated_struct_ref {
-      std::unique_ptr<uint8_t[]> Data;
-      struct_record *Def = nullptr;
-      lua_State *Lua = nullptr;
-
-      allocated_struct_ref() = default;
-      allocated_struct_ref(std::unique_ptr<uint8_t[]> InitData, struct_record *InitDef, lua_State *InitLua):
-         Data(std::move(InitData)), Def(InitDef), Lua(InitLua) { }
-
-      allocated_struct_ref(const allocated_struct_ref &) = delete;
-      allocated_struct_ref & operator=(const allocated_struct_ref &) = delete;
-
-      allocated_struct_ref(allocated_struct_ref &&Other) noexcept:
-         Data(std::move(Other.Data)), Def(Other.Def), Lua(Other.Lua) {
-         Other.Def = nullptr;
-         Other.Lua = nullptr;
-      }
-
-      allocated_struct_ref & operator=(allocated_struct_ref &&Other) noexcept {
-         if (this != &Other) {
-            release();
-            Data = std::move(Other.Data);
-            Def = Other.Def;
-            Lua = Other.Lua;
-            Other.Def = nullptr;
-            Other.Lua = nullptr;
-         }
-         return *this;
-      }
-
-      ~allocated_struct_ref() {
-         release();
-      }
-
-      void release() {
-         if (Data) {
-            if (Def) destroy_struct_cpp_strings(Lua, *Def, Data.get());
-            Data.reset();
-            Def = nullptr;
-            Lua = nullptr;
-         }
-      }
-   };
-
    struct mutable_cpp_string_ref {
       std::string *Source;
       GCstr *Target;
@@ -1329,7 +1278,6 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
 
    bounded_store<std::string, MAX_MODULE_ARGS> strings;
    bounded_store<std::string_view, MAX_MODULE_ARGS> string_views;
-   bounded_store<allocated_struct_ref, MAX_MODULE_ARGS> allocated_structs;
    bounded_store<mutable_cpp_string_ref, MAX_MODULE_ARGS> mutable_cpp_strings;
    bounded_store<cpp_array_result, MAX_MODULE_ARGS> cpp_arrays;
    std::array<module_span_arg, MAX_MODULE_ARGS> span_args;
@@ -1693,7 +1641,12 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
             }
             else ((CSTRING *)(buffer + j))[0] = strdatawr(string);
          }
-         else if (argtype & FD_CPP) { // Read-only std::string_view (enforced, cannot be nullptr)
+         else if (argtype & FD_CPP) { // Read-only std::string_view; nil has null data and zero length.
+            if ((type != LUA_TSTRING) and (type != LUA_TNIL) and (type != LUA_TNONE)) {
+               ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected string, got {} '{}'.", i, args[i].Name,
+                  lua_typename(Lua, type), value_string(Lua, i));
+               return ERR::InvalidType;
+            }
             size_t len;
             auto str = lua_tolstring(Lua, i, &len);
             auto view = str ? string_views.emplace(str, len) : string_views.emplace();
@@ -1703,7 +1656,7 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
             }
             ((std::string_view **)(buffer + j))[0] = view;
          }
-         else if ((type IS LUA_TSTRING) or (type IS LUA_TNUMBER) or (type IS LUA_TBOOLEAN)) {
+         else if (type IS LUA_TSTRING) {
             ((CSTRING *)(buffer + j))[0] = lua_tostring(Lua, i);
          }
          else if (type <= 0) {
@@ -1785,38 +1738,17 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
             in++;
             j += sizeof(APTR);
          }
-         else if (arg_type IS LUA_TTABLE) {
-            if (args[i].Type & FD_STRUCT) {
-               // Convert Lua table to C struct
-               lua_pushvalue(Lua, i); // Duplicate table for table_to_struct (consumes stack)
-               std::unique_ptr<uint8_t[]> struct_data;
-               if (!table_to_struct(Lua, args[i].Name, struct_data)) {
-                  auto struct_address = struct_data.get();
-                  auto def = find_struct(Lua, args[i].Name);
-                  if (not allocated_structs.emplace(std::move(struct_data), def, Lua)) {
-                     ErrorMsg = std::format("Function '{}' exceeded its structure storage.", callable->Name);
-                     return ERR::BufferOverflow;
-                  }
-                  ((APTR *)(buffer + j))[0] = struct_address;
-                  arg_values[in] = buffer + j;
-                  in++;
-                  j += sizeof(APTR);
-               }
-               else {
-                  ErrorMsg = std::format("Failed to convert table to struct for arg #{} ({}).", i, args[i].Name);
-                  return ERR::Failed;
-               }
-            }
-            else {
-               ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected pointer, got table.", i, args[i].Name);
-               return ERR::InvalidType;
-            }
-         }
-         else {
+         else if ((arg_type IS LUA_TUSERDATA) or (arg_type IS LUA_TLIGHTUSERDATA) or (arg_type IS LUA_TNIL) or
+                  (arg_type IS LUA_TNONE)) {
             ((APTR *)(buffer + j))[0] = lua_touserdata(Lua, i); //lua_topointer?
             arg_values[in] = buffer + j;
             in++;
             j += sizeof(APTR);
+         }
+         else {
+            ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected pointer-compatible storage, got {} '{}'.", i,
+               args[i].Name, lua_typename(Lua, arg_type), value_string(Lua, i));
+            return ERR::InvalidType;
          }
       }
       else if (argtype & FD_INT) {
@@ -1824,22 +1756,50 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
 
          if (argtype & FD_OBJECT) {
             if (tvisobject(tv)) ((int *)(buffer + j))[0] = objectV(tv)->uid;
+            else if (lua_type(Lua, i) <= LUA_TNIL) ((int *)(buffer + j))[0] = 0;
+            else if (lua_type(Lua, i) IS LUA_TNUMBER) ((int *)(buffer + j))[0] = lua_tointeger(Lua, i);
+            else {
+               ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected object or number, got {} '{}'.", i,
+                  args[i].Name, lua_typename(Lua, lua_type(Lua, i)), value_string(Lua, i));
+               return ERR::InvalidType;
+            }
+         }
+         else {
+            if (lua_type(Lua, i) <= LUA_TNIL) {
+               ((int *)(buffer + j))[0] = 0;
+            }
+            else if (lua_type(Lua, i) != LUA_TNUMBER) {
+               ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected number, got {} '{}'.", i, args[i].Name,
+                  lua_typename(Lua, lua_type(Lua, i)), value_string(Lua, i));
+               return ERR::InvalidType;
+            }
+            else if (argtype & FD_UNSIGNED) ((uint32_t *)(buffer + j))[0] = lua_tointeger(Lua, i);
             else ((int *)(buffer + j))[0] = lua_tointeger(Lua, i);
          }
-         else if (argtype & FD_UNSIGNED) ((uint32_t *)(buffer + j))[0] = lua_tointeger(Lua, i);
-         else ((int *)(buffer + j))[0] = lua_tointeger(Lua, i);
          arg_values[in] = buffer + j;
          in++;
          j += sizeof(int);
       }
       else if (argtype & FD_DOUBLE) {
-         ((double *)(buffer + j))[0] = lua_tonumber(Lua, i);
+         if (lua_type(Lua, i) <= LUA_TNIL) ((double *)(buffer + j))[0] = 0.0;
+         else if (lua_type(Lua, i) != LUA_TNUMBER) {
+            ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected number, got {} '{}'.", i, args[i].Name,
+               lua_typename(Lua, lua_type(Lua, i)), value_string(Lua, i));
+            return ERR::InvalidType;
+         }
+         else ((double *)(buffer + j))[0] = lua_tonumber(Lua, i);
          arg_values[in] = buffer + j;
          in++;
          j += sizeof(double);
       }
       else if (argtype & FD_INT64) {
-         ((int64_t *)(buffer + j))[0] = lua_tointeger(Lua, i);
+         if (lua_type(Lua, i) <= LUA_TNIL) ((int64_t *)(buffer + j))[0] = 0;
+         else if (lua_type(Lua, i) != LUA_TNUMBER) {
+            ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected number, got {} '{}'.", i, args[i].Name,
+               lua_typename(Lua, lua_type(Lua, i)), value_string(Lua, i));
+            return ERR::InvalidType;
+         }
+         else ((int64_t *)(buffer + j))[0] = lua_tointeger(Lua, i);
          arg_values[in] = buffer + j;
          in++;
          j += sizeof(int64_t);

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -1609,6 +1609,9 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
          j += sizeof(FUNCTION *);
       }
       else if (argtype & FD_STR) {
+         // Resolve thunks before reading the type so a thunk that yields a string is marshalled by its resolved
+         // value rather than rejected as its unresolved userdata container.
+         resolve_index(Lua, i);
          auto type = lua_type(Lua, i);
          int type_size = sizeof(APTR);
 
@@ -1681,6 +1684,7 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
          return ERR::NoSupport;
       }
       else if (argtype & FD_PTR) {
+         resolve_index(Lua, i); // Resolve thunks so the resolved value is marshalled, not the thunk userdata.
          auto arg_type = lua_type(Lua, i);
          if (arg_type IS LUA_TSTRING) {
             // Lua strings need to be converted to C strings
@@ -1781,6 +1785,7 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
          j += sizeof(int);
       }
       else if (argtype & FD_DOUBLE) {
+         resolve_index(Lua, i); // Resolve thunks so a number-yielding thunk is accepted by the strict check.
          if (lua_type(Lua, i) <= LUA_TNIL) ((double *)(buffer + j))[0] = 0.0;
          else if (lua_type(Lua, i) != LUA_TNUMBER) {
             ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected number, got {} '{}'.", i, args[i].Name,
@@ -1793,6 +1798,7 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
          j += sizeof(double);
       }
       else if (argtype & FD_INT64) {
+         resolve_index(Lua, i); // Resolve thunks so a number-yielding thunk is accepted by the strict check.
          if (lua_type(Lua, i) <= LUA_TNIL) ((int64_t *)(buffer + j))[0] = 0;
          else if (lua_type(Lua, i) != LUA_TNUMBER) {
             ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected number, got {} '{}'.", i, args[i].Name,

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -611,7 +611,7 @@ GCstruct * push_struct(extTiri *Self, APTR Address, std::string_view StructName,
       // an empty structure declaration.
 
       static struct_record empty("");
-      return push_struct_def(Self->Lua, Address, empty, false, Lifecycle);
+      return push_struct_def(Self->Lua, Address, empty, Deallocate, Lifecycle);
    }
    else {
       if (Deallocate) FreeResource(Address);
@@ -637,7 +637,7 @@ GCstruct * push_struct(extTiri *Self, APTR Address, uint32_t StructKey, bool Dea
       // Preserve the name-based overload's fallback for resource structs that Tiri does not know about.
 
       static struct_record empty("");
-      return push_struct_def(Self->Lua, Address, empty, false, Lifecycle);
+      return push_struct_def(Self->Lua, Address, empty, Deallocate, Lifecycle);
    }
    else {
       if (Deallocate) FreeResource(Address);


### PR DESCRIPTION
* make_struct_array now builds a native STRUCT array for trivial structs instead of a table of tables, sharing the input buffer when the stride matches
* Removed table-to-struct conversion from module calls; PTR|STRUCT arguments now require an existing Tiri struct
* Enforced strict type checking for STR|CPP, INT, DOUBLE and INT64 arguments, with nil/missing mapped to zero-length views or zero and mismatches reported as ERR::InvalidType
* Dropped the Structs marshalling profile field and the allocated_struct_ref cleanup machinery that table conversion required
* Exposed lj_array_struct_is_trivial for reuse by the struct-array builder
* push_struct now honours the Deallocate flag for unknown resource structs
* [Test] test_ipv6 asserts NetLookup.addresses is a native IPAddress struct array