### PR TITLE
[Tiri] Deferred JIT snapshots past jumps that branch to a MULTRES consumer

### DIFF
--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -4785,6 +4785,29 @@ static void rec_range_value(jit_State *J, BCREG Base)
 }
 
 //********************************************************************************************************************
+// Determine whether a pending snapshot must be deferred past the current instruction.
+//
+// MULTRES is VM state that is not covered by a snapshot.  lj_trace_exit() reconstructs it from L->top only when
+// the resumed PC is an instruction that consumes it, so an exit that resumes anywhere else leaves MULTRES at
+// zero.  That is safe in stock bytecode because a multi-result call is always immediately followed by its
+// consumer, but Tiri's dual-path builtin method dispatch emits `CALL (multi-result); JMP; <fallback>; CALLM`,
+// placing a jump between the producer and the consumer.  A snapshot taken at that jump therefore yields a
+// zero-argument CALLM after a side exit.
+//
+// BC_JMP emits neither IR nor guards, so deferring the snapshot until the consumer is recorded describes an
+// identical machine state and lets the existing BC_CALLM handling in lj_snap_restore() and lj_trace_exit()
+// recover MULTRES.
+
+static bool rec_defer_snapshot(jit_State *J)
+{
+   const BCIns *pc = J->pc;
+   if (bc_op(*pc) != BC_JMP) return false;
+   BCOp target = bc_op(pc[1 + bc_j(*pc)]);
+   return target IS BC_CALLM or target IS BC_CALLMT or target IS BC_CTXCALLM or target IS BC_CTXLEAVE or
+      target IS BC_RETM or target IS BC_TSETM;
+}
+
+//********************************************************************************************************************
 // Record the next bytecode instruction (_before_ it's executed).
 
 void lj_record_ins(jit_State *J)
@@ -4797,7 +4820,7 @@ void lj_record_ins(jit_State *J)
    if (not rec_handle_postproc(J)) return;
 
    // Need snapshot before recording next bytecode (e.g. after a store).
-   if (J->needsnap) {
+   if (J->needsnap and not rec_defer_snapshot(J)) {
       J->needsnap = 0;
       if (J->pt) lj_snap_purge(J);
       lj_snap_add(J);

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -3461,3 +3461,31 @@ end
    end
    assert(#t is 8, f"A numerically addressed table should keep its length, got {tostring(#t)}")
 end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test(hotpath=100) function MultiResultSurvivesBuiltinMethodDispatchJump()
+   -- Regression: a builtin method call used as the trailing argument of another builtin call compiles to
+   -- `CALL (multi-result); JMP; <dynamic fallback>; CALLM`.  MULTRES is not covered by a snapshot, so a side exit
+   -- that resumed at the jump left it cleared and the following CALLM ran with no arguments at all.
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=2', 'hotexit=1', 'minstitch=0')
+
+   local chunks = {}
+   local buffer = array.new('multi-result payload', 'byte')
+
+   function append_chunk(Source)
+      chunks.insert(Source.getString())
+   end
+
+   -- The table has to keep growing so that its bounds guard side-exits while the trace is hot.
+   for i in {1 into 200} do append_chunk(buffer) end
+
+   jit.opt.start()
+
+   assert(#chunks is 200, f'Expected 200 recorded chunks, got {tostring(#chunks)}')
+   assert(chunks[0] is 'multi-result payload', f'First chunk is wrong: {tostring(chunks[0])}')
+   assert(chunks[199] is 'multi-result payload', f'Last chunk is wrong: {tostring(chunks[199])}')
+end


### PR DESCRIPTION
* MULTRES is not covered by a snapshot and lj_trace_exit() only rebuilds it when the resumed PC consumes it, so an exit landing on a jump left it cleared
* Builtin method dispatch emits a multi-result call, a jump over the dynamic fallback path and a CALLM, which made a side exit at that jump call the CALLM with no arguments at all
* Added a Flute regression test covering a builtin method call used as the trailing argument of another builtin call