### PR TITLE
[Tiri] Validate Tiri LSP documentation caches against source manifests

### DIFF
--- a/tools/tiri_lsp/CMakeLists.txt
+++ b/tools/tiri_lsp/CMakeLists.txt
@@ -58,6 +58,7 @@ if (KOTUKU_INSTALL)
 endif ()
 
 flute_test(tiri_lsp_definition "${TIRI_LSP_DIR}/tests/test_definition.tiri")
+flute_test(tiri_lsp_cache "${TIRI_LSP_DIR}/tests/test_cache.tiri")
 flute_test(tiri_lsp_document_symbols "${TIRI_LSP_DIR}/tests/test_document_symbols.tiri")
 flute_test(tiri_lsp_folding "${TIRI_LSP_DIR}/tests/test_folding.tiri")
 flute_test(tiri_lsp_hover "${TIRI_LSP_DIR}/tests/test_hover.tiri")

--- a/tools/tiri_lsp/include/lsp_cache.tiri
+++ b/tools/tiri_lsp/include/lsp_cache.tiri
@@ -16,6 +16,103 @@ rx_source_file_plain = <{ regex.new([[<file>([^<]+)<\/file>]]) }>
 rx_input_param       = <{ regex.new([[<param\s+([^>]*)>(.*?)<\/param>]], regex.DOT_ALL) }>
 rx_xml_attr          = <{ regex.new([=[([A-Za-z_][A-Za-z0-9_]*)="([^"]*)"]=]) }>
 
+function countTableEntries(Tbl:table):num
+   local count = 0
+   for _ in pairs(Tbl or {}) do count++ end
+   return count
+end
+
+function countXmlElements(Content:str, TagName:str):num
+   local count = 0
+   local position = 0
+   local opening_tag = '<' .. TagName .. '>'
+
+   while true do
+      local found = Content.find(opening_tag, position, true)
+      found ?! break
+      count++
+      position = found + #opening_tag
+   end
+
+   return count
+end
+
+function createSourceManifestEntry(Content:str, Kind:str):table
+   return {
+      kind = Kind,
+      size = #Content,
+      hash = Content.hash(true),
+      functions = countXmlElements(Content, 'function'),
+      methods = countXmlElements(Content, 'method'),
+      actions = countXmlElements(Content, 'action'),
+      fields = countXmlElements(Content, 'field')
+   }
+end
+
+global function buildDocManifest(DocPath:str):table
+   local manifest = {}
+
+   function scanSources(Path:str, Kind:str, MaxDepth:num)
+      io.search(Path, {
+         nameFilter = regex.new([[\.xml$]]),
+         maxDepth = MaxDepth,
+         matchFeedback = function(FolderPath, FileName, _)
+            local full_path = FolderPath .. FileName
+            local content = io.readAll(full_path)
+            if content then
+               manifest[full_path.replace(DocPath, '')] = createSourceManifestEntry(content, Kind)
+            end
+         end
+      })
+   end
+
+   scanSources(DocPath .. 'modules/', 'module', 0)
+   scanSources(DocPath .. 'modules/classes/', 'class', 1)
+   return manifest
+end
+
+global function validateDocCache(Cache:table, DocPath:str, CurrentManifest:table):bool
+   if not Cache or Cache.version != 7 or Cache.sdkPath != DocPath then return false end
+   if not Cache.modules or not Cache.classes or not Cache.sourceManifest or not CurrentManifest then return false end
+   if countTableEntries(Cache.sourceManifest) != countTableEntries(CurrentManifest) then return false end
+
+   local entries_by_file = {}
+   for _, entry in pairs(Cache.modules) do
+      if not entry.file or entries_by_file[entry.file] then return false end
+      entries_by_file[entry.file] = entry
+   end
+   for _, entry in pairs(Cache.classes) do
+      if not entry.file or entries_by_file[entry.file] then return false end
+      entries_by_file[entry.file] = entry
+   end
+
+   if countTableEntries(entries_by_file) != countTableEntries(CurrentManifest) then return false end
+
+   local module_source_count = 0
+   local class_source_count = 0
+   for source_path, current_source in pairs(CurrentManifest) do
+      local cached_source = Cache.sourceManifest[source_path]
+      local cached_entry = entries_by_file[source_path]
+      if not cached_source or not cached_entry then return false end
+      if cached_source.kind != current_source.kind or cached_source.size != current_source.size or
+         cached_source.hash != current_source.hash then return false end
+
+      if current_source.kind is 'module' then
+         module_source_count++
+         if countTableEntries(cached_entry.functions) != current_source.functions then return false end
+      elseif current_source.kind is 'class' then
+         class_source_count++
+         if countTableEntries(cached_entry.methods) != current_source.methods or
+            countTableEntries(cached_entry.actions) != current_source.actions or
+            countTableEntries(cached_entry.fields) != current_source.fields then return false end
+      else
+         return false
+      end
+   end
+
+   return (module_source_count > 0) and (class_source_count > 0)
+end
+
 @Doc(text='Encode a field entry to compact string format')
 function encodeField(Access, Type, ByteStart, ByteEnd, Comment):str
    return f'A:{Access or "R"}\tL:{ByteStart},{ByteEnd}\tT:{Type or ""}\tC:{Comment or ""}'
@@ -308,11 +405,12 @@ global function buildDocCache(DocPath):table
    -- Build the documentation cache from XML files
 
    cache = {
-      version = 6,
+      version = 7,
       built   = mSys.PreciseTime() / 1000000,
       sdkPath = DocPath,
       modules = {},
-      classes = {}
+      classes = {},
+      sourceManifest = {}
    }
 
    modulesPath = DocPath .. 'modules/'
@@ -360,6 +458,7 @@ global function buildDocCache(DocPath):table
    msg('Scan completed')
 
    processing.collect()
+   cache.sourceManifest = buildDocManifest(DocPath)
    return cache
 end
 
@@ -425,15 +524,12 @@ global function loadDocCache(DocPath):table
       return
    end
 
-   if cache.version != 6 then msg('Unsupported version'); return end
+   if cache.version != 7 then msg('Unsupported version'); return end
    if cache.sdkPath != DocPath then msg('Path mismatch: ' .. cache.sdkPath .. ' != ' .. DocPath); return end
 
-   module_count = 0
-   class_count = 0
-   for k, v in pairs(cache.modules or {}) do module_count++ end
-   for k, v in pairs(cache.classes or {}) do class_count++ end
-   if module_count is 0 or class_count is 0 then
-      msg('Documentation cache is empty; rebuilding.')
+   local current_manifest = buildDocManifest(DocPath)
+   if not validateDocCache(cache, DocPath, current_manifest) then
+      msg('Documentation cache is stale or incomplete; rebuilding.')
       return
    end
 

--- a/tools/tiri_lsp/include/lsp_cache.tiri
+++ b/tools/tiri_lsp/include/lsp_cache.tiri
@@ -26,12 +26,18 @@ function countXmlElements(Content:str, TagName:str):num
    local count = 0
    local position = 0
    local opening_tag = '<' .. TagName .. '>'
+   local closing_tag = '</' .. TagName .. '>'
 
    while true do
       local found = Content.find(opening_tag, position, true)
       found ?! break
-      count++
-      position = found + #opening_tag
+
+      local closing = Content.find(closing_tag, found + #opening_tag, true)
+      closing ?! break
+
+      local name_tag = Content.find('<name>', found + #opening_tag, true)
+      if name_tag and name_tag < closing then count++ end
+      position = closing + #closing_tag
    end
 
    return count

--- a/tools/tiri_lsp/tests/test_cache.tiri
+++ b/tools/tiri_lsp/tests/test_cache.tiri
@@ -1,4 +1,4 @@
-extern validateDocCache
+extern buildDocCache, buildDocManifest, validateDocCache
 
 @BeforeAll function SetupCacheTests(State)
    local err, sdk_path = mSys.ResolvePath(State.folder .. '../../../')
@@ -40,6 +40,14 @@ end
 @Test function AcceptsCompleteCurrentCache()
    assert(validateDocCache(makeCache(), 'sdk:docs/xml/', makeManifest()),
       'A complete cache matching the current documentation should be accepted.')
+end
+
+@Test function AcceptsCacheBuiltFromCurrentDocumentation()
+   local doc_path = 'sdk:docs/xml/'
+   local cache = buildDocCache(doc_path)
+   local manifest = buildDocManifest(doc_path)
+   assert(validateDocCache(cache, doc_path, manifest),
+      'A cache built from the current documentation should be reusable.')
 end
 
 @Test function RejectsChangedDocumentation()

--- a/tools/tiri_lsp/tests/test_cache.tiri
+++ b/tools/tiri_lsp/tests/test_cache.tiri
@@ -1,0 +1,89 @@
+extern validateDocCache
+
+@BeforeAll function SetupCacheTests(State)
+   local err, sdk_path = mSys.ResolvePath(State.folder .. '../../../')
+   assert(err is ERR_Okay, 'Failed to resolve SDK path for LSP cache tests.')
+   mSys.SetVolume('sdk', sdk_path)
+   loadFile('sdk:tools/tiri_lsp/include/lsp_lib.tiri')
+end
+
+function makeManifest():table
+   return {
+      ['modules/core.xml'] = {
+         kind = 'module', size = 100, hash = 1234, functions = 1, methods = 0, actions = 0, fields = 0
+      },
+      ['modules/classes/xml.xml'] = {
+         kind = 'class', size = 200, hash = 5678, functions = 0, methods = 1, actions = 1, fields = 1
+      }
+   }
+end
+
+function makeCache():table
+   return {
+      version = 7,
+      sdkPath = 'sdk:docs/xml/',
+      sourceManifest = makeManifest(),
+      modules = {
+         Core = { file = 'modules/core.xml', functions = { ResolvePath = {} } }
+      },
+      classes = {
+         XML = {
+            file = 'modules/classes/xml.xml',
+            methods = { GetAttrib = {} },
+            actions = { Clear = {} },
+            fields = { Path = {} }
+         }
+      }
+   }
+end
+
+@Test function AcceptsCompleteCurrentCache()
+   assert(validateDocCache(makeCache(), 'sdk:docs/xml/', makeManifest()),
+      'A complete cache matching the current documentation should be accepted.')
+end
+
+@Test function RejectsChangedDocumentation()
+   local manifest = makeManifest()
+   manifest['modules/core.xml'].hash = 4321
+   assert(not validateDocCache(makeCache(), 'sdk:docs/xml/', manifest),
+      'A cache should be rejected when source documentation changes.')
+end
+
+@Test function RejectsAddedOrRemovedDocumentation()
+   local manifest = makeManifest()
+   manifest['modules/extra.xml'] = {
+      kind = 'module', size = 50, hash = 9012, functions = 0, methods = 0, actions = 0, fields = 0
+   }
+   assert(not validateDocCache(makeCache(), 'sdk:docs/xml/', manifest),
+      'A cache should be rejected when the documentation file set changes.')
+end
+
+@Test function RejectsMissingSourceEntry()
+   local cache = makeCache()
+   cache.classes.XML = nil
+   assert(not validateDocCache(cache, 'sdk:docs/xml/', makeManifest()),
+      'A cache should be rejected when a documented class was not cached.')
+end
+
+@Test function RejectsPartiallyParsedSource()
+   local cache = makeCache()
+   cache.modules.Core.functions.ResolvePath = nil
+   assert(not validateDocCache(cache, 'sdk:docs/xml/', makeManifest()),
+      'A cache should be rejected when an API member was omitted during parsing.')
+end
+
+@Test function RejectsOldSchemaAndDifferentSdk()
+   local cache = makeCache()
+   cache.version = 6
+   assert(not validateDocCache(cache, 'sdk:docs/xml/', makeManifest()), 'An old cache schema should be rejected.')
+
+   cache.version = 7
+   assert(not validateDocCache(cache, 'other:docs/xml/', makeManifest()),
+      'A cache built for another SDK path should be rejected.')
+end
+
+@Test function RejectsUnavailableDocumentationTree()
+   local cache = { version = 7, sdkPath = 'sdk:docs/xml/', sourceManifest = {}, modules = {}, classes = {} }
+   assert(not validateDocCache(cache, 'sdk:docs/xml/', {}),
+      'An empty documentation tree should not make an empty cache appear valid.')
+end


### PR DESCRIPTION
* Added documentation source manifests and cache completeness validation
* Registered cache validation coverage for the Tiri LSP