### PR TITLE
[Tiri] Preserved MULTRES state across trace snapshots and side exits

### DIFF
--- a/src/tiri/jit/src/debug/lj_jit.h
+++ b/src/tiri/jit/src/debug/lj_jit.h
@@ -198,6 +198,7 @@ struct SnapShot {
   IRRef1 context_refs[LJ_MAX_VIRTUAL_CONTEXTS]; // Virtual contextual receivers restored outermost first.
   uint16_t context_owner_slots[LJ_MAX_VIRTUAL_CONTEXTS]; // Root-frame slots owning virtual activations.
   uint16_t mcofs;   //  Offset into machine code in MCode units.
+  uint16_t multres; //  Unscaled MULTRES value at the snapshot.
   uint8_t nslots;   //  Number of valid slots.
   uint8_t topslot;   //  Maximum frame extent.
   uint8_t nent;      //  Number of compressed entries.
@@ -481,6 +482,7 @@ struct jit_State {
   int32_t framedepth;   //  Current frame depth.
   int32_t retdepth;     //  Return frame depth (count of RETF).
   uint8_t trydepth;     //  Current try block depth while recording.
+  uint16_t multres;     //  Unscaled implicit multi-result VM state.
 
   uint32_t k32[unsigned(K32::_MAX)];  //  Common 4 byte constants used by backends.
   TValue ksimd[unsigned(KSimd::_MAX)*2+1];  //  16 byte aligned SIMD constants.

--- a/src/tiri/jit/src/lj_asm.cpp
+++ b/src/tiri/jit/src/lj_asm.cpp
@@ -2038,23 +2038,26 @@ static void asm_tail_link(ASMState* as)
       // Setup fixed registers for exit to interpreter.
       const BCIns* pc = snap_pc(&as->T->snapmap[snap->mapofs + snap->nent]);
       int32_t mres;
-      if (bc_op(*pc) == BC_JLOOP) {  // NYI: find a better way to do this.
+      if (bc_op(*pc) IS BC_JLOOP) {  // NYI: find a better way to do this.
          BCIns* retpc = &traceref(as->J, bc_d(*pc))->startins;
          if (bc_isret(bc_op(*retpc)))
             pc = retpc;
       }
       emit_loadu64(as, RID_LPC, u64ptr(pc));
-      mres = (int32_t)(snap->nslots - baseslot - LJ_FR2);
-      switch (bc_op(*pc)) {
-      case BC_CALLM: case BC_CALLMT: case BC_CTXCALLM:
-         mres -= (int32_t)(1 + LJ_FR2 + bc_a(*pc) + bc_c(*pc)); break;
-      case BC_RETM: mres -= (int32_t)(bc_a(*pc) + bc_d(*pc)); break;
-      case BC_TSETM: mres -= (int32_t)bc_a(*pc); break;
-      default:
-         // Fast function pseudo-opcodes (>= BC__MAX) need the same treatment as function headers
-         // to ensure MULTRES is set correctly for the argument count after trace stitch exits.
-         if (not bc_is_func_header(bc_op(*pc)) and bc_op(*pc) < BC__MAX) mres = 0;
-         break;
+      if (bc_op(*pc) IS BC_JMP) mres = int32_t(snap->multres);
+      else {
+         mres = (int32_t)(snap->nslots - baseslot - LJ_FR2);
+         switch (bc_op(*pc)) {
+         case BC_CALLM: case BC_CALLMT: case BC_CTXCALLM:
+            mres -= (int32_t)(1 + LJ_FR2 + bc_a(*pc) + bc_c(*pc)); break;
+         case BC_RETM: mres -= (int32_t)(bc_a(*pc) + bc_d(*pc)); break;
+         case BC_TSETM: mres -= (int32_t)bc_a(*pc); break;
+         default:
+            // Fast function pseudo-opcodes (>= BC__MAX) need the same treatment as function headers
+            // to ensure MULTRES is set correctly for the argument count after trace stitch exits.
+            if (not bc_is_func_header(bc_op(*pc)) and bc_op(*pc) < BC__MAX) mres = 0;
+            break;
+         }
       }
       ra_allockreg(as, mres, RID_RET);  //  Return MULTRES or 0.
    }

--- a/src/tiri/jit/src/lj_opt_loop.cpp
+++ b/src/tiri/jit/src/lj_opt_loop.cpp
@@ -238,6 +238,7 @@ static void loop_subst_snap(jit_State* J, SnapShot* osnap, SnapEntry* loopmap, I
       snap->context_owner_slots[context_index] = osnap->context_owner_slots[context_index];
    }
    snap->mcofs = 0;
+   snap->multres = osnap->multres;
    snap->nslots = nslots;
    snap->topslot = osnap->topslot;
    snap->count = snap->context_count ? SNAPCOUNT_DONE : 0;

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1880,6 +1880,8 @@ void lj_record_ret(jit_State *J, BCREG rbase, ptrdiff_t gotresults)
       J->needsnap = 1;  //  Stop catching on-trace errors.
    }
 
+   J->multres = uint16_t(gotresults + 1);
+
    bool contextual_caller = false;
    if (frame_islua(frame)) {
       BCOp caller_op = bc_op(*(frame_pc(frame) - 1));
@@ -5491,6 +5493,7 @@ void lj_record_setup(jit_State *J)
    J->framedepth = 0;
    J->retdepth   = 0;
    J->trydepth   = rec_try_active_depth(J);
+   J->multres    = 0;
    J->instunroll = J->param[JIT_P_instunroll];
    J->loopunroll = J->param[JIT_P_loopunroll];
    J->tailcalled = 0;
@@ -5513,6 +5516,7 @@ void lj_record_setup(jit_State *J)
    setmref(J->cur.startpc, J->pc);
    if (J->parent) {  // Side trace.
       GCtrace *T = traceref(J, J->parent);
+      J->multres = T->snap[J->exitno].multres;
       TraceNo root = T->root ? T->root : J->parent;
       J->cur.root = (uint16_t)root;
       J->cur.startins = BCINS_AD(BC_JMP, 0, 0);

--- a/src/tiri/jit/src/lj_snap.cpp
+++ b/src/tiri/jit/src/lj_snap.cpp
@@ -12,6 +12,7 @@
 **   - nent:   Number of slot entries (NOT including frame links)
 **   - ref:    IR reference at which this snapshot was created
 **   - context_refs/context_owner_slots: Virtual contextual activations materialised on exit
+**   - multres: Unscaled count for restoring implicit multi-result VM state
 **   - nslots: Total number of stack slots
 **   - topslot: Top slot for stack sizing
 **
@@ -174,6 +175,7 @@ static void snapshot_stack(jit_State* J, SnapShot* snap, MSize nsnapmap)
    memset(snap->context_refs, 0, sizeof(snap->context_refs));
    memset(snap->context_owner_slots, 0, sizeof(snap->context_owner_slots));
    snap->mcofs = 0;
+   snap->multres = J->multres;
    snap->nslots = (uint8_t)nslots;
    snap->context_count = 0;
    snap->count = 0;

--- a/src/tiri/jit/src/lj_trace.cpp
+++ b/src/tiri/jit/src/lj_trace.cpp
@@ -1077,6 +1077,7 @@ int lj_trace_exit(jit_State *J, void *exptr)
    }
 #endif
    lj_assertJ(T != nullptr and J->exitno < T->nsnap, "bad trace or exit number");
+   uint16_t snapshot_multres = T->snap[J->exitno].multres;
    exd.J = J;
    exd.exptr = exptr;
    errcode = lj_vm_cpcall(L, nullptr, &exd, trace_exit_cp);
@@ -1126,6 +1127,7 @@ int lj_trace_exit(jit_State *J, void *exptr)
    }
    // Return MULTRES or 0.
    ERRNO_RESTORE
+      if (bc_op(*pc) IS BC_JMP) return int(snapshot_multres);
       switch (bc_op(*pc)) {
       case BC_CALLM: case BC_CALLMT: case BC_CTXCALLM:
          return (int)((BCREG)(L->top - L->base) - bc_a(*pc) - bc_c(*pc) - LJ_FR2);

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -3461,3 +3461,27 @@ end
    end
    assert(#t is 8, f"A numerically addressed table should keep its length, got {tostring(#t)}")
 end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test(hotpath=100) function MultiResultSurvivesBuiltinMethodDispatchJump()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=2', 'hotexit=1', 'minstitch=0')
+
+   local chunks = {}
+   local buffer = array.new('multi-result payload', 'byte')
+
+   function append_chunk(Source)
+      chunks.insert(Source.getString())
+   end
+
+   -- The table has to keep growing so that its bounds guard side-exits while the trace is hot.
+   for i in {1 into 200} do append_chunk(buffer) end
+
+   jit.opt.start()
+
+   assert(#chunks is 200, f'Expected 200 recorded chunks, got {tostring(#chunks)}')
+   assert(chunks[0] is 'multi-result payload', f'First chunk is wrong: {tostring(chunks[0])}')
+   assert(chunks[199] is 'multi-result payload', f'Last chunk is wrong: {tostring(chunks[199])}')
+end


### PR DESCRIPTION
* Recorded the unscaled MULTRES value in each snapshot and in jit_State, propagating it through loop snapshot substitution and into side trace setup
* Restored the snapshot MULTRES when exiting to a BC_JMP target in both the assembler tail link and the interpreter exit path, instead of deriving an incorrect count from the snapshot slot range
* [Test] Added MultiResultSurvivesBuiltinMethodDispatchJump to cover multi-result state surviving builtin method dispatch after a side exit