### PR TITLE
[Tiri] Optimised built-in array membership on JIT traces

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -778,6 +778,7 @@ set (TIRI_SOURCES "${MOD}.cpp" "tiri_module.cpp" "tiri_async.cpp" "tiri_struct.c
    "${JIT_SRC}/lib/lib_regex.cpp"
    "${JIT_SRC}/lib/lib_string.cpp"
    "${JIT_SRC}/lib/lib_table.cpp"
+   "${JIT_SRC}/runtime/lj_array_search.cpp"
    "${JIT_SRC}/bytecode/lj_bc.cpp"
    "${JIT_SRC}/bytecode/lj_bcread.cpp"
    "${JIT_SRC}/bytecode/lj_bcwrite.cpp"

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -1501,203 +1501,8 @@ LJLIB_CF(array_fill)
 }
 
 //********************************************************************************************************************
-// Template-based find for contiguous forward search (step=1). Hoists type dispatch outside the loop.
+#include "lj_array_search.h"
 
-template<typename T>
-static int32_t find_forward_contiguous(const void *Data, int32_t Start, int32_t Stop, lua_Number Value)
-{
-   const T *base = (const T *)Data;
-   T val = T(Value);
-   for (int32_t i = Start; i <= Stop; i++) {
-      if (base[i] IS val) return i;
-   }
-   return -1;
-}
-
-//********************************************************************************************************************
-// Template-based find for stepped ranges. Hoists type dispatch outside the loop.
-
-template<typename T>
-static int32_t find_stepped(const void *Data, int32_t Start, int32_t Stop, int32_t Step, lua_Number Value)
-{
-   const T *base = (const T *)Data;
-   T val = T(Value);
-   if (Step > 0) {
-      for (int32_t i = Start; i <= Stop; i += Step) {
-         if (base[i] IS val) return i;
-      }
-   }
-   else {
-      for (int32_t i = Start; i >= Stop; i += Step) {
-         if (base[i] IS val) return i;
-      }
-   }
-   return -1;
-}
-
-//********************************************************************************************************************
-// Dispatches find operation based on array element type.
-// Returns index if found, -1 if not found.
-
-static int32_t find_in_array(GCarray *Arr, lua_Number Value, int32_t Start, int32_t Stop, int32_t Step)
-{
-   const void *data = Arr->arraydata();
-
-   // Optimised path for contiguous forward search (step=1)
-   if (Step IS 1) {
-      switch (Arr->elemtype) {
-         case AET::BYTE:   return find_forward_contiguous<uint8_t>(data, Start, Stop, Value);
-         case AET::INT8:   return find_forward_contiguous<int8_t>(data, Start, Stop, Value);
-         case AET::INT16:  return find_forward_contiguous<int16_t>(data, Start, Stop, Value);
-         case AET::INT32:  return find_forward_contiguous<int32_t>(data, Start, Stop, Value);
-         case AET::INT64:  return find_forward_contiguous<int64_t>(data, Start, Stop, Value);
-         case AET::UINT8:  return find_forward_contiguous<uint8_t>(data, Start, Stop, Value);
-         case AET::UINT16: return find_forward_contiguous<uint16_t>(data, Start, Stop, Value);
-         case AET::UINT32: return find_forward_contiguous<uint32_t>(data, Start, Stop, Value);
-         case AET::UINT64: return find_forward_contiguous<uint64_t>(data, Start, Stop, Value);
-         case AET::FLOAT:  return find_forward_contiguous<float>(data, Start, Stop, Value);
-         case AET::DOUBLE: return find_forward_contiguous<double>(data, Start, Stop, Value);
-         default: return -1;
-      }
-   }
-
-   // Stepped search path (non-contiguous or reverse direction)
-   switch (Arr->elemtype) {
-      case AET::BYTE:   return find_stepped<uint8_t>(data, Start, Stop, Step, Value);
-      case AET::INT8:   return find_stepped<int8_t>(data, Start, Stop, Step, Value);
-      case AET::INT16:  return find_stepped<int16_t>(data, Start, Stop, Step, Value);
-      case AET::INT32:  return find_stepped<int32_t>(data, Start, Stop, Step, Value);
-      case AET::INT64:  return find_stepped<int64_t>(data, Start, Stop, Step, Value);
-      case AET::UINT8:  return find_stepped<uint8_t>(data, Start, Stop, Step, Value);
-      case AET::UINT16: return find_stepped<uint16_t>(data, Start, Stop, Step, Value);
-      case AET::UINT32: return find_stepped<uint32_t>(data, Start, Stop, Step, Value);
-      case AET::UINT64: return find_stepped<uint64_t>(data, Start, Stop, Step, Value);
-      case AET::FLOAT:  return find_stepped<float>(data, Start, Stop, Step, Value);
-      case AET::DOUBLE: return find_stepped<double>(data, Start, Stop, Step, Value);
-      default: return -1;
-   }
-}
-
-//********************************************************************************************************************
-// Object search by UID for stepped ranges.
-
-static int32_t find_object_in_array(GCarray *Arr, OBJECTID SearchUid, int32_t Start, int32_t Stop, int32_t Step)
-{
-   auto refs = Arr->get<GCRef>();
-   if (Step > 0) {
-      for (int32_t i = Start; i <= Stop; i += Step) {
-         GCRef ref = refs[i];
-         if (gcref(ref)) {
-            GCobject *obj = gco_to_object(gcref(ref));
-            if (obj and obj->uid IS SearchUid) return i;
-         }
-      }
-   }
-   else {
-      for (int32_t i = Start; i >= Stop; i += Step) {
-         GCRef ref = refs[i];
-         if (gcref(ref)) {
-            GCobject *obj = gco_to_object(gcref(ref));
-            if (obj and obj->uid IS SearchUid) return i;
-         }
-      }
-   }
-   return -1;
-}
-
-//********************************************************************************************************************
-// Canonical array membership helper shared by the library adapter, interpreter and trace recorder.
-
-extern "C" int32_t lj_arr_contains(lua_State *L, GCarray *Array, cTValue *Candidate)
-{
-   if (Array->len IS 0) return 0;
-
-   if (Array->elemtype IS AET::OBJECT) {
-      OBJECTID search_uid;
-      if (tvisobject(Candidate)) search_uid = objectV(Candidate)->uid;
-      else {
-         TValue converted;
-         auto candidate_uid = try_to_integer(Candidate, &converted);
-         if (not candidate_uid) {
-            lj_err_argv(L, 2, ErrMsg::BADTYPE, "object or uid", lj_typename(Candidate));
-            return 0;
-         }
-         search_uid = OBJECTID(*candidate_uid);
-      }
-      return find_object_in_array(Array, search_uid, 0, int32_t(Array->len - 1), 1) >= 0;
-   }
-
-   if (Array->elemtype IS AET::STR_GC) {
-      GCstr *candidate_string;
-      if (tvisstr(Candidate)) candidate_string = strV(Candidate);
-      else if (tvisnumber(Candidate)) {
-         TValue converted;
-         copyTV(L, &converted, Candidate);
-         candidate_string = lj_strfmt_number(L, &converted);
-      }
-      else {
-         lj_err_argv(L, 2, ErrMsg::BADTYPE, "string", lj_typename(Candidate));
-         return 0;
-      }
-      return find_string_in_array(Array, candidate_string, 0, int32_t(Array->len - 1), 1) >= 0;
-   }
-
-   TValue converted;
-   auto candidate_number = try_to_number(Candidate, &converted);
-   if (not candidate_number) {
-      lj_err_argv(L, 2, ErrMsg::BADTYPE, "number", lj_typename(Candidate));
-      return 0;
-   }
-   return find_in_array(Array, *candidate_number, 0, int32_t(Array->len - 1), 1) >= 0;
-}
-
-extern "C" int32_t lj_arr_contains_num(GCarray *Array, lua_Number Candidate)
-{
-   if (Array->len IS 0) return 0;
-   return find_in_array(Array, Candidate, 0, int32_t(Array->len - 1), 1) >= 0;
-}
-
-extern "C" int32_t lj_arr_contains_str(GCarray *Array, GCstr *Candidate)
-{
-   if (Array->len IS 0) return 0;
-   return find_string_in_array(Array, Candidate, 0, int32_t(Array->len - 1), 1) >= 0;
-}
-
-//********************************************************************************************************************
-// String search by value for stepped ranges.
-// Returns index if found, -1 if not found.
-
-static int32_t find_string_in_array(GCarray *Arr, GCstr *SearchStr, int32_t Start, int32_t Stop, int32_t Step)
-{
-   auto refs = Arr->get<GCRef>();
-   if (Step > 0) {
-      for (int32_t i = Start; i <= Stop; i += Step) {
-         GCRef ref = refs[i];
-         if (gcref(ref)) {
-            GCstr *elem = gco_to_string(gcref(ref));
-            if (elem->len IS SearchStr->len and
-                memcmp(strdata(elem), strdata(SearchStr), elem->len) IS 0) {
-               return i;
-            }
-         }
-      }
-   }
-   else {
-      for (int32_t i = Start; i >= Stop; i += Step) {
-         GCRef ref = refs[i];
-         if (gcref(ref)) {
-            GCstr *elem = gco_to_string(gcref(ref));
-            if (elem->len IS SearchStr->len and
-                memcmp(strdata(elem), strdata(SearchStr), elem->len) IS 0) {
-               return i;
-            }
-         }
-      }
-   }
-   return -1;
-}
-
-//********************************************************************************************************************
 // Usage: array.find(arr, value [, start]) or array.find(arr, value, {range})
 //
 // Searches for a value in the array.
@@ -1767,6 +1572,52 @@ LJLIB_CF(array_find)
    if (not array_find_start(start, arr->len, &start)) return array_push_find_result(L, -1);
    if (start >= stop) return array_push_find_result(L, -1);
    return array_push_find_result(L, find_in_array(arr, value, start, stop - 1, 1));
+}
+
+//********************************************************************************************************************
+// Canonical array membership helper shared by the library adapter, interpreter and trace recorder.
+
+extern "C" int32_t lj_arr_contains(lua_State *L, GCarray *Array, cTValue *Candidate)
+{
+   if (Array->len IS 0) return 0;
+
+   if (Array->elemtype IS AET::OBJECT) {
+      OBJECTID search_uid;
+      if (tvisobject(Candidate)) search_uid = objectV(Candidate)->uid;
+      else {
+         TValue converted;
+         auto candidate_uid = try_to_integer(Candidate, &converted);
+         if (not candidate_uid) {
+            lj_err_argv(L, 2, ErrMsg::BADTYPE, "object or uid", lj_typename(Candidate));
+            return 0;
+         }
+         search_uid = OBJECTID(*candidate_uid);
+      }
+      return lj_arr_find_object(Array, search_uid, 0, int32_t(Array->len - 1), 1) >= 0;
+   }
+
+   if (Array->elemtype IS AET::STR_GC) {
+      GCstr *candidate_string;
+      if (tvisstr(Candidate)) candidate_string = strV(Candidate);
+      else if (tvisnumber(Candidate)) {
+         TValue converted;
+         copyTV(L, &converted, Candidate);
+         candidate_string = lj_strfmt_number(L, &converted);
+      }
+      else {
+         lj_err_argv(L, 2, ErrMsg::BADTYPE, "string", lj_typename(Candidate));
+         return 0;
+      }
+      return lj_arr_find_str(Array, candidate_string, 0, int32_t(Array->len - 1), 1) >= 0;
+   }
+
+   TValue converted;
+   auto candidate_number = try_to_number(Candidate, &converted);
+   if (not candidate_number) {
+      lj_err_argv(L, 2, ErrMsg::BADTYPE, "number", lj_typename(Candidate));
+      return 0;
+   }
+   return lj_arr_find_num(Array, *candidate_number, 0, int32_t(Array->len - 1), 1) >= 0;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -25,7 +25,9 @@
 #include "lj_bulk.h"
 #include "lj_meta.h"
 #include "lj_struct.h"
+#include "lj_vmarray.h"
 #include "lib.h"
+#include "lib_utils.h"
 #include "lib_range.h"
 #include "../parser/static_type_descriptor.h"
 
@@ -58,6 +60,7 @@ constexpr auto HASH_ANY     = kt::strhash("any");
 // Forward declarations
 static int32_t find_in_array(GCarray *Arr, lua_Number Value, int32_t Start, int32_t Stop, int32_t Step);
 static int32_t find_object_in_array(GCarray *Arr, OBJECTID SearchUid, int32_t Start, int32_t Stop, int32_t Step);
+static int32_t find_string_in_array(GCarray *Arr, GCstr *SearchStr, int32_t Start, int32_t Stop, int32_t Step);
 static void array_push_element(lua_State *L, GCarray *Arr, MSize Idx);
 
 const array_meta glArrayConversion[size_t(AET::MAX)] = {
@@ -744,44 +747,13 @@ LJLIB_CF(array_concat)
 LJLIB_NOREG LJLIB_CF(array_contains)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
-
-   if (arr->len IS 0) {
-      lua_pushboolean(L, 0);
-      return 1;
-   }
-
-   if (arr->elemtype IS AET::OBJECT) {
-      OBJECTID search_uid = object_uid_from_value(L, 2);
-      int32_t result = find_object_in_array(arr, search_uid, 0, int32_t(arr->len - 1), 1);
-      lua_pushboolean(L, result >= 0 ? 1 : 0);
-      return 1;
-   }
-
-   // For string arrays, we need special handling
-   if (arr->elemtype IS AET::STR_GC) {
-      GCstr *search_str = lj_lib_checkstr(L, 2);
-      auto refs = arr->get<GCRef>();
-      for (MSize i = 0; i < arr->len; i++) {
-         GCRef ref = refs[i];
-         if (gcref(ref)) {
-            GCstr *elem = gco_to_string(gcref(ref));
-            if (elem->len IS search_str->len and
-                memcmp(strdata(elem), strdata(search_str), elem->len) IS 0) {
-               lua_pushboolean(L, 1);
-               return 1;
-            }
-         }
-      }
-      lua_pushboolean(L, 0);
-      return 1;
-   }
-
-   // For numeric types, use the existing find logic
-   lua_Number value = lj_lib_checknum(L, 2);
-   int32_t result = find_in_array(arr, value, 0, int32_t(arr->len - 1), 1);
-
-   lua_pushboolean(L, result >= 0 ? 1 : 0);
+   lua_pushboolean(L, lj_arr_contains(L, arr, L->base + 1));
    return 1;
+}
+
+extern "C" int32_t lj_arr_is_contains_handler(cTValue *Value)
+{
+   return tvisfunc(Value) and iscfunc(funcV(Value)) and funcV(Value)->c.f IS lj_cf_array_contains;
 }
 
 //********************************************************************************************************************
@@ -1631,6 +1603,64 @@ static int32_t find_object_in_array(GCarray *Arr, OBJECTID SearchUid, int32_t St
       }
    }
    return -1;
+}
+
+//********************************************************************************************************************
+// Canonical array membership helper shared by the library adapter, interpreter and trace recorder.
+
+extern "C" int32_t lj_arr_contains(lua_State *L, GCarray *Array, cTValue *Candidate)
+{
+   if (Array->len IS 0) return 0;
+
+   if (Array->elemtype IS AET::OBJECT) {
+      OBJECTID search_uid;
+      if (tvisobject(Candidate)) search_uid = objectV(Candidate)->uid;
+      else {
+         TValue converted;
+         auto candidate_uid = try_to_integer(Candidate, &converted);
+         if (not candidate_uid) {
+            lj_err_argv(L, 2, ErrMsg::BADTYPE, "object or uid", lj_typename(Candidate));
+            return 0;
+         }
+         search_uid = OBJECTID(*candidate_uid);
+      }
+      return find_object_in_array(Array, search_uid, 0, int32_t(Array->len - 1), 1) >= 0;
+   }
+
+   if (Array->elemtype IS AET::STR_GC) {
+      GCstr *candidate_string;
+      if (tvisstr(Candidate)) candidate_string = strV(Candidate);
+      else if (tvisnumber(Candidate)) {
+         TValue converted;
+         copyTV(L, &converted, Candidate);
+         candidate_string = lj_strfmt_number(L, &converted);
+      }
+      else {
+         lj_err_argv(L, 2, ErrMsg::BADTYPE, "string", lj_typename(Candidate));
+         return 0;
+      }
+      return find_string_in_array(Array, candidate_string, 0, int32_t(Array->len - 1), 1) >= 0;
+   }
+
+   TValue converted;
+   auto candidate_number = try_to_number(Candidate, &converted);
+   if (not candidate_number) {
+      lj_err_argv(L, 2, ErrMsg::BADTYPE, "number", lj_typename(Candidate));
+      return 0;
+   }
+   return find_in_array(Array, *candidate_number, 0, int32_t(Array->len - 1), 1) >= 0;
+}
+
+extern "C" int32_t lj_arr_contains_num(GCarray *Array, lua_Number Candidate)
+{
+   if (Array->len IS 0) return 0;
+   return find_in_array(Array, Candidate, 0, int32_t(Array->len - 1), 1) >= 0;
+}
+
+extern "C" int32_t lj_arr_contains_str(GCarray *Array, GCstr *Candidate)
+{
+   if (Array->len IS 0) return 0;
+   return find_string_in_array(Array, Candidate, 0, int32_t(Array->len - 1), 1) >= 0;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -218,6 +218,9 @@ typedef struct CCallInfo {
   _(ANY,        lj_arr_clear,      2,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_resize,     3,   S, INT, CCI_L|CCI_T) \
   _(ANY,        lj_arr_getstring,  4,   S, STR, CCI_L|CCI_T) \
+  _(ANY,        lj_arr_contains,   3,   S, INT, CCI_L|CCI_T) \
+  _(ANY,        lj_arr_contains_num, 2, S, INT, 0) \
+  _(ANY,        lj_arr_contains_str, 2, S, INT, 0) \
   /* Direct range-loop helpers */ \
   _(ANY,        lj_range_prepare_step,  5, N, NUM, CCI_L|CCI_T) \
   _(ANY,        lj_range_prepare_count, 5, N, NUM, CCI_L|CCI_T) \

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -3498,6 +3498,28 @@ static void rec_contains(jit_State *J, RecordOps *ops)
 
    rec_comp_prep(J);
    if (lj_record_mm_lookup(J, ix, MM_contains)) {
+      if (tref_isarray(ix->val) and lj_arr_is_contains_handler(&ix->mobjv)) {
+         GCarray *array = arrayV(&ix->valv);
+         TRef result_ref;
+         if (array->elemtype IS AET::STR_GC and tref_isstr(ix->key)) {
+            result_ref = lj_ir_call(J, IRCALL_lj_arr_contains_str, ix->val, ix->key);
+         }
+         else if (glArrayConversion[size_t(array->elemtype)].itype IS uint8_t(LJ_TNUMX) and
+             tref_isnumber(ix->key)) {
+            TRef candidate_ref = ix->key;
+            if (tref_isinteger(candidate_ref)) {
+               candidate_ref = emitir(IRTN(IR_CONV), candidate_ref, IRCONV_NUM_INT);
+            }
+            result_ref = lj_ir_call(J, IRCALL_lj_arr_contains_num, ix->val, candidate_ref);
+         }
+         else {
+            TRef candidate_ref = rec_tmpref(J, ix->key, IRTMPREF_IN1);
+            result_ref = lj_ir_call(J, IRCALL_lj_arr_contains, ix->val, candidate_ref);
+         }
+         emitir(IRTG(IR_NE, IRT_INT), result_ref, lj_ir_kint(J, 0));
+         rec_comp_fixup(J, J->pc, int(ops->op) & 1);
+         return;
+      }
       rec_mm_callcomp(J, ix, int(ops->op));
       return;
    }

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -3500,6 +3500,15 @@ static void rec_contains(jit_State *J, RecordOps *ops)
    if (lj_record_mm_lookup(J, ix, MM_contains)) {
       if (tref_isarray(ix->val) and lj_arr_is_contains_handler(&ix->mobjv)) {
          GCarray *array = arrayV(&ix->valv);
+         // Keep the element-type guard on its own snapshot.  A mismatch must re-execute membership instead of taking
+         // the branch recorded for the specialised helper.
+         rec_comp_prep(J);
+         IRBuilder ir(J);
+         TRef element_type_ref = ir.fload(ix->val, IRFL_ARRAY_ELEMTYPE, IRT_U8);
+         ir.guard_eq_int(element_type_ref, ir.kint(int32_t(array->elemtype)));
+
+         // The helper result guard needs the comparison snapshot that rec_comp_fixup adjusts.
+         rec_comp_prep(J);
          TRef result_ref;
          if (array->elemtype IS AET::STR_GC and tref_isstr(ix->key)) {
             result_ref = lj_ir_call(J, IRCALL_lj_arr_contains_str, ix->val, ix->key);

--- a/src/tiri/jit/src/runtime/lj_array_search.cpp
+++ b/src/tiri/jit/src/runtime/lj_array_search.cpp
@@ -1,0 +1,43 @@
+// Native array search runtime.
+// Copyright © 2026 Paul Manias.
+
+#define find_forward_contiguous runtime_find_forward_contiguous
+#define find_stepped runtime_find_stepped
+#define find_in_array runtime_find_in_array
+#define find_string_in_array runtime_find_string_in_array
+#define find_object_in_array runtime_find_object_in_array
+#define ARRAY_SEARCH_NOINLINE
+#include "lj_array_search.h"
+#undef find_forward_contiguous
+#undef find_stepped
+#undef find_in_array
+#undef find_string_in_array
+#undef find_object_in_array
+#include "lj_vmarray.h"
+
+LJ_NOAPI int32_t lj_arr_find_num(GCarray *Array, lua_Number Value, int32_t Start, int32_t Stop, int32_t Step)
+{
+   return runtime_find_in_array(Array, Value, Start, Stop, Step);
+}
+
+LJ_NOAPI int32_t lj_arr_find_str(GCarray *Array, GCstr *SearchStr, int32_t Start, int32_t Stop, int32_t Step)
+{
+   return runtime_find_string_in_array(Array, SearchStr, Start, Stop, Step);
+}
+
+LJ_NOAPI int32_t lj_arr_find_object(GCarray *Array, OBJECTID SearchUid, int32_t Start, int32_t Stop, int32_t Step)
+{
+   return runtime_find_object_in_array(Array, SearchUid, Start, Stop, Step);
+}
+
+extern "C" int32_t lj_arr_contains_num(GCarray *Array, lua_Number Candidate)
+{
+   if (Array->len IS 0) return 0;
+   return runtime_find_in_array(Array, Candidate, 0, int32_t(Array->len - 1), 1) >= 0;
+}
+
+extern "C" int32_t lj_arr_contains_str(GCarray *Array, GCstr *Candidate)
+{
+   if (Array->len IS 0) return 0;
+   return runtime_find_string_in_array(Array, Candidate, 0, int32_t(Array->len - 1), 1) >= 0;
+}

--- a/src/tiri/jit/src/runtime/lj_array_search.h
+++ b/src/tiri/jit/src/runtime/lj_array_search.h
@@ -1,0 +1,136 @@
+// Native array search kernels.
+// Copyright © 2026 Paul Manias.
+
+#ifndef LJ_ARRAY_SEARCH_H
+#define LJ_ARRAY_SEARCH_H
+
+#include "lj_obj.h"
+#include "lj_array.h"
+#include "lj_str.h"
+
+#include <cstring>
+
+#ifndef ARRAY_SEARCH_NOINLINE
+#define ARRAY_SEARCH_NOINLINE LJ_NOINLINE
+#endif
+
+template<typename T>
+static int32_t find_forward_contiguous(const void *Data, int32_t Start, int32_t Stop, lua_Number Value)
+{
+   const T *base = (const T *)Data;
+   T value = T(Value);
+   for (int32_t i = Start; i <= Stop; i++) {
+      if (base[i] IS value) return i;
+   }
+   return -1;
+}
+
+template<typename T>
+static int32_t find_stepped(const void *Data, int32_t Start, int32_t Stop, int32_t Step, lua_Number Value)
+{
+   const T *base = (const T *)Data;
+   T value = T(Value);
+   if (Step > 0) {
+      for (int32_t i = Start; i <= Stop; i += Step) {
+         if (base[i] IS value) return i;
+      }
+   }
+   else {
+      for (int32_t i = Start; i >= Stop; i += Step) {
+         if (base[i] IS value) return i;
+      }
+   }
+   return -1;
+}
+
+static ARRAY_SEARCH_NOINLINE int32_t find_in_array(GCarray *Array, lua_Number Value, int32_t Start, int32_t Stop,
+   int32_t Step)
+{
+   const void *data = Array->arraydata();
+
+   if (Step IS 1) {
+      switch (Array->elemtype) {
+         case AET::BYTE:   return find_forward_contiguous<uint8_t>(data, Start, Stop, Value);
+         case AET::INT8:   return find_forward_contiguous<int8_t>(data, Start, Stop, Value);
+         case AET::INT16:  return find_forward_contiguous<int16_t>(data, Start, Stop, Value);
+         case AET::INT32:  return find_forward_contiguous<int32_t>(data, Start, Stop, Value);
+         case AET::INT64:  return find_forward_contiguous<int64_t>(data, Start, Stop, Value);
+         case AET::UINT8:  return find_forward_contiguous<uint8_t>(data, Start, Stop, Value);
+         case AET::UINT16: return find_forward_contiguous<uint16_t>(data, Start, Stop, Value);
+         case AET::UINT32: return find_forward_contiguous<uint32_t>(data, Start, Stop, Value);
+         case AET::UINT64: return find_forward_contiguous<uint64_t>(data, Start, Stop, Value);
+         case AET::FLOAT:  return find_forward_contiguous<float>(data, Start, Stop, Value);
+         case AET::DOUBLE: return find_forward_contiguous<double>(data, Start, Stop, Value);
+         default: return -1;
+      }
+   }
+
+   switch (Array->elemtype) {
+      case AET::BYTE:   return find_stepped<uint8_t>(data, Start, Stop, Step, Value);
+      case AET::INT8:   return find_stepped<int8_t>(data, Start, Stop, Step, Value);
+      case AET::INT16:  return find_stepped<int16_t>(data, Start, Stop, Step, Value);
+      case AET::INT32:  return find_stepped<int32_t>(data, Start, Stop, Step, Value);
+      case AET::INT64:  return find_stepped<int64_t>(data, Start, Stop, Step, Value);
+      case AET::UINT8:  return find_stepped<uint8_t>(data, Start, Stop, Step, Value);
+      case AET::UINT16: return find_stepped<uint16_t>(data, Start, Stop, Step, Value);
+      case AET::UINT32: return find_stepped<uint32_t>(data, Start, Stop, Step, Value);
+      case AET::UINT64: return find_stepped<uint64_t>(data, Start, Stop, Step, Value);
+      case AET::FLOAT:  return find_stepped<float>(data, Start, Stop, Step, Value);
+      case AET::DOUBLE: return find_stepped<double>(data, Start, Stop, Step, Value);
+      default: return -1;
+   }
+}
+
+static int32_t find_object_in_array(GCarray *Array, OBJECTID SearchUid, int32_t Start, int32_t Stop, int32_t Step)
+{
+   auto refs = Array->get<GCRef>();
+   if (Step > 0) {
+      for (int32_t i = Start; i <= Stop; i += Step) {
+         GCRef ref = refs[i];
+         if (gcref(ref)) {
+            GCobject *object = gco_to_object(gcref(ref));
+            if (object and object->uid IS SearchUid) return i;
+         }
+      }
+   }
+   else {
+      for (int32_t i = Start; i >= Stop; i += Step) {
+         GCRef ref = refs[i];
+         if (gcref(ref)) {
+            GCobject *object = gco_to_object(gcref(ref));
+            if (object and object->uid IS SearchUid) return i;
+         }
+      }
+   }
+   return -1;
+}
+
+static int32_t find_string_in_array(GCarray *Array, GCstr *SearchStr, int32_t Start, int32_t Stop, int32_t Step)
+{
+   auto refs = Array->get<GCRef>();
+   if (Step > 0) {
+      for (int32_t i = Start; i <= Stop; i += Step) {
+         GCRef ref = refs[i];
+         if (gcref(ref)) {
+            GCstr *element = gco_to_string(gcref(ref));
+            if (element->len IS SearchStr->len and
+                memcmp(strdata(element), strdata(SearchStr), element->len) IS 0) return i;
+         }
+      }
+   }
+   else {
+      for (int32_t i = Start; i >= Stop; i += Step) {
+         GCRef ref = refs[i];
+         if (gcref(ref)) {
+            GCstr *element = gco_to_string(gcref(ref));
+            if (element->len IS SearchStr->len and
+                memcmp(strdata(element), strdata(SearchStr), element->len) IS 0) return i;
+         }
+      }
+   }
+   return -1;
+}
+
+#undef ARRAY_SEARCH_NOINLINE
+
+#endif // LJ_ARRAY_SEARCH_H

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -25,6 +25,7 @@
 #include "lj_thunk.h"
 #include "lj_object.h"
 #include "lj_contract.h"
+#include "lj_vmarray.h"
 #include "stack_helpers.h"
 #include "lib.h"
 #include "lib_range.h"
@@ -588,6 +589,10 @@ TValue * lj_meta_contains(lua_State *L, cTValue *Candidate, cTValue *Target, int
 
    cTValue *method = lj_meta_lookup(L, target, MM_contains);
    if (not tvisnil(method)) {
+      if (tvisarray(target) and lj_arr_is_contains_handler(method)) {
+         int32_t result = lj_arr_contains(L, arrayV(target), candidate);
+         return (TValue *)(intptr_t)(bool(result) != bool(Inverted));
+      }
       return mmcall(L, Inverted ? lj_cont_condf : lj_cont_condt, method, target, candidate,
          MetamethodCallKind::Index);
    }

--- a/src/tiri/jit/src/runtime/lj_vmarray.h
+++ b/src/tiri/jit/src/runtime/lj_vmarray.h
@@ -54,6 +54,9 @@ extern "C" [[nodiscard]] int32_t lj_arr_is_contains_handler(cTValue *);
 extern "C" [[nodiscard]] int32_t lj_arr_contains(lua_State *, GCarray *, cTValue *);
 extern "C" [[nodiscard]] int32_t lj_arr_contains_num(GCarray *, lua_Number);
 extern "C" [[nodiscard]] int32_t lj_arr_contains_str(GCarray *, GCstr *);
+LJ_NOAPI [[nodiscard]] int32_t lj_arr_find_num(GCarray *, lua_Number, int32_t, int32_t, int32_t);
+LJ_NOAPI [[nodiscard]] int32_t lj_arr_find_str(GCarray *, GCstr *, int32_t, int32_t, int32_t);
+LJ_NOAPI [[nodiscard]] int32_t lj_arr_find_object(GCarray *, OBJECTID, int32_t, int32_t, int32_t);
 
 // Safe array get - returns nil for out-of-bounds instead of throwing error
 // Used by safe navigation operator (?[]) on arrays

--- a/src/tiri/jit/src/runtime/lj_vmarray.h
+++ b/src/tiri/jit/src/runtime/lj_vmarray.h
@@ -45,6 +45,16 @@ extern "C" GCstr * lj_arr_getstring(lua_State *, GCarray *, int32_t, int32_t);
 
 extern "C" GCarray * lj_arr_new_jit(lua_State *, uint32_t, uint32_t);
 
+// Test whether a resolved __contains value is the canonical array provider.
+
+extern "C" [[nodiscard]] int32_t lj_arr_is_contains_handler(cTValue *);
+
+// Search an array using the canonical membership rules. Returns exactly zero or one.
+
+extern "C" [[nodiscard]] int32_t lj_arr_contains(lua_State *, GCarray *, cTValue *);
+extern "C" [[nodiscard]] int32_t lj_arr_contains_num(GCarray *, lua_Number);
+extern "C" [[nodiscard]] int32_t lj_arr_contains_str(GCarray *, GCstr *);
+
 // Safe array get - returns nil for out-of-bounds instead of throwing error
 // Used by safe navigation operator (?[]) on arrays
 

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -15,6 +15,7 @@
 #include "lj_str.h"
 #include "lj_struct.h"
 #include "lj_tab.h"
+#include "lj_object.h"
 #include "lj_vmarray.h"
 
 #include <cmath>
@@ -660,6 +661,96 @@ static bool test_array_element_contract(kt::Log &Log)
    setnilV(&value);
    if (lj_array_validate_element(pointers, &value) != ArrayElementResult::INVALID_TYPE) return false;
    if (lj_array_validate_element(cached_strings, &value) != ArrayElementResult::UNSUPPORTED_STORAGE) return false;
+
+   return true;
+}
+
+//********************************************************************************************************************
+
+template<typename T>
+static bool test_numeric_search_type(lua_State *L, AET ElementType, kt::Log &Log)
+{
+   GCarray *array = lj_array_new(L, 5, ElementType);
+   T *values = array->get<T>();
+   values[0] = T(3);
+   values[1] = T(7);
+   values[2] = T(11);
+   values[3] = T(7);
+   values[4] = T(19);
+
+   if (lj_arr_find_num(array, 3, 0, 4, 1) != 0 or lj_arr_find_num(array, 11, 0, 4, 1) != 2 or
+       lj_arr_find_num(array, 19, 0, 4, 1) != 4 or lj_arr_find_num(array, 23, 0, 4, 1) != -1 or
+       lj_arr_find_num(array, 7, 0, 4, 2) != -1 or lj_arr_find_num(array, 7, 4, 0, -1) != 3) {
+      Log.error("numeric runtime search failed for element type %d", int(ElementType));
+      return false;
+   }
+   return true;
+}
+
+static bool test_array_runtime_search(kt::Log &Log)
+{
+   LuaStateHolder holder;
+   lua_State *lua = holder.get();
+   if (not lua) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   if (not test_numeric_search_type<int32_t>(lua, AET::INT32, Log) or
+       not test_numeric_search_type<uint32_t>(lua, AET::UINT32, Log) or
+       not test_numeric_search_type<float>(lua, AET::FLOAT, Log) or
+       not test_numeric_search_type<double>(lua, AET::DOUBLE, Log)) return false;
+
+   GCarray *empty = lj_array_new(lua, 0, AET::INT32);
+   if (lj_arr_find_num(empty, 1, 0, -1, 1) != -1) {
+      Log.error("empty numeric runtime search returned a match");
+      return false;
+   }
+
+   GCarray *single = lj_array_new(lua, 1, AET::INT16);
+   single->get<int16_t>()[0] = 31;
+   if (lj_arr_find_num(single, 31, 0, 0, 1) != 0 or lj_arr_find_num(single, 31, 1, 0, 1) != -1 or
+       lj_arr_find_num(single, 31, 0, 1, -1) != -1) {
+      Log.error("single-element or empty-span numeric runtime search failed");
+      return false;
+   }
+
+   GCarray *strings = lj_array_new(lua, 3, AET::STR_GC);
+   TValue value;
+   const char embedded_text[] = { 'a', '\0', 'b' };
+   GCstr *first = lj_str_newz(lua, "first");
+   GCstr *embedded = lj_str_new(lua, embedded_text, sizeof(embedded_text));
+   GCstr *last = lj_str_newz(lua, "last");
+   setstrV(lua, &value, first);
+   lj_array_store_checked(lua, strings, 0, &value);
+   setstrV(lua, &value, embedded);
+   lj_array_store_checked(lua, strings, 1, &value);
+   setstrV(lua, &value, last);
+   lj_array_store_checked(lua, strings, 2, &value);
+
+   GCstr *embedded_match = lj_str_new(lua, embedded_text, sizeof(embedded_text));
+   GCstr *missing = lj_str_newz(lua, "missing");
+   if (lj_arr_find_str(strings, first, 0, 2, 1) != 0 or lj_arr_find_str(strings, embedded_match, 0, 2, 1) != 1 or
+       lj_arr_find_str(strings, last, 2, 0, -1) != 2 or lj_arr_find_str(strings, missing, 0, 2, 1) != -1 or
+       lj_arr_find_str(strings, embedded, 2, 0, -2) != -1) {
+      Log.error("string runtime search failed");
+      return false;
+   }
+
+   GCarray *objects = lj_array_new(lua, 2, AET::OBJECT);
+   GCobject *first_object = lj_object_new(lua, OBJECTID(101), nullptr, nullptr, GCOBJ_DETACHED);
+   GCobject *second_object = lj_object_new(lua, OBJECTID(202), nullptr, nullptr, GCOBJ_DETACHED);
+   setobjectV(lua, &value, first_object);
+   lj_array_store_checked(lua, objects, 0, &value);
+   setobjectV(lua, &value, second_object);
+   lj_array_store_checked(lua, objects, 1, &value);
+
+   if (lj_arr_find_object(objects, first_object->uid, 0, 1, 1) != 0 or
+       lj_arr_find_object(objects, second_object->uid, 1, 0, -1) != 1 or
+       lj_arr_find_object(objects, OBJECTID(303), 0, 1, 1) != -1) {
+      Log.error("object runtime search failed");
+      return false;
+   }
 
    return true;
 }
@@ -1426,7 +1517,7 @@ static bool test_lib_array_double_type(kt::Log &Log)
 
 void array_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 35> Tests = { {
+   constexpr std::array<TestCase, 36> Tests = { {
       // Core Data Structures
       { "array_creation_byte", test_array_creation_byte },
       { "array_creation_int32", test_array_creation_int32 },
@@ -1440,6 +1531,7 @@ void array_unit_tests(int &Passed, int &Total)
       { "array_external_unmanaged", test_array_external_unmanaged },
       { "array_external_resource", test_array_external_resource },
       { "array_element_contract", test_array_element_contract },
+      { "array_runtime_search", test_array_runtime_search },
       { "array_to_table", test_array_to_table },
       { "array_type_tag", test_array_type_tag },
       // VM Type System

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -1940,6 +1940,32 @@ end
    assert('nonempty' in arr, "contains('nonempty') should return true")
 end
 
+@Test function ArrayContainsStringCoercesNumber()
+   arr = array<str> { '1', '2.5' }
+
+   assert(1 in arr and 2.5 in arr, 'string array membership should retain numeric string coercion')
+end
+
+@Test function ArrayContainsStringEmbeddedNul()
+   nul = string.char(0)
+   needle = 'a' .. nul .. 'b'
+   arr = array<str> { 'prefix', needle, 'suffix' }
+
+   assert(needle in arr, 'contains should compare the complete embedded-NUL string')
+   assert(not (('a' .. nul .. 'c') in arr), 'contains should reject a differing embedded-NUL string')
+end
+
+@Test function ArrayContainsRejectsInvalidCandidate()
+   arr = array<int> { 1, 2, 3 }
+   rejected = false
+   try
+      ignored = {} in arr
+   except error_value
+      rejected = true
+   end
+   assert(rejected, 'numeric array membership should reject a non-numeric candidate')
+end
+
 @Test function ArrayContainsByte()
    arr = array<byte> { 65, 66, 67 }
 

--- a/src/tiri/tests/test_contains.tiri
+++ b/src/tiri/tests/test_contains.tiri
@@ -12,6 +12,14 @@ function builtin_array_membership_workload(Values:array<int>, Count:num):num
    return matches
 end
 
+function generic_array_membership_workload(Values:array<any>, Candidate:any, Count:num):num
+   local matches = 0
+   for index in {0 to Count} do
+      if Candidate in Values then matches++ end
+   end
+   return matches
+end
+
 @Test function PlainTablesUseRawKeyPresence()
    local values = { ready=false, present=true }
    assert('ready' in values, 'A false table value must still count as present')
@@ -121,6 +129,27 @@ end
    jit.opt.start()
 
    assert(native_calls > 0, 'Canonical array membership should lower to a native side-effecting helper call')
+end
+
+@Test function BuiltinArrayMembershipGuardsElementType()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=2', 'hotexit=1', 'minstitch=0')
+
+   local strings = array<str> { '2', '4', '6' }
+   local integers = array<int> { 2, 4, 6 }
+   assert(generic_array_membership_workload(strings, '4', 100) is 100,
+      'String array membership should warm the generic-array trace')
+   assert(generic_array_membership_workload(integers, '4', 100) is 100,
+      'A reused trace must not treat numeric array storage as strings')
+
+   jit.flush()
+   assert(generic_array_membership_workload(integers, 4, 100) is 100,
+      'Numeric array membership should warm the generic-array trace')
+   assert(generic_array_membership_workload(strings, 4, 100) is 100,
+      'A reused trace must retain numeric coercion for string arrays')
+
+   jit.opt.start()
 end
 
 @Test function ArrayContainsMutationLeavesCanonicalFastPath()

--- a/src/tiri/tests/test_contains.tiri
+++ b/src/tiri/tests/test_contains.tiri
@@ -3,6 +3,15 @@
 @BeforeEach(hotpath=40)
 function enforce_hotpath() end
 
+function builtin_array_membership_workload(Values:array<int>, Count:num):num
+   local matches = 0
+   for index in {0 to Count} do
+      if 4 in Values then matches++ end
+      if not (9 in Values) then matches++ end
+   end
+   return matches
+end
+
 @Test function PlainTablesUseRawKeyPresence()
    local values = { ready=false, present=true }
    assert('ready' in values, 'A false table value must still count as present')
@@ -86,4 +95,52 @@ end
       if 'needle' in target then matches++ end
    end
    assert(matches is 200, 'Membership should retain its result after JIT compilation')
+end
+
+@Test function BuiltinArrayMembershipUsesNativeTrace()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=2', 'hotexit=1', 'minstitch=0')
+
+   local values = array<int> { 2, 4, 6, 8 }
+   assert(builtin_array_membership_workload(values, 100) is 200,
+      'Built-in array membership should preserve in and negated-in results on trace')
+
+   jit.off()
+   local native_calls = 0
+   for trace_no in {1 into 40} do
+      local info = jit.util.traceInfo(trace_no)
+      if info is nil then continue end
+
+      for instruction in {1 into info.nins} do
+         local _, ir_ot, _, call_id = jit.util.traceIR(trace_no, instruction)
+         if ir_ot != nil and (ir_ot >> 8) is 98 and jit.util.irCallAddr(call_id) != nil then native_calls++ end
+      end
+   end
+   jit.on()
+   jit.opt.start()
+
+   assert(native_calls > 0, 'Canonical array membership should lower to a native side-effecting helper call')
+end
+
+@Test function ArrayContainsMutationLeavesCanonicalFastPath()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=2', 'hotexit=1', 'minstitch=0')
+
+   local values = array<int> { 2, 4, 6, 8 }
+   assert(builtin_array_membership_workload(values, 100) is 200,
+      'The canonical array handler should warm successfully before mutation')
+
+   local metatable = getmetatable(values)
+   local canonical_handler = metatable.__contains
+   defer metatable.__contains = canonical_handler end
+
+   metatable.__contains = function(Target:array<int>, Candidate:num):bool
+      return Candidate is 9
+   end
+   assert(not (4 in values) and 9 in values,
+      'Changing __contains should side-exit and select the custom array handler')
+
+   jit.opt.start()
 end


### PR DESCRIPTION
* Added canonical membership helpers shared by the interpreter, library adapter and trace recorder
* Recorded native array membership calls for numeric and string operands
* Added coverage for coercion, embedded NULs, invalid values and JIT behaviour