### PR TITLE
[Tiri] Add Stage A collection API compatibility

### DIFF
--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -50,10 +50,10 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // in struct.size, which shifts the generated fast-function ordering.  Version 0x92 expands private array member
 // identities with uint8, uint16, uint32 and uint64.  Version 0x93 gives int8 its own signed array member identity.
 // Version 0x96 adds BC_ISIN and BC_ISNIN. Version 0x97 adds rawtype and shifts the generated fast-function ordering.
-// Version 0x98 adds forEach and shifts the generated fast-function ordering.  Older chunks are rejected rather than
-// retaining compatibility shims.
+// Version 0x98 adds forEach and shifts the generated fast-function ordering.  Version 0x99 adds the Stage A array
+// and range collection compatibility callables.  Older chunks are rejected rather than retaining compatibility shims.
 
-constexpr uint8_t BCDUMP_VERSION = 0x98;
+constexpr uint8_t BCDUMP_VERSION = 0x99;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/debug/lj_ff.h
+++ b/src/tiri/jit/src/debug/lj_ff.h
@@ -76,7 +76,7 @@ static_assert(FF__MAX <= BUILTIN_CALLABLE_CAPACITY);
 static_assert(FF__MAX - 1 <= std::numeric_limits<uint16_t>::max());
 static_assert(builtin_callable_index(BuiltinCallableID::Invalid) >= FF__MAX);
 #ifdef FFDEF_BFUNC_ABI
-static_assert(builtin_callable_abi_fingerprint() IS 0x7bfb8237b6c7f9dbull,
+static_assert(builtin_callable_abi_fingerprint() IS 0x2a847e2d708bf847ull,
    "fast-function ordering changed: bump BCDUMP_VERSION and update the BC_BFUNC ABI fingerprint");
 #endif
 

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -26,6 +26,7 @@
 #include "lj_meta.h"
 #include "lj_struct.h"
 #include "lj_vmarray.h"
+#include "stack_helpers.h"
 #include "lib.h"
 #include "lib_utils.h"
 #include "lib_range.h"
@@ -103,6 +104,9 @@ static OBJECTID object_uid_from_value(lua_State *L, int ArgIndex)
 //********************************************************************************************************************
 // Helper to parse element type string
 
+static std::string_view array_struct_name(lua_State *L, int NArg);
+bool lj_array_struct_is_trivial(const struct_record &Def);
+
 static AET parse_elemtype(lua_State *L, int NArg)
 {
    GCstr *type_str = lj_lib_checkstr(L, NArg);
@@ -112,6 +116,28 @@ static AET parse_elemtype(lua_State *L, int NArg)
 
    lj_err_argv(L, NArg, ErrMsg::BADTYPE, "valid array type", strdata(type_str));
    return AET(0);  // unreachable
+}
+
+//********************************************************************************************************************
+// Allocate a mapped-result array using the same public element type rules as array.new() and array.of().
+//
+// TypeArg may identify an optional element-type argument.  A missing or nil type requests array<any> storage.
+
+GCarray * lj_array_new_map_result(lua_State *L, MSize Length, int TypeArg)
+{
+   if (TypeArg <= 0 or lua_isnoneornil(L, TypeArg)) return lj_array_new(L, Length, AET::ANY);
+
+   auto elem_type = parse_elemtype(L, TypeArg);
+   if (elem_type IS AET::PTR) lj_err_argv(L, TypeArg, ErrMsg::ARRTYPE);
+   if (elem_type != AET::STRUCT) return lj_array_new(L, Length, elem_type);
+
+   auto struct_name = array_struct_name(L, TypeArg);
+   if (struct_name.empty()) lj_err_argv(L, TypeArg, ErrMsg::ARRTYPE);
+   auto struct_def = find_struct(L, struct_name);
+   if ((not struct_def) or (not lj_array_struct_is_trivial(*struct_def))) {
+      lj_err_argv(L, TypeArg, ErrMsg::ARRTYPE);
+   }
+   return lj_array_new(L, Length, elem_type, nullptr, 0, struct_name, struct_def);
 }
 
 static std::string_view array_struct_name(lua_State *L, int NArg)
@@ -1475,7 +1501,7 @@ LJLIB_CF(array_fill)
 //********************************************************************************************************************
 #include "lj_array_search.h"
 
-// Usage: array.find(arr, value [, start]) or array.find(arr, value, {range})
+// Usage: array.indexOf(arr, value [, start]) or array.indexOf(arr, value, {range})
 //
 // Searches for a value in the array.
 //
@@ -1491,7 +1517,43 @@ LJLIB_CF(array_fill)
 //
 // Returns: index of first occurrence, or nil if not found
 
-LJLIB_CF(array_find)
+static bool array_values_equal(lua_State *L, GCarray *Array, MSize Index)
+{
+   ptrdiff_t saved_top = savestack(L, L->top);
+   array_push_element(L, Array, Index);
+   TValue *element = L->top - 1;
+   cTValue *candidate = L->base + 1;
+   bool equal = lj_obj_equal(element, candidate) != 0;
+
+   if (not equal and itype(element) IS itype(candidate) and
+       (tvistab(element) or tvisudata(element))) {
+      TValue *base = lj_meta_equal(L, gcV(element), gcV(candidate), 0);
+      equal = uintptr_t(base) > 1 and tvistruecond(MetaCall::invoke(L, base, 2, 1));
+   }
+
+   L->top = restorestack(L, saved_top);
+   return equal;
+}
+
+static int32_t array_find_generic(lua_State *L, GCarray *Array, int32_t Start, int32_t Stop, int32_t Step)
+{
+   MSize length = Array->len;
+   if (Step > 0) {
+      for (int32_t index = Start; index <= Stop and MSize(index) < length; index += Step) {
+         if (MSize(index) >= Array->len) break;
+         if (array_values_equal(L, Array, MSize(index))) return index;
+      }
+   }
+   else {
+      for (int32_t index = Start; index >= Stop and index >= 0 and MSize(index) < length; index += Step) {
+         if (MSize(index) >= Array->len) break;
+         if (array_values_equal(L, Array, MSize(index))) return index;
+      }
+   }
+   return -1;
+}
+
+static int array_index_of(lua_State *L)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
    const bool stop_provided = not lua_isnoneornil(L, 4);
@@ -1514,7 +1576,7 @@ LJLIB_CF(array_find)
       if (start >= stop) return array_push_find_result(L, -1);
       return array_push_find_result(L, find_object_in_array(arr, search_uid, start, stop - 1, 1));
    }
-   else if (arr->elemtype IS AET::STR_GC) { // Handle string arrays (STR_GC)
+   if (arr->elemtype IS AET::STR_GC) {
       GCstr *search_str = lj_lib_checkstr(L, 2);
 
       if (tiri_range *r = check_range(L, 3)) {
@@ -1529,21 +1591,46 @@ LJLIB_CF(array_find)
       return array_push_find_result(L, find_string_in_array(arr, search_str, start, stop - 1, 1));
    }
 
-   int ok;
-   lua_Number value = lua_tonumberx(L, 2, &ok);
-   if (not ok) luaL_error(L, "Unsupported value type '%s'", lua_typename(L, lua_type(L, 2)));
+   if (glArrayConversion[size_t(arr->elemtype)].primitive) {
+      int ok;
+      lua_Number value = lua_tonumberx(L, 2, &ok);
+      if (not ok) luaL_error(L, "Unsupported value type '%s'", lua_typename(L, lua_type(L, 2)));
+
+      if (tiri_range *r = check_range(L, 3)) {
+         auto span = array_range_to_span(L, r, arr->len);
+         if (span.empty) return array_push_find_result(L, -1);
+         return array_push_find_result(L, find_in_array(arr, value, span.start, span.stop, span.step));
+      }
+
+      auto start = lj_lib_optint(L, 3, 0);
+      if (not array_find_start(start, arr->len, &start)) return array_push_find_result(L, -1);
+      if (start >= stop) return array_push_find_result(L, -1);
+      return array_push_find_result(L, find_in_array(arr, value, start, stop - 1, 1));
+   }
 
    if (tiri_range *r = check_range(L, 3)) {
       auto span = array_range_to_span(L, r, arr->len);
       if (span.empty) return array_push_find_result(L, -1);
-      return array_push_find_result(L, find_in_array(arr, value, span.start, span.stop, span.step));
+      return array_push_find_result(L, array_find_generic(L, arr, span.start, span.stop, span.step));
    }
 
-   // Original integer-based find
    auto start = lj_lib_optint(L, 3, 0);
    if (not array_find_start(start, arr->len, &start)) return array_push_find_result(L, -1);
    if (start >= stop) return array_push_find_result(L, -1);
-   return array_push_find_result(L, find_in_array(arr, value, start, stop - 1, 1));
+   return array_push_find_result(L, array_find_generic(L, arr, start, stop - 1, 1));
+}
+
+LJLIB_CF(array_find)
+{
+   return array_index_of(L);
+}
+
+//********************************************************************************************************************
+// Stage A compatibility name for equality search.  array.find() remains available until the next breaking release.
+
+LJLIB_CF(array_indexOf)
+{
+   return array_index_of(L);
 }
 
 //********************************************************************************************************************
@@ -2049,12 +2136,17 @@ LJLIB_CF(array_each)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
    luaL_checktype(L, 2, LUA_TFUNCTION);
+   MSize count = arr->len;
 
-   for (MSize i = 0; i < arr->len; i++) {
+   for (MSize i = 0; i < count; i++) {
+      if (i >= arr->len) break;
       lua_pushvalue(L, 2);            // Push the callback function
       array_push_element(L, arr, i);  // Push value
       lua_pushinteger(L, i);          // Push index
-      if (lua_pcall(L, 2, 0, 0) != 0) lua_error(L);
+      if (lua_pcall(L, 2, 1, 0) != 0) lua_error(L);
+      bool terminate = not lua_isnil(L, -1) and not lua_toboolean(L, -1);
+      lua_pop(L, 1);
+      if (terminate) break;
    }
 
    // Return the array for chaining
@@ -2063,7 +2155,37 @@ LJLIB_CF(array_each)
 }
 
 //********************************************************************************************************************
-// Usage: array.map(arr, transform)
+static GCarray * array_new_like(lua_State *L, GCarray *Source, MSize Length)
+{
+   if (Source->elemtype IS AET::STRUCT) {
+      return lj_array_new(L, Length, Source->elemtype, nullptr, 0, Source->structdef->Name, Source->structdef);
+   }
+   return lj_array_new(L, Length, Source->elemtype);
+}
+
+static int array_map_same(lua_State *L)
+{
+   GCarray *arr = lj_lib_checkarray(L, 1);
+   luaL_checktype(L, 2, LUA_TFUNCTION);
+   MSize count = arr->len;
+
+   GCarray *result = array_new_like(L, arr, count);
+   setarrayV(L, L->top++, result);
+
+   for (MSize i = 0; i < count; i++) {
+      if (i >= arr->len) break;
+      lua_pushvalue(L, 2);
+      array_push_element(L, arr, i);
+      lua_pushinteger(L, i);
+      lua_call(L, 2, 1);
+      lj_array_store_checked(L, result, i, L->top - 1);
+      lua_pop(L, 1);
+   }
+   return 1;
+}
+
+//********************************************************************************************************************
+// Usage: array.map(arr, transform [, element_type])
 //
 // Returns a new array with each element transformed by the function.
 // The transform function receives (value, index) and returns the new value.
@@ -2072,32 +2194,66 @@ LJLIB_CF(array_each)
 //   arr: the source array
 //   transform: function(value, index) returning transformed value
 //
-// Returns: new array of the same type with transformed elements
+// Returns: a new array using element_type, or the source element type when the optional argument is omitted in Stage A
 
 LJLIB_CF(array_map)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
    luaL_checktype(L, 2, LUA_TFUNCTION);
+   if (lua_isnoneornil(L, 3)) return array_map_same(L);
 
-   GCarray *result = arr->elemtype IS AET::STRUCT ?
-      lj_array_new(L, arr->len, arr->elemtype, nullptr, 0, arr->structdef->Name, arr->structdef) :
-      lj_array_new(L, arr->len, arr->elemtype);
+   MSize count = arr->len;
+   GCarray *result = lj_array_new_map_result(L, count, 3);
    setarrayV(L, L->top++, result);
-   int result_idx = lua_gettop(L);
 
-   for (MSize i = 0; i < arr->len; i++) {
-      lua_pushvalue(L, 2);            // Push the transform function
-      array_push_element(L, arr, i);  // Push value
-      lua_pushinteger(L, i);          // Push index
-      lua_call(L, 2, 1);              // Call transform(value, index) -> result
-
+   for (MSize i = 0; i < count; i++) {
+      if (i >= arr->len) break;
+      lua_pushvalue(L, 2);
+      array_push_element(L, arr, i);
+      lua_pushinteger(L, i);
+      lua_call(L, 2, 1);
       lj_array_store_checked(L, result, i, L->top - 1);
+      lua_pop(L, 1);
+   }
+   return 1;
+}
 
-      lua_pop(L, 1);  // Pop the result value
+//********************************************************************************************************************
+// Usage: array.mapSame(arr, transform)
+//
+// Maps values into a new array with the source array's exact storage descriptor.
+
+LJLIB_CF(array_mapSame)
+{
+   return array_map_same(L);
+}
+
+//********************************************************************************************************************
+// Usage: array.findIndex(arr, predicate)
+//
+// Returns the zero-based index of the first element for which predicate(value, index) is truthy.
+
+LJLIB_CF(array_findIndex)
+{
+   GCarray *arr = lj_lib_checkarray(L, 1);
+   luaL_checktype(L, 2, LUA_TFUNCTION);
+   MSize count = arr->len;
+
+   for (MSize i = 0; i < count; i++) {
+      if (i >= arr->len) break;
+      lua_pushvalue(L, 2);
+      array_push_element(L, arr, i);
+      lua_pushinteger(L, i);
+      lua_call(L, 2, 1);
+      bool matched = lua_toboolean(L, -1);
+      lua_pop(L, 1);
+      if (matched) {
+         lua_pushinteger(L, i);
+         return 1;
+      }
    }
 
-   // Push the result array (already on stack at result_idx)
-   lua_pushvalue(L, result_idx);
+   lua_pushnil(L);
    return 1;
 }
 
@@ -2117,13 +2273,15 @@ LJLIB_CF(array_filter)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
    luaL_checktype(L, 2, LUA_TFUNCTION);
+   MSize count = arr->len;
 
    // Create result array with zero length (will grow dynamically)
-   GCarray *result = lj_array_new(L, 0, arr->elemtype);
+   GCarray *result = array_new_like(L, arr, 0);
    setarrayV(L, L->top++, result);
 
    // Single pass: filter and copy matching elements
-   for (MSize i = 0; i < arr->len; i++) {
+   for (MSize i = 0; i < count; i++) {
+      if (i >= arr->len) break;
       lua_pushvalue(L, 2);            // Push the predicate function
       array_push_element(L, arr, i);  // Push value
       lua_pushinteger(L, i);          // Push index
@@ -2167,8 +2325,10 @@ LJLIB_CF(array_reduce)
 
    // Start with the initial value on the stack
    lua_pushvalue(L, 2);  // Push initial value as current accumulator
+   MSize count = arr->len;
 
-   for (MSize i = 0; i < arr->len; i++) {
+   for (MSize i = 0; i < count; i++) {
+      if (i >= arr->len) break;
       lua_pushvalue(L, 3);            // Push the reducer function
       lua_pushvalue(L, -2);           // Push current accumulator
       lua_remove(L, -3);              // Remove old accumulator from stack
@@ -2198,8 +2358,10 @@ LJLIB_CF(array_any)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
    luaL_checktype(L, 2, LUA_TFUNCTION);
+   MSize count = arr->len;
 
-   for (MSize i = 0; i < arr->len; i++) {
+   for (MSize i = 0; i < count; i++) {
+      if (i >= arr->len) break;
       lua_pushvalue(L, 2);            // Push the predicate function
       array_push_element(L, arr, i);  // Push value
       lua_pushinteger(L, i);          // Push index
@@ -2232,8 +2394,10 @@ LJLIB_CF(array_all)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
    luaL_checktype(L, 2, LUA_TFUNCTION);
+   MSize count = arr->len;
 
-   for (MSize i = 0; i < arr->len; i++) {
+   for (MSize i = 0; i < count; i++) {
+      if (i >= arr->len) break;
       lua_pushvalue(L, 2);            // Push the predicate function
       array_push_element(L, arr, i);  // Push value
       lua_pushinteger(L, i);          // Push index
@@ -2748,6 +2912,8 @@ extern "C" int luaopen_array(lua_State *L)
       { TiriType::Array, TiriType::Any, TiriType::Any, TiriType::Num });
    reg_iface_method(L, "array", "find", TiriType::Array, builtin_callable_id(FastFunc::array_find),
       { TiriType::Num }, { TiriType::Array, TiriType::Any, TiriType::Any, TiriType::Num });
+   reg_iface_method(L, "array", "indexOf", TiriType::Array, builtin_callable_id(FastFunc::array_indexOf),
+      { TiriType::Num }, { TiriType::Array, TiriType::Any, TiriType::Any, TiriType::Num });
    reg_iface_method(L, "array", "reverse", TiriType::Array, builtin_callable_id(FastFunc::array_reverse),
       { TiriType::Array }, { TiriType::Array });
    reg_iface_method(L, "array", "slice", TiriType::Array, builtin_callable_id(FastFunc::array_slice),
@@ -2757,7 +2923,11 @@ extern "C" int luaopen_array(lua_State *L)
    reg_iface_method(L, "array", "each", TiriType::Array, builtin_callable_id(FastFunc::array_each), {},
       { TiriType::Array, TiriType::Func });
    reg_iface_method(L, "array", "map", TiriType::Array, builtin_callable_id(FastFunc::array_map),
+      { TiriType::Array }, { TiriType::Array, TiriType::Func, TiriType::Str });
+   reg_iface_method(L, "array", "mapSame", TiriType::Array, builtin_callable_id(FastFunc::array_mapSame),
       { TiriType::Array }, { TiriType::Array, TiriType::Func });
+   reg_iface_method(L, "array", "findIndex", TiriType::Array, builtin_callable_id(FastFunc::array_findIndex),
+      { TiriType::Num }, { TiriType::Array, TiriType::Func });
    reg_iface_method(L, "array", "filter", TiriType::Array, builtin_callable_id(FastFunc::array_filter),
       { TiriType::Array }, { TiriType::Array, TiriType::Func });
    reg_iface_method(L, "array", "reduce", TiriType::Array, builtin_callable_id(FastFunc::array_reduce),

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -1620,13 +1620,15 @@ static int array_index_of(lua_State *L)
    return array_push_find_result(L, array_find_generic(L, arr, start, stop - 1, 1));
 }
 
+static int array_find_predicate(lua_State *L, bool ReturnIndex);
+
 LJLIB_CF(array_find)
 {
-   return array_index_of(L);
+   return array_find_predicate(L, false);
 }
 
 //********************************************************************************************************************
-// Stage A compatibility name for equality search.  array.find() remains available until the next breaking release.
+// Equality search remains permanently available through array.indexOf().
 
 LJLIB_CF(array_indexOf)
 {
@@ -2194,13 +2196,12 @@ static int array_map_same(lua_State *L)
 //   arr: the source array
 //   transform: function(value, index) returning transformed value
 //
-// Returns: a new array using element_type, or the source element type when the optional argument is omitted in Stage A
+// Returns: a new array using element_type, or array<any> when the optional argument is omitted
 
 LJLIB_CF(array_map)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
    luaL_checktype(L, 2, LUA_TFUNCTION);
-   if (lua_isnoneornil(L, 3)) return array_map_same(L);
 
    MSize count = arr->len;
    GCarray *result = lj_array_new_map_result(L, count, 3);
@@ -2233,7 +2234,7 @@ LJLIB_CF(array_mapSame)
 //
 // Returns the zero-based index of the first element for which predicate(value, index) is truthy.
 
-LJLIB_CF(array_findIndex)
+static int array_find_predicate(lua_State *L, bool ReturnIndex)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
    luaL_checktype(L, 2, LUA_TFUNCTION);
@@ -2241,20 +2242,33 @@ LJLIB_CF(array_findIndex)
 
    for (MSize i = 0; i < count; i++) {
       if (i >= arr->len) break;
-      lua_pushvalue(L, 2);
+
+      // Preserve the value supplied to the predicate.  The callback may resize or rewrite the source array, but the
+      // result remains that matching value rather than an element re-read after re-entry.
       array_push_element(L, arr, i);
+      lua_pushvalue(L, 2);
+      lua_pushvalue(L, -2);
       lua_pushinteger(L, i);
       lua_call(L, 2, 1);
       bool matched = lua_toboolean(L, -1);
       lua_pop(L, 1);
       if (matched) {
-         lua_pushinteger(L, i);
+         if (ReturnIndex) {
+            lua_pop(L, 1);
+            lua_pushinteger(L, i);
+         }
          return 1;
       }
+      lua_pop(L, 1);
    }
 
    lua_pushnil(L);
    return 1;
+}
+
+LJLIB_CF(array_findIndex)
+{
+   return array_find_predicate(L, true);
 }
 
 //********************************************************************************************************************
@@ -2911,7 +2925,7 @@ extern "C" int luaopen_array(lua_State *L)
    reg_iface_method(L, "array", "fill", TiriType::Array, builtin_callable_id(FastFunc::array_fill), {},
       { TiriType::Array, TiriType::Any, TiriType::Any, TiriType::Num });
    reg_iface_method(L, "array", "find", TiriType::Array, builtin_callable_id(FastFunc::array_find),
-      { TiriType::Num }, { TiriType::Array, TiriType::Any, TiriType::Any, TiriType::Num });
+      { TiriType::Any }, { TiriType::Array, TiriType::Func });
    reg_iface_method(L, "array", "indexOf", TiriType::Array, builtin_callable_id(FastFunc::array_indexOf),
       { TiriType::Num }, { TiriType::Array, TiriType::Any, TiriType::Any, TiriType::Num });
    reg_iface_method(L, "array", "reverse", TiriType::Array, builtin_callable_id(FastFunc::array_reverse),

--- a/src/tiri/jit/src/lib/lib_debug.cpp
+++ b/src/tiri/jit/src/lib/lib_debug.cpp
@@ -1035,6 +1035,7 @@ static CSTRING diagnostic_code_name(ParserErrorCode Code)
       case ParserErrorCode::None:                   return "None";
       case ParserErrorCode::UnexpectedToken:        return "UnexpectedToken";
       case ParserErrorCode::DeprecatedSyntax:       return "DeprecatedSyntax";
+      case ParserErrorCode::DeprecatedApi:          return "DeprecatedApi";
       case ParserErrorCode::ExpectedToken:          return "ExpectedToken";
       case ParserErrorCode::ExpectedIdentifier:     return "ExpectedIdentifier";
       case ParserErrorCode::UnexpectedEndOfFile:    return "UnexpectedEndOfFile";

--- a/src/tiri/jit/src/lib/lib_range.cpp
+++ b/src/tiri/jit/src/lib/lib_range.cpp
@@ -358,7 +358,8 @@ static int fp_range_each(lua_State *L)
    for (size_t ordinal = 0; ordinal < count; ordinal++) {
       lua_pushvalue(L, 2);
       fp_range_push(L, fp_range_value(range, ordinal));
-      lua_call(L, 1, 1);
+      lua_pushinteger(L, lua_Integer(ordinal));
+      lua_call(L, 2, 1);
       bool terminate = not lua_isnil(L, -1) and not lua_toboolean(L, -1);
       lua_pop(L, 1);
       if (terminate) break;
@@ -374,12 +375,14 @@ static int fp_range_filter(lua_State *L)
    size_t count = fp_range_count(L, range, true);
    bool integer_array = fp_range_integer_array(range);
    GCarray *array = lj_array_new(L, uint32_t(count), integer_array ? AET::INT32 : AET::DOUBLE);
+   setarrayV(L, L->top++, array);
    uint32_t result_index = 0;
    for (size_t ordinal = 0; ordinal < count; ordinal++) {
       lua_Number value = fp_range_value(range, ordinal);
       lua_pushvalue(L, 2);
       fp_range_push(L, value);
-      lua_call(L, 1, 1);
+      lua_pushinteger(L, lua_Integer(ordinal));
+      lua_call(L, 2, 1);
       if (lua_toboolean(L, -1)) {
          if (integer_array) array->get<int32_t>()[result_index] = int32_t(value);
          else array->get<double>()[result_index] = value;
@@ -388,7 +391,6 @@ static int fp_range_filter(lua_State *L)
       lua_pop(L, 1);
    }
    array->len = result_index;
-   setarrayV(L, L->top++, array);
    return 1;
 }
 
@@ -403,7 +405,8 @@ static int fp_range_reduce(lua_State *L)
       lua_pushvalue(L, 3);
       lua_pushvalue(L, accumulator);
       fp_range_push(L, fp_range_value(range, ordinal));
-      lua_call(L, 2, 1);
+      lua_pushinteger(L, lua_Integer(ordinal));
+      lua_call(L, 3, 1);
       lua_replace(L, accumulator);
    }
    return 1;
@@ -414,18 +417,16 @@ static int fp_range_map(lua_State *L)
    auto range = get_range(L, 1);
    luaL_checktype(L, 2, LUA_TFUNCTION);
    size_t count = fp_range_count(L, range, true);
-   GCarray *array = lj_array_new(L, uint32_t(count), AET::ANY);
-   TValue *data = array->get<TValue>();
+   GCarray *array = lj_array_new_map_result(L, MSize(count), 3);
+   setarrayV(L, L->top++, array);
    for (size_t ordinal = 0; ordinal < count; ordinal++) {
       lua_pushvalue(L, 2);
       fp_range_push(L, fp_range_value(range, ordinal));
-      lua_call(L, 1, 1);
-      TValue *source = L->top - 1;
-      copyTV(L, &data[ordinal], source);
-      if (tvisgcv(source)) lj_gc_objbarrier(L, array, gcV(source));
+      lua_pushinteger(L, lua_Integer(ordinal));
+      lua_call(L, 2, 1);
+      lj_array_store_checked(L, array, MSize(ordinal), L->top - 1);
       lua_pop(L, 1);
    }
-   setarrayV(L, L->top++, array);
    return 1;
 }
 
@@ -449,7 +450,8 @@ static int fp_range_any(lua_State *L)
    for (size_t ordinal = 0; ordinal < count; ordinal++) {
       lua_pushvalue(L, 2);
       fp_range_push(L, fp_range_value(range, ordinal));
-      lua_call(L, 1, 1);
+      lua_pushinteger(L, lua_Integer(ordinal));
+      lua_call(L, 2, 1);
       bool matched = lua_toboolean(L, -1);
       lua_pop(L, 1);
       if (matched) {
@@ -469,7 +471,8 @@ static int fp_range_all(lua_State *L)
    for (size_t ordinal = 0; ordinal < count; ordinal++) {
       lua_pushvalue(L, 2);
       fp_range_push(L, fp_range_value(range, ordinal));
-      lua_call(L, 1, 1);
+      lua_pushinteger(L, lua_Integer(ordinal));
+      lua_call(L, 2, 1);
       bool matched = lua_toboolean(L, -1);
       lua_pop(L, 1);
       if (not matched) {
@@ -490,11 +493,33 @@ static int fp_range_find(lua_State *L)
       lua_Number value = fp_range_value(range, ordinal);
       lua_pushvalue(L, 2);
       fp_range_push(L, value);
-      lua_call(L, 1, 1);
+      lua_pushinteger(L, lua_Integer(ordinal));
+      lua_call(L, 2, 1);
       bool matched = lua_toboolean(L, -1);
       lua_pop(L, 1);
       if (matched) {
          fp_range_push(L, value);
+         return 1;
+      }
+   }
+   lua_pushnil(L);
+   return 1;
+}
+
+static int fp_range_find_index(lua_State *L)
+{
+   auto range = get_range(L, 1);
+   luaL_checktype(L, 2, LUA_TFUNCTION);
+   size_t count = fp_range_count(L, range, false);
+   for (size_t ordinal = 0; ordinal < count; ordinal++) {
+      lua_pushvalue(L, 2);
+      fp_range_push(L, fp_range_value(range, ordinal));
+      lua_pushinteger(L, lua_Integer(ordinal));
+      lua_call(L, 2, 1);
+      bool matched = lua_toboolean(L, -1);
+      lua_pop(L, 1);
+      if (matched) {
+         lua_pushinteger(L, lua_Integer(ordinal));
          return 1;
       }
    }
@@ -541,6 +566,14 @@ static int fp_range_len(lua_State *L)
    return 1;
 }
 
+static bool fp_range_ordinal(lua_State *L, const tiri_range *Range, lua_Number Value, size_t *Ordinal)
+{
+   long double distance = ((long double)Value - (long double)Range->start) / (long double)Range->step;
+   return std::isfinite(Value) and fp_range_in_bounds(Range, Value) and
+      fp_range_nearest_ordinal(distance, Ordinal) and
+      *Ordinal < fp_range_count(L, Range, false);
+}
+
 static int fp_range_contains(lua_State *L)
 {
    auto range = check_range(L, 1);
@@ -550,25 +583,24 @@ static int fp_range_contains(lua_State *L)
       return 1;
    }
    lua_Number value = lua_tonumber(L, argument);
-   if (not std::isfinite(value) or not fp_range_in_bounds(range, value)) {
-      lua_pushboolean(L, 0);
-      return 1;
-   }
-
    size_t ordinal;
-   long double distance = ((long double)value - (long double)range->start) / (long double)range->step;
-   if (not fp_range_nearest_ordinal(distance, &ordinal)) {
-      lua_pushboolean(L, 0);
+   bool member = fp_range_ordinal(L, range, value, &ordinal);
+   lua_pushboolean(L, member);
+   return 1;
+}
+
+static int fp_range_index_of(lua_State *L)
+{
+   auto range = get_range(L, 1);
+   if (lua_type(L, 2) != LUA_TNUMBER) {
+      lua_pushnil(L);
       return 1;
    }
-
-   size_t count = fp_range_count(L, range, false);
-   if (ordinal >= count) {
-      lua_pushboolean(L, 0);
-      return 1;
-   }
-
-   lua_pushboolean(L, 1);
+   lua_Number value = lua_tonumber(L, 2);
+   size_t ordinal;
+   bool member = fp_range_ordinal(L, range, value, &ordinal);
+   if (member) lua_pushinteger(L, lua_Integer(ordinal));
+   else lua_pushnil(L);
    return 1;
 }
 
@@ -590,6 +622,8 @@ LJLIB_CF(range_take) { return fp_range_take(L); }
 LJLIB_CF(range_any) { return fp_range_any(L); }
 LJLIB_CF(range_all) { return fp_range_all(L); }
 LJLIB_CF(range_find) { return fp_range_find(L); }
+LJLIB_CF(range_findIndex) { return fp_range_find_index(L); }
+LJLIB_CF(range_indexOf) { return fp_range_index_of(L); }
 LJLIB_CF(range_toArray) { return fp_range_toarray(L); }
 
 LJLIB_ASM(range_iterator_next) LJLIB_REC(.)
@@ -669,6 +703,8 @@ constexpr auto HASH_take      = kt::strhash("take");
 constexpr auto HASH_any       = kt::strhash("any");
 constexpr auto HASH_all       = kt::strhash("all");
 constexpr auto HASH_find      = kt::strhash("find");
+constexpr auto HASH_findIndex = kt::strhash("findIndex");
+constexpr auto HASH_indexOf   = kt::strhash("indexOf");
 
 static int range_index(lua_State *Lua)
 {
@@ -691,6 +727,8 @@ static int range_index(lua_State *Lua)
          case HASH_any:       lua_pushcfunction(Lua, fp_range_any); return 1;
          case HASH_all:       lua_pushcfunction(Lua, fp_range_all); return 1;
          case HASH_find:      lua_pushcfunction(Lua, fp_range_find); return 1;
+         case HASH_findIndex: lua_pushcfunction(Lua, fp_range_find_index); return 1;
+         case HASH_indexOf:   lua_pushcfunction(Lua, fp_range_index_of); return 1;
          case HASH_toArray:   break;
       }
    }
@@ -1065,7 +1103,7 @@ extern "C" int luaopen_range(lua_State *L)
    reg_iface_method(L, "range", "reduce", TiriType::Range, builtin_callable_id(FastFunc::range_reduce),
       { TiriType::Any }, { TiriType::Range, TiriType::Any, TiriType::Func });
    reg_iface_method(L, "range", "map", TiriType::Range, builtin_callable_id(FastFunc::range_map),
-      { TiriType::Array }, { TiriType::Range, TiriType::Func });
+      { TiriType::Array }, { TiriType::Range, TiriType::Func, TiriType::Str });
    reg_iface_method(L, "range", "take", TiriType::Range, builtin_callable_id(FastFunc::range_take),
       { TiriType::Array }, { TiriType::Range, TiriType::Num }, FProtoFlags::ContextIndependent);
    reg_iface_method(L, "range", "any", TiriType::Range, builtin_callable_id(FastFunc::range_any),
@@ -1074,6 +1112,10 @@ extern "C" int luaopen_range(lua_State *L)
       { TiriType::Bool }, { TiriType::Range, TiriType::Func });
    reg_iface_method(L, "range", "find", TiriType::Range, builtin_callable_id(FastFunc::range_find),
       { TiriType::Num }, { TiriType::Range, TiriType::Func });
+   reg_iface_method(L, "range", "findIndex", TiriType::Range, builtin_callable_id(FastFunc::range_findIndex),
+      { TiriType::Num }, { TiriType::Range, TiriType::Func });
+   reg_iface_method(L, "range", "indexOf", TiriType::Range, builtin_callable_id(FastFunc::range_indexOf),
+      { TiriType::Num }, { TiriType::Range, TiriType::Any });
    reg_iface_method(L, "range", "toArray", TiriType::Range, builtin_callable_id(FastFunc::range_toArray),
       { TiriType::Array }, { TiriType::Range }, FProtoFlags::ContextIndependent);
 

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -472,7 +472,6 @@ struct CallExprPayload {
    // leaves this Unknown unless the target was already contextual.
    mutable StaticContextuality contextual_designation_result = StaticContextuality::Unknown;
    mutable bool unresolved_method_reported = false;
-   mutable bool deprecated_api_reported = false;
    mutable TiriType result_type = TiriType::Unknown;  // Inferred return type (e.g., Object for obj.new())
    mutable CLASSID object_class_id = CLASSID::NIL; // CLASSID if result is Object
    mutable struct_record *struct_def = nullptr; // Resolved layout if result is Struct, or callable struct definition

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -472,6 +472,7 @@ struct CallExprPayload {
    // leaves this Unknown unless the target was already contextual.
    mutable StaticContextuality contextual_designation_result = StaticContextuality::Unknown;
    mutable bool unresolved_method_reported = false;
+   mutable bool deprecated_api_reported = false;
    mutable TiriType result_type = TiriType::Unknown;  // Inferred return type (e.g., Object for obj.new())
    mutable CLASSID object_class_id = CLASSID::NIL; // CLASSID if result is Object
    mutable struct_record *struct_def = nullptr; // Resolved layout if result is Struct, or callable struct definition

--- a/src/tiri/jit/src/parser/parser_diagnostics.cpp
+++ b/src/tiri/jit/src/parser/parser_diagnostics.cpp
@@ -52,6 +52,7 @@ static CSTRING error_code_name(ParserErrorCode Code)
       case ParserErrorCode::None:                      return "None";
       case ParserErrorCode::UnexpectedToken:           return "Unexpected Token";
       case ParserErrorCode::DeprecatedSyntax:          return "Deprecated syntax";
+      case ParserErrorCode::DeprecatedApi:             return "Deprecated API";
       case ParserErrorCode::ExpectedToken:             return "Expected Token";
       case ParserErrorCode::ExpectedIdentifier:        return "Expected Identifier";
       case ParserErrorCode::UnexpectedEndOfFile:       return "Unexpected EOF";

--- a/src/tiri/jit/src/parser/parser_diagnostics.h
+++ b/src/tiri/jit/src/parser/parser_diagnostics.h
@@ -43,6 +43,7 @@ enum class ParserErrorCode : uint16_t {
    OverrideProtectedGlobal, // Cannot override a host pre-registered global
    InvalidAssignment,       // Assignment form is syntactically valid but semantically forbidden
    DeprecatedSyntax,        // Removed source syntax with a targeted replacement diagnostic
+   DeprecatedApi,           // Supported API contract with a pending migration target
    UnresolvedMethodReceiver, // Dot-method receiver type must be classified at runtime
    FunctionSignatureMismatch // Function definition does not match an earlier forward declaration
 };

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -5222,10 +5222,11 @@ static bool test_builtin_method_registry(kt::Log &Log)
       return false;
    }
 
-   constexpr std::array<std::string_view, 27> array_methods = {
+   constexpr std::array<std::string_view, 30> array_methods = {
       "table", "concat", "first", "last", "clear", "resize", "push", "pop", "copy",
       "getString", "setString", "type", "readOnly", "fill", "find", "reverse", "slice", "sort", "each",
-      "map", "filter", "reduce", "any", "all", "insert", "remove", "clone"
+      "indexOf", "map", "mapSame", "findIndex", "filter", "reduce", "any", "all", "insert", "remove",
+      "clone"
    };
    constexpr std::array<std::string_view, 22> string_methods = {
       "byte", "cap", "count", "decap", "endsWith", "escXML", "find", "format", "hash", "len",
@@ -5236,8 +5237,8 @@ static bool test_builtin_method_registry(kt::Log &Log)
       "insert", "remove", "move", "concat", "sort", "empty", "kind", "size", "clear", "slice", "sortByKeys",
       "toXML"
    };
-   constexpr std::array<std::string_view, 9> range_methods = {
-      "each", "filter", "reduce", "map", "take", "any", "all", "find", "toArray"
+   constexpr std::array<std::string_view, 11> range_methods = {
+      "each", "filter", "reduce", "map", "take", "any", "all", "find", "findIndex", "indexOf", "toArray"
    };
    constexpr std::array<std::string_view, 2> struct_methods = { "copy", "clone" };
    constexpr std::array<std::string_view, 12> object_methods = {
@@ -5528,6 +5529,129 @@ static bool test_builtin_method_static_classification(kt::Log &Log)
        context.descriptors().results(upper_call->results).value_at(0).primary != TiriType::Str or
        not safe_call->results or not context.descriptors().results(safe_call->results).value_at(0).nullable) {
       Log.error("method result inference did not preserve registered result type or safe nullability");
+      return false;
+   }
+
+   return true;
+}
+
+static bool test_stage_a_collection_api_diagnostics(kt::Log &Log)
+{
+   constexpr std::string_view source =
+      "local values = array<int> { 10, 20 }\n"
+      "local legacy_find = values.find(20)\n"
+      "local legacy_map = values.map(function(Value) return Value * 2 end)\n"
+      "local index = values.indexOf(20)\n"
+      "local predicate_index = values.findIndex(function(Value, Index) return Value is 20 and Index is 1 end)\n"
+      "local typed = values.map(function(Value):str return tostring(Value) end, 'str')\n"
+      "local requested_type = tostring('str')\n"
+      "local dynamic = values.map(function(Value):str return tostring(Value) end, requested_type)\n"
+      "local source_preserving = values.mapSame(function(Value) return Value * 2 end)\n"
+      "local sequence = { 10 to 14 by 2 }\n"
+      "local range_index = sequence.indexOf(12)\n"
+      "local range_mapped = sequence.map(function(Value, Ordinal):str return tostring(Value + Ordinal) end, 'str')\n"
+      "local namespace_find = array.find(values, 20)\n"
+      "local namespace_map = array.map(values, function(Value) return Value * 2 end)\n"
+      "local array = { find = function(Values, Value) return 0 end, map = function(Transform):table return {} end }\n"
+      "local shadowed_find = array.find(values, 20)\n"
+      "local shadowed_map = array.map(function(Value:any):any return Value end)\n";
+
+   LuaStateHolder state;
+   lua_State *L = state.get();
+   luaL_openlibs(L);
+   StringReaderCtx reader{ source.data(), source.size() };
+   LexState lex(L, unit_reader, &reader, "stage-a-collection-api", std::nullopt);
+   FuncState &fs = lex.fs_init();
+   ParserContext context = ParserContext::from(lex, fs, ParserAllocator::from(L));
+   ParserConfig config;
+   config.abort_on_error = false;
+   config.max_diagnostics = 32;
+   ParserSession session(context, config);
+   lex.next();
+   AstBuilder builder(context);
+   auto chunk = builder.parse_chunk();
+   if (not chunk.ok()) {
+      Log.error("Stage A collection API fixture did not parse");
+      log_diagnostics(context.diagnostics().entries(), Log);
+      return false;
+   }
+   discover_static_bindings(context, *chunk.value_ref());
+   propagate_static_descriptors(context, *chunk.value_ref());
+   run_type_analysis(context, *chunk.value_ref());
+   propagate_static_descriptors(context, *chunk.value_ref());
+   for (const ParserDiagnostic &diagnostic : context.diagnostics().entries()) {
+      if (diagnostic.severity IS ParserDiagnosticSeverity::Error) {
+         Log.error("Stage A collection API fixture line %u produced an unexpected error: %s",
+            diagnostic.token.span().line.lineNumber(), diagnostic.message.c_str());
+         log_diagnostics(context.diagnostics().entries(), Log);
+         return false;
+      }
+   }
+
+   auto local_call = [&](size_t Index) -> const CallExprPayload * {
+      if (Index >= chunk.value_ref()->statements.size()) return nullptr;
+      const auto *statement = std::get_if<LocalDeclStmtPayload>(&chunk.value_ref()->statements[Index]->data);
+      if (not statement or statement->values.empty()) return nullptr;
+      return std::get_if<CallExprPayload>(&statement->values.front()->data);
+   };
+   const CallExprPayload *legacy_find = local_call(1);
+   const CallExprPayload *legacy_map = local_call(2);
+   const CallExprPayload *index = local_call(3);
+   const CallExprPayload *predicate_index = local_call(4);
+   const CallExprPayload *typed = local_call(5);
+   const CallExprPayload *dynamic = local_call(7);
+   const CallExprPayload *source_preserving = local_call(8);
+   const CallExprPayload *range_index = local_call(10);
+   const CallExprPayload *range_mapped = local_call(11);
+   if (not legacy_find or not legacy_map or not index or not predicate_index or not typed or not dynamic or
+       not source_preserving or not range_index or not range_mapped) {
+      Log.error("Stage A collection API fixture did not retain every tested call");
+      return false;
+   }
+   if (not legacy_find->builtin_method or not legacy_map->builtin_method or not index->builtin_method or
+       not predicate_index->builtin_method or not typed->builtin_method or not source_preserving->builtin_method or
+       not range_index->builtin_method or not range_mapped->builtin_method or
+       legacy_find->builtin_method->callable != builtin_callable_id(FastFunc::array_find) or
+       legacy_map->builtin_method->callable != builtin_callable_id(FastFunc::array_map) or
+       index->builtin_method->callable != builtin_callable_id(FastFunc::array_indexOf) or
+       predicate_index->builtin_method->callable != builtin_callable_id(FastFunc::array_findIndex) or
+       typed->builtin_method->callable != builtin_callable_id(FastFunc::array_map) or
+       source_preserving->builtin_method->callable != builtin_callable_id(FastFunc::array_mapSame) or
+       range_index->builtin_method->callable != builtin_callable_id(FastFunc::range_indexOf) or
+       range_mapped->builtin_method->callable != builtin_callable_id(FastFunc::range_map)) {
+      Log.error("Stage A collection methods did not resolve their canonical callable identities");
+      return false;
+   }
+
+   auto result_descriptor = [&](const CallExprPayload &Call) -> StaticValueDescriptor {
+      return Call.results ? context.descriptors().results(Call.results).value_at(0) : StaticValueDescriptor{};
+   };
+   StaticValueDescriptor typed_result = result_descriptor(*typed);
+   StaticValueDescriptor dynamic_result = result_descriptor(*dynamic);
+   StaticValueDescriptor same_result = result_descriptor(*source_preserving);
+   StaticValueDescriptor range_result = result_descriptor(*range_mapped);
+   if (typed_result.primary != TiriType::Array or typed_result.array_element.logical_type != TiriType::Str or
+       dynamic_result.primary != TiriType::Array or dynamic_result.array_element.known or
+       same_result.primary != TiriType::Array or same_result.array_element.logical_type != TiriType::Num or
+       range_result.primary != TiriType::Array or range_result.array_element.logical_type != TiriType::Str) {
+      Log.error("Stage A map calls did not retain their inferred result descriptors");
+      return false;
+   }
+
+   size_t warning_count = 0;
+   for (const ParserDiagnostic &diagnostic : context.diagnostics().entries()) {
+      if (diagnostic.code != ParserErrorCode::DeprecatedApi) continue;
+      ++warning_count;
+      if (diagnostic.severity != ParserDiagnosticSeverity::Warning or
+          diagnostic.message.find("array.") IS std::string::npos) {
+         Log.error("Stage A API deprecation diagnostic had incorrect content");
+         log_diagnostics(context.diagnostics().entries(), Log);
+         return false;
+      }
+   }
+   if (warning_count != 4) {
+      Log.error("expected four Stage A API deprecation warnings, got %zu", warning_count);
+      log_diagnostics(context.diagnostics().entries(), Log);
       return false;
    }
 
@@ -8632,7 +8756,7 @@ static bool test_contextual_designation_ownership(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 81> tests = { {
+   constexpr std::array<TestCase, 82> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -8691,6 +8815,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "builtin_method_registry", test_builtin_method_registry },
       { "builtin_method_table_initialiser_rejection", test_builtin_method_table_initialiser_rejection },
       { "builtin_method_static_classification", test_builtin_method_static_classification },
+      { "stage_a_collection_api_diagnostics", test_stage_a_collection_api_diagnostics },
       { "unresolved_method_receiver_diagnostic", test_unresolved_method_receiver_diagnostic },
       { "builtin_method_bytecode_emission", test_builtin_method_bytecode_emission },
       { "compiler_intrinsic_bytecode_emission", test_compiler_intrinsic_bytecode_emission },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -5535,12 +5535,12 @@ static bool test_builtin_method_static_classification(kt::Log &Log)
    return true;
 }
 
-static bool test_stage_a_collection_api_diagnostics(kt::Log &Log)
+static bool test_stage_b_collection_api_contracts(kt::Log &Log)
 {
    constexpr std::string_view source =
       "local values = array<int> { 10, 20 }\n"
-      "local legacy_find = values.find(20)\n"
-      "local legacy_map = values.map(function(Value) return Value * 2 end)\n"
+      "local found = values.find(function(Value, Index) return Value > 10 and Index is 1 end)\n"
+      "local default_mapped = values.map(function(Value):str return tostring(Value) end)\n"
       "local index = values.indexOf(20)\n"
       "local predicate_index = values.findIndex(function(Value, Index) return Value is 20 and Index is 1 end)\n"
       "local typed = values.map(function(Value):str return tostring(Value) end, 'str')\n"
@@ -5548,11 +5548,13 @@ static bool test_stage_a_collection_api_diagnostics(kt::Log &Log)
       "local dynamic = values.map(function(Value):str return tostring(Value) end, requested_type)\n"
       "local source_preserving = values.mapSame(function(Value) return Value * 2 end)\n"
       "local sequence = { 10 to 14 by 2 }\n"
+      "local range_found = sequence.find(function(Value, Ordinal) return Value is 12 and Ordinal is 1 end)\n"
       "local range_index = sequence.indexOf(12)\n"
       "local range_mapped = sequence.map(function(Value, Ordinal):str return tostring(Value + Ordinal) end, 'str')\n"
-      "local namespace_find = array.find(values, 20)\n"
+      "local namespace_find = array.find(values, function(Value) return Value > 10 end)\n"
       "local namespace_map = array.map(values, function(Value) return Value * 2 end)\n"
-      "local array = { find = function(Values, Value) return 0 end, map = function(Transform):table return {} end }\n"
+      "local array = { find = function(Values, Predicate) return 0 end, "
+      "map = function(Transform):table return {} end }\n"
       "local shadowed_find = array.find(values, 20)\n"
       "local shadowed_map = array.map(function(Value:any):any return Value end)\n";
 
@@ -5571,7 +5573,7 @@ static bool test_stage_a_collection_api_diagnostics(kt::Log &Log)
    AstBuilder builder(context);
    auto chunk = builder.parse_chunk();
    if (not chunk.ok()) {
-      Log.error("Stage A collection API fixture did not parse");
+      Log.error("Stage B collection API fixture did not parse");
       log_diagnostics(context.diagnostics().entries(), Log);
       return false;
    }
@@ -5581,7 +5583,7 @@ static bool test_stage_a_collection_api_diagnostics(kt::Log &Log)
    propagate_static_descriptors(context, *chunk.value_ref());
    for (const ParserDiagnostic &diagnostic : context.diagnostics().entries()) {
       if (diagnostic.severity IS ParserDiagnosticSeverity::Error) {
-         Log.error("Stage A collection API fixture line %u produced an unexpected error: %s",
+         Log.error("Stage B collection API fixture line %u produced an unexpected error: %s",
             diagnostic.token.span().line.lineNumber(), diagnostic.message.c_str());
          log_diagnostics(context.diagnostics().entries(), Log);
          return false;
@@ -5594,65 +5596,79 @@ static bool test_stage_a_collection_api_diagnostics(kt::Log &Log)
       if (not statement or statement->values.empty()) return nullptr;
       return std::get_if<CallExprPayload>(&statement->values.front()->data);
    };
-   const CallExprPayload *legacy_find = local_call(1);
-   const CallExprPayload *legacy_map = local_call(2);
+   const CallExprPayload *found = local_call(1);
+   const CallExprPayload *default_mapped = local_call(2);
    const CallExprPayload *index = local_call(3);
    const CallExprPayload *predicate_index = local_call(4);
    const CallExprPayload *typed = local_call(5);
    const CallExprPayload *dynamic = local_call(7);
    const CallExprPayload *source_preserving = local_call(8);
-   const CallExprPayload *range_index = local_call(10);
-   const CallExprPayload *range_mapped = local_call(11);
-   if (not legacy_find or not legacy_map or not index or not predicate_index or not typed or not dynamic or
-       not source_preserving or not range_index or not range_mapped) {
-      Log.error("Stage A collection API fixture did not retain every tested call");
+   const CallExprPayload *range_found = local_call(10);
+   const CallExprPayload *range_index = local_call(11);
+   const CallExprPayload *range_mapped = local_call(12);
+   const CallExprPayload *namespace_find = local_call(13);
+   const CallExprPayload *namespace_map = local_call(14);
+   const CallExprPayload *shadowed_find = local_call(16);
+   const CallExprPayload *shadowed_map = local_call(17);
+   if (not found or not default_mapped or not index or not predicate_index or not typed or not dynamic or
+       not source_preserving or not range_found or not range_index or not range_mapped or not namespace_find or
+       not namespace_map or not shadowed_find or not shadowed_map) {
+      Log.error("Stage B collection API fixture did not retain every tested call");
       return false;
    }
-   if (not legacy_find->builtin_method or not legacy_map->builtin_method or not index->builtin_method or
+   if (not found->builtin_method or not default_mapped->builtin_method or not index->builtin_method or
        not predicate_index->builtin_method or not typed->builtin_method or not source_preserving->builtin_method or
-       not range_index->builtin_method or not range_mapped->builtin_method or
-       legacy_find->builtin_method->callable != builtin_callable_id(FastFunc::array_find) or
-       legacy_map->builtin_method->callable != builtin_callable_id(FastFunc::array_map) or
+       not range_found->builtin_method or not range_index->builtin_method or not range_mapped->builtin_method or
+       found->builtin_method->callable != builtin_callable_id(FastFunc::array_find) or
+       default_mapped->builtin_method->callable != builtin_callable_id(FastFunc::array_map) or
        index->builtin_method->callable != builtin_callable_id(FastFunc::array_indexOf) or
        predicate_index->builtin_method->callable != builtin_callable_id(FastFunc::array_findIndex) or
        typed->builtin_method->callable != builtin_callable_id(FastFunc::array_map) or
        source_preserving->builtin_method->callable != builtin_callable_id(FastFunc::array_mapSame) or
+       range_found->builtin_method->callable != builtin_callable_id(FastFunc::range_find) or
        range_index->builtin_method->callable != builtin_callable_id(FastFunc::range_indexOf) or
        range_mapped->builtin_method->callable != builtin_callable_id(FastFunc::range_map)) {
-      Log.error("Stage A collection methods did not resolve their canonical callable identities");
+      Log.error("Stage B collection methods did not resolve their canonical callable identities");
       return false;
    }
 
    auto result_descriptor = [&](const CallExprPayload &Call) -> StaticValueDescriptor {
       return Call.results ? context.descriptors().results(Call.results).value_at(0) : StaticValueDescriptor{};
    };
+   StaticValueDescriptor found_result = result_descriptor(*found);
+   StaticValueDescriptor default_result = result_descriptor(*default_mapped);
+   StaticValueDescriptor index_result = result_descriptor(*index);
+   StaticValueDescriptor predicate_index_result = result_descriptor(*predicate_index);
    StaticValueDescriptor typed_result = result_descriptor(*typed);
    StaticValueDescriptor dynamic_result = result_descriptor(*dynamic);
    StaticValueDescriptor same_result = result_descriptor(*source_preserving);
+   StaticValueDescriptor range_found_result = result_descriptor(*range_found);
    StaticValueDescriptor range_result = result_descriptor(*range_mapped);
-   if (typed_result.primary != TiriType::Array or typed_result.array_element.logical_type != TiriType::Str or
+   StaticValueDescriptor namespace_find_result = result_descriptor(*namespace_find);
+   StaticValueDescriptor namespace_map_result = result_descriptor(*namespace_map);
+   if (found_result.primary != TiriType::Num or not found_result.nullable or
+       default_result.primary != TiriType::Array or not default_result.array_element.known or
+       default_result.array_element.logical_type != TiriType::Any or index_result.primary != TiriType::Num or
+       not index_result.nullable or predicate_index_result.primary != TiriType::Num or
+       not predicate_index_result.nullable or
+       typed_result.primary != TiriType::Array or typed_result.array_element.logical_type != TiriType::Str or
        dynamic_result.primary != TiriType::Array or dynamic_result.array_element.known or
        same_result.primary != TiriType::Array or same_result.array_element.logical_type != TiriType::Num or
-       range_result.primary != TiriType::Array or range_result.array_element.logical_type != TiriType::Str) {
-      Log.error("Stage A map calls did not retain their inferred result descriptors");
+       range_found_result.primary != TiriType::Num or not range_found_result.nullable or
+       range_result.primary != TiriType::Array or range_result.array_element.logical_type != TiriType::Str or
+       namespace_find_result.primary != TiriType::Num or not namespace_find_result.nullable or
+       namespace_map_result.primary != TiriType::Array or not namespace_map_result.array_element.known or
+       namespace_map_result.array_element.logical_type != TiriType::Any) {
+      Log.error("Stage B collection methods did not retain their inferred result descriptors");
       return false;
    }
 
-   size_t warning_count = 0;
    for (const ParserDiagnostic &diagnostic : context.diagnostics().entries()) {
-      if (diagnostic.code != ParserErrorCode::DeprecatedApi) continue;
-      ++warning_count;
-      if (diagnostic.severity != ParserDiagnosticSeverity::Warning or
-          diagnostic.message.find("array.") IS std::string::npos) {
-         Log.error("Stage A API deprecation diagnostic had incorrect content");
+      if (diagnostic.code IS ParserErrorCode::DeprecatedApi) {
+         Log.error("Stage B collection calls must not emit deprecation diagnostics");
          log_diagnostics(context.diagnostics().entries(), Log);
          return false;
       }
-   }
-   if (warning_count != 4) {
-      Log.error("expected four Stage A API deprecation warnings, got %zu", warning_count);
-      log_diagnostics(context.diagnostics().entries(), Log);
-      return false;
    }
 
    return true;
@@ -8815,7 +8831,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "builtin_method_registry", test_builtin_method_registry },
       { "builtin_method_table_initialiser_rejection", test_builtin_method_table_initialiser_rejection },
       { "builtin_method_static_classification", test_builtin_method_static_classification },
-      { "stage_a_collection_api_diagnostics", test_stage_a_collection_api_diagnostics },
+      { "stage_b_collection_api_contracts", test_stage_b_collection_api_contracts },
       { "unresolved_method_receiver_diagnostic", test_unresolved_method_receiver_diagnostic },
       { "builtin_method_bytecode_emission", test_builtin_method_bytecode_emission },
       { "compiler_intrinsic_bytecode_emission", test_compiler_intrinsic_bytecode_emission },

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -1202,9 +1202,10 @@ private:
       return {};
    }
 
-   struct ArrayFilterCall {
+   struct CollectionMethodCall {
       ExprNode *source = nullptr;
-      size_t predicate_index = 0;
+      GCstr *operation = nullptr;
+      bool receiver_first = false;
    };
 
    [[nodiscard]] static bool array_interface_member(
@@ -1219,55 +1220,183 @@ private:
          base.identifier.symbol->hash IS kt::strhash("array");
    }
 
-   [[nodiscard]] static std::optional<ArrayFilterCall> array_filter_call(CallExprPayload &Call)
+   [[nodiscard]] static std::optional<CollectionMethodCall> collection_method_call(const CallExprPayload &Call)
    {
-      if (auto *direct = std::get_if<DirectCallTarget>(&Call.target)) {
-         if (array_interface_member(*direct, kt::strhash("filter")) and Call.arguments.size() > 1) {
-            return ArrayFilterCall{ Call.arguments[0].get(), 1 };
-         }
-         if (direct->callable and direct->callable->kind IS AstNodeKind::MemberExpr and not Call.arguments.empty()) {
-            auto &member = std::get<MemberExprPayload>(direct->callable->data);
-            if (member.table and member.member.symbol and member.member.symbol->hash IS kt::strhash("filter")) {
-               return ArrayFilterCall{ member.table.get(), 0 };
-            }
+      auto *direct = std::get_if<DirectCallTarget>(&Call.target);
+      if (not direct or not direct->callable or direct->callable->kind != AstNodeKind::MemberExpr) return std::nullopt;
+
+      auto &member = std::get<MemberExprPayload>(direct->callable->data);
+      if (not member.table or not member.member.symbol) return std::nullopt;
+      if (member.table->kind IS AstNodeKind::IdentifierExpr) {
+         const auto &base = std::get<NameRef>(member.table->data);
+         bool collection_interface = base.identifier.symbol and
+            (base.identifier.symbol->hash IS kt::strhash("array") or
+             base.identifier.symbol->hash IS kt::strhash("range"));
+         if (not base.binding_id and collection_interface) {
+            if (Call.arguments.empty()) return std::nullopt;
+            return CollectionMethodCall{ Call.arguments[0].get(), member.member.symbol, true };
          }
       }
-      return std::nullopt;
+      return CollectionMethodCall{ member.table.get(), member.member.symbol, false };
+   }
+
+   struct CollectionCallbackCall {
+      ExprNode *source = nullptr;
+      GCstr *operation = nullptr;
+      size_t callback_index = 0;
+      bool reduce = false;
+   };
+
+   [[nodiscard]] static std::optional<CollectionCallbackCall> collection_callback_call(const CallExprPayload &Call)
+   {
+      auto collection = collection_method_call(Call);
+      if (not collection or not collection->operation) return std::nullopt;
+
+      bool reduce = collection->operation->hash IS kt::strhash("reduce");
+      bool callback_operation = reduce or collection->operation->hash IS kt::strhash("each") or
+         collection->operation->hash IS kt::strhash("filter") or collection->operation->hash IS kt::strhash("map") or
+         collection->operation->hash IS kt::strhash("mapSame") or collection->operation->hash IS kt::strhash("any") or
+         collection->operation->hash IS kt::strhash("all") or collection->operation->hash IS kt::strhash("find") or
+         collection->operation->hash IS kt::strhash("findIndex");
+      if (not callback_operation) return std::nullopt;
+
+      size_t callback_index = collection->receiver_first ? (reduce ? 2 : 1) : (reduce ? 1 : 0);
+      if (callback_index >= Call.arguments.size()) return std::nullopt;
+      return CollectionCallbackCall{ collection->source, collection->operation, callback_index, reduce };
+   }
+
+   [[nodiscard]] StaticValueDescriptor mapped_array_descriptor(const CallExprPayload &Call) const
+   {
+      auto collection = collection_method_call(Call);
+      if (not collection or not collection->source or not collection->operation) return {};
+
+      StaticValueDescriptor source = this->descriptor_of(*collection->source);
+      if (source.primary != TiriType::Array and source.primary != TiriType::Range) return {};
+
+      uint32_t operation = collection->operation->hash;
+      if (operation IS kt::strhash("mapSame")) {
+         if (source.primary IS TiriType::Array and source.array_element.known) {
+            source.proof = StaticProof::Trusted;
+            source.nullable = false;
+            return source;
+         }
+         return {};
+      }
+      if (operation != kt::strhash("map")) return {};
+
+      size_t type_index = collection->receiver_first ? 2 : 1;
+      if (type_index < Call.arguments.size()) {
+         const ExprNode &type_expression = *Call.arguments[type_index];
+         if (type_expression.kind IS AstNodeKind::LiteralExpr) {
+            const auto &literal = std::get<LiteralValue>(type_expression.data);
+            if (literal.kind IS LiteralKind::Nil and source.primary IS TiriType::Array and source.array_element.known) {
+               source.proof = StaticProof::Trusted;
+               source.nullable = false;
+               return source;
+            }
+            if (literal.kind IS LiteralKind::String and literal.string_value) {
+               std::string_view type_name(strdata(literal.string_value), literal.string_value->len);
+               if (auto element = describe_array_element(type_name, &this->context_.lua())) {
+                  StaticValueDescriptor result;
+                  result.primary = TiriType::Array;
+                  result.array_element = *element;
+                  result.proof = StaticProof::Trusted;
+                  result.nullable = false;
+                  return result;
+               }
+            }
+         }
+
+         StaticValueDescriptor result;
+         result.primary = TiriType::Array;
+         result.proof = StaticProof::Trusted;
+         result.nullable = false;
+         return result;
+      }
+
+      if (source.primary IS TiriType::Array and source.array_element.known) {
+         source.proof = StaticProof::Trusted;
+         source.nullable = false;
+         return source;
+      }
+
+      StaticValueDescriptor result;
+      result.primary = TiriType::Array;
+      if (auto element = describe_array_element("any", &this->context_.lua())) result.array_element = *element;
+      result.proof = StaticProof::Trusted;
+      result.nullable = false;
+      return result;
+   }
+
+   void update_call_result_descriptor(CallExprPayload &Call, const StaticValueDescriptor &Result)
+   {
+      StaticResultSet results;
+      results.stored_count = 1;
+      results.values[0] = Result;
+      if (Call.results) {
+         results = this->catalogue_.results(Call.results);
+         if (results.stored_count IS 0) results.stored_count = 1;
+         results.values[0] = Result;
+      }
+      Call.results = this->catalogue_.add_results(results);
+   }
+
+   void emit_stage_a_collection_deprecation(CallExprPayload &Call)
+   {
+      if (Call.deprecated_api_reported) return;
+      auto collection = collection_method_call(Call);
+      if (not collection or not collection->source or not collection->operation) return;
+      StaticValueDescriptor source = this->descriptor_of(*collection->source);
+      if (source.primary != TiriType::Array or not source.proved()) return;
+
+      bool builtin_find = collection->operation->hash IS kt::strhash("find") and
+         ((Call.builtin_method and Call.builtin_method->callable IS builtin_callable_id(FastFunc::array_find)) or
+          (collection->receiver_first and [&] {
+             const auto *direct = std::get_if<DirectCallTarget>(&Call.target);
+             return direct and array_interface_member(*direct, kt::strhash("find"));
+          }()));
+      bool legacy_map = collection->operation->hash IS kt::strhash("map") and
+         ((Call.builtin_method and Call.builtin_method->callable IS builtin_callable_id(FastFunc::array_map)) or
+          (collection->receiver_first and [&] {
+             const auto *direct = std::get_if<DirectCallTarget>(&Call.target);
+             return direct and array_interface_member(*direct, kt::strhash("map"));
+          }()));
+      size_t type_index = collection->receiver_first ? 2 : 1;
+      if (legacy_map and type_index < Call.arguments.size()) legacy_map = false;
+      if (not builtin_find and not legacy_map) return;
+
+      const auto *direct = std::get_if<DirectCallTarget>(&Call.target);
+      if (not direct or not direct->callable) return;
+      this->context_.emit_warning(ParserErrorCode::DeprecatedApi,
+         Token::from_span(direct->callable->span, TokenKind::Identifier), builtin_find ?
+            "array.find(Value, ...) is deprecated; use array.indexOf(Value, ...) instead" :
+            "one-argument array.map(Transform) is deprecated; use array.mapSame(Transform) instead");
+      Call.deprecated_api_reported = true;
    }
 
    [[nodiscard]] StaticValueDescriptor array_preserving_call_descriptor(const CallExprPayload &Call) const
    {
-      const ExprNode *source = nullptr;
-      GCstr *operation = nullptr;
-
-      if (const auto *direct = std::get_if<DirectCallTarget>(&Call.target);
-               direct and direct->callable and direct->callable->kind IS AstNodeKind::MemberExpr) {
-         const auto &member = std::get<MemberExprPayload>(direct->callable->data);
-         const auto *base = member.table and member.table->kind IS AstNodeKind::IdentifierExpr ?
-            std::get_if<NameRef>(&member.table->data) : nullptr;
-         if (base and not base->binding_id and base->identifier.symbol and
-             base->identifier.symbol->hash IS kt::strhash("array") and not Call.arguments.empty()) {
-            source = Call.arguments.front().get();
-            operation = member.member.symbol;
-         }
-         else {
-            source = member.table.get();
-            operation = member.member.symbol;
-         }
-      }
-
-      if (not source or not operation) return {};
-      StaticValueDescriptor receiver = this->descriptor_of(*source);
+      auto collection = collection_method_call(Call);
+      if (not collection or not collection->source or not collection->operation) return {};
+      StaticValueDescriptor receiver = this->descriptor_of(*collection->source);
       if (receiver.primary != TiriType::Array or not receiver.array_element.known) return {};
 
-      switch (operation->hash) {
+      switch (collection->operation->hash) {
          case kt::strhash("each"):
-         case kt::strhash("map"):
          case kt::strhash("filter"):
          case kt::strhash("slice"):
          case kt::strhash("clone"):
+         case kt::strhash("mapSame"):
             receiver.proof = StaticProof::Trusted;
             return receiver;
+         case kt::strhash("map"): {
+            size_t type_index = collection->receiver_first ? 2 : 1;
+            if (type_index >= Call.arguments.size()) {
+               receiver.proof = StaticProof::Trusted;
+               return receiver;
+            }
+            return {};
+         }
          default:
             return {};
       }
@@ -1481,21 +1610,34 @@ private:
          if (direct->callable) this->propagate_expression(*direct->callable);
       }
 
-      auto filter = array_filter_call(Call);
+      auto collection_callback = collection_callback_call(Call);
       for (size_t i = 0; i < Call.arguments.size(); ++i) {
          auto &argument = Call.arguments[i];
          if (not argument) continue;
 
-         bool contextual_filter = filter and i IS filter->predicate_index and filter->source and
+         bool contextual_callback = collection_callback and i IS collection_callback->callback_index and
+            collection_callback->source and
             argument->kind IS AstNodeKind::FunctionExpr;
-         StaticValueDescriptor source = contextual_filter ? this->descriptor_of(*filter->source) :
+         StaticValueDescriptor source = contextual_callback ? this->descriptor_of(*collection_callback->source) :
             StaticValueDescriptor{};
-         if (contextual_filter and source.primary IS TiriType::Array and source.array_element.known) {
-            std::array<StaticValueDescriptor, 2> parameters;
-            parameters[0] = array_element_value(source.array_element);
+         if (contextual_callback and
+             not (source.primary IS TiriType::Array and
+                  collection_callback->operation->hash IS kt::strhash("find")) and
+             ((source.primary IS TiriType::Array and source.array_element.known) or
+              source.primary IS TiriType::Range)) {
+            std::array<StaticValueDescriptor, 3> parameters;
+            size_t parameter_count = 2;
+            parameters[0] = source.primary IS TiriType::Array ? array_element_value(source.array_element) :
+               StaticValueDescriptor{ .primary=TiriType::Num, .proof=StaticProof::Trusted, .nullable=false };
             parameters[1].primary = TiriType::Num;
             parameters[1].proof = StaticProof::Trusted;
-            this->propagate_function_expression(*argument, parameters);
+            parameters[1].nullable = false;
+            if (collection_callback->reduce) {
+               parameters[2] = parameters[1];
+               parameters[1] = this->descriptor_of(*Call.arguments[collection_callback->callback_index - 1]);
+               parameter_count = 3;
+            }
+            this->propagate_function_expression(*argument, std::span(parameters.data(), parameter_count));
          }
          else this->propagate_expression(*argument);
       }
@@ -1566,6 +1708,12 @@ private:
             auto &call = std::get<CallExprPayload>(Expression.data);
             if (Expression.kind IS AstNodeKind::CallExpr) this->analyse_contextual_designation(call);
             value = this->call_descriptor(call, Expression.kind IS AstNodeKind::SafeCallExpr);
+            this->emit_stage_a_collection_deprecation(call);
+            StaticValueDescriptor mapped = this->mapped_array_descriptor(call);
+            if (mapped.primary != TiriType::Unknown) {
+               this->update_call_result_descriptor(call, mapped);
+               value = mapped;
+            }
             StaticValueDescriptor transferred = this->array_preserving_call_descriptor(call);
             if (transferred.primary != TiriType::Unknown) {
                transferred.nullable = value.nullable;

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -1208,8 +1208,8 @@ private:
       bool receiver_first = false;
    };
 
-   [[nodiscard]] static bool array_interface_member(
-      const DirectCallTarget &Direct, uint32_t MemberHash)
+   [[nodiscard]] static bool collection_interface_member(
+      const DirectCallTarget &Direct, uint32_t InterfaceHash, uint32_t MemberHash)
    {
       if (not Direct.callable or Direct.callable->kind != AstNodeKind::MemberExpr) return false;
       const auto &member = std::get<MemberExprPayload>(Direct.callable->data);
@@ -1217,7 +1217,7 @@ private:
           not member.member.symbol or member.member.symbol->hash != MemberHash) return false;
       const auto &base = std::get<NameRef>(member.table->data);
       return not base.binding_id and base.identifier.symbol and
-         base.identifier.symbol->hash IS kt::strhash("array");
+         base.identifier.symbol->hash IS InterfaceHash;
    }
 
    [[nodiscard]] static std::optional<CollectionMethodCall> collection_method_call(const CallExprPayload &Call)
@@ -1289,11 +1289,6 @@ private:
          const ExprNode &type_expression = *Call.arguments[type_index];
          if (type_expression.kind IS AstNodeKind::LiteralExpr) {
             const auto &literal = std::get<LiteralValue>(type_expression.data);
-            if (literal.kind IS LiteralKind::Nil and source.primary IS TiriType::Array and source.array_element.known) {
-               source.proof = StaticProof::Trusted;
-               source.nullable = false;
-               return source;
-            }
             if (literal.kind IS LiteralKind::String and literal.string_value) {
                std::string_view type_name(strdata(literal.string_value), literal.string_value->len);
                if (auto element = describe_array_element(type_name, &this->context_.lua())) {
@@ -1305,6 +1300,16 @@ private:
                   return result;
                }
             }
+            if (literal.kind IS LiteralKind::Nil) {
+               StaticValueDescriptor result;
+               result.primary = TiriType::Array;
+               if (auto element = describe_array_element("any", &this->context_.lua())) {
+                  result.array_element = *element;
+               }
+               result.proof = StaticProof::Trusted;
+               result.nullable = false;
+               return result;
+            }
          }
 
          StaticValueDescriptor result;
@@ -1312,12 +1317,6 @@ private:
          result.proof = StaticProof::Trusted;
          result.nullable = false;
          return result;
-      }
-
-      if (source.primary IS TiriType::Array and source.array_element.known) {
-         source.proof = StaticProof::Trusted;
-         source.nullable = false;
-         return source;
       }
 
       StaticValueDescriptor result;
@@ -1341,39 +1340,6 @@ private:
       Call.results = this->catalogue_.add_results(results);
    }
 
-   void emit_stage_a_collection_deprecation(CallExprPayload &Call)
-   {
-      if (Call.deprecated_api_reported) return;
-      auto collection = collection_method_call(Call);
-      if (not collection or not collection->source or not collection->operation) return;
-      StaticValueDescriptor source = this->descriptor_of(*collection->source);
-      if (source.primary != TiriType::Array or not source.proved()) return;
-
-      bool builtin_find = collection->operation->hash IS kt::strhash("find") and
-         ((Call.builtin_method and Call.builtin_method->callable IS builtin_callable_id(FastFunc::array_find)) or
-          (collection->receiver_first and [&] {
-             const auto *direct = std::get_if<DirectCallTarget>(&Call.target);
-             return direct and array_interface_member(*direct, kt::strhash("find"));
-          }()));
-      bool legacy_map = collection->operation->hash IS kt::strhash("map") and
-         ((Call.builtin_method and Call.builtin_method->callable IS builtin_callable_id(FastFunc::array_map)) or
-          (collection->receiver_first and [&] {
-             const auto *direct = std::get_if<DirectCallTarget>(&Call.target);
-             return direct and array_interface_member(*direct, kt::strhash("map"));
-          }()));
-      size_t type_index = collection->receiver_first ? 2 : 1;
-      if (legacy_map and type_index < Call.arguments.size()) legacy_map = false;
-      if (not builtin_find and not legacy_map) return;
-
-      const auto *direct = std::get_if<DirectCallTarget>(&Call.target);
-      if (not direct or not direct->callable) return;
-      this->context_.emit_warning(ParserErrorCode::DeprecatedApi,
-         Token::from_span(direct->callable->span, TokenKind::Identifier), builtin_find ?
-            "array.find(Value, ...) is deprecated; use array.indexOf(Value, ...) instead" :
-            "one-argument array.map(Transform) is deprecated; use array.mapSame(Transform) instead");
-      Call.deprecated_api_reported = true;
-   }
-
    [[nodiscard]] StaticValueDescriptor array_preserving_call_descriptor(const CallExprPayload &Call) const
    {
       auto collection = collection_method_call(Call);
@@ -1389,14 +1355,6 @@ private:
          case kt::strhash("mapSame"):
             receiver.proof = StaticProof::Trusted;
             return receiver;
-         case kt::strhash("map"): {
-            size_t type_index = collection->receiver_first ? 2 : 1;
-            if (type_index >= Call.arguments.size()) {
-               receiver.proof = StaticProof::Trusted;
-               return receiver;
-            }
-            return {};
-         }
          default:
             return {};
       }
@@ -1464,6 +1422,48 @@ private:
       result.nullable = Element.storage IS AET::STR_GC or Element.storage IS AET::OBJECT or
          Element.storage IS AET::TABLE or Element.storage IS AET::ARRAY;
       return result;
+   }
+
+   [[nodiscard]] StaticValueDescriptor collection_search_result_descriptor(const CallExprPayload &Call) const
+   {
+      auto collection = collection_method_call(Call);
+      if (not collection or not collection->source or not collection->operation) return {};
+
+      StaticValueDescriptor source = this->descriptor_of(*collection->source);
+      if (source.primary != TiriType::Array and source.primary != TiriType::Range) return {};
+
+      const auto *direct = std::get_if<DirectCallTarget>(&Call.target);
+      bool builtin = (source.primary IS TiriType::Array and Call.builtin_method and
+         (Call.builtin_method->callable IS builtin_callable_id(FastFunc::array_find) or
+          Call.builtin_method->callable IS builtin_callable_id(FastFunc::array_findIndex) or
+          Call.builtin_method->callable IS builtin_callable_id(FastFunc::array_indexOf))) or
+         (source.primary IS TiriType::Range and Call.builtin_method and
+         (Call.builtin_method->callable IS builtin_callable_id(FastFunc::range_find) or
+          Call.builtin_method->callable IS builtin_callable_id(FastFunc::range_findIndex) or
+          Call.builtin_method->callable IS builtin_callable_id(FastFunc::range_indexOf)));
+      if (not builtin and collection->receiver_first and direct) {
+         builtin = (source.primary IS TiriType::Array and collection_interface_member(
+            *direct, kt::strhash("array"), collection->operation->hash)) or
+            (source.primary IS TiriType::Range and collection_interface_member(
+            *direct, kt::strhash("range"), collection->operation->hash));
+      }
+      if (not builtin) return {};
+
+      uint32_t operation = collection->operation->hash;
+      if (operation IS kt::strhash("find")) {
+         if (source.primary IS TiriType::Array and source.array_element.known) {
+            StaticValueDescriptor result = array_element_value(source.array_element);
+            result.nullable = true;
+            return result;
+         }
+         if (source.primary IS TiriType::Range) {
+            return StaticValueDescriptor{ .primary=TiriType::Num, .proof=StaticProof::Trusted, .nullable=true };
+         }
+      }
+      if (operation IS kt::strhash("findIndex") or operation IS kt::strhash("indexOf")) {
+         return StaticValueDescriptor{ .primary=TiriType::Num, .proof=StaticProof::Trusted, .nullable=true };
+      }
+      return {};
    }
 
    void propagate_function_expression(
@@ -1708,11 +1708,15 @@ private:
             auto &call = std::get<CallExprPayload>(Expression.data);
             if (Expression.kind IS AstNodeKind::CallExpr) this->analyse_contextual_designation(call);
             value = this->call_descriptor(call, Expression.kind IS AstNodeKind::SafeCallExpr);
-            this->emit_stage_a_collection_deprecation(call);
             StaticValueDescriptor mapped = this->mapped_array_descriptor(call);
             if (mapped.primary != TiriType::Unknown) {
                this->update_call_result_descriptor(call, mapped);
                value = mapped;
+            }
+            StaticValueDescriptor search_result = this->collection_search_result_descriptor(call);
+            if (search_result.primary != TiriType::Unknown) {
+               this->update_call_result_descriptor(call, search_result);
+               value = search_result;
             }
             StaticValueDescriptor transferred = this->array_preserving_call_descriptor(call);
             if (transferred.primary != TiriType::Unknown) {

--- a/src/tiri/jit/src/runtime/lj_array.h
+++ b/src/tiri/jit/src/runtime/lj_array.h
@@ -28,6 +28,7 @@ extern void lj_array_check_element(lua_State *, GCarray *, cTValue *);
 extern void lj_array_store_validated(lua_State *, GCarray *, MSize Index, cTValue *);
 extern void lj_array_store_checked(lua_State *, GCarray *, MSize Index, cTValue *);
 extern void lj_array_store_new_values(lua_State *, GCarray *, cTValue *Values, MSize Count);
+[[nodiscard]] extern GCarray *lj_array_new_map_result(lua_State *, MSize Length, int TypeArg);
 
 //********************************************************************************************************************
 

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -2445,7 +2445,7 @@ end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Stage A collection compatibility APIs
+-- Final collection search APIs
 
 @Test function IndexOfRetainsTypedSearchBounds()
    arr = array<int> { 10, 20, 30, 20, 40 }
@@ -2483,7 +2483,8 @@ end
    assert(values.indexOf(second) is 0, 'indexOf() should honour the same equality metamethod as is')
 end
 
-@Test function LegacyFindRemainsEqualitySearchDuringStageA()
+@Test function FindUsesPredicateDuringStageB()
    local items = array<int> { 10, 20, 30 }
-   assert(items.find(20) is 1, 'the Stage A compatibility find() should retain equality-search semantics')
+   assert(items.find(Value => Value > 10) is 20, 'find() should return the first value selected by its predicate')
+   assert(items.indexOf(20) is 1, 'indexOf() should retain equality-search semantics')
 end

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -717,7 +717,7 @@ end
 end
 
 -----------------------------------------------------------------------------------------------------------------------
--- Test array.find() functionality
+-- Test array.indexOf() functionality
 
 @Test function ArrayFind()
    arr = array<int, 10>
@@ -725,21 +725,21 @@ end
       arr[i] = i * 10
    end
 
-   -- Find existing values
-   assert(arr.find(0) is 0, "find(0) should return 0")
-   assert(arr.find(50) is 5, "find(50) should return 5")
-   assert(arr.find(90) is 9, "find(90) should return 9")
+   -- indexOf existing values
+   assert(arr.indexOf(0) is 0, "indexOf(0) should return 0")
+   assert(arr.indexOf(50) is 5, "indexOf(50) should return 5")
+   assert(arr.indexOf(90) is 9, "indexOf(90) should return 9")
 
-   -- Find non-existing value
-   assert(arr.find(55) is nil, "find(55) should return nil")
+   -- indexOf non-existing value
+   assert(arr.indexOf(55) is nil, "indexOf(55) should return nil")
 
-   -- Find with start index
-   assert(arr.find(50, 5) is 5, "find(50, 5) should return 5")
-   assert(arr.find(50, 6) is nil, "find(50, 6) should return nil")
-   assert(arr.find(50, 0, 5) is nil, "an exclusive stop should exclude index 5")
-   assert(arr.find(50, 0, 6) is 5, "an exclusive stop should include index 5")
-   assert(arr.find(90, 9, #arr) is 9, "a stop equal to array length should be valid")
-   assert(arr.find(50, 5, 5) is nil, "an empty span should not find a value")
+   -- indexOf with start index
+   assert(arr.indexOf(50, 5) is 5, "indexOf(50, 5) should return 5")
+   assert(arr.indexOf(50, 6) is nil, "indexOf(50, 6) should return nil")
+   assert(arr.indexOf(50, 0, 5) is nil, "an exclusive stop should exclude index 5")
+   assert(arr.indexOf(50, 0, 6) is 5, "an exclusive stop should include index 5")
+   assert(arr.indexOf(90, 9, #arr) is 9, "a stop equal to array length should be valid")
+   assert(arr.indexOf(50, 5, 5) is nil, "an empty span should not return a value")
 end
 
 @Test function ArrayFindFloat()
@@ -750,9 +750,9 @@ end
    arr[3] = 2.5  -- duplicate
    arr[4] = 4.5
 
-   assert(arr.find(2.5) is 1, "find(2.5) should return 1 (first occurrence)")
-   assert(arr.find(3.5) is 2, "find(3.5) should return 2")
-   assert(arr.find(5.5) is nil, "find(5.5) should return nil")
+   assert(arr.indexOf(2.5) is 1, "indexOf(2.5) should return 1 (first occurrence)")
+   assert(arr.indexOf(3.5) is 2, "indexOf(3.5) should return 2")
+   assert(arr.indexOf(5.5) is nil, "indexOf(5.5) should return nil")
 end
 
 @Test function ArrayFindObject()
@@ -760,10 +760,10 @@ end
    obj_two = obj.new('file')
    arr = array<obj> { obj_one, obj_two }
 
-   assert(arr.find(obj_one) is 0, "find(object) should return 0")
-   assert(arr.find(obj_two.id) is 1, "find(uid) should return 1")
-   assert(arr.find(obj_one, 1) is nil, "find(object, 1) should return nil")
-   assert(arr.find(obj_two, {0 into 1}) is 1, "find(object, range) should return 1")
+   assert(arr.indexOf(obj_one) is 0, "indexOf(object) should return 0")
+   assert(arr.indexOf(obj_two.id) is 1, "indexOf(uid) should return 1")
+   assert(arr.indexOf(obj_one, 1) is nil, "indexOf(object, 1) should return nil")
+   assert(arr.indexOf(obj_two, {0 into 1}) is 1, "indexOf(object, range) should return 1")
 
    obj_one.free()
    obj_two.free()
@@ -915,7 +915,7 @@ end
 end
 
 -----------------------------------------------------------------------------------------------------------------------
--- Test array.find() with range support
+-- Test array.indexOf() with range support
 
 @Test function ArrayFindWithRange()
    arr = array<int, 10>
@@ -924,11 +924,11 @@ end
    end
 
    -- Find within a range (exclusive)
-   assert(arr.find(30, {0 to 5}) is 3, "find in range: should find 30 at index 3")
-   assert(arr.find(50, {0 to 5}) is nil, "find in range: 50 should not be found (outside range)")
-   assert(arr.find(70, {5 to 10}) is 7, "find in range: should find 70 at index 7")
-   assert(arr.find(30, {-20 into 3}) is 3, "find in clipped negative range should still find 30")
-   assert(arr.find(30, {20 to 30}) is nil, "find in empty clipped range should return nil")
+   assert(arr.indexOf(30, {0 to 5}) is 3, "find in range: should find 30 at index 3")
+   assert(arr.indexOf(50, {0 to 5}) is nil, "find in range: 50 should not be found (outside range)")
+   assert(arr.indexOf(70, {5 to 10}) is 7, "find in range: should find 70 at index 7")
+   assert(arr.indexOf(30, {-20 into 3}) is 3, "find in clipped negative range should still find 30")
+   assert(arr.indexOf(30, {20 to 30}) is nil, "find in empty clipped range should return nil")
 end
 
 @Test function ArrayFindWithInclusiveRange()
@@ -938,8 +938,8 @@ end
    end
 
    -- Find within an inclusive range
-   assert(arr.find(50, {0 into 5}) is 5, "find inclusive: should find 50 at index 5")
-   assert(arr.find(50, {0 to 5}) is nil, "find exclusive: 50 should not be found at boundary")
+   assert(arr.indexOf(50, {0 into 5}) is 5, "find inclusive: should find 50 at index 5")
+   assert(arr.indexOf(50, {0 to 5}) is nil, "find exclusive: 50 should not be found at boundary")
 end
 
 @Test function ArrayFindWithNegativeRange()
@@ -951,8 +951,8 @@ end
    arr[4] = 40
 
    -- Find in last 3 elements using negative indices
-   assert(arr.find(20, {-3 to -1}) is 3, "find negative: should find 20 at index 3")
-   assert(arr.find(10, {-3 to -1}) is nil, "find negative: 10 should not be found in last 3")
+   assert(arr.indexOf(20, {-3 to -1}) is 3, "find negative: should find 20 at index 3")
+   assert(arr.indexOf(10, {-3 to -1}) is nil, "find negative: 10 should not be found in last 3")
 end
 
 @Test function ArrayFindWithReverseRange()
@@ -964,8 +964,8 @@ end
    arr[4] = 40
 
    -- Find searching backwards (should find the later occurrence first)
-   assert(arr.find(20, {4 into 0}) is 3, "find reverse: should find 20 at index 3 (searching from end)")
-   assert(arr.find(10, range.new(4, 0, false, -1)) is nil, "exclusive reverse range should exclude the stop boundary")
+   assert(arr.indexOf(20, {4 into 0}) is 3, "find reverse: should find 20 at index 3 (searching from end)")
+   assert(arr.indexOf(10, range.new(4, 0, false, -1)) is nil, "exclusive reverse range should exclude the stop boundary")
 end
 
 @Test function ArrayFindWithSteppedRange()
@@ -976,8 +976,8 @@ end
    -- arr = {100, 10, 100, 30, 100, 50, 100, 70, 100, 90}
 
    -- Find only checking odd indices
-   assert(arr.find(30, range.new(1, 9, false, 2)) is 3, "find stepped: should find 30 at index 3")
-   assert(arr.find(100, range.new(1, 9, false, 2)) is nil, "find stepped: 100 not at odd indices")
+   assert(arr.indexOf(30, range.new(1, 9, false, 2)) is 3, "find stepped: should find 30 at index 3")
+   assert(arr.indexOf(100, range.new(1, 9, false, 2)) is nil, "find stepped: 100 not at odd indices")
 end
 
 @Test function ArrayFindOriginalSyntax()
@@ -987,9 +987,9 @@ end
       arr[i] = i * 10
    end
 
-   assert(arr.find(0) is 0, "find original: should find 0 at index 0")
-   assert(arr.find(50) is 5, "find original: should find 50 at index 5")
-   assert(arr.find(50, 6) is nil, "find original: 50 should not be found starting at 6")
+   assert(arr.indexOf(0) is 0, "find original: should find 0 at index 0")
+   assert(arr.indexOf(50) is 5, "find original: should find 50 at index 5")
+   assert(arr.indexOf(50, 6) is nil, "find original: 50 should not be found starting at 6")
 end
 
 -----------------------------------------------------------------------------------------------------------------------
@@ -1073,7 +1073,7 @@ end
    assert(result is '', "concat on empty array should return empty string")
 
    -- find on empty array should return nil
-   found = empty_int.find(42)
+   found = empty_int.indexOf(42)
    assert(found is nil, "find on empty array should return nil")
 
    -- reverse on empty array should not error
@@ -1120,7 +1120,7 @@ end
    assert(arr[999] is 999, "large array last element should be 999")
 
    -- Test find on large array
-   found = arr.find(500)
+   found = arr.indexOf(500)
    assert(found is 500, "find on large array should work")
 
    -- Test reverse on large array
@@ -1458,7 +1458,7 @@ end
    assert(arr[4] is 50, "sorted arr[4] should be 50")
 
    -- Test find
-   idx = arr.find(30)
+   idx = arr.indexOf(30)
    assert(idx is 2, "find(30) should return 2")
 
    -- Test reverse
@@ -2024,17 +2024,17 @@ end
 end
 
 @Test function ArrayContainsVsFind()
-   -- Verify contains() is consistent with find()
+   -- Verify contains() is consistent with indexOf()
    arr = array<int> { 5, 10, 15, 20, 25 }
 
    for _, v in arr do
-      found = arr.find(v) != nil
+      found = arr.indexOf(v) != nil
       has_v = v in arr
-      assert(found is has_v, "contains() should agree with find() for value " .. v)
+      assert(found is has_v, "contains() should agree with indexOf() for value " .. v)
    end
 
    -- Test non-existent value
-   assert((arr.find(99) != nil) is (99 in arr), "contains and find should agree on missing value")
+   assert((arr.indexOf(99) != nil) is (99 in arr), "contains and indexOf should agree on missing value")
 end
 
 -----------------------------------------------------------------------------------------------------------------------
@@ -2442,4 +2442,48 @@ end
    processing.collect('full')
 
    assert(arr[3].k is 21, "Read stress final: arr[3].k corrupted")
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Stage A collection compatibility APIs
+
+@Test function IndexOfRetainsTypedSearchBounds()
+   arr = array<int> { 10, 20, 30, 20, 40 }
+   assert(arr.indexOf(20) is 1, 'indexOf() should return the first matching index')
+   assert(arr.indexOf(20, 2) is 3, 'indexOf() should honour a zero-based start')
+   assert(arr.indexOf(20, 2, 3) is nil, 'indexOf() should honour an exclusive stop')
+   assert(arr.indexOf(20, {4 into 0}) is 3, 'indexOf() should preserve reverse range traversal')
+end
+
+@Test function IndexOfSearchesVariantCallableValues()
+   local identity = function(Value:any):any
+      return Value
+   end
+   local items = array<any> { identity, 'value' }
+   assert(items.indexOf(identity) is 0, 'indexOf() should compare callable values instead of invoking them')
+   assert(items.indexOf(function(Value:any):any return Value end) is nil,
+      'indexOf() should use callable identity for distinct functions')
+end
+
+@Test function IndexOfSearchesReferenceValues()
+   local first = { id=1 }
+   local second = { id=2 }
+   local items = array<any> { first, second }
+   assert(items.indexOf(second) is 1, 'indexOf() should search variant reference values')
+   assert(items.indexOf({ id=2 }) is nil, 'indexOf() should retain reference identity without an equality metamethod')
+end
+
+@Test function IndexOfHonoursReferenceEqualityMetamethods()
+   local equality_mt = {
+      __eq = function(Other:table!):bool return &id is Other.id end
+   }
+   local first = setmetatable({ id=7 }, equality_mt)
+   local second = setmetatable({ id=7 }, equality_mt)
+   local values = array<table> { first }
+   assert(values.indexOf(second) is 0, 'indexOf() should honour the same equality metamethod as is')
+end
+
+@Test function LegacyFindRemainsEqualitySearchDuringStageA()
+   local items = array<int> { 10, 20, 30 }
+   assert(items.find(20) is 1, 'the Stage A compatibility find() should retain equality-search semantics')
 end

--- a/src/tiri/tests/test_array_any.tiri
+++ b/src/tiri/tests/test_array_any.tiri
@@ -203,7 +203,7 @@ end
 
 @Test function ArrayAnyMap()
    arr = array<any> { 1, 2, 3 }
-   mapped = array.map(arr, i => i * 10)
+   mapped = array.mapSame(arr, i => i * 10)
 
    assert(mapped[0] is 10, "first should be 10, got " .. tostring(mapped[0]))
    assert(mapped[1] is 20, "second should be 20, got " .. tostring(mapped[1]))

--- a/src/tiri/tests/test_array_element_validation.tiri
+++ b/src/tiri/tests/test_array_element_validation.tiri
@@ -42,7 +42,7 @@ end
 
       local source = array.new(1, element_type)
       source[0] = 1
-      expect_failure(() => do source.map(Value => str: '12') end, element_type .. ' map accepted a string')
+      expect_failure(() => do source.mapSame(Value => str: '12') end, element_type .. ' map accepted a string')
    end
 
    local appended = array<int> { 1 }
@@ -57,7 +57,7 @@ end
    expect_failure(() => do indexed.fill(12) end, 'String fill accepted a number')
    expect_failure(() => do array.of('str', 12) end, 'String constructor accepted a number')
    expect_failure(() => do indexed.copy({ [0]=12 }) end, 'String table copy accepted a number')
-   expect_failure(() => do indexed.map(Value => num: 12) end, 'String map accepted a number')
+   expect_failure(() => do indexed.mapSame(Value => num: 12) end, 'String map accepted a number')
    expect_failure(() => do array.new(0, 'string') end, "Legacy 'string' element name was accepted")
 end
 
@@ -115,7 +115,7 @@ end
    values.insert(0, 'first')
    values[1] = table_value
    values.fill(array_value, 2, 1)
-   local mapped = values.map(Value => any: Value)
+   local mapped = values.mapSame(Value => any: Value)
    assert(mapped[0] is 'first' and mapped[1] is table_value and mapped[2] is array_value,
       'Any writers did not preserve mixed categories')
 

--- a/src/tiri/tests/test_array_functional.tiri
+++ b/src/tiri/tests/test_array_functional.tiri
@@ -69,63 +69,63 @@ end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- array.map() tests
+-- array.mapSame() tests
 
 @Test function MapDoubleValues()
    arr = array<int> { 1, 2, 3, 4, 5 }
-   doubled = arr.map(v => num: v * 2)
-   assert(#doubled is 5, "map() should return array of same length")
+   doubled = arr.mapSame(v => num: v * 2)
+   assert(#doubled is 5, "mapSame() should return array of same length")
    assert(doubled[0] is 2 and doubled[1] is 4 and doubled[2] is 6 and doubled[3] is 8 and doubled[4] is 10,
-      "map() should transform each element")
+      "mapSame() should transform each element")
 end
 
 @Test function MapPreservesOriginal()
    arr = array<int> { 1, 2, 3 }
-   doubled = arr.map(v => num: v * 2)
-   assert(arr[0] is 1 and arr[1] is 2 and arr[2] is 3, "map() should not modify original array")
+   doubled = arr.mapSame(v => num: v * 2)
+   assert(arr[0] is 1 and arr[1] is 2 and arr[2] is 3, "mapSame() should not modify original array")
 end
 
 @Test function MapEmptyArray()
    arr = array<int>
-   result = arr.map(v => num: v * 2)
-   assert(#result is 0, "map() on empty array should return empty array")
+   result = arr.mapSame(v => num: v * 2)
+   assert(#result is 0, "mapSame() on empty array should return empty array")
 end
 
 @Test function MapWithIndex()
    arr = array<int> { 10, 20, 30 }
-   indexed = arr.map(function(v, i):num
+   indexed = arr.mapSame(function(v, i):num
       return v + i
    end)
-   assert(indexed[0] is 10 and indexed[1] is 21 and indexed[2] is 32, "map() should pass index as second argument")
+   assert(indexed[0] is 10 and indexed[1] is 21 and indexed[2] is 32, "mapSame() should pass index as second argument")
 end
 
 @Test function MapFloatArray()
    arr = array<float> { 1.5, 2.5, 3.5 }
-   squared = arr.map(v => num: v * v)
-   assert(math.abs(squared[0] - 2.25) < 0.001, "map() should work with float arrays")
-   assert(math.abs(squared[1] - 6.25) < 0.001, "map() should work with float arrays")
+   squared = arr.mapSame(v => num: v * v)
+   assert(math.abs(squared[0] - 2.25) < 0.001, "mapSame() should work with float arrays")
+   assert(math.abs(squared[1] - 6.25) < 0.001, "mapSame() should work with float arrays")
 end
 
 @Test function MapStringArray()
    arr = array<str> { 'hello', 'world' }
-   upper = arr.map(v => str: v.upper())
-   assert(upper[0] is 'HELLO' and upper[1] is 'WORLD', "map() should work with string arrays")
+   upper = arr.mapSame(v => str: v.upper())
+   assert(upper[0] is 'HELLO' and upper[1] is 'WORLD', "mapSame() should work with string arrays")
 end
 
 @Test function MapObjectArray()
    obj_one = obj.new('time')
    obj_two = obj.new('file')
    arr = array<obj> { obj_one, obj_two }
-   copied = arr.map(Value => obj: Value)
-   assert(copied[0].id is obj_one.id and copied[1].id is obj_two.id, "map() should preserve objects")
+   copied = arr.mapSame(Value => obj: Value)
+   assert(copied[0].id is obj_one.id and copied[1].id is obj_two.id, "mapSame() should preserve objects")
    obj_one.free()
    obj_two.free()
 end
 
 @Test function MapSingleElement()
    arr = array<int> { 42 }
-   result = arr.map(v => v * 2)
-   assert(#result is 1 and result[0] is 84, "map() should work with single element array")
+   result = arr.mapSame(v => v * 2)
+   assert(#result is 1 and result[0] is 84, "mapSame() should work with single element array")
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -372,7 +372,7 @@ end
 
 @Test function ChainMapFilter()
    arr = array<int> { 1, 2, 3, 4, 5 }
-   result = arr.map(v => v * 2).filter(v => v > 5)
+   result = arr.mapSame(v => v * 2).filter(v => v > 5)
    assert(#result is 3, "chained map/filter should work")
    assert(result[0] is 6 and result[1] is 8 and result[2] is 10,
       "chained map/filter should produce correct values")
@@ -380,7 +380,7 @@ end
 
 @Test function ChainFilterMap()
    arr = array<int> { 1, 2, 3, 4, 5, 6 }
-   result = arr.filter(v => v % 2 is 0).map(v => v * 10)
+   result = arr.filter(v => v % 2 is 0).mapSame(v => v * 10)
    assert(#result is 3, "chained filter/map should work")
    assert(result[0] is 20 and result[1] is 40 and result[2] is 60,
       "chained filter/map should produce correct values")
@@ -394,16 +394,16 @@ end
 
 @Test function ChainMapReduceAny()
    arr = array<int> { 1, 2, 3, 4, 5 }
-   hasLarge = arr.map(v => v * 10).any(v => v > 40)
+   hasLarge = arr.mapSame(v => v * 10).any(v => v > 40)
    assert(hasLarge, "chained map/any should work")
 end
 
 @Test function ChainEachReturnsOriginal()
    arr = array<int> { 1, 2, 3 }
    count = 0
-   result = arr.each(v => do count += 1 end).map(v => v * 2)
+   result = arr.each(v => do count += 1 end).mapSame(v => v * 2)
    assert(count is 3, "each() in chain should process all elements")
-   assert(#result is 3 and result[0] is 2, "map() after each() should work")
+   assert(#result is 3 and result[0] is 2, "mapSame() after each() should work")
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -421,9 +421,9 @@ end
 
    try
       local invalid:any = 42
-      arr.map(invalid)
+      arr.mapSame(invalid)
    success
-      error("map() should reject non-function argument")
+      error("mapSame() should reject non-function argument")
    end
 
    try
@@ -442,9 +442,9 @@ end
 
 @Test function MapWithByteArray()
    arr = array<byte> { 65, 66, 67 }
-   result = arr.map(v => v + 1)
+   result = arr.mapSame(v => v + 1)
    assert(result[0] is 66 and result[1] is 67 and result[2] is 68,
-      "map() should work with byte arrays")
+      "mapSame() should work with byte arrays")
 end
 
 @Test function FilterWithDoubleArray()
@@ -457,4 +457,75 @@ end
    arr = array<int64> { 1000000000, 2000000000, 3000000000 }
    sum = arr.reduce(0, (acc, v) => acc + v)
    assert(sum is 6000000000, "reduce() should work with int64 arrays")
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Stage A collection compatibility APIs
+
+@Test function EachStopsOnlyForExplicitFalse()
+   local items = array<int> { 10, 20, 30 }
+   local calls = 0
+   local result = items.each(function(Value, Index)
+      calls++
+      if Index is 1 then return false end
+   end)
+   assert(calls is 2 and result is items, 'each() should stop on false and return its receiver')
+
+   calls = 0
+   items.each(function(Value, Index)
+      calls++
+      if Index is 1 then return nil end
+      return true
+   end)
+   assert(calls is 3, 'each() should continue on nil and true')
+end
+
+@Test function FindIndexUsesPredicateAndPosition()
+   local items = array<int> { 10, 20, 30, 40 }
+   local calls = 0
+   local found = items.findIndex(function(Value, Index)
+      calls++
+      return Value > 20 and Index is 2
+   end)
+   assert(found is 2 and calls is 3, 'findIndex() should return the first matching index and short-circuit')
+   assert(items.findIndex(Value => Value > 100) is nil, 'findIndex() should return nil when no element matches')
+end
+
+@Test function MapSamePreservesSourceStorage()
+   bytes = array<byte> { 65, 66 }
+   mapped = bytes.mapSame(Value => Value + 1)
+   assert(mapped.type() is 'byte' and mapped[0] is 66 and mapped[1] is 67,
+      'mapSame() should retain the source element storage')
+
+   labels = bytes.map(Value => 'n' .. tostring(Value), 'str')
+   assert(labels.type() is 'str' and labels[0] is 'n65' and labels[1] is 'n66',
+      'map() should allocate the requested destination type')
+end
+
+@Test function MapValidatesDestinationBeforeCallback()
+   local items = array<int> { 1, 2 }
+   local calls = 0
+   try
+      items.map(function(Value)
+         calls++
+         return Value
+      end, 'not-an-array-type')
+   success
+      error('map() should reject an invalid destination type')
+   end
+   assert(calls is 0, 'map() should validate the destination type before invoking callbacks')
+
+   try
+      items.map(Value => 'wrong', 'int')
+   success
+      error('map() should reject an incompatible transformed value')
+   end
+   assert(items[0] is 1 and items[1] is 2, 'a failed map() should not modify its source array')
+end
+
+@Test function LegacyMapRetainsSourceStorageDuringStageA()
+   local items = array<byte> { 65, 66 }
+   local mapped = items.map(Value => Value + 1)
+   assert(mapped.type() is 'byte' and mapped[0] is 66 and mapped[1] is 67,
+      'the Stage A compatibility map() should preserve the source storage descriptor')
 end

--- a/src/tiri/tests/test_array_functional.tiri
+++ b/src/tiri/tests/test_array_functional.tiri
@@ -491,6 +491,23 @@ end
    assert(items.findIndex(Value => Value > 100) is nil, 'findIndex() should return nil when no element matches')
 end
 
+@Test function FindReturnsMatchingPredicateValue()
+   local items = array<int> { 10, 20, 30, 40 }
+   local calls = 0
+   local found = items.find(function(Value, Index)
+      calls++
+      return Value > 20 and Index is 2
+   end)
+   assert(found is 30 and calls is 3, 'find() should return the first matching value and short-circuit')
+   assert(items.find(Value => Value > 100) is nil, 'find() should return nil when no element matches')
+
+   found = items.find(function(Value, Index)
+      if Index is 0 then items[0] = 99 end
+      return true
+   end)
+   assert(found is 10, 'find() should return the value supplied to a matching callback before that callback mutates it')
+end
+
 @Test function MapSamePreservesSourceStorage()
    bytes = array<byte> { 65, 66 }
    mapped = bytes.mapSame(Value => Value + 1)
@@ -523,9 +540,16 @@ end
    assert(items[0] is 1 and items[1] is 2, 'a failed map() should not modify its source array')
 end
 
-@Test function LegacyMapRetainsSourceStorageDuringStageA()
+@Test function MapDefaultsToVariantStorageDuringStageB()
    local items = array<byte> { 65, 66 }
-   local mapped = items.map(Value => Value + 1)
-   assert(mapped.type() is 'byte' and mapped[0] is 66 and mapped[1] is 67,
-      'the Stage A compatibility map() should preserve the source storage descriptor')
+   local mapped = items.map(function(Value, Index):any
+      if Index is 0 then return 'first' end
+      return Value + 1
+   end)
+   local empty = array<int>
+   local empty_mapped = empty.map(Value => Value)
+   assert(rawtype(mapped) is 'array<any>' and mapped[0] is 'first' and mapped[1] is 67,
+      'untyped map() should allocate variant storage for type-changing results')
+   assert(rawtype(empty_mapped) is 'array<any>' and #empty_mapped is 0,
+      'untyped map() should allocate array<any> for empty inputs')
 end

--- a/src/tiri/tests/test_array_manip.tiri
+++ b/src/tiri/tests/test_array_manip.tiri
@@ -102,13 +102,13 @@ end
 
    local values = array<uint> { 2147483648, 3, 4294967295 }
    values.sort()
-   assert(values[0] is 3 and values[1] is 2147483648 and values.find(4294967295) is 2,
+   assert(values[0] is 3 and values[1] is 2147483648 and values.indexOf(4294967295) is 2,
       'uint ordering or find used signed comparison')
    local copy = values.clone().slice({0 into 1})
    assert(copy.type() is 'uint' and copy[1] is 2147483648, 'uint clone or slice lost its identity')
 
    local words = array<uint16> { 1, 2, 3 }
-   local mapped = words.map(Value => num: Value + 65535).filter(Value => bool: Value is 0)
+   local mapped = words.mapSame(Value => num: Value + 65535).filter(Value => bool: Value is 0)
    assert(mapped.type() is 'uint16' and #mapped is 1 and mapped[0] is 0, 'unsigned map/filter lost modulo storage')
    assert(array<uint64> { 9007199254740991 }.concat('', '%llu') is '9007199254740991',
       'uint64 concat did not use an unsigned long long format')

--- a/src/tiri/tests/test_array_typed_syntax.tiri
+++ b/src/tiri/tests/test_array_typed_syntax.tiri
@@ -404,7 +404,7 @@ end
 @Test function ArrayTypedFindMethod()
    -- Find method should locate values
    arr = array<int> { 10, 20, 30, 40, 50 }
-   idx = arr.find(30)
+   idx = arr.indexOf(30)
    assert(idx is 2, "Find should return index 2 for value 30, got " .. tostring(idx))
 end
 

--- a/src/tiri/tests/test_builtin_methods.tiri
+++ b/src/tiri/tests/test_builtin_methods.tiri
@@ -12,7 +12,7 @@ function enforce_hotpath() end
    values.push(3)
    assert(2 in values and #values is 3, 'Array query and mutation methods should use dot calls')
 
-   local mapped = values.map(Value => num: Value * 2)
+   local mapped = values.mapSame(Value => num: Value * 2)
    assert(mapped[0] is 2 and mapped[2] is 6, 'Array map should retain its array result')
    assert(values.reduce(0, (Total, Value) => num: Total + Value) is 6,
       'Array reduce should return the accumulator result')
@@ -321,4 +321,22 @@ end
    values.insert(7)
    table.insert = original
    assert(values[0] is 7, 'Compiled instance calls should ignore later public namespace rebinding')
+end
+
+@Test function CollectionCompatibilityMethodDispatch()
+   local values = array<int> { 10, 20, 30 }
+   local dynamic_values:any = values
+   assert(values.indexOf(20) is 1 and array.indexOf(values, 30) is 2,
+      'array.indexOf should support method and receiver-first calls')
+   assert(dynamic_values.findIndex((Value, Index) => Value is 20 and Index is 1) is 1,
+      'a dynamic array receiver should dispatch findIndex at runtime')
+   assert(values.mapSame(Value => Value + 1)[2] is 31,
+      'mapSame should dispatch as a canonical array method')
+
+   local sequence = {10 to 16 by 2}
+   local dynamic_sequence:any = sequence
+   assert(sequence.indexOf(14) is 2 and range.indexOf(sequence, 12) is 1,
+      'range.indexOf should support method and receiver-first calls')
+   assert(dynamic_sequence.findIndex((Value, Ordinal) => Value is 14 and Ordinal is 2) is 2,
+      'a dynamic range receiver should dispatch findIndex at runtime')
 end

--- a/src/tiri/tests/test_builtin_methods.tiri
+++ b/src/tiri/tests/test_builtin_methods.tiri
@@ -328,6 +328,9 @@ end
    local dynamic_values:any = values
    assert(values.indexOf(20) is 1 and array.indexOf(values, 30) is 2,
       'array.indexOf should support method and receiver-first calls')
+   assert(values.find((Value, Index) => Value > 10 and Index is 1) is 20 and
+      array.find(values, Value => Value > 20) is 30,
+      'array.find should support predicate method and receiver-first calls')
    assert(dynamic_values.findIndex((Value, Index) => Value is 20 and Index is 1) is 1,
       'a dynamic array receiver should dispatch findIndex at runtime')
    assert(values.mapSame(Value => Value + 1)[2] is 31,

--- a/src/tiri/tests/test_ranges.tiri
+++ b/src/tiri/tests/test_ranges.tiri
@@ -1897,9 +1897,9 @@ end
       error("array.fill should reject fractional ranges")
    end
    try
-      data_values.find(2, range(0.5, 4))
+      data_values.indexOf(2, range(0.5, 4))
    success
-      error("array.find should reject fractional ranges")
+      error("array.indexOf should reject fractional ranges")
    end
    try
       tmp = range.slice(data_values, range(0, 4, false, 0.5))
@@ -1942,4 +1942,42 @@ end
       end
    end
    assert(approximately(interpreter_sum, compiled_sum), "JIT and interpreter range sequences should agree")
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Stage A collection compatibility APIs
+
+@Test function RangeIndexOfAndFindIndexUseOrdinals()
+   sequence = {10 to 20 by 2}
+   assert(sequence.indexOf(10) is 0 and sequence.indexOf(16) is 3, 'range.indexOf() should return generated ordinals')
+   assert(sequence.indexOf(17) is nil, 'range.indexOf() should reject unaligned values')
+   assert(sequence.findIndex((Value, Ordinal) => Value > 13 and Ordinal is 2) is 2,
+      'range.findIndex() should pass the generated value and ordinal')
+
+   descending = range(1, 0, true, -0.2)
+   assert(descending.indexOf(0.6) is 2, 'range.indexOf() should retain descending fractional tolerance')
+end
+
+@Test function RangeFunctionalCallbacksReceiveOrdinals()
+   sequence = {10 to 16 by 2}
+   each_ordinals = {}
+   result = sequence.each(function(Value, Ordinal)
+      each_ordinals[Ordinal] = Value
+      if Ordinal is 1 then return false end
+   end)
+   assert(result is sequence and each_ordinals[0] is 10 and each_ordinals[1] is 12 and each_ordinals[2] is nil,
+      'range.each() should pass ordinals, stop on false and return its receiver')
+
+   mapped = sequence.map((Value, Ordinal) => Value + Ordinal, 'int')
+   assert(mapped.type() is 'int' and mapped[0] is 10 and mapped[2] is 16,
+      'range.map() should pass ordinals and honour an explicit destination type')
+
+   reduced = sequence.reduce(0, (Total, Value, Ordinal) => Total + Value + Ordinal)
+   assert(reduced is 39, 'range.reduce() should pass the ordinal as its third callback argument')
+   assert(sequence.any((Value, Ordinal) => Ordinal is 2 and Value is 14),
+      'range.any() should pass an ordinal')
+   assert(sequence.all((Value, Ordinal) => Value is 10 + Ordinal * 2),
+      'range.all() should pass an ordinal')
+   assert(sequence.find((Value, Ordinal) => Ordinal is 1) is 12,
+      'range.find() should pass an ordinal')
 end

--- a/src/tiri/tests/test_ranges.tiri
+++ b/src/tiri/tests/test_ranges.tiri
@@ -1945,7 +1945,7 @@ end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Stage A collection compatibility APIs
+-- Final collection APIs
 
 @Test function RangeIndexOfAndFindIndexUseOrdinals()
    sequence = {10 to 20 by 2}

--- a/src/tiri/tests/test_type_guided_emission.tiri
+++ b/src/tiri/tests/test_type_guided_emission.tiri
@@ -112,7 +112,7 @@ end
    end
 
    local clone = alias.clone()
-   local mapped = clone.map(Value => Value * 2)
+   local mapped = clone.mapSame(Value => Value * 2)
    local returned = make_number_array()
    assert(captured_sum() is 12, 'Array element descriptors should survive immutable capture and iteration')
    assert(mapped[2] is 12, 'Array element descriptors should survive preserving methods')

--- a/tools/benchmark/benchmark_array.tiri
+++ b/tools/benchmark/benchmark_array.tiri
@@ -191,20 +191,20 @@ end
    local checksum = 0
    for i in {0 to 1000} do
       -- Find in integer array
-      local idx1 = int_arr.find(0)
-      local idx2 = int_arr.find(5000)
-      local idx3 = int_arr.find(9990)
-      local idx4 = int_arr.find(12345)  -- Not found
+      local idx1 = int_arr.indexOf(0)
+      local idx2 = int_arr.indexOf(5000)
+      local idx3 = int_arr.indexOf(9990)
+      local idx4 = int_arr.indexOf(12345)  -- Not found
 
       -- Find in double array
-      local idx5 = dbl_arr.find(0.0)
-      local idx6 = dbl_arr.find(750.0)
-      local idx7 = dbl_arr.find(999.999)  -- Not found
+      local idx5 = dbl_arr.indexOf(0.0)
+      local idx6 = dbl_arr.indexOf(750.0)
+      local idx7 = dbl_arr.indexOf(999.999)  -- Not found
 
       -- Find in string array
-      local idx8 = str_arr.find("apple")
-      local idx9 = str_arr.find("grape")
-      local idx10 = str_arr.find("mango")  -- Not found
+      local idx8 = str_arr.indexOf("apple")
+      local idx9 = str_arr.indexOf("grape")
+      local idx10 = str_arr.indexOf("mango")  -- Not found
       checksum += (idx1 is nil ? -1 : idx1) + (idx2 is nil ? -1 : idx2) +
          (idx3 is nil ? -1 : idx3) + (idx4 is nil ? -1 : idx4) +
          (idx5 is nil ? -1 : idx5) + (idx6 is nil ? -1 : idx6) +
@@ -621,8 +621,8 @@ end
       end
 
       -- Find values
-      local idx1 = arr.find(5000)
-      local idx2 = arr.find(9999)
+      local idx1 = arr.indexOf(5000)
+      local idx2 = arr.indexOf(9999)
 
       -- Check contains
       local has1 = 5000 in arr


### PR DESCRIPTION
## Summary
- add Stage A array and range collection APIs, deprecation diagnostics, descriptors, and callable metadata
- finalise predicate-based `array.find()` and retain equality search via `array.indexOf()`
- expand parser and collection API coverage, including typed mapping paths

## Testing
- Not run (creating PR from existing pushed commits).