### PR TITLE
[Tiri] Extended rawtype() with parameterised type names and JIT recording support

### DIFF
--- a/scripts/gui.tiri
+++ b/scripts/gui.tiri
@@ -80,6 +80,7 @@ end
 
 gui.mtHSV = { -- HSV metatable
    __context = true,
+   __name = "HSV",
    __newindex = function(Key, Value)
       error(f'Table structure is immutable: Cannot set {Key}')
    end,
@@ -146,6 +147,7 @@ end
 
 gui.mtRGB = { -- sRGB metatable
    __context = true,
+   __name = "RGB",
    __newindex = function(Key, Value)
       error(f'Table structure is immutable: Cannot set {Key}')
    end,

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -1168,13 +1168,8 @@ static void build_subroutines(BuildCtx *ctx)
   |  b ->fff_fallback
   |
   |.ffunc_1 rawtype
-  |  mov TMP0, #~LJ_TISNUM
-  |  asr ITYPE, CARG1, #47
-  |  cmn ITYPE, #~LJ_TISNUM
-  |  csinv TMP1, TMP0, ITYPE, lo
-  |  add TMP1, TMP1, #offsetof(GCfuncC, upvalue)/8
-  |  ldr CARG1, [CFUNC:CARG3, TMP1, lsl #3]
-  |  b ->fff_restv
+  |  // Parameterised names require C fallback; add a tag-only fast path only if profiling warrants it.
+  |  b ->fff_fallback
   |
   |//-- Base library: getters and setters ---------------------------------
   |

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -1640,24 +1640,8 @@ static void build_subroutines(BuildCtx *ctx)
   |  b ->fff_fallback
   |
   |.ffunc rawtype
-  |  cmplwi NARGS8:RC, 8
-  |   lwz CARG1, 0(BASE)
-  |  blt ->fff_fallback
-  |  .gpr64 extsw CARG1, CARG1
-  |  subfc TMP0, TISNUM, CARG1
-  |  subfe TMP2, CARG1, CARG1
-  |  orc TMP1, TMP2, TMP0
-  |  addi TMP1, TMP1, ~LJ_TISNUM+1
-  |  slwi TMP1, TMP1, 3
-  |.if FPU
-  |   la TMP2, CFUNC:RB->upvalue
-  |  lfdx FARG1, TMP2, TMP1
-  |.else
-  |  add TMP1, CFUNC:RB, TMP1
-  |  lwz CARG1, CFUNC:TMP1->upvalue[0].u32.hi
-  |  lwz CARG2, CFUNC:TMP1->upvalue[0].u32.lo
-  |.endif
-  |  b ->fff_resn
+  |  // Parameterised names require C fallback; add a tag-only fast path only if profiling warrants it.
+  |  b ->fff_fallback
   |
   |//-- Base library: getters and setters ---------------------------------
   |

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -1436,19 +1436,8 @@ static void build_subroutines(BuildCtx *ctx)
   |  jmp ->fff_fallback
   |
   |.ffunc_1 rawtype
-  |  mov RC, [BASE]
-  |  sar RC, 47
-  |  mov RBd, LJ_TISNUM
-  |  cmp RCd, RBd
-  |  cmovb RCd, RBd
-  |  not RCd
-  |  mov CFUNC:RB, [BASE-16]
-  |  cleartp CFUNC:RB
-  |  mov STR:RC, [CFUNC:RB+RC*8+((char *)(&((GCfuncC *)0)->upvalue))]
-  |  mov PC, [BASE-8]
-  |  settp STR:RC, LJ_TSTR
-  |  mov [BASE-16], STR:RC
-  |  jmp ->fff_res1
+  |  // Parameterised names require C fallback; add a tag-only fast path only if profiling warrants it.
+  |  jmp ->fff_fallback
   |
   |//-- Base library: getters and setters ---------------------------------
   |

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -140,7 +140,7 @@ bool lj_array_struct_is_trivial(const struct_record &Def)
 }
 
 //********************************************************************************************************************
-// Helper to get element type name
+// Helper to get the legacy public element name.  array.type() and array tostring intentionally retain char for BYTE.
 
 static CSTRING elemtype_name(AET Type)
 {

--- a/src/tiri/jit/src/lib/lib_base.cpp
+++ b/src/tiri/jit/src/lib/lib_base.cpp
@@ -207,23 +207,30 @@ LJLIB_PUSH("nil")
 LJLIB_PUSH("bool")
 LJLIB_PUSH(top-1)
 LJLIB_PUSH("userdata")
-LJLIB_PUSH("string")
+LJLIB_PUSH("str")
 LJLIB_PUSH("upval")
 LJLIB_PUSH("struct")
 LJLIB_PUSH("proto")
-LJLIB_PUSH("function")
+LJLIB_PUSH("func")
 LJLIB_PUSH("trace")
-LJLIB_PUSH("object")
+LJLIB_PUSH("obj")
 LJLIB_PUSH("table")
 LJLIB_PUSH(top-9)
 LJLIB_PUSH("array")
-LJLIB_PUSH("number")
+LJLIB_PUSH("num")
 LJLIB_PUSH("range")
+LJLIB_PUSH("thunk")
 LJLIB_ASM(rawtype)      LJLIB_REC(.)
 {
-   lj_lib_checkany(L, 1);
-   GCfunc *fn = funcV(L->base - 1 - LJ_FR2);
-   setstrV(L, L->base - 1 - LJ_FR2, strV(&fn->c.upvalue[TYPE_NAME_USERDATA]));
+   TValue *value = lj_lib_checkany(L, 1);
+   GCfunc *function = funcV(L->base - 1 - LJ_FR2);
+   if (not (tvisarray(value) or tvisobject(value) or tvisstruct(value) or tvisudata(value))) {
+      uint32_t type_index = tvisnumber(value) ? ~LJ_TNUMX : ~itype(value);
+      setstrV(L, L->base - 1 - LJ_FR2, strV(&function->c.upvalue[type_index]));
+      return FFH_RES(1);
+   }
+
+   setstrV(L, L->base - 1 - LJ_FR2, lj_meta_raw_type_name(L, value));
    return FFH_RES(1);
 }
 

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -29,6 +29,7 @@
 #include "lj_buf.h"
 #include "lj_str.h"
 #include "lj_tab.h"
+#include "lj_meta.h"
 #include "lj_frame.h"
 #include "lj_bc.h"
 #include "lj_ff.h"
@@ -44,6 +45,8 @@
 #include "lj_vm.h"
 #include "lj_strscan.h"
 #include "runtime/lj_array.h"
+#include "runtime/lj_proto_registry.h"
+#include "jit/frame_manager.h"
 #include "lj_strfmt.h"
 #include "lj_serialize.h"
 #include "lib_range.h"
@@ -258,11 +261,7 @@ static uint32_t recff_type_name_index(TiriType Type)
 
 static bool recff_is_range_userdata(jit_State *J, GCudata *Userdata)
 {
-   GCtab *mt = tabref(Userdata->metatable);
-   if (not mt) return false;
-
-   cTValue *range_metatable = lj_tab_getstr(tabV(registry(J->L)), lj_str_newz(J->L, RANGE_METATABLE));
-   return range_metatable and tvistab(range_metatable) and tabV(range_metatable) IS mt;
+   return is_range_userdata(J->L, Userdata);
 }
 
 static void recff_type(jit_State* J, RecordFFData* rd)
@@ -344,10 +343,60 @@ static void recff_type(jit_State* J, RecordFFData* rd)
 
 static void recff_rawtype(jit_State* J, RecordFFData* Data)
 {
-   uint32_t t;
-   if (tvisnumber(&Data->argv[0])) t = ~LJ_TNUMX;
-   else t = ~itype(&Data->argv[0]);
-   J->base[0] = lj_ir_kstr(J, strV(&J->fn->c.upvalue[t]));
+   cTValue *value = &Data->argv[0];
+   TRef value_ref = J->base[0];
+
+   if (tvisarray(value)) {
+      GCarray *array = arrayV(value);
+      IRBuilder ir(J);
+      TRef element_type_ref = ir.fload(value_ref, IRFL_ARRAY_ELEMTYPE, IRT_U8);
+      ir.guard_eq_int(element_type_ref, ir.kint(int32_t(array->elemtype)));
+      if (array->elemtype IS AET::STRUCT) {
+         TRef definition_ref = ir.fload(value_ref, IRFL_ARRAY_STRUCTDEF, IRT_PTR);
+         TRef definition = array->structdef ? ir.kkptr(array->structdef) : ir.knull(IRT_PTR);
+         ir.guard_eq(definition_ref, definition, IRT_PTR);
+      }
+   }
+   else if (tvisobject(value)) {
+      GCobject *object = objectV(value);
+      IRBuilder ir(J);
+      TRef class_ref = ir.fload(value_ref, IRFL_OBJ_CLASSPTR, IRT_PTR);
+      TRef class_pointer = object->classptr ? ir.kkptr(object->classptr) : ir.knull(IRT_PTR);
+      ir.guard_eq(class_ref, class_pointer, IRT_PTR);
+   }
+   else if (tvisstruct(value)) {
+      GCstruct *structure = structV(value);
+      IRBuilder ir(J);
+      TRef definition_ref = ir.fload(value_ref, IRFL_STRUCT_DEF, IRT_PTR);
+      TRef definition = structure->def ? ir.kkptr(structure->def) : ir.knull(IRT_PTR);
+      ir.guard_eq(definition_ref, definition, IRT_PTR);
+   }
+   else if (tvisudata(value)) {
+      GCudata *userdata = udataV(value);
+      IRBuilder ir(J);
+      TRef userdata_type = ir.fload(value_ref, IRFL_UDATA_UDTYPE, IRT_U8);
+      if (userdata->udtype IS UDTYPE_THUNK) {
+         ir.guard_eq_int(userdata_type, ir.kint(UDTYPE_THUNK));
+      }
+      else {
+         ir.guard_ne_int(userdata_type, ir.kint(UDTYPE_THUNK));
+         TRef range_metatable = lj_record_range_metatable(J);
+         // The debug registry is mutable, so its guarded lookup can return nil or another non-table value.
+         if (tref_istab(range_metatable)) {
+            TRef metatable_ref = ir.fload_tab(value_ref, IRFL_UDATA_META);
+            if (recff_is_range_userdata(J, userdata)) ir.guard_eq(metatable_ref, range_metatable, IRT_TAB);
+            else ir.guard_ne(metatable_ref, range_metatable, IRT_TAB);
+         }
+      }
+   }
+   else {
+      uint32_t type_index = tvisnumber(value) ? ~LJ_TNUMX : ~itype(value);
+      J->base[0] = lj_ir_kstr(J, strV(&J->fn->c.upvalue[type_index]));
+      return;
+   }
+
+   GCstr *name = lj_meta_raw_type_name(J->L, value);
+   J->base[0] = lj_ir_kstr(J, name);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -385,7 +385,7 @@ static TRef sload(jit_State *J, int32_t slot)
 // Record exact runtime contracts.  Stack specialisation handles simple TValue tags.  Predicates that refine a tag
 // emit their own guards so a failed guard resumes at BC_CONTRACT and preserves the interpreter's diagnostic.
 
-static TRef rec_contract_range_metatable(jit_State *J)
+TRef lj_record_range_metatable(jit_State *J)
 {
    IRBuilder ir(J);
    GCtab *registry_table = tabV(registry(J->L));
@@ -414,7 +414,7 @@ static RecordedContract rec_contract_guard_range(jit_State *J, TRef ValueRef, cT
    bool is_range = rec_contract_is_range(J, Value);
    if (is_range != Expected) return RecordedContract::Mismatch;
 
-   TRef registered_ref = rec_contract_range_metatable(J);
+   TRef registered_ref = lj_record_range_metatable(J);
    if (not tref_istab(registered_ref)) return RecordedContract::Mismatch;
 
    IRBuilder ir(J);

--- a/src/tiri/jit/src/lj_record.h
+++ b/src/tiri/jit/src/lj_record.h
@@ -41,6 +41,7 @@ LJ_FUNC void lj_record_metamethod_tailcall(jit_State* J, BCREG Func, ptrdiff_t A
 LJ_FUNC void lj_record_ret(jit_State* J, BCREG rbase, ptrdiff_t gotresults);
 LJ_FUNC int lj_record_mm_lookup(jit_State* J, RecordIndex* ix, MMS mm);
 LJ_FUNC TRef lj_record_idx(jit_State* J, RecordIndex* ix);
+LJ_FUNC TRef lj_record_range_metatable(jit_State *J);
 LJ_FUNC int lj_record_next(jit_State* J, RecordIndex* ix);
 LJ_FUNC void lj_record_try_materialise(jit_State* J);
 LJ_FUNC void lj_record_ins(jit_State* J);

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -11,6 +11,7 @@
 
 #include "ast/nodes.h"
 #include "parse_types.h"
+#include "../runtime/lj_array.h"
 #include "../runtime/lj_struct.h"
 
 bool StaticValueDescriptor::constrained() const noexcept
@@ -84,34 +85,9 @@ bool array_element_matches(const ArrayElementDescriptor &Expected, const GCarray
 std::string array_element_name(const ArrayElementDescriptor &Element)
 {
    if (not Element.known) return "array";
-   std::string_view name = "any";
-   switch (public_array_storage(Element.storage)) {
-      case AET::BYTE:   name = "byte"; break;
-      case AET::INT8:   name = "int8"; break;
-      case AET::INT16:  name = "int16"; break;
-      case AET::INT32:  name = "int"; break;
-      case AET::INT64:  name = "int64"; break;
-      case AET::UINT8:  name = "uint8"; break;
-      case AET::UINT16: name = "uint16"; break;
-      case AET::UINT32: name = "uint"; break;
-      case AET::UINT64: name = "uint64"; break;
-      case AET::FLOAT:  name = "float"; break;
-      case AET::DOUBLE: name = "double"; break;
-      case AET::STR_GC: name = "str"; break;
-      case AET::TABLE:  name = "table"; break;
-      case AET::ARRAY:  name = "array"; break;
-      case AET::OBJECT: name = "object"; break;
-      case AET::PTR:    name = "pointer"; break;
-      case AET::ANY:    name = "any"; break;
-      case AET::STRUCT:
-         if (Element.struct_def) return std::format("struct<{}>", Element.struct_def->Name);
-         name = "struct";
-         break;
-      case AET::CSTR:
-      case AET::STR_CPP:
-      case AET::MAX: break;
-   }
-   return std::string(name);
+   AET storage = public_array_storage(Element.storage);
+   if (storage IS AET::STRUCT and Element.struct_def) return std::format("struct<{}>", Element.struct_def->Name);
+   return std::string(lj_array_elemtype_name(storage));
 }
 
 StaticValueDescriptor StaticResultSet::value_at(size_t Position) const

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -60,6 +60,36 @@ uint8_t lj_array_elemsize(AET Type)
 
 //********************************************************************************************************************
 
+CSTRING lj_array_elemtype_name(AET Type) noexcept
+{
+   switch (Type) {
+      case AET::BYTE:   return "byte";
+      case AET::INT8:   return "int8";
+      case AET::INT16:  return "int16";
+      case AET::INT32:  return "int";
+      case AET::INT64:  return "int64";
+      case AET::UINT8:  return "uint8";
+      case AET::UINT16: return "uint16";
+      case AET::UINT32: return "uint";
+      case AET::UINT64: return "uint64";
+      case AET::FLOAT:  return "float";
+      case AET::DOUBLE: return "double";
+      case AET::CSTR:
+      case AET::STR_CPP:
+      case AET::STR_GC: return "str";
+      case AET::TABLE:  return "table";
+      case AET::ARRAY:  return "array";
+      case AET::PTR:    return "pointer";
+      case AET::ANY:    return "any";
+      case AET::OBJECT: return "object";
+      case AET::STRUCT: return "struct";
+      case AET::MAX:    return "any";
+   }
+   return "any";
+}
+
+//********************************************************************************************************************
+
 static bool array_is_gc_ref_type(AET Type)
 {
    return Type IS AET::STR_GC or Type IS AET::TABLE or Type IS AET::ARRAY or Type IS AET::OBJECT;

--- a/src/tiri/jit/src/runtime/lj_array.h
+++ b/src/tiri/jit/src/runtime/lj_array.h
@@ -9,6 +9,7 @@ extern GCarray * lj_array_new(lua_State *, uint32_t, AET, void *Data = nullptr, 
    std::string_view StructName = {}, struct_record *StructDef = nullptr);
 extern void lj_array_free(global_State *, GCarray *);
 [[nodiscard]] extern uint8_t lj_array_elemsize(AET);
+[[nodiscard]] extern CSTRING lj_array_elemtype_name(AET) noexcept;
 [[nodiscard]] extern bool lj_array_struct_is_trivial(const struct_record &Def);
 extern void lj_array_clear_range(GCarray *, MSize Start, MSize Count);
 extern void lj_array_copy(lua_State *, GCarray *, uint32_t dstidx, GCarray *, uint32_t srcidx, uint32_t count);

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -26,6 +26,8 @@
 #include "lj_object.h"
 #include "lj_contract.h"
 #include "lj_vmarray.h"
+#include "lj_array.h"
+#include "lj_proto_registry.h"
 #include "stack_helpers.h"
 #include "lib.h"
 #include "lib_range.h"
@@ -165,6 +167,70 @@ const char *lj_meta_display_name(lua_State *L, cTValue *Value) noexcept
 {
    GCstr *name = lj_meta_type_name(L, Value);
    return name ? strdata(name) : lj_typename(Value);
+}
+
+//********************************************************************************************************************
+
+[[nodiscard]] static CSTRING raw_type_fixed_name(lua_State *L, cTValue *Value) noexcept
+{
+   if (tvisnil(Value)) return "nil";
+   if (tvisbool(Value)) return "bool";
+   if (tvisnumber(Value)) return "num";
+   if (tvisstr(Value)) return "str";
+   if (tvistab(Value)) return "table";
+   if (tvisfunc(Value)) return "func";
+   if (tvislightud(Value)) return "userdata";
+   if (tvisudata(Value)) {
+      GCudata *userdata = udataV(Value);
+      if (userdata->udtype IS UDTYPE_THUNK) return "thunk";
+      if (is_range_userdata(L, userdata)) return "range";
+      return "userdata";
+   }
+   return nullptr;
+}
+
+void lj_meta_raw_type_text(lua_State *L, cTValue *Value, char *Buffer, size_t Size) noexcept
+{
+   if (not Size) return;
+
+   if (CSTRING name = raw_type_fixed_name(L, Value)) {
+      std::snprintf(Buffer, Size, "%s", name);
+      return;
+   }
+
+   if (tvisarray(Value)) {
+      GCarray *array = arrayV(Value);
+      if (array->elemtype IS AET::STRUCT and array->structdef) {
+         std::snprintf(Buffer, Size, "array<struct<%s>>", array->structdef->Name.c_str());
+      }
+      else std::snprintf(Buffer, Size, "array<%s>", lj_array_elemtype_name(array->elemtype));
+      return;
+   }
+
+   if (tvisobject(Value)) {
+      GCobject *object = objectV(Value);
+      if (object->classptr) std::snprintf(Buffer, Size, "obj<%s>", object->classptr->ClassName.c_str());
+      else std::snprintf(Buffer, Size, "obj");
+      return;
+   }
+
+   if (tvisstruct(Value)) {
+      GCstruct *structure = structV(Value);
+      if (structure->def) std::snprintf(Buffer, Size, "struct<%s>", structure->def->Name.c_str());
+      else std::snprintf(Buffer, Size, "struct");
+      return;
+   }
+
+   std::snprintf(Buffer, Size, "userdata");
+}
+
+//********************************************************************************************************************
+
+GCstr *lj_meta_raw_type_name(lua_State *L, cTValue *Value) noexcept
+{
+   char name[280];
+   lj_meta_raw_type_text(L, Value, name, sizeof(name));
+   return lj_str_newz(L, name);
 }
 
 //********************************************************************************************************************
@@ -939,38 +1005,12 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
    }
 
    if (Entry.type IS TiriType::Array) {
-      const char *member = "any";
-      switch (Entry.array_element_type) {
-         case AET::BYTE:   member = "byte"; break;
-         case AET::INT8:   member = "int8"; break;
-         case AET::INT16:  member = "int16"; break;
-         case AET::INT32:  member = "int"; break;
-         case AET::INT64:  member = "int64"; break;
-         case AET::UINT8:  member = "uint8"; break;
-         case AET::UINT16: member = "uint16"; break;
-         case AET::UINT32: member = "uint"; break;
-         case AET::UINT64: member = "uint64"; break;
-         case AET::FLOAT:  member = "float"; break;
-         case AET::DOUBLE: member = "double"; break;
-         case AET::CSTR:
-         case AET::STR_CPP:
-         case AET::STR_GC: member = "str"; break;
-         case AET::TABLE:  member = "table"; break;
-         case AET::ARRAY:  member = "array"; break;
-         case AET::PTR:    member = "pointer"; break;
-         case AET::ANY:    member = "any"; break;
-         case AET::OBJECT: member = "object"; break;
-         case AET::STRUCT:
-            if (not Entry.constraint_name.empty()) {
-               std::snprintf(Buffer, Size, "array<struct<%.*s>>", int(Entry.constraint_name.size()),
-                  Entry.constraint_name.data());
-               return;
-            }
-            member = "struct";
-            break;
-         case AET::MAX: break;
+      if (Entry.array_element_type IS AET::STRUCT and not Entry.constraint_name.empty()) {
+         std::snprintf(Buffer, Size, "array<struct<%.*s>>", int(Entry.constraint_name.size()),
+            Entry.constraint_name.data());
+         return;
       }
-      std::snprintf(Buffer, Size, "array<%s>", member);
+      std::snprintf(Buffer, Size, "array<%s>", lj_array_elemtype_name(Entry.array_element_type));
       return;
    }
 
@@ -1000,25 +1040,18 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
    char actual[280];
    contract_type_name(expected, sizeof(expected), Entry);
 
-   if (tvisobject(Value)) {
-      GCobject *object = objectV(Value);
-      if (object->classptr) std::snprintf(actual, sizeof(actual), "obj<%s>", object->classptr->ClassName.c_str());
-      else std::snprintf(actual, sizeof(actual), "obj<invalid>");
+   if (tvisobject(Value) and not objectV(Value)->classptr) {
+      std::snprintf(actual, sizeof(actual), "obj<invalid>");
    }
-   else if (tvisstruct(Value) and structV(Value)->def) {
-      const auto &name = structV(Value)->def->Name;
-      std::snprintf(actual, sizeof(actual), "struct<%.*s>", int(name.size()), name.data());
+   else if (contract_is_range(L, Value)) {
+      lj_meta_raw_type_text(L, Value, actual, sizeof(actual));
    }
-   else if (tvisarray(Value)) {
-      RuntimeContractEntry actual_entry;
-      actual_entry.type = TiriType::Array;
-      actual_entry.array_element_type = arrayV(Value)->elemtype;
-      if (arrayV(Value)->elemtype IS AET::STRUCT and arrayV(Value)->structdef) {
-         actual_entry.constraint_name = arrayV(Value)->structdef->Name;
-      }
-      contract_type_name(actual, sizeof(actual), actual_entry);
+   else if (GCstr *display_name = lj_meta_type_name(L, Value)) {
+      std::snprintf(actual, sizeof(actual), "%s", strdata(display_name));
    }
-   else if (contract_is_range(L, Value)) std::snprintf(actual, sizeof(actual), "range");
+   else if (tvisobject(Value) or tvisstruct(Value) or tvisarray(Value)) {
+      lj_meta_raw_type_text(L, Value, actual, sizeof(actual));
+   }
    else std::snprintf(actual, sizeof(actual), "%s", lj_meta_display_name(L, Value));
 
    const char *boundary = contract_boundary_name(Boundary);

--- a/src/tiri/jit/src/runtime/lj_meta.h
+++ b/src/tiri/jit/src/runtime/lj_meta.h
@@ -11,6 +11,8 @@ LJ_FUNC [[nodiscard]] cTValue* lj_meta_cache(GCtab* mt, MMS mm, GCstr* name);
 LJ_FUNC [[nodiscard]] cTValue* lj_meta_lookup(lua_State* L, cTValue* o, MMS mm);
 LJ_FUNC [[nodiscard]] GCstr* lj_meta_type_name(lua_State* L, cTValue* Value) noexcept;
 LJ_FUNC [[nodiscard]] const char* lj_meta_display_name(lua_State* L, cTValue* Value) noexcept;
+LJ_FUNC void lj_meta_raw_type_text(lua_State *L, cTValue *Value, char *Buffer, size_t Size) noexcept;
+LJ_FUNC [[nodiscard]] GCstr* lj_meta_raw_type_name(lua_State *L, cTValue *Value) noexcept;
 
 [[nodiscard]] inline cTValue* lj_meta_fastg(global_State* g, GCtab* mt, MMS mm) noexcept
 {

--- a/src/tiri/tests/test_type_name.tiri
+++ b/src/tiri/tests/test_type_name.tiri
@@ -8,6 +8,35 @@ function dynamic_value(Value):any
    return Value
 end
 
+struct RawTypeNamePoint
+   Value: int
+end
+
+function raw_type_query(Value:any):str
+   return rawtype(Value)
+end
+
+function raw_type_runtime_call_count():num
+   local ir_calln <const> = 95
+   local ir_calla <const> = 96
+   local ir_calll <const> = 97
+   local ir_calls <const> = 98
+   local call_count = 0
+   jit.off()
+   for trace_no in {1 into 100} do
+      local info = jit.util.traceInfo(trace_no)
+      if info is nil then continue end
+      for instruction in {1 into info.nins} do
+         local _, ir_ot = jit.util.traceIR(trace_no, instruction)
+         if ir_ot is nil then continue end
+         local opcode = ir_ot >> 8
+         if opcode is ir_calln or opcode is ir_calla or opcode is ir_calll or opcode is ir_calls then call_count++ end
+      end
+   end
+   jit.on()
+   return call_count
+end
+
 @Test function NamedTableReportsDisplayAndStorageTypes()
    local vector = named_value('Vector')
    assert(type(vector) is 'Vector', 'type() should return the metatable display name')
@@ -69,30 +98,177 @@ end
    assert(type(value) is 'table', 'removing the metatable should restore the built-in name')
 end
 
-@Test function PrimitiveAndContainerRawTypesRemainStable()
-   assert(rawtype(nil) is 'nil', 'nil raw type should be unchanged')
-   assert(rawtype(true) is 'bool', 'boolean raw type should be unchanged')
-   assert(rawtype(1) is 'number', 'number raw type should be unchanged')
-   assert(rawtype('text') is 'string', 'string raw type should be unchanged')
-   assert(rawtype(function() end) is 'function', 'function raw type should be unchanged')
-   assert(rawtype({}) is 'table', 'table raw type should be unchanged')
-   assert(rawtype(array<int> { 1 }) is 'array', 'array raw type should be unchanged')
-   assert(rawtype(newproxy(true)) is 'userdata', 'userdata raw type should be unchanged')
-   assert(type({0 to 2}) is 'range', 'a range should preserve its logical display name')
-   assert(rawtype({0 to 2}) is 'userdata', 'a range container should expose its underlying userdata category')
+@Test function RawTypeVocabularyAndParameterisation()
+   assert(rawtype(nil) is 'nil', 'nil should use its annotation name')
+   assert(rawtype(true) is 'bool', 'boolean should use its annotation name')
+   assert(rawtype(1) is 'num' and rawtype(1.5) is 'num', 'both numeric representations should report num')
+   assert(rawtype('text') is 'str', 'strings should use their annotation name')
+   assert(rawtype({}) is 'table', 'tables should retain their category name')
+   assert(rawtype(function() end) is 'func', 'Tiri functions should use func')
+   assert(rawtype(print) is 'func' and rawtype(assert) is 'func', 'native and fast functions should use func')
+
+   assert(rawtype(array<byte> { 1 }) is 'array<byte>', 'byte arrays should report their canonical member name')
+   assert(rawtype(array<char> { 1 }) is 'array<byte>', 'char arrays should report the canonical byte alias')
+   assert(rawtype(array<int8> { 1 }) is 'array<int8>', 'int8 arrays should retain their exact member type')
+   assert(rawtype(array<int16> { 1 }) is 'array<int16>', 'int16 arrays should retain their exact member type')
+   assert(rawtype(array<int> { 1 }) is 'array<int>', 'int arrays should retain their exact member type')
+   assert(rawtype(array<int64> { 1 }) is 'array<int64>', 'int64 arrays should retain their exact member type')
+   assert(rawtype(array<uint> { 1 }) is 'array<uint>', 'uint arrays should retain their exact member type')
+   assert(rawtype(array<float> { 1 }) is 'array<float>', 'float arrays should retain their exact member type')
+   assert(rawtype(array<double> { 1 }) is 'array<double>', 'double arrays should retain their exact member type')
+   assert(rawtype(array<str> { 'text' }) is 'array<str>', 'string arrays should use the str member name')
+   assert(rawtype(array<table> { {} }) is 'array<table>', 'table arrays should retain their member category')
+   assert(rawtype(array<array> { array<int> { 1 } }) is 'array<array>', 'nested arrays should retain their member category')
+   assert(rawtype(array<any> { 1, 'text' }) is 'array<any>', 'mixed arrays should retain their wildcard member type')
+
+   local point = struct<RawTypeNamePoint> { Value=7 }
+   local clock = obj.new('time')
+   assert(rawtype(point) is 'struct<RawTypeNamePoint>', 'struct values should include their resolved layout')
+   assert(rawtype(array<struct<RawTypeNamePoint>> { point }) is 'array<struct<RawTypeNamePoint>>',
+      'struct arrays should include their resolved element layout')
+   assert(rawtype(clock) is 'obj<Time>', 'object values should include their runtime class')
+   assert(rawtype(array<obj> { clock }) is 'array<object>', 'object arrays should use their annotation member spelling')
+
+   local stop = 2
+   assert(rawtype({0 to stop}) is 'range', 'variable-bound ranges should be recognised')
+   assert(rawtype({2 to -1 by -1}) is 'range', 'descending ranges should be recognised')
+   assert(rawtype(newproxy(true)) is 'userdata', 'full userdata should retain its category name')
+   local captured = 1
+   function capture() return captured end
+   assert(rawtype(debug.upvalueID(capture, 0)) is 'userdata', 'light userdata should retain its category name')
 end
 
-@Test function DeclaredThunkNameTakesPrecedenceWithoutResolution()
+@Test function RawTypeReportsThunkContainersWithoutResolution()
    local executed = false
    thunk deferred_number():num
       executed = true
-      return 42
+      error('rawtype() must not resolve a declared thunk')
    end
 
    local value = deferred_number()
    assert(type(value) is 'number', 'type() should preserve a thunk declaration')
-   assert(rawtype(value) is 'userdata', 'rawtype() should expose the thunk container')
+   assert(rawtype(value) is 'thunk', 'rawtype() should identify the declared thunk container')
    assert(executed is false, 'neither type query should resolve the thunk')
+
+   function undeclared_body():any
+      executed = true
+      error('rawtype() must not resolve an undeclared thunk')
+   end
+   local undeclared:any = <{ undeclared_body() }>
+   assert(rawtype(undeclared) is 'thunk', 'rawtype() should identify an undeclared thunk container')
+   assert(executed is false, 'rawtype() should not resolve an undeclared thunk')
+end
+
+@Test function RawTypeIgnoresMetamethods()
+   local invoked = false
+   local table_value = setmetatable({}, {
+      __name = 'NamedTable',
+      __index = { __name = 'IndexedName' },
+      __tostring = function():str
+         invoked = true
+         return 'unexpected'
+      end,
+      __call = function()
+         invoked = true
+      end
+   })
+
+   assert(type(table_value) is 'NamedTable', 'the test table should expose its display name')
+   assert(rawtype(table_value) is 'table', 'a table name or index value must not affect rawtype()')
+   assert(invoked is false, 'rawtype() must not invoke __tostring or __call')
+end
+
+@Test function RawTypePreservesDisplayTypesAndContractDiagnostics()
+   local point = struct<RawTypeNamePoint> { Value=3 }
+   local clock = obj.new('time')
+   local deferred = <{ 1 }>
+   assert(type(1) is 'number' and type('text') is 'string' and type(function() end) is 'function',
+      'type() should retain its Lua-facing scalar vocabulary')
+   assert(type(array<int> { 1 }) is 'array' and type(point) is 'struct' and type(clock) is 'object',
+      'type() should retain its container categories: ' .. type(array<int> { 1 }) .. ', ' .. type(point) .. ', ' ..
+         type(clock))
+   assert(type({0 to 2}) is 'range' and type(deferred) is 'number',
+      'type() should retain its range and undeclared-thunk behaviour')
+   assert(array<byte> { 1 }.type() is 'char', 'array.type() should retain its char alias')
+   assert(tostring(array<byte> { 65 }) is 'A', 'array tostring should retain byte-array string conversion')
+   assert(point is <struct> and clock is <obj> and array<int> { 1 } is <array>,
+      'runtime type tests should remain independent of rawtype()')
+
+   function accept_number(Value:num)
+   end
+   local message = ''
+   try
+      accept_number(dynamic_value('text'))
+   except e
+      message = e.message
+   end
+   assert(message is "type contract failed for parameter 1 ('Value'): expected num, got string",
+      'the contract diagnostic should retain its exact established wording')
+end
+
+@Test function RawTypeJitParityAndGuards()
+   local integers = array<int16> { 1 }
+   local floats = array<float> { 1 }
+   local point = struct<RawTypeNamePoint> { Value=5 }
+   local clock = obj.new('time')
+   local proxy = newproxy(true)
+   local sequence = {0 to 2}
+   local deferred:any = <{ 1 }>
+
+   jit.off()
+   assert(raw_type_query(integers) is 'array<int16>', 'the interpreter should describe exact array members')
+   assert(raw_type_query(point) is 'struct<RawTypeNamePoint>', 'the interpreter should describe struct layouts')
+   assert(raw_type_query(clock) is 'obj<Time>', 'the interpreter should describe object classes')
+   assert(raw_type_query(proxy) is 'userdata' and raw_type_query(sequence) is 'range' and
+      raw_type_query(deferred) is 'thunk', 'the interpreter should distinguish userdata containers')
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   for _ in {1 into 100} do
+      assert(raw_type_query(integers) is 'array<int16>', 'a traced array query should retain its element type')
+      assert(raw_type_query(point) is 'struct<RawTypeNamePoint>', 'a traced struct query should retain its layout')
+      assert(raw_type_query(clock) is 'obj<Time>', 'a traced object query should retain its class')
+   end
+   assert(raw_type_query(floats) is 'array<float>', 'an array member mismatch should leave the trace')
+   clock.free()
+   assert(raw_type_query(clock) is 'obj', 'a cleared object class should leave the trace and report obj')
+
+   for _ in {1 into 100} do assert(raw_type_query(proxy) is 'userdata', 'a traced userdata query should be stable') end
+   assert(raw_type_query(sequence) is 'range', 'a range should leave a userdata trace')
+   assert(raw_type_query(deferred) is 'thunk', 'a thunk should leave a userdata trace without resolution')
+   assert(raw_type_runtime_call_count() is 0, 'rawtype() traces should fold to constants without runtime calls')
+   jit.opt.start()
+end
+
+@Test function RawTypeJitHandlesInvalidRangeRegistry()
+   local registry = debug.getRegistry()
+   local range_metatable = registry['Tiri.range']
+   local sequence = {0 to 2}
+   assert(range_metatable is <table>, 'the range metatable should be registered before the test')
+
+   defer
+      registry['Tiri.range'] = range_metatable
+      jit.flush()
+      jit.opt.start()
+   end
+
+   registry['Tiri.range'] = nil
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   for _ in {1 into 100} do
+      assert(raw_type_query(sequence) is 'userdata', 'a range without its registry entry should trace as userdata')
+   end
+
+   registry['Tiri.range'] = 'invalid'
+   jit.flush()
+   for _ in {1 into 100} do
+      assert(raw_type_query(sequence) is 'userdata', 'a non-table range registry entry should trace as userdata')
+   end
+
+   registry['Tiri.range'] = range_metatable
+   assert(raw_type_query(sequence) is 'range', 'restoring the range metatable should leave the userdata trace')
 end
 
 @Test function DiagnosticsUseTheDisplayName()


### PR DESCRIPTION
* rawtype() now reports the annotation vocabulary (num, str, func, obj, thunk) and parameterised names for containers, e.g. array<int>, array<struct<Name>>, obj<Time> and struct<Name>
* Thunk containers and range userdata are now distinguished from generic userdata without resolving the thunk
* Added lj_meta_raw_type_text() and lj_meta_raw_type_name() as the single source of raw type naming, reused by the runtime contract mismatch reporter
* Added recff_rawtype() recording that emits element type, struct definition, class pointer, userdata type and range metatable guards so parameterised names fold to a constant string on trace
* Removed the x64, ARM64 and PPC assembly fast paths for rawtype(), which can no longer serve parameterised names
* Exported lj_record_range_metatable() and lj_array_elemtype_name(), replacing the duplicated AET name switches in the contract reporter and static type descriptor
* [Script] Declared __name on the gui HSV and RGB metatables