### PR TITLE
[Tiri] Added __name metamethod support for user-facing type reporting

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -867,7 +867,7 @@ set (TIRI_TESTS
    jitoptions fstring const const_optimisation import_scope unicode ellipsis safe_nav close type_annotations type_fixing
    type_inference jit jit_try_regex pipe pipe_iteration arrow_functions result_filter thunks deferred_expr shadow_assert
    ranges contains bare_iteration compiler_intrinsics
-   annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options
+   annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options type_name
    try_except import include_list processing metatables with thunk_table_index debug malformed_syntax numeric_limits return_types url tips tempus
    comparison_chaining reserved_keywords compile_if_import overflow protected_globals constant_shadowing config_library
    module_namespaces builtin_methods

--- a/src/tiri/jit/src/bytecode/lj_bc.h
+++ b/src/tiri/jit/src/bytecode/lj_bc.h
@@ -534,7 +534,7 @@ static_assert((int)BC_FUNCV + 1 == (int)BC_IFUNCV);
 static_assert((int)BC_FUNCV + 2 == (int)BC_JFUNCV);
 
 // This solves a circular dependency problem, change as needed.
-#define FF_next_N   4
+#define FF_next_N   5
 
 // Stack slots used by FORI/FORL, relative to operand A.
 enum {

--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -49,10 +49,10 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // separates object.create, object.new and object._state callable identities.  Version 0x90 accepts a struct reference
 // in struct.size, which shifts the generated fast-function ordering.  Version 0x92 expands private array member
 // identities with uint8, uint16, uint32 and uint64.  Version 0x93 gives int8 its own signed array member identity.
-// Version 0x96 adds BC_ISIN and BC_ISNIN.
+// Version 0x96 adds BC_ISIN and BC_ISNIN. Version 0x97 adds rawtype and shifts the generated fast-function ordering.
 // Older chunks are rejected rather than retaining compatibility shims.
 
-constexpr uint8_t BCDUMP_VERSION = 0x96;
+constexpr uint8_t BCDUMP_VERSION = 0x97;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/debug/lj_err.cpp
+++ b/src/tiri/jit/src/debug/lj_err.cpp
@@ -68,6 +68,7 @@
 #include "lj_state.h"
 #include "lj_frame.h"
 #include "lj_ff.h"
+#include "lj_meta.h"
 #include "lj_trace.h"
 #include "lj_vm.h"
 #include "lj_strfmt.h"
@@ -1319,7 +1320,7 @@ LJ_NOINLINE void lj_err_lex(lua_State *L, GCstr* src, CSTRING tok, BCLine line, 
 
 LJ_NOINLINE void lj_err_optype(lua_State *L, cTValue *o, ErrMsg opm)
 {
-   auto tname = lj_typename(o);
+   auto tname = lj_meta_display_name(L, o);
    auto opname = err2msg(opm);
    if (curr_funcisL(L)) {
       GCproto *pt = curr_proto(L);
@@ -1336,8 +1337,8 @@ LJ_NOINLINE void lj_err_optype(lua_State *L, cTValue *o, ErrMsg opm)
 
 LJ_NOINLINE void lj_err_comp(lua_State *L, cTValue* o1, cTValue* o2)
 {
-   auto t1 = lj_typename(o1);
-   auto t2 = lj_typename(o2);
+   auto t1 = lj_meta_display_name(L, o1);
+   auto t2 = lj_meta_display_name(L, o2);
    err_msgv(L, t1 IS t2 ? ErrMsg::BADCMPV : ErrMsg::BADCMPT, t1, t2);
    // This assumes the two "boolean" entries are commoned by the C compiler.
 }
@@ -1353,11 +1354,17 @@ LJ_NOINLINE void lj_err_optype_call(lua_State *L, TValue* o)
 
    const BCIns* pc = cframe_Lpc(L);
    if (((ptrdiff_t)pc & FRAME_TYPE) != FRAME_LUA) {
-      CSTRING tname = lj_typename(o);
+      GCstr *custom_name = lj_meta_type_name(L, o);
+      CSTRING tname = custom_name ? strdata(custom_name) : lj_typename(o);
       setframe_gc(o, obj2gco(L), LJ_TSTRUCT);
       o++;
       setframe_pc(o, pc);
-      L->top = L->base = o + 1;
+      L->base = o + 1;
+      if (custom_name) {
+         setstrV(L, L->base, custom_name);
+         L->top = L->base + 1;
+      }
+      else L->top = L->base;
       err_msgv(L, ErrMsg::BADCALL, tname);
    }
    lj_err_optype(L, o, ErrMsg::OPCALL);
@@ -1480,13 +1487,13 @@ LJ_NOINLINE void lj_err_argtype(lua_State *L, int narg, CSTRING xname)
       else {
          GCfunc* fn = curr_func(L);
          int idx = LUA_GLOBALSINDEX - narg;
-         if (idx <= fn->c.nupvalues) tname = lj_typename(&fn->c.upvalue[idx - 1]);
+         if (idx <= fn->c.nupvalues) tname = lj_meta_display_name(L, &fn->c.upvalue[idx - 1]);
          else tname = lj_obj_typename[0];
       }
    }
    else {
       TValue *o = narg < 0 ? L->top + narg : L->base + narg - 1;
-      tname = o < L->top ? lj_typename(o) : lj_obj_typename[0];
+      tname = o < L->top ? lj_meta_display_name(L, o) : lj_obj_typename[0];
    }
    auto msg = lj_strfmt_pushf(L, err2msg(ErrMsg::BADTYPE), xname, tname);
    err_argmsg(L, narg, msg);
@@ -1506,7 +1513,7 @@ LJ_NOINLINE void lj_err_argt(lua_State *L, int narg, int tt)
 LJ_NOINLINE void lj_err_assigntype(lua_State *L, int slot, CSTRING expected_type)
 {
    TValue *o = L->base + slot;
-   CSTRING actual_type = o < L->top ? lj_typename(o) : lj_obj_typename[0];
+   CSTRING actual_type = o < L->top ? lj_meta_display_name(L, o) : lj_obj_typename[0];
    CSTRING msg = lj_strfmt_pushf(L, err2msg(ErrMsg::BADASSIGN), actual_type, expected_type);
    lj_err_callermsg(L, msg);
 }

--- a/src/tiri/jit/src/debug/lj_ff.h
+++ b/src/tiri/jit/src/debug/lj_ff.h
@@ -76,7 +76,7 @@ static_assert(FF__MAX <= BUILTIN_CALLABLE_CAPACITY);
 static_assert(FF__MAX - 1 <= std::numeric_limits<uint16_t>::max());
 static_assert(builtin_callable_index(BuiltinCallableID::Invalid) >= FF__MAX);
 #ifdef FFDEF_BFUNC_ABI
-static_assert(builtin_callable_abi_fingerprint() IS 0x62328237390d0b55ull,
+static_assert(builtin_callable_abi_fingerprint() IS 0xe65619e35439c23aull,
    "fast-function ordering changed: bump BCDUMP_VERSION and update the BC_BFUNC ABI fingerprint");
 #endif
 

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -1165,12 +1165,13 @@ static void build_subroutines(BuildCtx *ctx)
   |  b ->fff_res
   |
   |.ffunc_1 type
+  |  b ->fff_fallback
+  |
+  |.ffunc_1 rawtype
   |  mov TMP0, #~LJ_TISNUM
   |  asr ITYPE, CARG1, #47
   |  cmn ITYPE, #~LJ_TISNUM
   |  csinv TMP1, TMP0, ITYPE, lo
-  |  cmp TMP1, #~LJ_TUDATA
-  |  beq ->fff_fallback
   |  add TMP1, TMP1, #offsetof(GCfuncC, upvalue)/8
   |  ldr CARG1, [CFUNC:CARG3, TMP1, lsl #3]
   |  b ->fff_restv

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -1637,6 +1637,9 @@ static void build_subroutines(BuildCtx *ctx)
   |  b ->fff_res
   |
   |.ffunc type
+  |  b ->fff_fallback
+  |
+  |.ffunc rawtype
   |  cmplwi NARGS8:RC, 8
   |   lwz CARG1, 0(BASE)
   |  blt ->fff_fallback
@@ -1645,7 +1648,6 @@ static void build_subroutines(BuildCtx *ctx)
   |  subfe TMP2, CARG1, CARG1
   |  orc TMP1, TMP2, TMP0
   |  addi TMP1, TMP1, ~LJ_TISNUM+1
-  |  cmpwi TMP1, ~LJ_TUDATA; beq ->fff_fallback
   |  slwi TMP1, TMP1, 3
   |.if FPU
   |   la TMP2, CFUNC:RB->upvalue

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -1433,16 +1433,15 @@ static void build_subroutines(BuildCtx *ctx)
   |  jmp ->fff_res0  // Return 0 values (assert no longer returns its arguments)
   |
   |.ffunc_1 type
+  |  jmp ->fff_fallback
+  |
+  |.ffunc_1 rawtype
   |  mov RC, [BASE]
   |  sar RC, 47
   |  mov RBd, LJ_TISNUM
   |  cmp RCd, RBd
   |  cmovb RCd, RBd
   |  not RCd
-  |  // Check for userdata (base type 12) - defer to C fallback for thunk handling
-  |  cmp RCd, ~LJ_TUDATA
-  |  je ->fff_fallback
-  |2:
   |  mov CFUNC:RB, [BASE-16]
   |  cleartp CFUNC:RB
   |  mov STR:RC, [CFUNC:RB+RC*8+((char *)(&((GCfuncC *)0)->upvalue))]

--- a/src/tiri/jit/src/lib/lib_base.cpp
+++ b/src/tiri/jit/src/lib/lib_base.cpp
@@ -171,8 +171,7 @@ LJLIB_PUSH("number")
 LJLIB_PUSH("range")
 LJLIB_ASM(type)      LJLIB_REC(.)
 {
-   // C fallback for type() - handles thunks with declared types
-   TValue *o = L->base;
+   TValue *o = lj_lib_checkany(L, 1);
    GCfunc *fn = funcV(L->base - 1 - LJ_FR2);
    if (tvisudata(o)) {
       GCudata *ud = udataV(o);
@@ -191,7 +190,39 @@ LJLIB_ASM(type)      LJLIB_REC(.)
          }
       }
    }
-   // For non-thunk userdata, return "userdata" string (upvalue index 3)
+
+   if (GCstr *name = lj_meta_type_name(L, o)) {
+      setstrV(L, L->base - 1 - LJ_FR2, name);
+      return FFH_RES(1);
+   }
+
+   uint32_t type_index;
+   if (tvisnumber(o)) type_index = ~LJ_TNUMX;
+   else type_index = ~itype(o);
+   setstrV(L, L->base - 1 - LJ_FR2, strV(&fn->c.upvalue[type_index]));
+   return FFH_RES(1);
+}
+
+LJLIB_PUSH("nil")
+LJLIB_PUSH("bool")
+LJLIB_PUSH(top-1)
+LJLIB_PUSH("userdata")
+LJLIB_PUSH("string")
+LJLIB_PUSH("upval")
+LJLIB_PUSH("struct")
+LJLIB_PUSH("proto")
+LJLIB_PUSH("function")
+LJLIB_PUSH("trace")
+LJLIB_PUSH("object")
+LJLIB_PUSH("table")
+LJLIB_PUSH(top-9)
+LJLIB_PUSH("array")
+LJLIB_PUSH("number")
+LJLIB_PUSH("range")
+LJLIB_ASM(rawtype)      LJLIB_REC(.)
+{
+   lj_lib_checkany(L, 1);
+   GCfunc *fn = funcV(L->base - 1 - LJ_FR2);
    setstrV(L, L->base - 1 - LJ_FR2, strV(&fn->c.upvalue[TYPE_NAME_USERDATA]));
    return FFH_RES(1);
 }
@@ -1173,6 +1204,7 @@ extern int luaopen_base(lua_State* L)
    reg_func_prototype("print", { }, {}, FProtoFlags::Variadic);
    reg_func_prototype("assert", { TiriType::Any }, { TiriType::Any, TiriType::Str });
    reg_func_prototype("type", { TiriType::Str }, { TiriType::Any });
+   reg_func_prototype("rawtype", { TiriType::Str }, { TiriType::Any });
    reg_func_prototype("tonumber", { TiriType::Num }, { TiriType::Any, TiriType::Num });
    reg_func_prototype("tostring", { TiriType::Str }, { TiriType::Any });
    reg_func_prototype("pairs", { TiriType::Func, TiriType::Table, TiriType::Nil }, { TiriType::Any });

--- a/src/tiri/jit/src/lj_dispatch.h
+++ b/src/tiri/jit/src/lj_dispatch.h
@@ -20,7 +20,7 @@ constexpr int HOTCOUNT_LOOP = 2;
 constexpr int HOTCOUNT_CALL = 1;
 
 // This solves a circular dependency problem -- bump as needed. Sigh.
-constexpr int GG_NUM_ASMFF = 55;
+constexpr int GG_NUM_ASMFF = 56;
 
 constexpr int GG_LEN_DDISP = (BC__MAX + GG_NUM_ASMFF);
 constexpr int GG_LEN_SDISP = BC__MAX;

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -298,7 +298,33 @@ static void recff_type(jit_State* J, RecordFFData* rd)
    RecordIndex ix{};
    ix.tab = J->base[0];
    copyTV(J->L, &ix.tabv, &rd->argv[0]);
-   if (lj_record_mm_lookup(J, &ix, MM_name)) {
+   bool has_name = lj_record_mm_lookup(J, &ix, MM_name);
+
+   // lj_meta_lookup() falls back to the array base metatable when an instance has none, whereas the generic recorder
+   // stops after guarding the per-instance metatable as nil. Mirror the interpreter's fallback for type().
+
+   if (not has_name and tvisarray(&rd->argv[0]) and not tabref(arrayV(&rd->argv[0])->metatable)) {
+      GCtab *base_mt = tabref(basemt_it(J2G(J), LJ_TARRAY));
+      if (base_mt) {
+         // Load the base table from gcroot and record its raw __name access so later table mutations leave the trace
+         // through the lookup guards instead of preserving a stale folded result.
+
+         GCstr *name_key = mmname_str(J2G(J), MM_name);
+         cTValue *observed = lj_tab_getstr(base_mt, name_key);
+         int base_mt_offset = GG_OFS(g.gcroot) + int((GCROOT_BASEMT + ~LJ_TARRAY) * sizeof(GCRef));
+         ix.tab = lj_ir_ggfload(J, IRT_TAB, base_mt_offset);
+         settabV(J->L, &ix.tabv, base_mt);
+         ix.key = lj_ir_kstr(J, name_key);
+         setstrV(J->L, &ix.keyv, name_key);
+         ix.val = 0;
+         ix.idxchain = 0;
+         ix.mobj = lj_record_idx(J, &ix);
+         if (observed and not tvisnil(observed)) copyTV(J->L, &ix.mobjv, observed);
+         has_name = not tref_isnil(ix.mobj);
+      }
+   }
+
+   if (has_name) {
       cTValue *observed = &ix.mobjv;
       if (tvisstr(observed)) {
          GCstr *name = strV(observed);

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -267,32 +267,61 @@ static bool recff_is_range_userdata(jit_State *J, GCudata *Userdata)
 
 static void recff_type(jit_State* J, RecordFFData* rd)
 {
-   // Arguments already specialized. Result is a constant string. Neat, huh?
    uint32_t t;
    if (tvisnumber(&rd->argv[0])) t = ~LJ_TNUMX;
    else t = ~itype(&rd->argv[0]);
 
-   // Check for thunk userdata with declared type
-
-   if (t IS ~LJ_TUDATA) {  // 12 = base value for userdata
+   if (t IS ~LJ_TUDATA) {
       GCudata *ud = udataV(&rd->argv[0]);
       if (recff_is_range_userdata(J, ud)) {
-         t = TYPE_NAME_RANGE;
+         J->base[0] = lj_ir_kstr(J, strV(&J->fn->c.upvalue[TYPE_NAME_RANGE]));
+         return;
       }
       else if (ud->udtype IS UDTYPE_THUNK) {
          ThunkPayload *payload = thunk_payload(ud);
          if (payload->expected_type != 0xFF) {
-            // Use the declared logical type instead of the thunk container's userdata tag.
             t = recff_type_name_index(TiriType(payload->expected_type));
+            J->base[0] = lj_ir_kstr(J, strV(&J->fn->c.upvalue[t]));
+            return;
          }
       }
-      else {
-         t = TYPE_NAME_USERDATA;
+
+      // Metatables on special userdata are treated as immutable by the generic recorder. Leave their display-name
+      // lookup to the interpreter, while rawtype() remains recordable for these containers.
+      if (ud->udtype != UDTYPE_USERDATA) lj_trace_err(J, LJ_TRERR_NYIFFU);
+   }
+
+   // GCobject and GCstruct have per-instance metatables that are not represented by the generic metamethod recorder.
+   // Abort this fast-function recording until those IR field loads are available rather than folding an unsafe name.
+   if (tvisobject(&rd->argv[0]) or tvisstruct(&rd->argv[0])) lj_trace_err(J, LJ_TRERR_NYIFFU);
+
+   RecordIndex ix{};
+   ix.tab = J->base[0];
+   copyTV(J->L, &ix.tabv, &rd->argv[0]);
+   if (lj_record_mm_lookup(J, &ix, MM_name)) {
+      cTValue *observed = &ix.mobjv;
+      if (tvisstr(observed)) {
+         GCstr *name = strV(observed);
+         TRef name_ref = lj_ir_kstr(J, name);
+         emitir(IRTG(IR_EQ, IRT_STR), ix.mobj, name_ref);
+         if (name->len > 0) {
+            J->base[0] = name_ref;
+            return;
+         }
       }
    }
 
    J->base[0] = lj_ir_kstr(J, strV(&J->fn->c.upvalue[t]));
-   UNUSED(rd);
+}
+
+//********************************************************************************************************************
+
+static void recff_rawtype(jit_State* J, RecordFFData* Data)
+{
+   uint32_t t;
+   if (tvisnumber(&Data->argv[0])) t = ~LJ_TNUMX;
+   else t = ~itype(&Data->argv[0]);
+   J->base[0] = lj_ir_kstr(J, strV(&J->fn->c.upvalue[t]));
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -149,6 +149,25 @@ cTValue * lj_meta_lookup(lua_State *L, cTValue *o, MMS mm)
 }
 
 //********************************************************************************************************************
+// Return a non-empty string from the raw __name metatable slot, without invoking Tiri code.
+
+GCstr *lj_meta_type_name(lua_State *L, cTValue *Value) noexcept
+{
+   cTValue *name = lj_meta_lookup(L, Value, MM_name);
+   if (name and tvisstr(name) and strV(name)->len > 0) return strV(name);
+   return nullptr;
+}
+
+//********************************************************************************************************************
+// Return the user-facing name for a concrete value, falling back to its built-in runtime category.
+
+const char *lj_meta_display_name(lua_State *L, cTValue *Value) noexcept
+{
+   GCstr *name = lj_meta_type_name(L, Value);
+   return name ? strdata(name) : lj_typename(Value);
+}
+
+//********************************************************************************************************************
 
 #if LJ_HASFFI
 // Tailcall from C function.
@@ -1000,7 +1019,7 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
       contract_type_name(actual, sizeof(actual), actual_entry);
    }
    else if (contract_is_range(L, Value)) std::snprintf(actual, sizeof(actual), "range");
-   else std::snprintf(actual, sizeof(actual), "%s", lj_typename(Value));
+   else std::snprintf(actual, sizeof(actual), "%s", lj_meta_display_name(L, Value));
 
    const char *boundary = contract_boundary_name(Boundary);
    if (not Entry.label.empty()) {

--- a/src/tiri/jit/src/runtime/lj_meta.h
+++ b/src/tiri/jit/src/runtime/lj_meta.h
@@ -9,6 +9,8 @@
 LJ_FUNC void lj_meta_init(lua_State* L);
 LJ_FUNC [[nodiscard]] cTValue* lj_meta_cache(GCtab* mt, MMS mm, GCstr* name);
 LJ_FUNC [[nodiscard]] cTValue* lj_meta_lookup(lua_State* L, cTValue* o, MMS mm);
+LJ_FUNC [[nodiscard]] GCstr* lj_meta_type_name(lua_State* L, cTValue* Value) noexcept;
+LJ_FUNC [[nodiscard]] const char* lj_meta_display_name(lua_State* L, cTValue* Value) noexcept;
 
 [[nodiscard]] inline cTValue* lj_meta_fastg(global_State* g, GCtab* mt, MMS mm) noexcept
 {

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -1496,7 +1496,7 @@ enum {
   _(add) _(sub) _(mul) _(div) _(mod) _(pow) _(unm) \
   /* The following are used in the standard libraries. */ \
   _(metatable) _(tostring) \
-  _(close) MMDEF_FFI(_) MMDEF_PAIRS(_) _(clear) _(contains) _(iter)
+  _(close) MMDEF_FFI(_) MMDEF_PAIRS(_) _(clear) _(contains) _(iter) _(name)
 
 // Metamethod IDs - uses typedef enum because MMDEF generates conditional members
 // and the X-macro pattern is required for string generation in lj_meta.cpp

--- a/src/tiri/tests/test_type_name.tiri
+++ b/src/tiri/tests/test_type_name.tiri
@@ -167,3 +167,30 @@ end
 
    jit.opt.start()
 end
+
+@Test function JitArrayNameUsesBaseMetatableAfterInstanceRemoval()
+   function query_array_name(Value:array<int>):str
+      return type(Value)
+   end
+
+   local original_name:any = array.__name
+   defer
+      array.__name = original_name
+      jit.flush()
+      jit.opt.start()
+   end
+
+   array.__name = 'Vector'
+   local value = array<int> { 1, 2, 3 }
+   debug.setMetatable(value, { __name = 'InstanceArray' })
+   debug.setMetatable(value, nil)
+   assert(type(value) is 'Vector', 'an array without an instance metatable should use the base display name')
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   local observed = ''
+   for _ in {1 into 100} do observed = query_array_name(value) end
+   assert(observed is 'Vector', 'compiled type() calls should use the array base-metatable display name')
+end

--- a/src/tiri/tests/test_type_name.tiri
+++ b/src/tiri/tests/test_type_name.tiri
@@ -1,0 +1,169 @@
+-- Flute coverage for the __name display-name metamethod and rawtype().
+
+function named_value(Name:str):table
+   return setmetatable({}, { __name = Name })
+end
+
+function dynamic_value(Value):any
+   return Value
+end
+
+@Test function NamedTableReportsDisplayAndStorageTypes()
+   local vector = named_value('Vector')
+   assert(type(vector) is 'Vector', 'type() should return the metatable display name')
+   assert(rawtype(vector) is 'table', 'rawtype() should retain the built-in table category')
+   assert(vector is <table>, '__name must not affect runtime type identity')
+end
+
+@Test function DirectAndInvalidNamesFallBack()
+   local direct = { __name = 'DirectField' }
+   assert(type(direct) is 'table', 'a direct __name field must be ignored')
+
+   local value = {}
+   local metatable = {}
+   setmetatable(value, metatable)
+
+   local invalid:any = nil
+   metatable.__name = invalid
+   assert(type(value) is 'table', 'nil __name should fall back')
+   invalid = ''
+   metatable.__name = invalid
+   assert(type(value) is 'table', 'an empty __name should fall back')
+   invalid = 42
+   metatable.__name = invalid
+   assert(type(value) is 'table', 'a numeric __name should fall back')
+   invalid = false
+   metatable.__name = invalid
+   assert(type(value) is 'table', 'a boolean __name should fall back')
+   invalid = {}
+   metatable.__name = invalid
+   assert(type(value) is 'table', 'a table __name should fall back')
+   invalid = function() error('__name must never be called') end
+   metatable.__name = invalid
+   assert(type(value) is 'table', 'a function __name should fall back without being called')
+end
+
+@Test function LookupIsRawAndSupportsProtectedMetatables()
+   local indexed = setmetatable({}, { __index = { __name = 'IndexedName' } })
+   assert(type(indexed) is 'table', '__index must not participate in __name lookup')
+
+   local protected = setmetatable({}, { __name = 'ProtectedValue', __metatable = 'locked' })
+   assert(getmetatable(protected) is 'locked', 'the test metatable should be protected')
+   assert(type(protected) is 'ProtectedValue', 'protected metatables should still provide a display name')
+   assert(rawtype(protected) is 'table', 'metatable protection must not affect rawtype()')
+end
+
+@Test function MetatableAndNameMutationAreObserved()
+   local first = { __name = 'FirstName' }
+   local second = { __name = 'SecondName' }
+   local value = setmetatable({}, first)
+   assert(type(value) is 'FirstName', 'the initial name should be visible')
+
+   first.__name = 'Renamed'
+   assert(type(value) is 'Renamed', 'mutating __name should change type() immediately')
+   first.__name = nil
+   assert(type(value) is 'table', 'removing __name should restore the built-in name')
+   setmetatable(value, second)
+   assert(type(value) is 'SecondName', 'replacing the metatable should change type()')
+   setmetatable(value, nil)
+   assert(type(value) is 'table', 'removing the metatable should restore the built-in name')
+end
+
+@Test function PrimitiveAndContainerRawTypesRemainStable()
+   assert(rawtype(nil) is 'nil', 'nil raw type should be unchanged')
+   assert(rawtype(true) is 'bool', 'boolean raw type should be unchanged')
+   assert(rawtype(1) is 'number', 'number raw type should be unchanged')
+   assert(rawtype('text') is 'string', 'string raw type should be unchanged')
+   assert(rawtype(function() end) is 'function', 'function raw type should be unchanged')
+   assert(rawtype({}) is 'table', 'table raw type should be unchanged')
+   assert(rawtype(array<int> { 1 }) is 'array', 'array raw type should be unchanged')
+   assert(rawtype(newproxy(true)) is 'userdata', 'userdata raw type should be unchanged')
+   assert(type({0 to 2}) is 'range', 'a range should preserve its logical display name')
+   assert(rawtype({0 to 2}) is 'userdata', 'a range container should expose its underlying userdata category')
+end
+
+@Test function DeclaredThunkNameTakesPrecedenceWithoutResolution()
+   local executed = false
+   thunk deferred_number():num
+      executed = true
+      return 42
+   end
+
+   local value = deferred_number()
+   assert(type(value) is 'number', 'type() should preserve a thunk declaration')
+   assert(rawtype(value) is 'userdata', 'rawtype() should expose the thunk container')
+   assert(executed is false, 'neither type query should resolve the thunk')
+end
+
+@Test function DiagnosticsUseTheDisplayName()
+   local vector:any = named_value('Vector')
+   local argument_error = false
+   try
+      math.abs(vector)
+   except e
+      argument_error = e.message.find('number expected, got Vector') != nil
+   end
+   assert(argument_error, 'argument diagnostics should use the custom actual type name')
+
+   local call_error = false
+   try
+      vector()
+   except e
+      call_error = e.message.find('Vector') != nil
+   end
+   assert(call_error, 'non-callable diagnostics should use the custom actual type name')
+
+   local comparison_error = false
+   try
+      local _ = vector < 1
+   except e
+      comparison_error = e.message.find('Vector') != nil
+   end
+   assert(comparison_error, 'comparison diagnostics should use the custom actual type name')
+
+   local operand_error = false
+   try
+      local _ = vector + 1
+   except e
+      operand_error = e.message.find('Vector') != nil
+   end
+   assert(operand_error, 'operand diagnostics should use the custom actual type name')
+
+   local assignment_error = false
+   try
+      local number:num = dynamic_value(vector)
+   except e
+      assignment_error = e.message.find('expected num, got Vector') != nil
+   end
+   assert(assignment_error, 'typed-assignment diagnostics should use the custom actual type name')
+end
+
+@Test function JitGuardsNameAndMetatableMutations()
+   function query_name(Value:any):str
+      return type(Value)
+   end
+
+   local metatable = { __name = 'BeforeTrace' }
+   local value = setmetatable({}, metatable)
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   local observed = ''
+   for _ in {1 into 100} do observed = query_name(value) end
+   assert(observed is 'BeforeTrace', 'compiled type() calls should return the custom name')
+
+   metatable.__name = 'AfterTrace'
+   assert(query_name(value) is 'AfterTrace', 'changing __name should leave a trace and observe the new name')
+   metatable.__name = ''
+   assert(query_name(value) is 'table', 'an empty name after tracing should restore the fallback')
+   metatable.__name = 'Restored'
+   assert(query_name(value) is 'Restored', 'a valid name after an empty value should be observed')
+
+   setmetatable(value, { __name = 'Replacement' })
+   assert(query_name(value) is 'Replacement', 'replacing the metatable should be observed after tracing')
+   setmetatable(value, nil)
+   assert(query_name(value) is 'table', 'removing the metatable should be observed after tracing')
+
+   jit.opt.start()
+end


### PR DESCRIPTION
* type() now resolves the __name metatable slot to a display name, with lj_meta_type_name() and lj_meta_display_name() providing raw, non-reentrant lookups
* Introduced rawtype() as a fast-function returning the built-in runtime category, retaining the original assembly type() path across x64, ARM64 and PPC
* Runtime error messages for operand, comparison, call, argument, assignment and contract failures now report the display name
* JIT recording of type() emits a guarded __name check and aborts for object, struct and special userdata metatables; rawtype() records as a constant fold
* Bumped BCDUMP_VERSION to 0x97 and updated the BC_BFUNC ABI fingerprint for the new fast-function ordering
* Added the type_name Flute test covering display names, fallbacks and JIT behaviour