### PR TITLE
[Tiri] Synchronise JIT helper stack pointers without penalising hot paths

### DIFF
--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -353,8 +353,14 @@ void lj_array_store_checked(lua_State *L, GCarray *Array, MSize Index, cTValue *
    bool exact_integer = tvisint(Value) and glArrayConversion[size_t(Array->elemtype)].primitive;
    if (not exact_integer) {
       auto result = array_validate_element(Array, Value);
-      if (result IS ArrayElementResult::OUT_OF_RANGE) lj_err_msg(L, ErrMsg::NUMRNG);
-      if (result != ArrayElementResult::OK) lj_err_msg(L, ErrMsg::ARRTYPE);
+      if (result IS ArrayElementResult::OUT_OF_RANGE) {
+         JITStackSync stack_sync(L);
+         lj_err_msg(L, ErrMsg::NUMRNG);
+      }
+      if (result != ArrayElementResult::OK) {
+         JITStackSync stack_sync(L);
+         lj_err_msg(L, ErrMsg::ARRTYPE);
+      }
    }
    array_store_validated(L, Array, Index, Value);
 }
@@ -407,46 +413,75 @@ void lj_array_store_new_values(lua_State *L, GCarray *Array, cTValue *Values, MS
 
 extern "C" void lj_arr_push1(lua_State *L, GCarray *Array, cTValue *Value)
 {
-   JITStackSync stack_sync(L);
-   if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
+   if (Array->flags & ARRAY_READONLY) {
+      JITStackSync stack_sync(L);
+      lj_err_msg(L, ErrMsg::ARRRO);
+   }
 
    if (Array->elemtype IS AET::BYTE and tvisstr(Value)) {
       GCstr *string = strV(Value);
-      if (string->len > (~MSize(0) - Array->len)) lj_err_msg(L, ErrMsg::ARREXT);
+      if (string->len > (~MSize(0) - Array->len)) {
+         JITStackSync stack_sync(L);
+         lj_err_msg(L, ErrMsg::ARREXT);
+      }
       MSize new_len = Array->len + string->len;
-      if (new_len > Array->capacity and not lj_array_grow(L, Array, new_len)) lj_err_msg(L, ErrMsg::ARREXT);
+      if (new_len > Array->capacity) {
+         JITStackSync stack_sync(L);
+         if (not lj_array_grow(L, Array, new_len)) lj_err_msg(L, ErrMsg::ARREXT);
+         stack_sync.restore();
+      }
       if (string->len > 0) memcpy((uint8_t *)Array->arraydata() + Array->len, strdata(string), string->len);
       Array->len = new_len;
-      stack_sync.restore();
       return;
    }
 
    MSize index = Array->len;
-   if (index IS ~MSize(0)) lj_err_msg(L, ErrMsg::ARREXT);
+   if (index IS ~MSize(0)) {
+      JITStackSync stack_sync(L);
+      lj_err_msg(L, ErrMsg::ARREXT);
+   }
 
    if (Array->elemtype IS AET::INT32) {
       uint32_t bits;
       auto result = array_prepare_int32(Value, &bits);
-      if (result IS ArrayElementResult::OUT_OF_RANGE) lj_err_msg(L, ErrMsg::NUMRNG);
-      if (result != ArrayElementResult::OK) lj_err_msg(L, ErrMsg::ARRTYPE);
-      if (index + 1 > Array->capacity and not lj_array_grow(L, Array, index + 1)) lj_err_msg(L, ErrMsg::ARREXT);
+      if (result IS ArrayElementResult::OUT_OF_RANGE) {
+         JITStackSync stack_sync(L);
+         lj_err_msg(L, ErrMsg::NUMRNG);
+      }
+      if (result != ArrayElementResult::OK) {
+         JITStackSync stack_sync(L);
+         lj_err_msg(L, ErrMsg::ARRTYPE);
+      }
+      if (index + 1 > Array->capacity) {
+         JITStackSync stack_sync(L);
+         if (not lj_array_grow(L, Array, index + 1)) lj_err_msg(L, ErrMsg::ARREXT);
+         stack_sync.restore();
+      }
       std::memcpy(lj_array_index(Array, index), &bits, sizeof(bits));
       Array->len = index + 1;
-      stack_sync.restore();
       return;
    }
 
    bool exact_integer = tvisint(Value) and glArrayConversion[size_t(Array->elemtype)].primitive;
    if (not exact_integer) {
       auto result = array_validate_element(Array, Value);
-      if (result IS ArrayElementResult::OUT_OF_RANGE) lj_err_msg(L, ErrMsg::NUMRNG);
-      if (result != ArrayElementResult::OK) lj_err_msg(L, ErrMsg::ARRTYPE);
+      if (result IS ArrayElementResult::OUT_OF_RANGE) {
+         JITStackSync stack_sync(L);
+         lj_err_msg(L, ErrMsg::NUMRNG);
+      }
+      if (result != ArrayElementResult::OK) {
+         JITStackSync stack_sync(L);
+         lj_err_msg(L, ErrMsg::ARRTYPE);
+      }
    }
 
-   if (index + 1 > Array->capacity and not lj_array_grow(L, Array, index + 1)) lj_err_msg(L, ErrMsg::ARREXT);
+   if (index + 1 > Array->capacity) {
+      JITStackSync stack_sync(L);
+      if (not lj_array_grow(L, Array, index + 1)) lj_err_msg(L, ErrMsg::ARREXT);
+      stack_sync.restore();
+   }
    array_store_validated(L, Array, index, Value);
    Array->len = index + 1;
-   stack_sync.restore();
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -12,6 +12,7 @@
 #include "lj_object.h"
 #include "lj_str.h"
 #include "lj_tab.h"
+#include "stack_helpers.h"
 
 #include <cstring>
 #include <cfloat>
@@ -406,6 +407,7 @@ void lj_array_store_new_values(lua_State *L, GCarray *Array, cTValue *Values, MS
 
 extern "C" void lj_arr_push1(lua_State *L, GCarray *Array, cTValue *Value)
 {
+   JITStackSync stack_sync(L);
    if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
 
    if (Array->elemtype IS AET::BYTE and tvisstr(Value)) {
@@ -415,6 +417,7 @@ extern "C" void lj_arr_push1(lua_State *L, GCarray *Array, cTValue *Value)
       if (new_len > Array->capacity and not lj_array_grow(L, Array, new_len)) lj_err_msg(L, ErrMsg::ARREXT);
       if (string->len > 0) memcpy((uint8_t *)Array->arraydata() + Array->len, strdata(string), string->len);
       Array->len = new_len;
+      stack_sync.restore();
       return;
    }
 
@@ -429,6 +432,7 @@ extern "C" void lj_arr_push1(lua_State *L, GCarray *Array, cTValue *Value)
       if (index + 1 > Array->capacity and not lj_array_grow(L, Array, index + 1)) lj_err_msg(L, ErrMsg::ARREXT);
       std::memcpy(lj_array_index(Array, index), &bits, sizeof(bits));
       Array->len = index + 1;
+      stack_sync.restore();
       return;
    }
 
@@ -442,6 +446,7 @@ extern "C" void lj_arr_push1(lua_State *L, GCarray *Array, cTValue *Value)
    if (index + 1 > Array->capacity and not lj_array_grow(L, Array, index + 1)) lj_err_msg(L, ErrMsg::ARREXT);
    array_store_validated(L, Array, index, Value);
    Array->len = index + 1;
+   stack_sync.restore();
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -1414,15 +1414,40 @@ static void env_check_contract(lua_State *L, GCtab *Environment, GCstr *Name, cT
    }
 }
 
+//********************************************************************************************************************
+// Synchronise the interpreter's view of the stack before the policy check can raise.
+//
+// The recorder lowers environment stores to lj_env_check(), so this runs from compiled traces as well as from the
+// interpreter and the C API.  A trace does not maintain L->base or L->top, which therefore still describe whichever
+// interpreter frame ran last - normally a frame *below* the trace.  Every error path from env_check_contract() pushes
+// its message at L->top (lj_strfmt_pushf(), then lj_debug_addloc()), so a stale top writes the message straight into
+// the live slots of those lower frames.  The try-except unwinder later walks that frame chain, reads an overwritten
+// slot as a GCfunc and faults on the resulting wild prototype pointer.
+//
+// Re-basing on G(L)->jit_base places the message above the trace's own frame instead.  Off-trace the sync is inert
+// because jit_base is null and L->top already matches the active frame.
+
+static void env_check_synced(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value,
+   GCstr *DeclarationOverride)
+{
+   JITStackSync stack_sync(L);
+
+   env_check_contract(L, Environment, Name, Value, DeclarationOverride);
+
+   // Only reached when the policy check passed; a rejection leaves the synchronised values in place for unwinding.
+
+   stack_sync.restore();
+}
+
 extern "C" void lj_env_check(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value)
 {
-   env_check_contract(L, Environment, Name, Value, nullptr);
+   env_check_synced(L, Environment, Name, Value, nullptr);
 }
 
 extern "C" void lj_env_check_override(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value,
    GCstr *DeclarationOverride)
 {
-   env_check_contract(L, Environment, Name, Value, DeclarationOverride);
+   env_check_synced(L, Environment, Name, Value, DeclarationOverride);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -1351,13 +1351,14 @@ extern "C" void lj_meta_contract_pc(lua_State *L, const BCIns *PC, uint32_t Dyna
 // built-ins are enforced regardless of source syntax or table aliasing.  Checks run strictly before mutation, so a
 // failed store leaves both the stored value and the persisted policy unchanged.
 //
-// Value must reference a rooted Lua stack slot and L->top must be valid.  The recorder materialises JIT values in
-// their corresponding Lua stack slot before emitting this call.
+// Value must reference a rooted Lua stack slot.  The recorder materialises JIT values in their corresponding Lua stack
+// slot before emitting this call; branches that allocate or raise synchronise the interpreter stack on demand.
 
 static void env_check_contract(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value,
    GCstr *DeclarationOverride)
 {
    if ((Name->flags & STRFLAG_PROTECTED_GLOBAL) != 0) {
+      JITStackSync stack_sync(L);
       CSTRING message = lj_strfmt_pushf(L, "cannot override built-in '%s'", strdata(Name));
       lj_err_callermsg(L, message);
    }
@@ -1366,7 +1367,9 @@ static void env_check_contract(lua_State *L, GCtab *Environment, GCstr *Name, cT
    RuntimeContractDescriptor descriptor;
    const RuntimeContractEntry *entry = nullptr;
    if (DeclarationOverride) {
+      JITStackSync stack_sync(L);
       decode_contract_or_error(L, DeclarationOverride, descriptor);
+      stack_sync.restore();
       if (descriptor.contract_count >= 1) entry = &descriptor.entries[0];
    }
    else if (const CachedGlobalContractRecord *cached =
@@ -1389,12 +1392,15 @@ static void env_check_contract(lua_State *L, GCtab *Environment, GCstr *Name, cT
       entry = &cached_entry;
    }
    else if (GCstr *persisted = lj_tab_get_global_contract(Environment, Name)) {
+      JITStackSync stack_sync(L);
       decode_contract_or_error(L, persisted, descriptor);
+      stack_sync.restore();
       if (descriptor.contract_count >= 1) entry = &descriptor.entries[0];
    }
 
    if (entry) {
       if (contract_entry_is_const(*entry) and not contract_entry_is_initialising(*entry)) {
+         JITStackSync stack_sync(L);
          const_global_error(L, Name);
       }
       if (entry->type != TiriType::Any and entry->type != TiriType::Unknown) {
@@ -1402,12 +1408,17 @@ static void env_check_contract(lua_State *L, GCtab *Environment, GCstr *Name, cT
          TValue resolved_value;
          if (lj_is_thunk(Value)) {
             // Validate the resolved value, but store the original thunk to preserve lazy evaluation on read.
-            VMHelperGuard guard(L);
-            cTValue *resolved = lj_thunk_resolve(L, udataV(Value));
-            copyTV(L, &resolved_value, resolved);
+            JITStackSync stack_sync(L);
+            {
+               VMHelperGuard guard(L);
+               cTValue *resolved = lj_thunk_resolve(L, udataV(Value));
+               copyTV(L, &resolved_value, resolved);
+            }
             checked = &resolved_value;
+            stack_sync.restore();
          }
          if (not contract_matches(L, checked, *entry)) {
+            JITStackSync stack_sync(L);
             contract_error(L, checked, ContractBoundary::Global, *entry, entry->position);
          }
       }
@@ -1415,39 +1426,22 @@ static void env_check_contract(lua_State *L, GCtab *Environment, GCstr *Name, cT
 }
 
 //********************************************************************************************************************
-// Synchronise the interpreter's view of the stack before the policy check can raise.
+// Validate a global environment store.
 //
 // The recorder lowers environment stores to lj_env_check(), so this runs from compiled traces as well as from the
-// interpreter and the C API.  A trace does not maintain L->base or L->top, which therefore still describe whichever
-// interpreter frame ran last - normally a frame *below* the trace.  Every error path from env_check_contract() pushes
-// its message at L->top (lj_strfmt_pushf(), then lj_debug_addloc()), so a stale top writes the message straight into
-// the live slots of those lower frames.  The try-except unwinder later walks that frame chain, reads an overwritten
-// slot as a GCfunc and faults on the resulting wild prototype pointer.
-//
-// Re-basing on G(L)->jit_base places the message above the trace's own frame instead.  Off-trace the sync is inert
-// because jit_base is null and L->top already matches the active frame.
-
-static void env_check_synced(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value,
-   GCstr *DeclarationOverride)
-{
-   JITStackSync stack_sync(L);
-
-   env_check_contract(L, Environment, Name, Value, DeclarationOverride);
-
-   // Only reached when the policy check passed; a rejection leaves the synchronised values in place for unwinding.
-
-   stack_sync.restore();
-}
+// interpreter and the C API.  Successful checks deliberately leave the interpreter stack untouched.  Individual
+// allocating and error branches synchronise immediately before they need a valid trace frame, keeping ordinary global
+// stores out of this stack-management path.
 
 extern "C" void lj_env_check(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value)
 {
-   env_check_synced(L, Environment, Name, Value, nullptr);
+   env_check_contract(L, Environment, Name, Value, nullptr);
 }
 
 extern "C" void lj_env_check_override(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value,
    GCstr *DeclarationOverride)
 {
-   env_check_synced(L, Environment, Name, Value, DeclarationOverride);
+   env_check_contract(L, Environment, Name, Value, DeclarationOverride);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -176,6 +176,7 @@ static void resizestack(lua_State *L, MSize n)
    TValue* st, * oldst = tvref(L->stack);
    ptrdiff_t delta;
    MSize oldsize = L->stacksize;
+   const size_t old_byte_size = size_t(oldsize) * sizeof(TValue);
    MSize realsize = n + 1 + LJ_STACK_EXTRA;
    GCobj* up;
 
@@ -188,7 +189,13 @@ static void resizestack(lua_State *L, MSize n)
    while (oldsize < realsize) setnilV(st + oldsize++); // Clear new slots.
 
    L->stacksize = realsize;
-   if ((size_t)(mref<char>(G(L)->jit_base) - (char*)oldst) < oldsize) {
+
+   // Relocate the running trace's base when it refers to the buffer that has just moved.  The containment test must
+   // use the *old* byte size: upstream compares a byte offset against a slot count, so any jit_base beyond the first
+   // few slots is left pointing into freed memory, and lj_vm_exit_handler() then restores L->base from it on the
+   // next trace exit.  oldsize is consumed by the slot-clearing loop above, hence the size captured on entry.
+
+   if (size_t(mref<char>(G(L)->jit_base) - (char*)oldst) < old_byte_size) {
       setmref(G(L)->jit_base, mref<char>(G(L)->jit_base) + delta);
    }
 

--- a/src/tiri/jit/src/runtime/lj_vmarray.cpp
+++ b/src/tiri/jit/src/runtime/lj_vmarray.cpp
@@ -17,6 +17,7 @@
 #include "lj_vmarray.h"
 #include "lj_vm.h"
 #include "lj_frame.h"
+#include "stack_helpers.h"
 
 #include <cstring>
 #include <string>
@@ -232,8 +233,10 @@ extern "C" int lj_arr_set(lua_State *L, cTValue *O, cTValue *K, cTValue *V)
 
 extern "C" void lj_arr_getidx(lua_State *L, GCarray *Array, int32_t Idx, TValue *Result)
 {
+   JITStackSync stack_sync(L);
    if (Idx < 0 or MSize(Idx) >= Array->len) lj_err_msgv(L, ErrMsg::ARROB, Idx, int(Array->len));
    arr_load_elem(L, Array, uint32_t(Idx), Result);
+   stack_sync.restore();
 }
 
 //********************************************************************************************************************
@@ -254,9 +257,11 @@ extern "C" void lj_arr_safe_getidx(lua_State *L, GCarray *Array, int32_t Idx, TV
 
 extern "C" void lj_arr_setidx(lua_State *L, GCarray *Array, int32_t Idx, cTValue *Val)
 {
+   JITStackSync stack_sync(L);
    if (Idx < 0 or MSize(Idx) >= Array->len) lj_err_msgv(L, ErrMsg::ARROB, Idx, int(Array->len));
    if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
    lj_array_store_checked(L, Array, uint32_t(Idx), Val);
+   stack_sync.restore();
 }
 
 //********************************************************************************************************************
@@ -278,7 +283,9 @@ static void lj_arr_append_bytes(lua_State *L, GCarray *Array, const char *Data, 
 
 extern "C" void lj_arr_putstr(lua_State *L, GCarray *Array, GCstr *Str)
 {
+   JITStackSync stack_sync(L);
    lj_arr_append_bytes(L, Array, strdata(Str), Str->len);
+   stack_sync.restore();
 }
 
 //********************************************************************************************************************
@@ -286,7 +293,9 @@ extern "C" void lj_arr_putstr(lua_State *L, GCarray *Array, GCstr *Str)
 
 extern "C" void lj_arr_putsbuf(lua_State *L, GCarray *Array, SBuf *Buf)
 {
+   JITStackSync stack_sync(L);
    lj_arr_append_bytes(L, Array, Buf->b, sbuflen(Buf));
+   stack_sync.restore();
 }
 
 //********************************************************************************************************************
@@ -294,11 +303,13 @@ extern "C" void lj_arr_putsbuf(lua_State *L, GCarray *Array, SBuf *Buf)
 
 extern "C" void lj_arr_putnumtv(lua_State *L, GCarray *Array, cTValue *Value)
 {
+   JITStackSync stack_sync(L);
    SBuf *sb;
    if (tvisint(Value)) sb = lj_strfmt_putint(lj_buf_tmp_(L), intV(Value));
    else if (tvisnum(Value)) sb = lj_strfmt_putfnum(lj_buf_tmp_(L), STRFMT_G14, numV(Value));
    else lj_err_msg(L, ErrMsg::BADVAL);
    lj_arr_append_bytes(L, Array, sb->b, sbuflen(sb));
+   stack_sync.restore();
 }
 
 //********************************************************************************************************************
@@ -306,10 +317,12 @@ extern "C" void lj_arr_putnumtv(lua_State *L, GCarray *Array, cTValue *Value)
 
 extern "C" void lj_arr_clear(lua_State *L, GCarray *Array)
 {
+   JITStackSync stack_sync(L);
    if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
 
    lj_array_clear_range(Array, 0, Array->len);
    Array->len = 0;
+   stack_sync.restore();
 }
 
 //********************************************************************************************************************
@@ -317,6 +330,7 @@ extern "C" void lj_arr_clear(lua_State *L, GCarray *Array)
 
 extern "C" int32_t lj_arr_resize(lua_State *L, GCarray *Array, int32_t NewSize)
 {
+   JITStackSync stack_sync(L);
    if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
    if (NewSize < 0) lj_err_msgv(L, ErrMsg::NUMRNG, "non-negative", "negative");
 
@@ -341,7 +355,9 @@ extern "C" int32_t lj_arr_resize(lua_State *L, GCarray *Array, int32_t NewSize)
    }
 
    Array->len = target_len;
-   return int32_t(Array->len);
+   int32_t result = int32_t(Array->len);
+   stack_sync.restore();
+   return result;
 }
 
 //********************************************************************************************************************
@@ -349,6 +365,7 @@ extern "C" int32_t lj_arr_resize(lua_State *L, GCarray *Array, int32_t NewSize)
 
 extern "C" GCstr * lj_arr_getstring(lua_State *L, GCarray *Array, int32_t Start, int32_t Len)
 {
+   JITStackSync stack_sync(L);
    if (not (Array->elemtype IS AET::BYTE)) lj_err_msg(L, ErrMsg::ARRSTR);
 
    int32_t count = Len;
@@ -364,7 +381,9 @@ extern "C" GCstr * lj_arr_getstring(lua_State *L, GCarray *Array, int32_t Start,
    if (byte_count > Array->len - start) lj_err_msg(L, ErrMsg::IDXRNG);
 
    CSTRING data = byte_count > 0 ? Array->get<const char>() + start : "";
-   return lj_str_new(L, data, byte_count);
+   GCstr *result = lj_str_new(L, data, byte_count);
+   stack_sync.restore();
+   return result;
 }
 
 //********************************************************************************************************************
@@ -372,5 +391,8 @@ extern "C" GCstr * lj_arr_getstring(lua_State *L, GCarray *Array, int32_t Start,
 
 extern "C" GCarray * lj_arr_new_jit(lua_State *L, uint32_t Length, uint32_t ElemType)
 {
-   return lj_array_new(L, Length, AET(ElemType));
+   JITStackSync stack_sync(L);
+   GCarray *result = lj_array_new(L, Length, AET(ElemType));
+   stack_sync.restore();
+   return result;
 }

--- a/src/tiri/jit/src/runtime/lj_vmarray.cpp
+++ b/src/tiri/jit/src/runtime/lj_vmarray.cpp
@@ -233,10 +233,22 @@ extern "C" int lj_arr_set(lua_State *L, cTValue *O, cTValue *K, cTValue *V)
 
 extern "C" void lj_arr_getidx(lua_State *L, GCarray *Array, int32_t Idx, TValue *Result)
 {
-   JITStackSync stack_sync(L);
-   if (Idx < 0 or MSize(Idx) >= Array->len) lj_err_msgv(L, ErrMsg::ARROB, Idx, int(Array->len));
+   if (Idx < 0 or MSize(Idx) >= Array->len) {
+      JITStackSync stack_sync(L);
+      lj_err_msgv(L, ErrMsg::ARROB, Idx, int(Array->len));
+   }
+
+   // C string and structure loads allocate.  Other element types only copy an immediate value or an existing GC
+   // reference, so synchronising the interpreter stack for every indexed read would penalise array iteration.
+
+   if (Array->elemtype IS AET::CSTR or Array->elemtype IS AET::STR_CPP or Array->elemtype IS AET::STRUCT) {
+      JITStackSync stack_sync(L);
+      arr_load_elem(L, Array, uint32_t(Idx), Result);
+      stack_sync.restore();
+      return;
+   }
+
    arr_load_elem(L, Array, uint32_t(Idx), Result);
-   stack_sync.restore();
 }
 
 //********************************************************************************************************************
@@ -249,6 +261,14 @@ extern "C" void lj_arr_safe_getidx(lua_State *L, GCarray *Array, int32_t Idx, TV
       setnilV(Result);
       return;
    }
+
+   if (Array->elemtype IS AET::CSTR or Array->elemtype IS AET::STR_CPP or Array->elemtype IS AET::STRUCT) {
+      JITStackSync stack_sync(L);
+      arr_load_elem(L, Array, uint32_t(Idx), Result);
+      stack_sync.restore();
+      return;
+   }
+
    arr_load_elem(L, Array, uint32_t(Idx), Result);
 }
 
@@ -257,23 +277,40 @@ extern "C" void lj_arr_safe_getidx(lua_State *L, GCarray *Array, int32_t Idx, TV
 
 extern "C" void lj_arr_setidx(lua_State *L, GCarray *Array, int32_t Idx, cTValue *Val)
 {
-   JITStackSync stack_sync(L);
-   if (Idx < 0 or MSize(Idx) >= Array->len) lj_err_msgv(L, ErrMsg::ARROB, Idx, int(Array->len));
-   if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
+   if (Idx < 0 or MSize(Idx) >= Array->len) {
+      JITStackSync stack_sync(L);
+      lj_err_msgv(L, ErrMsg::ARROB, Idx, int(Array->len));
+   }
+   if (Array->flags & ARRAY_READONLY) {
+      JITStackSync stack_sync(L);
+      lj_err_msg(L, ErrMsg::ARRRO);
+   }
    lj_array_store_checked(L, Array, uint32_t(Idx), Val);
-   stack_sync.restore();
 }
 
 //********************************************************************************************************************
 
 static void lj_arr_append_bytes(lua_State *L, GCarray *Array, const char *Data, MSize Len)
 {
-   if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
-   if (not (Array->elemtype IS AET::BYTE)) lj_err_msg(L, ErrMsg::ARRSTR);
-   if (Len > (~MSize(0) - Array->len)) lj_err_msg(L, ErrMsg::ARREXT);
+   if (Array->flags & ARRAY_READONLY) {
+      JITStackSync stack_sync(L);
+      lj_err_msg(L, ErrMsg::ARRRO);
+   }
+   if (not (Array->elemtype IS AET::BYTE)) {
+      JITStackSync stack_sync(L);
+      lj_err_msg(L, ErrMsg::ARRSTR);
+   }
+   if (Len > (~MSize(0) - Array->len)) {
+      JITStackSync stack_sync(L);
+      lj_err_msg(L, ErrMsg::ARREXT);
+   }
 
    MSize new_len = Array->len + Len;
-   if (new_len > Array->capacity and not lj_array_grow(L, Array, new_len)) lj_err_msg(L, ErrMsg::ARREXT);
+   if (new_len > Array->capacity) {
+      JITStackSync stack_sync(L);
+      if (not lj_array_grow(L, Array, new_len)) lj_err_msg(L, ErrMsg::ARREXT);
+      stack_sync.restore();
+   }
    if (Len > 0) memcpy((uint8_t*)Array->arraydata() + Array->len, Data, Len);
    Array->len = new_len;
 }
@@ -283,9 +320,7 @@ static void lj_arr_append_bytes(lua_State *L, GCarray *Array, const char *Data, 
 
 extern "C" void lj_arr_putstr(lua_State *L, GCarray *Array, GCstr *Str)
 {
-   JITStackSync stack_sync(L);
    lj_arr_append_bytes(L, Array, strdata(Str), Str->len);
-   stack_sync.restore();
 }
 
 //********************************************************************************************************************
@@ -293,9 +328,7 @@ extern "C" void lj_arr_putstr(lua_State *L, GCarray *Array, GCstr *Str)
 
 extern "C" void lj_arr_putsbuf(lua_State *L, GCarray *Array, SBuf *Buf)
 {
-   JITStackSync stack_sync(L);
    lj_arr_append_bytes(L, Array, Buf->b, sbuflen(Buf));
-   stack_sync.restore();
 }
 
 //********************************************************************************************************************
@@ -317,12 +350,13 @@ extern "C" void lj_arr_putnumtv(lua_State *L, GCarray *Array, cTValue *Value)
 
 extern "C" void lj_arr_clear(lua_State *L, GCarray *Array)
 {
-   JITStackSync stack_sync(L);
-   if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
+   if (Array->flags & ARRAY_READONLY) {
+      JITStackSync stack_sync(L);
+      lj_err_msg(L, ErrMsg::ARRRO);
+   }
 
    lj_array_clear_range(Array, 0, Array->len);
    Array->len = 0;
-   stack_sync.restore();
 }
 
 //********************************************************************************************************************
@@ -330,15 +364,24 @@ extern "C" void lj_arr_clear(lua_State *L, GCarray *Array)
 
 extern "C" int32_t lj_arr_resize(lua_State *L, GCarray *Array, int32_t NewSize)
 {
-   JITStackSync stack_sync(L);
-   if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
-   if (NewSize < 0) lj_err_msgv(L, ErrMsg::NUMRNG, "non-negative", "negative");
+   if (Array->flags & ARRAY_READONLY) {
+      JITStackSync stack_sync(L);
+      lj_err_msg(L, ErrMsg::ARRRO);
+   }
+   if (NewSize < 0) {
+      JITStackSync stack_sync(L);
+      lj_err_msgv(L, ErrMsg::NUMRNG, "non-negative", "negative");
+   }
 
    MSize target_len = MSize(NewSize);
    MSize old_len = Array->len;
 
    if (target_len > old_len) {
-      if (target_len > Array->capacity and not lj_array_grow(L, Array, target_len)) lj_err_msg(L, ErrMsg::ARREXT);
+      if (target_len > Array->capacity) {
+         JITStackSync stack_sync(L);
+         if (not lj_array_grow(L, Array, target_len)) lj_err_msg(L, ErrMsg::ARREXT);
+         stack_sync.restore();
+      }
 
       if (Array->elemtype IS AET::STR_GC or Array->elemtype IS AET::TABLE or
           Array->elemtype IS AET::ARRAY or Array->elemtype IS AET::OBJECT or Array->elemtype IS AET::ANY) {
@@ -355,9 +398,7 @@ extern "C" int32_t lj_arr_resize(lua_State *L, GCarray *Array, int32_t NewSize)
    }
 
    Array->len = target_len;
-   int32_t result = int32_t(Array->len);
-   stack_sync.restore();
-   return result;
+   return int32_t(Array->len);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/stack_helpers.h
+++ b/src/tiri/jit/src/runtime/stack_helpers.h
@@ -12,6 +12,45 @@
 #include "lua.h"
 
 //********************************************************************************************************************
+// JITStackSync: synchronise interpreter stack pointers while a recorded C helper is running.
+//
+// Compiled traces keep their active base in global_State::jit_base and do not maintain L->base or L->top.  Helpers
+// that allocate or raise must expose the trace frame to the GC and error unwinder.  restore() is deliberately explicit:
+// normal returns restore the prior interpreter view, while a non-local error leaves the synchronised state intact for
+// unwinding.
+
+class JITStackSync {
+   lua_State *lua_;
+   ptrdiff_t saved_base_;
+   ptrdiff_t saved_top_;
+   bool active_;
+
+public:
+   explicit JITStackSync(lua_State *L) noexcept :
+      lua_(L), saved_base_(0), saved_top_(0), active_(false)
+   {
+      if (auto jit_base = tvref(G(L)->jit_base); jit_base) {
+         saved_base_ = savestack(L, L->base);
+         saved_top_ = savestack(L, L->top);
+         active_ = true;
+         L->base = jit_base;
+         if (curr_funcisL(L)) L->top = curr_topL(L);
+      }
+   }
+
+   void restore() noexcept
+   {
+      if (active_) {
+         lua_->base = restorestack(lua_, saved_base_);
+         lua_->top = restorestack(lua_, saved_top_);
+      }
+   }
+
+   JITStackSync(const JITStackSync &) = delete;
+   JITStackSync & operator=(const JITStackSync &) = delete;
+};
+
+//********************************************************************************************************************
 // VMHelperGuard: RAII guard for C functions called from VM assembler code
 //
 // When the VM assembler calls C helper functions (marked LJ_FUNCA), the Lua state may be in a partially synchronised

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -2116,6 +2116,79 @@ end
    assert(trace_found is true, "Expected array.getString() to produce a JIT trace")
 end
 
+function traced_struct_array_get(Values:array<struct<JITArrayContractAlpha>>, Index:num):struct<JITArrayContractAlpha>
+   return Values[Index]
+end
+
+function traced_struct_array_set(Values:array<struct<JITArrayContractAlpha>>, Value:any)
+   Values[0] = Value
+end
+
+function traced_float_array_push(Values:array<float>, Value:num):num
+   return Values.push(Value)
+end
+
+function traced_array_resize_sync(Values:array<int>, Size:num):num
+   return Values.resize(Size)
+end
+
+function traced_array_get_string_error(Values:array<byte>, Start:num):str
+   return Values.getString(Start, 1)
+end
+
+@Test(hotpath=80) function JITArrayHelpersPreserveErrorStack()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   local alpha = struct<JITArrayContractAlpha> { Value=7 }
+   local beta = struct<JITArrayContractBeta> { Value=9 }
+   local structs = array<struct<JITArrayContractAlpha>> { alpha }
+   local floats = array<float>
+   local integers = array<int> { 1 }
+   local bytes = array.new("abc")
+
+   for i in {1 into 200} do
+      assert(traced_struct_array_get(structs, 0).Value is 7,
+         'A helper-backed structure array get should remain valid while hot')
+      traced_struct_array_set(structs, alpha)
+      traced_float_array_push(floats, 1.5)
+      traced_array_resize_sync(integers, (i % 3) + 1)
+      assert(traced_array_get_string_error(bytes, 0) is 'a',
+         'A helper-backed byte string extraction should remain valid while hot')
+   end
+
+   try
+      traced_struct_array_set(structs, beta)
+   except error_value
+      assert(error_value != nil, 'A traced structure-array mismatch should provide an error value')
+   success
+      error('A traced structure-array mismatch should fail')
+   end
+
+   try
+      traced_float_array_push(floats, 1e100)
+   except error_value
+      assert(error_value != nil, 'A traced float-array overflow should provide an error value')
+   success
+      error('A traced float-array overflow should fail')
+   end
+
+   try
+      traced_array_get_string_error(bytes, -1)
+   except error_value
+      assert(error_value != nil, 'A traced getString range error should provide an error value')
+   success
+      error('A traced getString range error should fail')
+   end
+
+   assert(traced_struct_array_get(structs, 0).Value is 7,
+      'Caught helper errors must preserve the original structure-array value and frame')
+   assert(traced_array_resize_sync(integers, 4) is 4 and traced_array_get_string_error(bytes, 1) is 'b',
+      'Array helper calls must remain usable after caught trace errors')
+   assert(count_jit_traces(30) > 0, 'Expected the array helper workload to produce JIT traces')
+end
+
 @Test(hotpath=80) function ArrayPushSingleValueTracesAndReturnsLength()
    jit.on()
    jit.flush()


### PR DESCRIPTION
## Summary

* Synchronise interpreter stack pointers when JIT array and environment helpers allocate or raise, preventing error messages from corrupting active lower frames.
* Relocate `jit_base` correctly when stack storage moves.
* Restrict synchronisation to allocating and error paths so successful array iteration, mutation and global contract checks remain fast.
* Add regression coverage for traced array helper failures and recovery after caught errors.

## Validation

* Built `tiri` and `origo_cmd` in Debug configuration.
* Installed the resulting build.
* Ran `src/tiri/tests/test_jit.tiri`: 93/93 tests passed.
* Controlled same-build A/B improved `IterateArrayPairs` from approximately 67 ms to 11 ms and `ScopeGlobal` from approximately 86 ms to 51 ms; iterator workloads that exceeded the one-second measurement window with blanket synchronisation completed at approximately 38 ms with selective synchronisation.

## Benchmark note

`ArrayContainsValue` was unchanged in the controlled A/B and does not execute the guarded helper paths changed here, so its previously reported movement appears independent of stack synchronisation.