### PR TITLE
[Tiri] Added live read-only views for object array fields

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -861,7 +861,7 @@ endif ()
 
 set (TIRI_TESTS
    defer debuglog io object regex struct async async_actions async_wait xml strings math array array_any array_manip
-   array_element_validation
+   array_element_validation array_view
    array_functional array_typed_syntax bitshift bitwise has_operator approx if_empty if_empty_guard presence blank ternary table stress unit_tests
    jitoptions fstring const const_optimisation import_scope unicode ellipsis safe_nav close type_annotations type_fixing
    type_inference jit jit_try_regex pipe pipe_iteration arrow_functions result_filter thunks deferred_expr shadow_assert

--- a/src/tiri/jit/src/bytecode/lj_bc.h
+++ b/src/tiri/jit/src/bytecode/lj_bc.h
@@ -296,7 +296,9 @@ constexpr uint8_t  NO_REG = BCMAX_A;
   _(CLOSEARM,  var,  ___, ___, ___) \
   _(CLOSE,     var,  ___, ___, ___) \
   /* Boolean contextual type test. */ \
-  _(TYPETEST,  var,  ___, str, ___)
+  _(TYPETEST,  var,  ___, str, ___) \
+  /* Arm or clear the one-shot object array view read mode. */ \
+  _(VIEW,      ___,  ___, lit, ___)
 
 // Bytecode opcode numbers.
 // Explicitly enumerated for debugger visibility and easy value lookup.
@@ -473,8 +475,9 @@ typedef enum {
    BC_CLOSEARM = 132,
    BC_CLOSE = 133,
    BC_TYPETEST = 134,
+   BC_VIEW = 135,
 
-   BC__MAX   = 135
+   BC__MAX   = 136
 } BCOp;
 
 [[nodiscard]] inline constexpr bool bc_is_func_header(BCOp Op) noexcept

--- a/src/tiri/jit/src/bytecode/lj_bcread.cpp
+++ b/src/tiri/jit/src/bytecode/lj_bcread.cpp
@@ -342,6 +342,9 @@ static void bcread_bytecode(LexState *State, GCproto *pt, MSize sizebc)
          BCREG slot = bc_a(bc[i]);
          if (slot >= pt->framesize or slot >= 64) bcread_error(State, ErrMsg::BCBAD);
       }
+      else if (op IS BC_VIEW) {
+         if (bc_a(bc[i]) != 0 or bc_d(bc[i]) > 1) bcread_error(State, ErrMsg::BCBAD);
+      }
       else if (op IS BC_CTXENTER or op IS BC_CTXCALL or op IS BC_CTXCALLM or op IS BC_CTXLEAVE or
                op IS BC_CTXCALLT) {
          BCREG call_base = bc_a(bc[i]);

--- a/src/tiri/jit/src/debug/lj_err.cpp
+++ b/src/tiri/jit/src/debug/lj_err.cpp
@@ -593,6 +593,8 @@ extern "C" void setup_try_handler(lua_State *L)
 
    L->base = restorestack(L, try_frame->frame_base);
    L->top = restorestack(L, try_frame->saved_top);
+   L->array_view_scopes = try_frame->array_view_scopes;
+   L->array_view_depth = try_frame->array_view_depth;
    L->try_stack.depth--; // Pop try frame
 
    // Build exception table and place in handler's register (pass pending_trace, which may be null)
@@ -1118,6 +1120,8 @@ static void err_raise_ext(global_State* g, int errcode)
 
 LJ_NOINLINE void lj_err_throw(lua_State *L, int errcode)
 {
+   L->array_view_scopes = 0;
+   L->array_view_depth = 0;
    global_State* g = G(L);
 
    auto J = G2J(g);

--- a/src/tiri/jit/src/debug/lj_err.cpp
+++ b/src/tiri/jit/src/debug/lj_err.cpp
@@ -1120,11 +1120,13 @@ static void err_raise_ext(global_State* g, int errcode)
 
 LJ_NOINLINE void lj_err_throw(lua_State *L, int errcode)
 {
-   L->array_view_scopes = 0;
-   L->array_view_depth = 0;
    global_State* g = G(L);
 
    auto J = G2J(g);
+   if (not J->abort_in_progress) {
+      L->array_view_scopes = 0;
+      L->array_view_depth = 0;
+   }
    kt::Log(__FUNCTION__).detail("Throwing error: code=%d, Abort: %d, Top: %p, Base: %p, Valid Stack: %d", errcode, J->abort_in_progress, L->top, L->base, L->top >= L->base);
 
    lj_trace_abort(g);

--- a/src/tiri/jit/src/debug/try_except.cpp
+++ b/src/tiri/jit/src/debug/try_except.cpp
@@ -254,6 +254,8 @@ extern "C" void lj_try_enter(lua_State *L, GCfunc *Func, TValue *Base, uint16_t 
    try_frame->flags           = block_desc->flags;
    try_frame->context_depth   = L->context_stack.size();
    try_frame->context_floor   = L->context_root_floors.empty() ? 0 : L->context_root_floors.back();
+   try_frame->array_view_scopes = L->array_view_scopes;
+   try_frame->array_view_depth  = L->array_view_depth;
    lj_assertL(try_frame->context_depth >= try_frame->context_floor,
       "try context depth is below the active asynchronous root floor");
 }

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -4872,6 +4872,17 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_next
     break;
 
+  case BC_VIEW:
+    |  ldr L, SAVE_L
+    |  str BASE, L->base
+    |  mov CARG1, L
+    |  mov CARG2w, RDw
+    |  str PC, SAVE_PC
+    |  bl extern lj_array_view_mode
+    |  ldr BASE, L->base
+    |  ins_next
+    break;
+
   case BC_TYPETEST:
     |  ldr L, SAVE_L
     |  str BASE, L->base

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -6938,6 +6938,17 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_next
     break;
 
+  case BC_VIEW:
+    |  lwz L, SAVE_L
+    |  stp BASE, L->base
+    |  mr CARG1, L
+    |  mr CARG2, RD
+    |  stw PC, SAVE_PC
+    |  bl extern lj_array_view_mode
+    |  lp BASE, L->base
+    |  ins_next
+    break;
+
   case BC_TYPETEST:
     |  lwz L, SAVE_L
     |  stp BASE, L->base

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -5883,6 +5883,18 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_next
     break;
 
+  case BC_VIEW:
+    |  ins_AD
+    |  mov L:RB, SAVE_L
+    |  mov L:RB->base, BASE
+    |  mov CARG2d, RDd
+    |  mov L:CARG1, L:RB
+    |  mov SAVE_PC, PC
+    |  call extern lj_array_view_mode
+    |  mov BASE, L:RB->base
+    |  ins_next
+    break;
+
   case BC_TYPETEST:
     |  mov L:RB, SAVE_L
     |  mov L:RB->base, BASE

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -5084,6 +5084,7 @@ void lj_record_ins(jit_State *J)
 
    case BC_CLOSEARM:
    case BC_CLOSE:
+   case BC_VIEW:
       lj_trace_err_info(J, LJ_TRERR_NYIBC);
       break;
 

--- a/src/tiri/jit/src/parser/ast/builder.cpp
+++ b/src/tiri/jit/src/parser/ast/builder.cpp
@@ -809,7 +809,7 @@ ParserResult<std::unique_ptr<BlockStmt>> AstBuilder::parse_block(std::span<const
 }
 
 //********************************************************************************************************************
-// Check if an identifier is followed by a <const> or <close> attribute.  Due to lexer lookahead buffer complexities,
+// Check if an identifier is followed by a recognised declaration attribute.  Due to lexer lookahead complexities,
 // we access the lexer's buffered_tokens directly when the special '<identifier' handling has been triggered.
 //
 // Patterns: `name <attr>`, `name:type <attr>`
@@ -830,7 +830,7 @@ static bool is_implicit_local_with_attribute(TokenStreamAdapter& Tokens)
    // - peek(2): <
    // - peek(3): >
    //
-   // We need to detect: identifier (current) followed by 'const'/'close' then '<' then '>'
+   // We need to detect: identifier (current) followed by the attribute name, '<', then '>'.
 
    size_t pos = 1;
    Token next = Tokens.peek(pos);
@@ -847,14 +847,14 @@ static bool is_implicit_local_with_attribute(TokenStreamAdapter& Tokens)
       next = Tokens.peek(pos);
    }
 
-   // Next should be 'const' or 'close' (the buffered identifier from '<identifier' handling)
+   // Next should be a recognised attribute (the buffered identifier from '<identifier' handling)
    if (next.kind() != TokenKind::Identifier) return false;
 
    GCstr* attr_name = next.identifier();
    if (!attr_name) return false;
 
    std::string_view attr_str(strdata(attr_name), attr_name->len);
-   if (attr_str != "const" and attr_str != "close") return false;
+   if (attr_str != "const" and attr_str != "close" and attr_str != "view") return false;
 
    // After the attribute name, we should see '<' (which was returned by the lexer)
    Token angle_open = Tokens.peek(pos + 1);
@@ -937,7 +937,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_statement()
             }
          }
 
-         // Check for implicit local declaration with <const> or <close> attribute
+         // Check for an implicit local declaration carrying an attribute.
          if (is_implicit_local_with_attribute(this->ctx.tokens())) {
             return this->parse_local();
          }

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -415,7 +415,7 @@ ParserResult<std::vector<Identifier>> AstBuilder::parse_name_list()
          }
       }
 
-      // Check for attribute: either '<' (normal case) or 'const'/'close' followed by '<' (buffered case)
+      // Check for attribute: either '<' (normal case) or its buffered identifier followed by '<'.
       // The buffered case occurs when the lexer's '<identifier' handling put the identifier in the buffer
       // before the '<', and then when we advanced past the variable name, we got the buffered identifier.
       bool is_buffered_attribute = false;
@@ -423,7 +423,8 @@ ParserResult<std::vector<Identifier>> AstBuilder::parse_name_list()
          GCstr *maybe_attr = this->ctx.tokens().current().identifier();
          if (maybe_attr) {
             std::string_view attr_view(strdata(maybe_attr), maybe_attr->len);
-            if ((attr_view IS "const" or attr_view IS "close") and this->ctx.tokens().peek(1).raw() IS '<') {
+            if ((attr_view IS "const" or attr_view IS "close" or attr_view IS "view") and
+                  this->ctx.tokens().peek(1).raw() IS '<') {
                is_buffered_attribute = true;
             }
          }
@@ -432,15 +433,17 @@ ParserResult<std::vector<Identifier>> AstBuilder::parse_name_list()
       if (this->ctx.tokens().current().raw() IS '<' or is_buffered_attribute) {
          bool is_close_attribute = false;
          bool is_const_attribute = false;
+         bool is_view_attribute = false;
 
          if (is_buffered_attribute) {
-            // Current token is already the attribute name ('const' or 'close')
+            // Current token is already the attribute name.
             GCstr *attr_name = this->ctx.tokens().current().identifier();
             std::string_view view(strdata(attr_name), attr_name->len);
             if (view IS "close") is_close_attribute = true;
             else if (view IS "const") is_const_attribute = true;
+            else if (view IS "view") is_view_attribute = true;
 
-            this->ctx.tokens().advance();  // Advance past 'const'/'close'
+            this->ctx.tokens().advance();  // Advance past the attribute name
             this->ctx.tokens().advance();  // Advance past '<'
          }
          else {
@@ -454,6 +457,7 @@ ParserResult<std::vector<Identifier>> AstBuilder::parse_name_list()
                std::string_view view(strdata(attr_name), attr_name->len);
                if (view IS std::string_view("close")) is_close_attribute = true;
                else if (view IS std::string_view("const")) is_const_attribute = true;
+               else if (view IS std::string_view("view")) is_view_attribute = true;
             }
          }
 
@@ -466,6 +470,7 @@ ParserResult<std::vector<Identifier>> AstBuilder::parse_name_list()
 
          if (is_close_attribute) identifier.has_close = true;
          else if (is_const_attribute) identifier.has_const = true;
+         else if (is_view_attribute) identifier.has_view = true;
          else {
             this->ctx.emit_error(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(), "unknown attribute");
          }

--- a/src/tiri/jit/src/parser/ast/nodes.cpp
+++ b/src/tiri/jit/src/parser/ast/nodes.cpp
@@ -1069,6 +1069,7 @@ size_t ast_expression_child_count(const ExprNode &Node)
 // Constructor for Identifier that creates an identifier from a string.
 
 Identifier::Identifier(lua_State* L, const char* Name, SourceSpan Span)
-   : symbol(lj_str_new(L, Name, std::strlen(Name))), span(Span), is_blank(false), has_close(false), type(TiriType::Unknown)
+   : symbol(lj_str_new(L, Name, std::strlen(Name))), span(Span), is_blank(false), has_close(false), has_const(false),
+     has_view(false), type(TiriType::Unknown)
 {
 }

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -235,6 +235,7 @@ struct Identifier {
    bool is_blank = false;
    bool has_close = false;
    bool has_const = false;  // Const attribute flag - variable cannot be reassigned
+   bool has_view = false;   // View attribute flag - first object array read is non-owning
    bool is_future_reserved = false;  // True when parsed from a keyword reserved for future syntax
    TiriType type = TiriType::Unknown;  // Explicit type annotation (Unknown = no annotation)
    struct_record *struct_def = nullptr; // Resolved layout for struct<Name> annotations
@@ -263,6 +264,7 @@ struct Identifier {
       id.is_blank = false;
       id.has_close = false;
       id.has_const = false;
+      id.has_view = false;
       id.is_future_reserved = false;
       return id;
    }

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -11,7 +11,7 @@
 
 //********************************************************************************************************************
 // Parses local variable declarations, local function statements and local thunk function statements.
-// Supports both explicit 'local' keyword and implicit local declarations with <const>/<close> attributes.
+// Supports both explicit 'local' keyword and implicit local declarations with declaration attributes.
 
 ParserResult<StmtNodePtr> AstBuilder::parse_local()
 {
@@ -109,6 +109,27 @@ ParserResult<StmtNodePtr> AstBuilder::parse_local()
       values.resize(name_count);
    }
 
+   auto view = std::find_if(name_list.begin(), name_list.end(), [](const Identifier &Identifier) {
+      return Identifier.has_view;
+   });
+   if (view != name_list.end()) {
+      if (name_list.size() != 1) {
+         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken,
+            Token::from_span(view->span, TokenKind::Identifier),
+            "A <view> declaration requires exactly one local name");
+      }
+      if (values.empty() or assign_op != AssignmentOperator::Plain) {
+         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken,
+            Token::from_span(view->span, TokenKind::Identifier),
+            "A <view> local requires an initialiser");
+      }
+      if (view->has_close or view->has_const) {
+         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken,
+            Token::from_span(view->span, TokenKind::Identifier),
+            "The <view> attribute cannot be combined with <close> or <const>");
+      }
+   }
+
    auto stmt = std::make_unique<StmtNode>(AstNodeKind::LocalDeclStmt, local_token.span());
    stmt->data.emplace<LocalDeclStmtPayload>(assign_op, std::move(name_list), std::move(values));
    return ParserResult<StmtNodePtr>::success(std::move(stmt));
@@ -169,6 +190,14 @@ ParserResult<StmtNodePtr> AstBuilder::parse_global()
 
    auto names = this->parse_name_list();
    if (not names.ok()) return ParserResult<StmtNodePtr>::failure(names.error_ref());
+
+   for (const Identifier &identifier : names.value_ref()) {
+      if (identifier.has_view) {
+         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken,
+            Token::from_span(identifier.span, TokenKind::Identifier),
+            "The <view> attribute is only valid on local declarations");
+      }
+   }
 
    ExprNodeList values;
    AssignmentOperator assign_op = AssignmentOperator::Plain;
@@ -272,7 +301,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_extern()
             Token::from_span(identifier.span, TokenKind::Identifier), "extern declarations require named symbols");
       }
 
-      if (identifier.type != TiriType::Unknown or identifier.has_const or identifier.has_close) {
+      if (identifier.type != TiriType::Unknown or identifier.has_const or identifier.has_close or identifier.has_view) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken,
             Token::from_span(identifier.span, TokenKind::Identifier),
             "Extern declarations cannot have type annotations or attributes");
@@ -682,7 +711,7 @@ static bool is_prefixed_attribute_token(TokenStreamAdapter &Tokens)
    if (not symbol) return false;
 
    std::string_view name(strdata(symbol), symbol->len);
-   if (name != "const" and name != "close") return false;
+   if (name != "const" and name != "close" and name != "view") return false;
    return Tokens.peek(1).raw() IS '<';
 }
 
@@ -746,7 +775,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_enum(const Token &StartToken)
 
    if (is_prefixed_attribute_token(this->ctx.tokens())) {
       return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-         "Enum prefixes cannot use <const> or <close> attributes");
+         "Enum prefixes cannot use declaration attributes");
    }
 
    auto open_brace = this->ctx.consume(TokenKind::LeftBrace, ParserErrorCode::ExpectedToken);

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1891,9 +1891,11 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
 
    ExpDesc tail;
    auto nexps = BCReg(0);
+   bool is_view = Payload.names.size() IS 1 and Payload.names[0].has_view;
    std::vector<std::optional<CompileTimeValue>> compile_time_values(Payload.names.size());
    if (Payload.values.empty()) tail = ExpDesc(ExpKind::Void);
    else {
+      if (is_view) bcemit_AD(&this->func_state, BC_VIEW, 0, 1);
       auto list = this->emit_expression_list(Payload.values, nexps);
       if (not list.ok()) return ParserResult<IrEmitUnit>::failure(list.error_ref());
       tail = list.value_ref();
@@ -1909,6 +1911,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
    }
 
    this->lex_state.assign_adjust(nvars.raw(), nexps.raw(), &tail);
+   if (is_view) bcemit_AD(&this->func_state, BC_VIEW, 0, 0);
    this->lex_state.var_add(nvars);
    auto base = BCReg(this->func_state.varmap.size() - nvars.raw());
 

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -485,7 +485,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
 
    lj_assertL(elem_size > 0, "invalid element size for array creation");
 
-   if (Data) {
+   if (Data or (Flags & ARRAY_EXTERNAL)) {
       if (Flags & ARRAY_EXTERNAL) {
          // External data - caller manages lifetime (no storage allocation needed)
          // External arrays have capacity = length and cannot grow
@@ -657,12 +657,21 @@ bool lj_array_grow(lua_State *L, GCarray *Array, MSize MinCapacity)
 
 void lj_array_free(global_State *g, GCarray *Array)
 {
+   RESOURCEID resource_id = Array->resource_id;
+   Array->resource_id = 0;
+
    // Free owned storage first (external storage is managed by caller)
    size_t storage_size = Array->storage_size();
    if (storage_size > 0) {
       lj_mem_free(g, Array->storage, storage_size);
    }
    Array->~GCarray(); // Call destructor (handles strcache cleanup)
+   if (resource_id) {
+      if (auto error = UnpinResource(resource_id); error != ERR::Okay) {
+         kt::Log("lj_array_free").warning("Failed to release resource pin #%d: %s", resource_id,
+            GetErrorMsg(error));
+      }
+   }
    lj_mem_free(g, Array, sizeof(GCarray));
 }
 

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -675,9 +675,7 @@ int lj_meta_isfalsey(lua_State *L, BCIns Ins)
    VMHelperGuard guard(L);
 
    cTValue *value = &L->base[bc_a(Ins)];
-   if (not lj_is_thunk(value)) return 0;
-
-   value = lj_thunk_resolve(L, udataV(value));
+   if (lj_is_thunk(value)) value = lj_thunk_resolve(L, udataV(value));
    uint32_t mask = bc_d(Ins);
 
    if (tvisnil(value)) return 1;

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -802,6 +802,8 @@ struct TryFrame {
    BCREG     saved_nactvar;    // Active slot count at try entry (first free register)
    size_t    context_depth;     // Absolute context-stack depth at try entry
    size_t    context_floor;     // Active asynchronous root floor at try entry
+   uint64_t  array_view_scopes; // Armed <view> scopes at try entry
+   uint8_t   array_view_depth;  // Active <view> scope depth at try entry
 };
 
 // Stack of try frames for exception unwinding
@@ -1314,6 +1316,7 @@ struct GCarray {
    MSize   elemsize;    // Size of each element in bytes
    struct struct_record *structdef;  // Optional: struct definition for struct arrays
    std::vector<char> *strcache; // Optional: cached string content for CSTRING/STRING_CPP arrays
+   RESOURCEID resource_id; // Optional Core resource pin owned by an external view
 
 public:
    // Initialise the array structure. Storage must be pre-allocated by the caller using lj_mem_new()
@@ -1337,6 +1340,7 @@ public:
       elemsize  = ElemSize;
       structdef = StructDef;
       strcache  = nullptr;
+      resource_id = 0;
    }
 
    // Destructor only handles strcache. Storage is freed by lj_array_free() for proper GC tracking.
@@ -1646,6 +1650,8 @@ struct lua_State {
    class extTiri *script;  // Back-reference to the script that owns this lua_State
    bool    sent_traceback;   // True if traceback has been sent for the current error
    uint8_t resolving_thunk;  // Flag to prevent recursive thunk resolution
+   uint64_t array_view_scopes = 0; // One armed bit per active <view> declaration initialiser
+   uint8_t array_view_depth = 0;   // Number of active <view> initialiser scopes
    ParserDiagnostics *parser_diagnostics; // Stores ParserDiagnostics* during parsing errors
    TipEmitter *parser_tips;               // Stores TipEmitter* during parsing for code hints
    ParserSymbolCollection *parser_symbols; // Stores parser symbol metadata for LSP/documentation tooling

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -448,6 +448,27 @@ extern "C" void lj_close_arm(lua_State *L, uint32_t Slot)
    state->armed_slots |= uint64_t(1) << Slot;
 }
 
+extern "C" void lj_array_view_mode(lua_State *L, uint32_t Enabled)
+{
+   if (Enabled) {
+      if (L->array_view_depth >= 64) lj_err_msg(L, ErrMsg::XNEST);
+      L->array_view_scopes |= uint64_t(1) << L->array_view_depth++;
+   }
+   else if (L->array_view_depth > 0) {
+      L->array_view_depth--;
+      L->array_view_scopes &= ~(uint64_t(1) << L->array_view_depth);
+   }
+}
+
+bool lj_array_take_view_mode(lua_State *L) noexcept
+{
+   if (L->array_view_depth IS 0) return false;
+   uint64_t scope = uint64_t(1) << (L->array_view_depth - 1);
+   bool armed = (L->array_view_scopes & scope) != 0;
+   L->array_view_scopes &= ~scope;
+   return armed;
+}
+
 uint64_t lj_close_take_armed(
    lua_State *L, const TValue *OwnerBase, uint32_t LowerSlot, uint32_t UpperSlot) noexcept
 {

--- a/src/tiri/jit/src/runtime/lj_state.h
+++ b/src/tiri/jit/src/runtime/lj_state.h
@@ -68,6 +68,8 @@ extern "C" LJ_FUNC void lj_context_end_block_jit(
    lua_State *L, TValue *OwnerBase, uint32_t BlockIndex) noexcept;
 extern "C" LJ_FUNC void lj_close_arm(lua_State *L, uint32_t Slot);
 extern "C" LJ_FUNC void lj_close_consume(lua_State *L, uint32_t Slot);
+extern "C" LJ_FUNC void lj_array_view_mode(lua_State *L, uint32_t Enabled);
+LJ_FUNC [[nodiscard]] bool lj_array_take_view_mode(lua_State *L) noexcept;
 LJ_FUNC uint64_t lj_close_take_armed(
    lua_State *L, const TValue *OwnerBase, uint32_t LowerSlot, uint32_t UpperSlot) noexcept;
 extern "C" LJ_FUNC void lj_context_enter_call(lua_State *L, uint32_t CallBase);

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -21,11 +21,25 @@
 #include <cfloat>
 #include <cstring>
 #include <array>
+#include <atomic>
 #include <limits>
 
 #include "../../defs.h"
 
 static extTiri* glArrayTestScript = nullptr;
+static std::atomic_int glArrayResourceFrees = 0;
+
+static ERR array_test_resource_free(ResourceRecord &, APTR)
+{
+   glArrayResourceFrees.fetch_add(1, std::memory_order_relaxed);
+   return ERR::Terminate;
+}
+
+static ResourceManager glArrayResourceManager = {
+   "TiriArrayTest",
+   &array_test_resource_free,
+   false
+};
 
 // Helper: dostring equivalent - loads and executes a string
 static int dostring(lua_State *L, const char* s)
@@ -469,6 +483,122 @@ static bool test_array_external(kt::Log &Log)
    int32_t* data = (int32_t*)arr->arraydata();
    if (data[2] != 30) {
       Log.error("external array reads incorrectly: got %d, expected 30", data[2]);
+      return false;
+   }
+
+   return true;
+}
+
+static bool test_array_external_unmanaged(kt::Log &Log)
+{
+   LuaStateHolder holder;
+   lua_State *lua = holder.get();
+   if (not lua) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   int32_t external_data[2] = { 10, 20 };
+   GCarray *array = lj_array_new(lua, 2, AET::INT32, external_data, ARRAY_EXTERNAL|ARRAY_READONLY);
+   if (array->resource_id) {
+      Log.error("unmanaged external array retained a resource pin");
+      return false;
+   }
+
+   external_data[1] = 30;
+   if (array->get<int32_t>()[1] != 30) {
+      Log.error("unmanaged external array did not observe native mutation");
+      return false;
+   }
+
+   setarrayV(lua, lua->top++, array);
+   lua_settop(lua, 0);
+   lua_gc(lua, LUA_GCCOLLECT);
+   return true;
+}
+
+static bool test_array_external_resource(kt::Log &Log)
+{
+   LuaStateHolder holder;
+   lua_State *lua = holder.get();
+   if (not lua) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+   luaL_openlibs(lua);
+
+   APTR memory = nullptr;
+   if (AllocResource(sizeof(int32_t) * 2, MEM::NIL, &memory, &glArrayResourceManager) != ERR::Okay) return false;
+   auto resource_id = GetMemoryID(memory);
+   auto values = (int32_t *)memory;
+   values[0] = 10;
+   values[1] = 20;
+   glArrayResourceFrees.store(0, std::memory_order_relaxed);
+
+   GCarray *array = lj_array_new(lua, 2, AET::INT32, memory, ARRAY_EXTERNAL|ARRAY_READONLY);
+   setarrayV(lua, lua->top++, array);
+   if (PinResource(resource_id) != ERR::Okay) return false;
+   array->resource_id = resource_id;
+   lua_setglobal(lua, "array_resource_view");
+
+   if (dostring(lua, "local total = 0; for index in {0 to 200} do "
+         "total += array_resource_view[index % #array_resource_view] end; assert(total is 3000)") != 0) {
+      Log.error("resource-backed external array did not use the normal hot-loop load path");
+      return false;
+   }
+
+   if ((array->resource_id != resource_id) or (FreeResource(resource_id) != ERR::InUse) or
+       (array->get<int32_t>()[1] != 20)) {
+      Log.error("resource-backed external array did not retain readable storage");
+      return false;
+   }
+
+   lua_pushnil(lua);
+   lua_setglobal(lua, "array_resource_view");
+   lua_gc(lua, LUA_GCCOLLECT);
+   if (glArrayResourceFrees.load(std::memory_order_relaxed) != 1) {
+      Log.error("resource-backed external array did not release its pin exactly once");
+      return false;
+   }
+
+   memory = nullptr;
+   if (AllocResource(sizeof(int32_t), MEM::NIL, &memory, &glArrayResourceManager) != ERR::Okay) return false;
+   resource_id = GetMemoryID(memory);
+   values = (int32_t *)memory;
+   values[0] = 42;
+   glArrayResourceFrees.store(0, std::memory_order_relaxed);
+
+   GCarray *first = lj_array_new(lua, 1, AET::INT32, memory, ARRAY_EXTERNAL|ARRAY_READONLY);
+   setarrayV(lua, lua->top++, first);
+   if (PinResource(resource_id) != ERR::Okay) return false;
+   first->resource_id = resource_id;
+
+   GCarray *second = lj_array_new(lua, 1, AET::INT32, memory, ARRAY_EXTERNAL|ARRAY_READONLY);
+   setarrayV(lua, lua->top++, second);
+   if (PinResource(resource_id) != ERR::Okay) return false;
+   second->resource_id = resource_id;
+
+   if (FreeResource(resource_id) != ERR::InUse) return false;
+   lua_settop(lua, 1);
+   lua_gc(lua, LUA_GCCOLLECT);
+   if ((glArrayResourceFrees.load(std::memory_order_relaxed) != 0) or (first->get<int32_t>()[0] != 42)) {
+      Log.error("the first collected view released a multiply pinned resource");
+      return false;
+   }
+
+   lua_settop(lua, 0);
+   lua_gc(lua, LUA_GCCOLLECT);
+   if (glArrayResourceFrees.load(std::memory_order_relaxed) != 1) {
+      Log.error("the final collected view did not release the deferred resource");
+      return false;
+   }
+
+   int32_t local_value = 7;
+   GCarray *failed = lj_array_new(lua, 1, AET::INT32, &local_value, ARRAY_EXTERNAL|ARRAY_READONLY);
+   setarrayV(lua, lua->top++, failed);
+   auto missing_id = AllocateID(IDTYPE::RESOURCE);
+   if ((PinResource(missing_id) IS ERR::Okay) or failed->resource_id) {
+      Log.error("a failed resource pin left an ownership token on the array");
       return false;
    }
 
@@ -1296,7 +1426,7 @@ static bool test_lib_array_double_type(kt::Log &Log)
 
 void array_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 33> Tests = { {
+   constexpr std::array<TestCase, 35> Tests = { {
       // Core Data Structures
       { "array_creation_byte", test_array_creation_byte },
       { "array_creation_int32", test_array_creation_int32 },
@@ -1307,6 +1437,8 @@ void array_unit_tests(int &Passed, int &Total)
       { "array_index_access", test_array_index_access },
       { "array_elemsize", test_array_elemsize },
       { "array_external", test_array_external },
+      { "array_external_unmanaged", test_array_external_unmanaged },
+      { "array_external_resource", test_array_external_resource },
       { "array_element_contract", test_array_element_contract },
       { "array_to_table", test_array_to_table },
       { "array_type_tag", test_array_type_tag },

--- a/src/tiri/tests/test_array_view.tiri
+++ b/src/tiri/tests/test_array_view.tiri
@@ -20,6 +20,11 @@ function new_bitmap():obj
    return bitmap
 end
 
+function read_after_nested_view(Bitmap:obj):array<any>
+   local benign <view> = 42
+   return Bitmap.data
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test; @Requires(display=true)
@@ -91,13 +96,18 @@ end
 function NestedViewScopesAreIndependent()
    local bitmap = new_bitmap()
 
-   function read_after_nested_view(Bitmap:obj):array<any>
-      local benign <view> = 42
-      return Bitmap.data
-   end
-
    local pixels <view> = read_after_nested_view(bitmap)
    assert(array.readOnly(pixels), 'A nested view declaration must not clear its outer view scope')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test(hotpath=80); @Requires(display=true)
+function JITAbortPreservesOuterViewScope()
+   local bitmap = new_bitmap()
+   local pixels <view> = read_after_nested_view(bitmap)
+
+   assert(array.readOnly(pixels), 'An internal JIT abort must preserve the outer view scope')
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_array_view.tiri
+++ b/src/tiri/tests/test_array_view.tiri
@@ -1,0 +1,145 @@
+-- Flute regression coverage for non-owning object array-field views.
+
+include 'display'
+
+function expect_failure(Action:func, Description:str)
+   local caught = false
+   try
+      Action()
+   except error_value
+      caught = true
+   end
+   assert(caught, Description)
+end
+
+function new_bitmap():obj
+   local bitmap = obj.new('bitmap', {
+      width=2, height=2, bitsPerPixel=32, bkgd='255,255,255,255'
+   })
+   bitmap.acClear()
+   return bitmap
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(display=true)
+function PrimitiveFieldViewIsLiveAndReadOnly()
+   local bitmap = new_bitmap()
+   local pixels <view> = bitmap.data
+
+   assert(array.readOnly(pixels), 'A field view must be read-only')
+   assert(pixels[0] is 255, 'The initial view should expose the bitmap storage')
+
+   bitmap.bkgd = '0,0,0,255'
+   bitmap.acClear()
+   assert(pixels[0] is 0, 'A view should observe native mutations without another field read')
+
+   expect_failure(() => do pixels[0] = 1 end, 'Element assignment through a view must fail')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(display=true)
+function ViewModeIsOneShot()
+   local bitmap = new_bitmap()
+   local second
+
+   function read_twice(Bitmap:obj):array<any>
+      local first = Bitmap.data
+      second = Bitmap.data
+      return first
+   end
+
+   local first <view> = read_twice(bitmap)
+   assert(array.readOnly(first), 'The first object array read should consume view mode')
+   assert(not array.readOnly(second), 'A second object array read in the initialiser must remain a copy')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(display=true)
+function ErrorUnwindClearsViewMode()
+   expect_failure(() => do local failed <view> = error('expected failure') end,
+      'The failing view initialiser should be catchable')
+
+   local bitmap = new_bitmap()
+   local copied = bitmap.data
+   assert(not array.readOnly(copied), 'A failed view initialiser must not arm a later field read')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(display=true)
+function CaughtErrorPreservesOuterViewMode()
+   local bitmap = new_bitmap()
+
+   function read_after_error(Bitmap:obj):array<any>
+      try
+         error('expected failure')
+      except error_value
+      end
+      return Bitmap.data
+   end
+
+   local pixels <view> = read_after_error(bitmap)
+   assert(array.readOnly(pixels), 'A caught error inside the initialiser must preserve its active view scope')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(display=true)
+function NestedViewScopesAreIndependent()
+   local bitmap = new_bitmap()
+
+   function read_after_nested_view(Bitmap:obj):array<any>
+      local benign <view> = 42
+      return Bitmap.data
+   end
+
+   local pixels <view> = read_after_nested_view(bitmap)
+   assert(array.readOnly(pixels), 'A nested view declaration must not clear its outer view scope')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(display=true)
+function HotLoopUsesNormalArrayLoads()
+   local bitmap = new_bitmap()
+   local pixels <view> = bitmap.data
+   local total = 0
+
+   for index in {0 to 200} do
+      total += pixels[index % #pixels]
+   end
+
+   assert(total is 51000, 'A hot loop should read an unmanaged view through the normal array load path')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function UnsupportedAndBenignInitialisers()
+   local script = obj.new('script')
+   expect_failure(() => do local strings <view> = script.results end,
+      'String-array fields must reject view materialisation')
+
+   local number <view> = 42
+   assert(number is 42, 'A non-array view initialiser should be a benign no-op')
+
+   local existing = array<int> { 1, 2 }
+   local same <view> = existing
+   assert(same is existing and not array.readOnly(same),
+      'An existing array reference should pass through without changing its ownership or mutability')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function InvalidViewDeclarationsAreRejected()
+   expect_failure(() => exec('local first <view>, second = 1, 2'),
+      'A view declaration must reject multiple local names')
+   expect_failure(() => exec('local missing <view>'),
+      'A view declaration must require an initialiser')
+   expect_failure(() => exec('local combined <view><close> = 1'),
+      'A view declaration must reject another attribute on the same name')
+   expect_failure(() => exec('global invalid <view> = 1'),
+      'The view attribute must be local-only')
+end

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -43,6 +43,7 @@ For more information on the Tiri syntax, please refer to the official Tiri Refer
 #include "lj_bc.h"
 #include "lj_array.h"
 #include "lj_gc.h"
+#include "lj_state.h"
 #include "lj_vm.h"
 
 JUMPTABLE_CORE

--- a/src/tiri/tiri_objects_indexes.cpp
+++ b/src/tiri/tiri_objects_indexes.cpp
@@ -678,8 +678,27 @@ template <class Callback> static int object_get_field(lua_State *Lua, const obj_
    return error != ERR::Okay ? 0 : 1;
 }
 
-static ERR make_object_field_array(lua_State *Lua, const Field *Field, size_t Elements, CPTR Values)
+static ERR make_object_field_array(lua_State *Lua, const Field *Field, size_t Elements, CPTR Values, bool View)
 {
+   if (View) {
+      if (Field->Flags & (FD_STRING|FD_OBJECT|FD_POINTER|FD_STRUCT)) return ERR::FieldTypeMismatch;
+      AET type = ff_to_aet(Field->Flags);
+      if (type IS AET::MAX) return ERR::FieldTypeMismatch;
+
+      GCarray *array = lj_array_new(Lua, Elements, type, (void *)Values, ARRAY_EXTERNAL|ARRAY_READONLY);
+      setarrayV(Lua, Lua->top++, array);
+      lj_gc_check(Lua);
+
+      if (Field->Flags & FD_RESOURCE) {
+         if (auto error = PinResource(Values); error != ERR::Okay) {
+            Lua->top--;
+            return error;
+         }
+         array->resource_id = ((const RESOURCEID *)Values)[RESOURCE_ID_OFFSET];
+      }
+      return ERR::Okay;
+   }
+
    struct_record *struct_def = nullptr;
    std::string_view struct_name;
 
@@ -700,10 +719,12 @@ static ERR make_object_field_array(lua_State *Lua, const Field *Field, size_t El
 static int object_get_array(lua_State *Lua, const obj_read &Handle, GCobject *Def)
 {
    return object_get_field(Lua, Handle, Def, [Lua](OBJECTPTR Object, const Field *Field) -> ERR {
+      bool view = lj_array_take_view_mode(Lua);
       ERR error;
       std::span<int> span;
       if (Field->Flags & FD_VECTOR) { // kt::vector<>
          if (Field->Flags & FD_STRING) { // kt::vector<std::string>
+            if (view) return ERR::FieldTypeMismatch;
             std::span<std::string> values;
             if (!(error = Object->get(Field->FieldID, values))) {
                kt::vector<std::string> strings(values.data(), values.data() + values.size());
@@ -717,19 +738,21 @@ static int object_get_array(lua_State *Lua, const obj_read &Handle, GCobject *De
             // For kt::vector primitives we can just convert to a raw data array.
             std::span<int> values; // The type doesn't matter.
             if (!(error = Object->get(Field->FieldID, values, false))) {
-               error = make_object_field_array(Lua, Field, values.size(), values.data());
+               error = make_object_field_array(Lua, Field, values.size(), values.data(), view);
             }
          }
       }
       else if (!(error = Object->get(Field->FieldID, span, false))) {
          if (Field->Flags & FD_STRING) {
+            if (view) return ERR::FieldTypeMismatch;
             make_array(Lua, AET::CSTR, span.size(), span.data());
          }
          else if (Field->Flags & FD_OBJECT) {
+            if (view) return ERR::FieldTypeMismatch;
             make_array(Lua, AET::OBJECT, span.size(), span.data());
          }
          else if (Field->Flags & (FD_INT|FD_INT64|FD_FLOAT|FD_DOUBLE|FD_POINTER|FD_BYTE|FD_WORD|FD_STRUCT)) {
-            error = make_object_field_array(Lua, Field, span.size(), span.data());
+            error = make_object_field_array(Lua, Field, span.size(), span.data(), view);
          }
          else {
             kt::Log("object_get_array").warning("Invalid array type for '%s', flags: $%.8x", Field->Name,


### PR DESCRIPTION
* Implemented one-shot view semantics with non-owning native storage and resource lifetime handling

* Added runtime unit coverage and Flute regression tests for array views and external resources