### PR TITLE
Enhance runtime contract caching and array equality handling

### DIFF
--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -24,9 +24,10 @@
 #include "lj_array.h"
 #include "lj_bulk.h"
 #include "lj_meta.h"
+#include "lj_state.h"
 #include "lj_struct.h"
+#include "lj_vm.h"
 #include "lj_vmarray.h"
-#include "stack_helpers.h"
 #include "lib.h"
 #include "lib_utils.h"
 #include "lib_range.h"
@@ -1527,8 +1528,38 @@ static bool array_values_equal(lua_State *L, GCarray *Array, MSize Index)
 
    if (not equal and itype(element) IS itype(candidate) and
        (tvistab(element) or tvisudata(element))) {
-      TValue *base = lj_meta_equal(L, gcV(element), gcV(candidate), 0);
-      equal = uintptr_t(base) > 1 and tvistruecond(MetaCall::invoke(L, base, 2, 1));
+      cTValue *method = lj_meta_fast(L, tabref(gcV(element)->gch.metatable), MM_eq);
+      if (method) {
+         if (tabref(gcV(element)->gch.metatable) != tabref(gcV(candidate)->gch.metatable)) {
+            cTValue *candidate_method = lj_meta_fast(L, tabref(gcV(candidate)->gch.metatable), MM_eq);
+            if (candidate_method IS nullptr or not lj_obj_equal(method, candidate_method)) method = nullptr;
+         }
+
+         if (method) {
+            copyTV(L, L->top++, method);
+            setnilV(L->top++);
+            TValue *base = L->top;
+            [[maybe_unused]] size_t context_depth = lj_context_depth(L);
+            size_t context_size = L->context_stack.size();
+            if (tvistab(element)) {
+               copyTV(L, L->top++, candidate);
+               element = restorestack(L, saved_top);
+               [[maybe_unused]] uint32_t argument_count =
+                  lj_context_prepare_metamethod_call(L, element, base, 1, 2);
+               lj_assertL(argument_count IS 1, "table equality metamethod retained its receiver argument");
+            }
+            else {
+               copyTV(L, L->top++, element);
+               copyTV(L, L->top++, candidate);
+            }
+            int call_error = lj_vm_pcall(L, base, 2, -1);
+            lj_context_restore_depth(L, context_size);
+            if (call_error) lua_error(L);
+            lj_assertL(lj_context_depth(L) IS context_depth,
+               "equality metamethod returned with an unbalanced context");
+            equal = tvistruecond(L->top - 1);
+         }
+      }
    }
 
    L->top = restorestack(L, saved_top);

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -2573,6 +2573,21 @@ static bool test_runtime_contract_batching(kt::Log &Log)
    }
    lua_pop(lua, 1);
 
+   GCproto *type_test = compile_child(
+      "return function(Value:any):bool return Value is <array int> end\n", "cached-type-test");
+   const RuntimeContractCache *type_test_cache = type_test ? proto_contract_cache(type_test) : nullptr;
+   const CachedRuntimeContractRecord *type_test_records =
+      type_test_cache ? runtime_contract_cache_records(type_test_cache) : nullptr;
+   const CachedRuntimeContractEntry *type_test_entries =
+      type_test_cache ? runtime_contract_cache_entries(type_test_cache) : nullptr;
+   if (not type_test_cache or type_test_cache->record_count != 1 or type_test_cache->entry_count != 1 or
+       bc_op(proto_bc(type_test)[type_test_records[0].bytecode_position]) != BC_TYPETEST or
+       type_test_entries[0].type != TiriType::Array) {
+      Log.error("a native type test did not build a reusable runtime contract cache entry");
+      return false;
+   }
+   lua_pop(lua, 1);
+
    GCproto *wide = compile_child(
       "return function(A:num, B:num, C:num, D:num, E:num, F:num, G:num, H:num, I:num) return A end\n",
       "wide-parameter-contracts");

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -1179,30 +1179,53 @@ extern "C" void lj_meta_type_test_pc(lua_State *L, const BCIns *PC)
    if (bc_op(instruction) != BC_TYPETEST) lj_err_callermsg(L, "invalid type-test resume point");
 
    GCstr *encoded = gco_to_string(proto_kgc(prototype, ~(ptrdiff_t)bc_d(instruction)));
-   RuntimeContractDescriptor descriptor;
-   decode_contract_or_error(L, encoded, descriptor);
-   if (descriptor.contract_count != 1) lj_err_callermsg(L, "invalid type-test descriptor");
+   RuntimeContractEntry decoded_entry;
+   const RuntimeContractEntry *entry;
+   const CachedRuntimeContractEntry *cached_entries = nullptr;
+   uint32_t bytecode_position = uint32_t((PC - 1) - proto_bc(prototype));
+   const CachedRuntimeContractRecord *cached_record =
+      find_cached_contract(prototype, bytecode_position, cached_entries);
+   if (cached_record and cached_record->contract_count IS 1) {
+      const CachedRuntimeContractEntry &cached = cached_entries[0];
+      decoded_entry.type = cached.type;
+      decoded_entry.array_element_type = cached.array_element_type;
+      decoded_entry.flags = cached.flags;
+      decoded_entry.position = cached.position;
+      if (cached.type IS TiriType::Object) decoded_entry.object_class_id = CLASSID(cached.object_class_id);
+      else if (cached.type IS TiriType::Struct or
+               (cached.type IS TiriType::Array and cached.array_element_type IS AET::STRUCT)) {
+         decoded_entry.constraint_name = cached_contract_text(encoded, cached.constraint_offset);
+      }
+      decoded_entry.label = cached_contract_text(encoded, cached.label_offset);
+      entry = &decoded_entry;
+   }
+   else {
+      RuntimeContractDescriptor descriptor;
+      decode_contract_or_error(L, encoded, descriptor);
+      if (descriptor.contract_count != 1) lj_err_callermsg(L, "invalid type-test descriptor");
+      decoded_entry = descriptor.entries[0];
+      entry = &decoded_entry;
+   }
 
-   RuntimeContractEntry &entry = descriptor.entries[0];
    TValue *value = L->base + bc_a(instruction);
    bool matched;
    if (lj_is_thunk(value)) {
       ThunkPayload *payload = thunk_payload(udataV(value));
-      if (entry.type IS TiriType::Any) matched = true;
-      else if (payload->resolved) matched = contract_matches(L, &payload->cached_value, entry);
+      if (entry->type IS TiriType::Any) matched = true;
+      else if (payload->resolved) matched = contract_matches(L, &payload->cached_value, *entry);
       else if (payload->expected_type != 0xff and
-          entry.object_class_id IS CLASSID::NIL and entry.constraint_name.empty() and
-          (entry.type != TiriType::Array or entry.array_element_type IS AET::ANY)) {
-         matched = entry.type IS TiriType(payload->expected_type);
+          entry->object_class_id IS CLASSID::NIL and entry->constraint_name.empty() and
+          (entry->type != TiriType::Array or entry->array_element_type IS AET::ANY)) {
+         matched = entry->type IS TiriType(payload->expected_type);
       }
       else {
          TValue *resolved = lj_thunk_resolve(L, udataV(value));
          value = L->base + bc_a(instruction);
-         matched = contract_matches(L, resolved, entry);
+         matched = contract_matches(L, resolved, *entry);
       }
    }
-   else matched = contract_matches(L, value, entry);
-   if ((entry.flags & contract_flag(ContractEntryFlag::Negated)) != 0) matched = not matched;
+   else matched = contract_matches(L, value, *entry);
+   if ((entry->flags & contract_flag(ContractEntryFlag::Negated)) != 0) matched = not matched;
    setboolV(value, matched);
 }
 
@@ -1214,7 +1237,7 @@ void lj_contract_build_cache(lua_State *L, GCproto *Prototype)
    uint16_t entry_count = 0;
    for (uint32_t i = 1; i < Prototype->sizebc; ++i) {
       BCIns instruction = proto_bc(Prototype)[i];
-      if (bc_op(instruction) != BC_CONTRACT) continue;
+      if (bc_op(instruction) != BC_CONTRACT and bc_op(instruction) != BC_TYPETEST) continue;
 
       GCobj *constant = proto_kgc(Prototype, ~(ptrdiff_t)bc_d(instruction));
       if (constant->gch.gct != uint8_t(~LJ_TSTR)) continue;
@@ -1245,7 +1268,7 @@ void lj_contract_build_cache(lua_State *L, GCproto *Prototype)
    uint16_t entry_index = 0;
    for (uint32_t i = 1; i < Prototype->sizebc; ++i) {
       BCIns instruction = proto_bc(Prototype)[i];
-      if (bc_op(instruction) != BC_CONTRACT) continue;
+      if (bc_op(instruction) != BC_CONTRACT and bc_op(instruction) != BC_TYPETEST) continue;
 
       GCobj *constant = proto_kgc(Prototype, ~(ptrdiff_t)bc_d(instruction));
       if (constant->gch.gct != uint8_t(~LJ_TSTR)) continue;

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -2479,8 +2479,22 @@ end
    }
    local first = setmetatable({ id=7 }, equality_mt)
    local second = setmetatable({ id=7 }, equality_mt)
-   local values = array<table> { first }
+   local values = array<any> { first }
    assert(values.indexOf(second) is 0, 'indexOf() should honour the same equality metamethod as is')
+end
+
+@Test function IndexOfPropagatesEqualityMetamethodErrors()
+   local equality_mt = {
+      __eq = function(First:table!, Second:table!):bool return First.id is Second.id end
+   }
+   local values = array<any> { setmetatable({ id=1 }, equality_mt) }
+   local error_caught = false
+   try
+      values.indexOf(setmetatable({ id=1 }, equality_mt))
+   except error_value
+      error_caught = true
+   end
+   assert(error_caught, 'indexOf() should propagate equality metamethod errors to the caller')
 end
 
 @Test function FindUsesPredicateDuringStageB()

--- a/tools/benchmark/benchmark_language.tiri
+++ b/tools/benchmark/benchmark_language.tiri
@@ -482,50 +482,53 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- TYPE OPERATIONS
 ----------------------------------------------------------------------------------------------------------------------
--- Goal: Measure overhead of type() function calls
+-- Goal: Compare native type tests with type() string comparisons
 
-@Test function TypeCheckType()
+@Test function TypeCheckNativeCMP()
    -- Create values of different types
    local num_int = 42
-   local num_float = 3.14159
    local str = "hello"
    local tbl = { a = 1, b = 2 }
-   local arr = array<int> { 1, 2, 3 }
    local func = function() return 1 end
    local bool_true = true
-   local bool_false = false
-   local nil_val = nil
 
    local acc = 0
-   for i in {0 to 10000} do
-      -- Check type of numbers
-      local t1 = type(num_int)
-      local t2 = type(num_float)
-      local t3 = type(i)
+   for i in {0 to 200000} do
+      -- Type comparisons
+      local is_num = num_int is <num>
+      local is_str = str is <str>
+      local is_tbl = tbl is <table>
+      local is_func = func is <func>
+      local is_bool = bool_true is <bool>
 
-      -- Check type of strings
-      local t4 = type(str)
-      local t5 = type("literal")
+      -- Conditional based on type
+      local val = (i % 3 is 0) and str or (i % 3 is 1 and num_int or tbl)
+      if val is <str> then
+         acc += #val
+      elseif val is <num> then
+         acc += val * 2
+      elseif val is <table> then
+         acc += val.a
+      end
 
-      -- Check type of tables
-      local t6 = type(tbl)
-      local t7 = type({})
+      -- Consume the type results so that the loop body cannot be eliminated by the JIT
+      acc += (is_num and 1 or 0) + (is_str and 1 or 0) + (is_tbl and 1 or 0) +
+             (is_func and 1 or 0) + (is_bool and 1 or 0)
+   end
 
-      -- Check type of arrays
-      local t8 = type(arr)
+   return acc
+end
 
-      -- Check type of functions
-      local t9 = type(func)
-      local t10 = type(function() end)
+@Test function TypeCheckTypeCMP()
+   -- Create values of different types
+   local num_int = 42
+   local str = "hello"
+   local tbl = { a = 1, b = 2 }
+   local func = function() return 1 end
+   local bool_true = true
 
-      -- Check type of booleans
-      local t11 = type(bool_true)
-      local t12 = type(bool_false)
-
-      -- Check type of nil
-      local t13 = type(nil_val)
-      local t14 = type(nil)
-
+   local acc = 0
+   for i in {0 to 200000} do
       -- Type comparisons
       local is_num = type(num_int) is "number"
       local is_str = type(str) is "string"
@@ -534,7 +537,7 @@ end
       local is_bool = type(bool_true) is "bool"
 
       -- Conditional based on type
-      local val = i % 3 is 0 and str or (i % 3 is 1 and num_int or tbl)
+      local val = (i % 3 is 0) and str or (i % 3 is 1 and num_int or tbl)
       if type(val) is "string" then
          acc += #val
       elseif type(val) is "number" then
@@ -544,7 +547,6 @@ end
       end
 
       -- Consume the type results so that the loop body cannot be eliminated by the JIT
-      acc += #t1 + #t2 + #t3 + #t4 + #t5 + #t6 + #t7 + #t8 + #t9 + #t10 + #t11 + #t12 + #t13 + #t14
       acc += (is_num and 1 or 0) + (is_str and 1 or 0) + (is_tbl and 1 or 0) +
              (is_func and 1 or 0) + (is_bool and 1 or 0)
    end


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to native type tests, contract caching, and array equality handling, as well as updates to benchmarks and tests to validate and measure these changes. The main themes are enhancements to the runtime contract system, improved handling of equality metamethods, and updated benchmarks to compare native and string-based type checks.

**Runtime contract and type test improvements:**

* Extended contract caching and lookup to support both `BC_CONTRACT` and `BC_TYPETEST` bytecodes, improving performance and correctness for native type tests (`lj_contract_build_cache`, `lj_meta_type_test_pc`). [[1]](diffhunk://#diff-e63cfc3af099603dea172339bdb1ed67a1df59af6cf5e85cf5078547200c97e5L1217-R1240) [[2]](diffhunk://#diff-e63cfc3af099603dea172339bdb1ed67a1df59af6cf5e85cf5078547200c97e5L1248-R1271)
* Updated the runtime type test handler to use cached contract entries when available, falling back to decoding as needed, and refactored logic to work with pointer-based contract entries.

**Array equality and metamethod handling:**

* Refactored `array_values_equal` to more robustly handle equality metamethods, including proper error propagation and context management, and to ensure that equality is only considered when both metatables agree on the `__eq` method.
* Added a new test to verify that errors raised in equality metamethods are properly propagated by `array.indexOf`.

**Benchmark and test updates:**

* Rewrote the type checking benchmark to compare native type tests (`is <type>`) with string-based type checks (`type(x) is "type"`), providing better performance insights. [[1]](diffhunk://#diff-a18412c19f8206d03e4d60ac6963d2479b821ecb4875b1f04565050be359d14cL485-R531) [[2]](diffhunk://#diff-a18412c19f8206d03e4d60ac6963d2479b821ecb4875b1f04565050be359d14cL537-R540) [[3]](diffhunk://#diff-a18412c19f8206d03e4d60ac6963d2479b821ecb4875b1f04565050be359d14cL547)
* Added a parser unit test to ensure that native type tests generate reusable contract cache entries.

**Code maintenance:**

* Updated includes in `lib_array.cpp` to remove unused headers and add necessary ones for consistency.

These changes collectively improve type checking performance, correctness of equality operations, and test coverage for contracts and arrays.