### PR TITLE
Enhance tostring output and normalize array type names

### DIFF
--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -140,36 +140,6 @@ bool lj_array_struct_is_trivial(const struct_record &Def)
 }
 
 //********************************************************************************************************************
-// Helper to get the legacy public element name.  array.type() and array tostring intentionally retain char for BYTE.
-
-static CSTRING elemtype_name(AET Type)
-{
-   switch (Type) {
-      case AET::BYTE:       return "char";
-      case AET::INT8:       return "int8";
-      case AET::INT16:      return "int16";
-      case AET::INT32:      return "int";
-      case AET::INT64:      return "int64";
-      case AET::UINT8:      return "uint8";
-      case AET::UINT16:     return "uint16";
-      case AET::UINT32:     return "uint";
-      case AET::UINT64:     return "uint64";
-      case AET::FLOAT:      return "float";
-      case AET::DOUBLE:     return "double";
-      case AET::PTR:        return "pointer";
-      case AET::STRUCT:     return "struct";
-      case AET::TABLE:      return "table";
-      case AET::ARRAY:      return "array";
-      case AET::OBJECT:     return "object";
-      case AET::CSTR:
-      case AET::STR_GC:
-      case AET::STR_CPP:    return "str";
-      case AET::ANY:        return "any";
-      default: return "unknown";
-   }
-}
-
-//********************************************************************************************************************
 
 template <typename... Args>
 static void append_formatted(std::string &Result, CSTRING Format, Args... Values)
@@ -664,7 +634,8 @@ LJLIB_CF(array_concat)
                append_formatted(result, format, unsigned(arr->get<uint8_t>()[i]));
                break;
             default:
-               luaL_error(L, ERR::InvalidType, "concat() does not support %s types.", elemtype_name(arr->elemtype));
+               luaL_error(L, ERR::InvalidType, "concat() does not support %s types.",
+                  lj_array_elemtype_name(arr->elemtype));
          }
       }
       else {
@@ -721,7 +692,8 @@ LJLIB_CF(array_concat)
                append_integer(result, arr->get<uint8_t>()[i]);
                break;
             default:
-               luaL_error(L, ERR::InvalidType, "concat() does not support %s types.", elemtype_name(arr->elemtype));
+               luaL_error(L, ERR::InvalidType, "concat() does not support %s types.",
+                  lj_array_elemtype_name(arr->elemtype));
          }
       }
    }
@@ -1330,7 +1302,7 @@ LJLIB_CF(array_setString)
 LJLIB_CF(array_type)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
-   auto name = elemtype_name(arr->elemtype);
+   auto name = lj_array_elemtype_name(arr->elemtype);
    setstrV(L, L->top++, lj_str_newz(L, name));
    return 1;
 }
@@ -2587,7 +2559,7 @@ static int array_tostring(lua_State *L)
       return 1;
    }
 
-   CSTRING type_name = elemtype_name(arr->elemtype);
+   CSTRING type_name = lj_array_elemtype_name(arr->elemtype);
    lua_pushfstring(L, "array<%s, %d>", type_name, int(arr->len));
    return 1;
 }

--- a/src/tiri/jit/src/lib/lib_base.cpp
+++ b/src/tiri/jit/src/lib/lib_base.cpp
@@ -338,13 +338,13 @@ static bool prepare_iter_metamethod(lua_State *L, TValue *Target)
    if (tvisnil(metamethod)) return false;
 
    if (tvistab(Target)) {
-      size_t context_depth = lj_context_depth(L);
-      size_t context_size = L->context_stack.size();
+      [[maybe_unused]] size_t context_depth = lj_context_depth(L);
+      [[maybe_unused]] size_t context_size = L->context_stack.size();
       copyTV(L, L->top++, metamethod);
       TValue *top = L->top;
       setnilV(top++);
       L->top = top;
-      uint32_t argument_count = lj_context_prepare_metamethod_call(L, Target, top, 0, 1);
+      [[maybe_unused]] uint32_t argument_count = lj_context_prepare_metamethod_call(L, Target, top, 0, 1);
       lj_assertL(argument_count IS 0, "table __iter retained its receiver argument");
       int call_error = lj_vm_pcall(L, top, 2, -1);
       lj_context_restore_depth(L, context_size);

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -81,7 +81,7 @@ CSTRING lj_array_elemtype_name(AET Type) noexcept
       case AET::ARRAY:  return "array";
       case AET::PTR:    return "pointer";
       case AET::ANY:    return "any";
-      case AET::OBJECT: return "object";
+      case AET::OBJECT: return "obj";
       case AET::STRUCT: return "struct";
       case AET::MAX:    return "any";
    }

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -620,7 +620,7 @@ void lj_context_push(lua_State *L, GCtab *Table, const TValue *OwnerBase)
    TValue *stack = tvref(L->stack);
    // A call frame base may temporarily occupy LuaJIT's reserved stack area before the function header grows the
    // soft stack limit. Context owners are offsets only and remain valid throughout that interval.
-   TValue *stack_end = stack + L->stacksize;
+   [[maybe_unused]] TValue *stack_end = stack + L->stacksize;
    lj_assertL(OwnerBase >= stack and OwnerBase < stack_end, "context owner is outside the state stack allocation");
 
    lua_State::ContextFrame frame;

--- a/src/tiri/jit/src/runtime/lj_strfmt.cpp
+++ b/src/tiri/jit/src/runtime/lj_strfmt.cpp
@@ -530,6 +530,7 @@ GCstr* lj_strfmt_char(lua_State* L, int c)
 GCstr * lj_strfmt_obj(lua_State *L, cTValue *o)
 {
    if (tvisstr(o)) return strV(o);
+   else if (GCstr *display_name = lj_meta_type_name(L, o)) return display_name;
    else if (tvisnumber(o)) return lj_strfmt_number(L, o);
    else if (tvisnil(o)) return lj_str_newlit(L, "nil");
    else if (tvisfalse(o)) return lj_str_newlit(L, "false");
@@ -559,19 +560,9 @@ GCstr * lj_strfmt_obj(lua_State *L, cTValue *o)
          }
       }
 
-      // Anonymous function or C function - use address
-      char buf[32], *p = buf;
-      p = lj_buf_wmem(p, "function: ", 10);
-      p = lj_strfmt_wptr(p, lj_obj_ptr(G(L), o));
-      return lj_str_new(L, buf, (size_t)(p - buf));
+      return lj_str_newlit(L, "function");
    }
-   else {
-      char buf[8 + 2 + 2 + 16], * p = buf;
-      p = lj_buf_wmem(p, lj_typename(o), (MSize)strlen(lj_typename(o)));
-      *p++ = ':'; *p++ = ' ';
-      p = lj_strfmt_wptr(p, lj_obj_ptr(G(L), o));
-      return lj_str_new(L, buf, (size_t)(p - buf));
-   }
+   else return lj_str_newz(L, lj_typename(o));
 }
 
 /*

--- a/src/tiri/jit/src/runtime/lj_strfmt.cpp
+++ b/src/tiri/jit/src/runtime/lj_strfmt.cpp
@@ -456,7 +456,7 @@ int lj_strfmt_putarg(lua_State* L, SBuf* sb, int arg, int retry)
                   copyTV(L, &receiver, o);
                   setnilV(L->top++);
                   TValue *base = L->top;
-                  uint32_t argument_count = lj_context_prepare_metamethod_call(L, &receiver, base, 0, 1);
+                  [[maybe_unused]] uint32_t argument_count = lj_context_prepare_metamethod_call(L, &receiver, base, 0, 1);
                   lj_assertL(argument_count IS 0, "formatted table metamethod retained its receiver argument");
                   lj_vm_call(L, base, 2);
                }

--- a/src/tiri/jit/src/runtime/lj_thunk.cpp
+++ b/src/tiri/jit/src/runtime/lj_thunk.cpp
@@ -236,7 +236,7 @@ static void call_table_metamethod(
    lj_assertL(L and Receiver and tvistab(Receiver), "invalid thunk table metamethod receiver");
    lj_assertL(ArgumentCount >= 0, "invalid thunk table metamethod argument count");
 
-   size_t context_depth = lj_context_depth(L);
+   [[maybe_unused]] size_t context_depth = lj_context_depth(L);
    TValue *top = L->top;
    TValue *base = top - ArgumentCount;
    L->top = top + 1;
@@ -244,7 +244,7 @@ static void call_table_metamethod(
    setnilV(base);
    base++;
 
-   uint32_t argument_count = lj_context_prepare_metamethod_call(
+   [[maybe_unused]] uint32_t argument_count = lj_context_prepare_metamethod_call(
       L, Receiver, base, uint32_t(ArgumentCount), uint32_t(ArgumentCount + 1));
    lj_assertL(argument_count IS uint32_t(ArgumentCount),
       "thunk table metamethod retained its receiver argument");

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -1006,10 +1006,10 @@ end
    assert(double_arr.type() is 'double', "double array type should be 'double'")
 
    byte_arr = array<byte, 5>
-   assert(byte_arr.type() is 'char', "byte array type should be 'char'")
+   assert(byte_arr.type() is 'byte', "byte array type should be 'byte'")
 
    char_arr = array<char, 5>
-   assert(char_arr.type() is 'char', "char array type should be 'char'")
+   assert(char_arr.type() is 'byte', "char array type should be 'byte'")
 
    int16_arr = array<int16, 5>
    assert(int16_arr.type() is 'int16', "int16 array type should be 'int16'")
@@ -1093,7 +1093,7 @@ end
    arr = array.new(str)
 
    assert(#arr is 5, "array from string should have correct length")
-   assert(arr.type() is 'char', "array from string should be char type")
+   assert(arr.type() is 'byte', "array from string should be byte type")
    assert(arr[0] is 72, "arr[0] should be 'H' (72)")
    assert(arr[1] is 101, "arr[1] should be 'e' (101)")
    assert(arr[4] is 111, "arr[4] should be 'o' (111)")
@@ -1420,7 +1420,7 @@ end
    arr = array<byte> { 65, 66, 67, 68 }  -- ASCII A, B, C, D
 
    assert(#arr is 4, "array.of byte should have length 4")
-   assert(arr.type() is 'char', "array.of byte type should be 'char'")
+   assert(arr.type() is 'byte', "array.of byte type should be 'byte'")
    assert(arr[0] is 65, "arr[0] should be 65 (A)")
    assert(arr[1] is 66, "arr[1] should be 66 (B)")
    assert(arr[2] is 67, "arr[2] should be 67 (C)")
@@ -1431,7 +1431,7 @@ end
    arr = array<char> { 72, 101, 108, 108, 111 }  -- Hello
 
    assert(#arr is 5, "array.of char should have length 5")
-   assert(arr.type() is 'char', "array.of char type should be 'char'")
+   assert(arr.type() is 'byte', "array.of char type should be 'byte'")
    assert(arr.getString() is 'Hello', "getString should return 'Hello'")
 end
 
@@ -1525,7 +1525,7 @@ end
    arr = array<obj> { obj_one, obj_two }
 
    assert(#arr is 2, "array<obj> should have 2 elements")
-   assert(arr.type() is 'object', "array<obj> type should be 'object'")
+   assert(arr.type() is 'obj', "array<obj> type should be 'obj'")
    assert(arr[0].id is obj_one.id, "first object should match obj_one")
    assert(arr[1].id is obj_two.id, "second object should match obj_two")
 

--- a/src/tiri/tests/test_array_typed_syntax.tiri
+++ b/src/tiri/tests/test_array_typed_syntax.tiri
@@ -33,7 +33,7 @@ end
 @Test function ArrayTypedBasicObject()
    arr = array<obj>
    assert(#arr is 0, "Empty array<obj> should have length 0")
-   assert(arr.type() is 'object', "Type should be 'object'")
+   assert(arr.type() is 'obj', "Type should be 'obj'")
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -107,10 +107,10 @@ end
 @Test function ArrayTypedAllTypes()
    -- byte and char are aliases that map to 'char'
    byte_arr = array<byte>
-   assert(byte_arr.type() is 'char', "byte should map to 'char', got '" .. byte_arr.type() .. "'")
+   assert(byte_arr.type() is 'byte', "byte should be 'byte', got '" .. byte_arr.type() .. "'")
 
    char_arr = array<char>
-   assert(char_arr.type() is 'char', "char should be 'char'")
+   assert(char_arr.type() is 'byte', "char should map to 'byte'")
 
    int16_arr = array<int16>
    assert(int16_arr.type() is 'int16', "int16 should be 'int16'")
@@ -184,7 +184,7 @@ end
    assert(signed_values[0] is -128 and signed_values[1] is -1 and signed_values[3] is 127,
       'int8 did not preserve signed values')
    assert(signed_values[4] is -128 and signed_values[5] is -1, 'int8 values did not wrap as signed 8-bit integers')
-   assert(bytes.type() is 'char' and bytes[0] is 255 and bytes[1] is 255,
+   assert(bytes.type() is 'byte' and bytes[0] is 255 and bytes[1] is 255,
       'byte did not remain an unsigned byte buffer')
    assert(legacy.type() is 'int8' and legacy[0] is -128 and legacy[1] is 127,
       'legacy int8 construction did not retain signed storage')
@@ -294,7 +294,7 @@ end
    buffer_size = 400
    arr = array<byte, buffer_size>
    assert(#arr is 400, "Variable size should work, got " .. #arr)
-   assert(arr.type() is 'char', "Type should be 'char' (byte maps to char)")
+   assert(arr.type() is 'byte', "Type should be 'byte'")
 
    -- Size can also be a more complex unary expression
    local obj = { size = 100 }

--- a/src/tiri/tests/test_type_name.tiri
+++ b/src/tiri/tests/test_type_name.tiri
@@ -143,7 +143,7 @@ end
    assert(rawtype(array<struct<RawTypeNamePoint>> { point }) is 'array<struct<RawTypeNamePoint>>',
       'struct arrays should include their resolved element layout')
    assert(rawtype(clock) is 'obj<Time>', 'object values should include their runtime class')
-   assert(rawtype(array<obj> { clock }) is 'array<object>', 'object arrays should use their annotation member spelling')
+   assert(rawtype(array<obj> { clock }) is 'array<obj>', 'object arrays should use their annotation member spelling')
 
    local stop = 2
    assert(rawtype({0 to stop}) is 'range', 'variable-bound ranges should be recognised')
@@ -205,7 +205,7 @@ end
          type(clock))
    assert(type({0 to 2}) is 'range' and type(deferred) is 'number',
       'type() should retain its range and undeclared-thunk behaviour')
-   assert(array<byte> { 1 }.type() is 'char', 'array.type() should retain its char alias')
+   assert(array<byte> { 1 }.type() is 'byte', 'array.type() should retain its byte name')
    assert(tostring(array<byte> { 65 }) is 'A', 'array tostring should retain byte-array string conversion')
    assert(point is <struct> and clock is <obj> and array<int> { 1 } is <array>,
       'runtime type tests should remain independent of rawtype()')
@@ -227,12 +227,14 @@ end
    local floats = array<float> { 1 }
    local point = struct<RawTypeNamePoint> { Value=5 }
    local clock = obj.new('time')
+   local objects = array<obj> { clock }
    local proxy = newproxy(true)
    local sequence = {0 to 2}
    local deferred:any = <{ 1 }>
 
    jit.off()
    assert(raw_type_query(integers) is 'array<int16>', 'the interpreter should describe exact array members')
+   assert(raw_type_query(objects) is 'array<obj>', 'the interpreter should use annotation text for object arrays')
    assert(raw_type_query(point) is 'struct<RawTypeNamePoint>', 'the interpreter should describe struct layouts')
    assert(raw_type_query(clock) is 'obj<Time>', 'the interpreter should describe object classes')
    assert(raw_type_query(proxy) is 'userdata' and raw_type_query(sequence) is 'range' and

--- a/src/tiri/tests/test_type_name.tiri
+++ b/src/tiri/tests/test_type_name.tiri
@@ -44,6 +44,22 @@ end
    assert(vector is <table>, '__name must not affect runtime type identity')
 end
 
+@Test function NameProvidesDefaultStringRepresentation()
+   local vector = named_value('Vector')
+   local text = tostring(vector)
+   assert(text is 'Vector', '__name should provide the complete default tostring() result, got ' .. text)
+   assert(f'{vector}' is text, 'string interpolation should use the __name fallback')
+   assert(tostring({}) is 'table', 'unnamed tables should stringify without an address')
+   assert(tostring(function() end) is 'function', 'anonymous functions should stringify without an address')
+
+   local custom = setmetatable({}, {
+      __name = 'NamedValue',
+      __tostring = function():str return 'custom text' end
+   })
+   assert(tostring(custom) is 'custom text', '__tostring should take precedence over __name')
+   assert(f'{custom}' is 'custom text', 'string interpolation should prefer __tostring over __name')
+end
+
 @Test function DirectAndInvalidNamesFallBack()
    local direct = { __name = 'DirectField' }
    assert(type(direct) is 'table', 'a direct __name field must be ignored')


### PR DESCRIPTION
This pull request makes several important changes to type naming conventions and string representations for arrays and objects in the Tiri runtime, aiming for clearer, more consistent, and less legacy-driven naming. It also improves test coverage for these behaviors and makes minor refactoring for clarity and correctness.

**Type Naming and String Representation Updates:**

* The legacy element type name helper `elemtype_name` was removed from `lib_array.cpp`, and all references were updated to use the canonical `lj_array_elemtype_name` function. This ensures that array types like `byte` and `obj` are reported with their actual names instead of legacy aliases like `char` and `object`. [[1]](diffhunk://#diff-4afbdaf64849d61d8bc43b90096e6edb11328ea901094aebb4de1f020431ad0eL142-L171) [[2]](diffhunk://#diff-4afbdaf64849d61d8bc43b90096e6edb11328ea901094aebb4de1f020431ad0eL667-R638) [[3]](diffhunk://#diff-4afbdaf64849d61d8bc43b90096e6edb11328ea901094aebb4de1f020431ad0eL724-R696) [[4]](diffhunk://#diff-4afbdaf64849d61d8bc43b90096e6edb11328ea901094aebb4de1f020431ad0eL1333-R1305) [[5]](diffhunk://#diff-4afbdaf64849d61d8bc43b90096e6edb11328ea901094aebb4de1f020431ad0eL2590-R2562) [[6]](diffhunk://#diff-56c885faf4b3ddf8c506aa7a642cd8bb27717f70b32bea0a6ccf83e205e663acL84-R84)
* The string representation of anonymous functions and unnamed tables now omits memory addresses, returning just `"function"` or `"table"`, and objects with a `__name` metatable field use that as their default string representation. Custom `__tostring` methods still take precedence. [[1]](diffhunk://#diff-10533117eb23f13666c883261b8123c5ec5b292ed6a07cb39d928655e5ecec0eR533) [[2]](diffhunk://#diff-2179f0757111835e30d4f3dd9f0b97a7dd63f162b9de844f9371e11d9194d777R47-R62)
* The canonical element type name for arrays of type `byte` and `char` is now `"byte"`, and for object arrays, `"obj"`, reflected in both runtime and test assertions. [[1]](diffhunk://#diff-e2c72a21bbdf9ef88005e2142f5b6d63afff179a740b2db5761449277a14392aL1009-R1012) [[2]](diffhunk://#diff-e2c72a21bbdf9ef88005e2142f5b6d63afff179a740b2db5761449277a14392aL1096-R1096) [[3]](diffhunk://#diff-e2c72a21bbdf9ef88005e2142f5b6d63afff179a740b2db5761449277a14392aL1423-R1423) [[4]](diffhunk://#diff-e2c72a21bbdf9ef88005e2142f5b6d63afff179a740b2db5761449277a14392aL1434-R1434) [[5]](diffhunk://#diff-e2c72a21bbdf9ef88005e2142f5b6d63afff179a740b2db5761449277a14392aL1528-R1528) [[6]](diffhunk://#diff-2b4850895377aa6f5c909d22454592d6ee0016a5730696de8d25477b3b8c0e28L36-R36) [[7]](diffhunk://#diff-2b4850895377aa6f5c909d22454592d6ee0016a5730696de8d25477b3b8c0e28L110-R113) [[8]](diffhunk://#diff-2b4850895377aa6f5c909d22454592d6ee0016a5730696de8d25477b3b8c0e28L187-R187) [[9]](diffhunk://#diff-2b4850895377aa6f5c909d22454592d6ee0016a5730696de8d25477b3b8c0e28L297-R297) [[10]](diffhunk://#diff-2179f0757111835e30d4f3dd9f0b97a7dd63f162b9de844f9371e11d9194d777L130-R146) [[11]](diffhunk://#diff-2179f0757111835e30d4f3dd9f0b97a7dd63f162b9de844f9371e11d9194d777L192-R208) [[12]](diffhunk://#diff-2179f0757111835e30d4f3dd9f0b97a7dd63f162b9de844f9371e11d9194d777R230-R237)

**Testing and Validation:**

* Test cases were updated or added to ensure that `array<byte>` and `array<char>` report their type as `"byte"`, and `array<obj>` as `"obj"`, both in `type()` and `rawtype()` queries. Additional tests verify that the new string representation logic for objects, tables, and functions works as intended. [[1]](diffhunk://#diff-e2c72a21bbdf9ef88005e2142f5b6d63afff179a740b2db5761449277a14392aL1009-R1012) [[2]](diffhunk://#diff-e2c72a21bbdf9ef88005e2142f5b6d63afff179a740b2db5761449277a14392aL1096-R1096) [[3]](diffhunk://#diff-e2c72a21bbdf9ef88005e2142f5b6d63afff179a740b2db5761449277a14392aL1423-R1423) [[4]](diffhunk://#diff-e2c72a21bbdf9ef88005e2142f5b6d63afff179a740b2db5761449277a14392aL1434-R1434) [[5]](diffhunk://#diff-e2c72a21bbdf9ef88005e2142f5b6d63afff179a740b2db5761449277a14392aL1528-R1528) [[6]](diffhunk://#diff-2b4850895377aa6f5c909d22454592d6ee0016a5730696de8d25477b3b8c0e28L36-R36) [[7]](diffhunk://#diff-2b4850895377aa6f5c909d22454592d6ee0016a5730696de8d25477b3b8c0e28L110-R113) [[8]](diffhunk://#diff-2b4850895377aa6f5c909d22454592d6ee0016a5730696de8d25477b3b8c0e28L187-R187) [[9]](diffhunk://#diff-2b4850895377aa6f5c909d22454592d6ee0016a5730696de8d25477b3b8c0e28L297-R297) [[10]](diffhunk://#diff-2179f0757111835e30d4f3dd9f0b97a7dd63f162b9de844f9371e11d9194d777R47-R62) [[11]](diffhunk://#diff-2179f0757111835e30d4f3dd9f0b97a7dd63f162b9de844f9371e11d9194d777L130-R146) [[12]](diffhunk://#diff-2179f0757111835e30d4f3dd9f0b97a7dd63f162b9de844f9371e11d9194d777L192-R208) [[13]](diffhunk://#diff-2179f0757111835e30d4f3dd9f0b97a7dd63f162b9de844f9371e11d9194d777R230-R237)

**Minor Refactoring:**

* Several variables used only for assertions or debugging (such as context stack depth and argument counts in metamethod preparation) are now marked as `[[maybe_unused]]` to avoid compiler warnings. [[1]](diffhunk://#diff-23221bfdc3b4842d398d0e49119cf3cc0cca939c6a08394f14375f2a2b511587L341-R347) [[2]](diffhunk://#diff-8668f14f127bf6721bfc5e8b5ce35105e29a813e3d5329694b58c5a556ba5b67L623-R623) [[3]](diffhunk://#diff-10533117eb23f13666c883261b8123c5ec5b292ed6a07cb39d928655e5ecec0eL459-R459) [[4]](diffhunk://#diff-762096c82a80797af81196697d32dd1d822c6c1382d3eaffd533c05d5353c77dL239-R247)

These changes modernize and clarify the runtime's handling of type names and string representations, making type introspection and debugging more intuitive and less dependent on legacy behaviors.