### PR TITLE
[Tiri] Corrected variant array membership equality

### DIFF
--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -1518,20 +1518,21 @@ LJLIB_CF(array_fill)
 //
 // Returns: index of first occurrence, or nil if not found
 
-static bool array_values_equal(lua_State *L, GCarray *Array, MSize Index)
+static bool array_values_equal(lua_State *L, GCarray *Array, MSize Index, cTValue *Candidate)
 {
    ptrdiff_t saved_top = savestack(L, L->top);
+   TValue candidate_copy;
+   copyTV(L, &candidate_copy, Candidate);
    array_push_element(L, Array, Index);
    TValue *element = L->top - 1;
-   cTValue *candidate = L->base + 1;
-   bool equal = lj_obj_equal(element, candidate) != 0;
+   bool equal = lj_obj_equal(element, &candidate_copy) != 0;
 
-   if (not equal and itype(element) IS itype(candidate) and
+   if (not equal and itype(element) IS itype(&candidate_copy) and
        (tvistab(element) or tvisudata(element))) {
       cTValue *method = lj_meta_fast(L, tabref(gcV(element)->gch.metatable), MM_eq);
       if (method) {
-         if (tabref(gcV(element)->gch.metatable) != tabref(gcV(candidate)->gch.metatable)) {
-            cTValue *candidate_method = lj_meta_fast(L, tabref(gcV(candidate)->gch.metatable), MM_eq);
+         if (tabref(gcV(element)->gch.metatable) != tabref(gcV(&candidate_copy)->gch.metatable)) {
+            cTValue *candidate_method = lj_meta_fast(L, tabref(gcV(&candidate_copy)->gch.metatable), MM_eq);
             if (candidate_method IS nullptr or not lj_obj_equal(method, candidate_method)) method = nullptr;
          }
 
@@ -1542,7 +1543,7 @@ static bool array_values_equal(lua_State *L, GCarray *Array, MSize Index)
             [[maybe_unused]] size_t context_depth = lj_context_depth(L);
             size_t context_size = L->context_stack.size();
             if (tvistab(element)) {
-               copyTV(L, L->top++, candidate);
+               copyTV(L, L->top++, &candidate_copy);
                element = restorestack(L, saved_top);
                [[maybe_unused]] uint32_t argument_count =
                   lj_context_prepare_metamethod_call(L, element, base, 1, 2);
@@ -1550,7 +1551,7 @@ static bool array_values_equal(lua_State *L, GCarray *Array, MSize Index)
             }
             else {
                copyTV(L, L->top++, element);
-               copyTV(L, L->top++, candidate);
+               copyTV(L, L->top++, &candidate_copy);
             }
             int call_error = lj_vm_pcall(L, base, 2, -1);
             lj_context_restore_depth(L, context_size);
@@ -1566,19 +1567,20 @@ static bool array_values_equal(lua_State *L, GCarray *Array, MSize Index)
    return equal;
 }
 
-static int32_t array_find_generic(lua_State *L, GCarray *Array, int32_t Start, int32_t Stop, int32_t Step)
+static int32_t array_find_generic(lua_State *L, GCarray *Array, cTValue *Candidate, int32_t Start, int32_t Stop,
+   int32_t Step)
 {
    MSize length = Array->len;
    if (Step > 0) {
       for (int32_t index = Start; index <= Stop and MSize(index) < length; index += Step) {
          if (MSize(index) >= Array->len) break;
-         if (array_values_equal(L, Array, MSize(index))) return index;
+         if (array_values_equal(L, Array, MSize(index), Candidate)) return index;
       }
    }
    else {
       for (int32_t index = Start; index >= Stop and index >= 0 and MSize(index) < length; index += Step) {
          if (MSize(index) >= Array->len) break;
-         if (array_values_equal(L, Array, MSize(index))) return index;
+         if (array_values_equal(L, Array, MSize(index), Candidate)) return index;
       }
    }
    return -1;
@@ -1642,13 +1644,13 @@ static int array_index_of(lua_State *L)
    if (tiri_range *r = check_range(L, 3)) {
       auto span = array_range_to_span(L, r, arr->len);
       if (span.empty) return array_push_find_result(L, -1);
-      return array_push_find_result(L, array_find_generic(L, arr, span.start, span.stop, span.step));
+      return array_push_find_result(L, array_find_generic(L, arr, L->base + 1, span.start, span.stop, span.step));
    }
 
    auto start = lj_lib_optint(L, 3, 0);
    if (not array_find_start(start, arr->len, &start)) return array_push_find_result(L, -1);
    if (start >= stop) return array_push_find_result(L, -1);
-   return array_push_find_result(L, array_find_generic(L, arr, start, stop - 1, 1));
+   return array_push_find_result(L, array_find_generic(L, arr, L->base + 1, start, stop - 1, 1));
 }
 
 static int array_find_predicate(lua_State *L, bool ReturnIndex);
@@ -1703,13 +1705,17 @@ extern "C" int32_t lj_arr_contains(lua_State *L, GCarray *Array, cTValue *Candid
       return lj_arr_find_str(Array, candidate_string, 0, int32_t(Array->len - 1), 1) >= 0;
    }
 
-   TValue converted;
-   auto candidate_number = try_to_number(Candidate, &converted);
-   if (not candidate_number) {
-      lj_err_argv(L, 2, ErrMsg::BADTYPE, "number", lj_typename(Candidate));
-      return 0;
+   if (glArrayConversion[size_t(Array->elemtype)].primitive) {
+      TValue converted;
+      auto candidate_number = try_to_number(Candidate, &converted);
+      if (not candidate_number) {
+         lj_err_argv(L, 2, ErrMsg::BADTYPE, "number", lj_typename(Candidate));
+         return 0;
+      }
+      return lj_arr_find_num(Array, *candidate_number, 0, int32_t(Array->len - 1), 1) >= 0;
    }
-   return lj_arr_find_num(Array, *candidate_number, 0, int32_t(Array->len - 1), 1) >= 0;
+
+   return array_find_generic(L, Array, Candidate, 0, int32_t(Array->len - 1), 1) >= 0;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -28,6 +28,7 @@
 #include "lj_struct.h"
 #include "lj_vm.h"
 #include "lj_vmarray.h"
+#include "stack_helpers.h"
 #include "lib.h"
 #include "lib_utils.h"
 #include "lib_range.h"
@@ -1570,20 +1571,32 @@ static bool array_values_equal(lua_State *L, GCarray *Array, MSize Index, cTValu
 static int32_t array_find_generic(lua_State *L, GCarray *Array, cTValue *Candidate, int32_t Start, int32_t Stop,
    int32_t Step)
 {
+   ptrdiff_t saved_top = savestack(L, L->top);
+   copyTV(L, L->top, Candidate);
+   incr_top(L);
+   ptrdiff_t candidate_offset = savestack(L, L->top - 1);
    MSize length = Array->len;
+   int32_t result = -1;
    if (Step > 0) {
       for (int32_t index = Start; index <= Stop and MSize(index) < length; index += Step) {
          if (MSize(index) >= Array->len) break;
-         if (array_values_equal(L, Array, MSize(index), Candidate)) return index;
+         if (array_values_equal(L, Array, MSize(index), restorestack(L, candidate_offset))) {
+            result = index;
+            break;
+         }
       }
    }
    else {
       for (int32_t index = Start; index >= Stop and index >= 0 and MSize(index) < length; index += Step) {
          if (MSize(index) >= Array->len) break;
-         if (array_values_equal(L, Array, MSize(index), Candidate)) return index;
+         if (array_values_equal(L, Array, MSize(index), restorestack(L, candidate_offset))) {
+            result = index;
+            break;
+         }
       }
    }
-   return -1;
+   L->top = restorestack(L, saved_top);
+   return result;
 }
 
 static int array_index_of(lua_State *L)
@@ -1715,6 +1728,7 @@ extern "C" int32_t lj_arr_contains(lua_State *L, GCarray *Array, cTValue *Candid
       return lj_arr_find_num(Array, *candidate_number, 0, int32_t(Array->len - 1), 1) >= 0;
    }
 
+   VMHelperGuard guard(L);
    return array_find_generic(L, Array, Candidate, 0, int32_t(Array->len - 1), 1) >= 0;
 }
 

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -3521,9 +3521,14 @@ static void rec_contains(jit_State *J, RecordOps *ops)
             }
             result_ref = lj_ir_call(J, IRCALL_lj_arr_contains_num, ix->val, candidate_ref);
          }
-         else {
+         else if (array->elemtype IS AET::STR_GC or array->elemtype IS AET::OBJECT or
+             glArrayConversion[size_t(array->elemtype)].primitive) {
             TRef candidate_ref = rec_tmpref(J, ix->key, IRTMPREF_IN1);
             result_ref = lj_ir_call(J, IRCALL_lj_arr_contains, ix->val, candidate_ref);
+         }
+         else {
+            // Variant and reference equality may invoke __eq, which cannot re-enter the VM from a native trace call.
+            lj_trace_err(J, LJ_TRERR_NYICALL);
          }
          emitir(IRTG(IR_NE, IRT_INT), result_ref, lj_ir_kint(J, 0));
          rec_comp_fixup(J, J->pc, int(ops->op) & 1);

--- a/src/tiri/tests/test_contains.tiri
+++ b/src/tiri/tests/test_contains.tiri
@@ -94,6 +94,54 @@ end
    assert(matches is 100, 'Variant array membership should remain correct after reaching the JIT threshold')
 end
 
+@Test function VariantArrayMembershipRootsCandidateAcrossStackGrowth()
+   function grow_stack(Depth:num):bool
+      if Depth is 0 then return true end
+      return grow_stack(Depth - 1)
+   end
+
+   local equality_mt = {
+      __eq = function(Other:table!):bool
+         if &id is 1 then grow_stack(500) end
+         return &id is Other.id
+      end
+   }
+   local first = setmetatable({ id=1 }, equality_mt)
+   local second = setmetatable({ id=2 }, equality_mt)
+   local probe = setmetatable({ id=2 }, equality_mt)
+   local items = array<any> { first, second }
+
+   assert(probe in items,
+      'Variant array membership should retain its candidate when an earlier comparison relocates the stack')
+end
+
+function interpreted_variant_membership(Items:array<any>, Probe:table):bool
+   local v00, v01, v02, v03, v04, v05, v06, v07 = 0, 1, 2, 3, 4, 5, 6, 7
+   local v08, v09, v10, v11, v12, v13, v14, v15 = 8, 9, 10, 11, 12, 13, 14, 15
+   local v16, v17, v18, v19, v20, v21, v22, v23 = 16, 17, 18, 19, 20, 21, 22, 23
+   local v24, v25, v26, v27, v28, v29, v30, v31 = 24, 25, 26, 27, 28, 29, 30, 31
+   local found = Probe in Items
+   assert(v00 is 0 and v07 is 7 and v15 is 15 and v23 is 23 and v31 is 31,
+      'Interpreted membership should preserve live frame slots')
+   return found
+end
+
+@Test function InterpretedVariantMembershipSynchronisesVMTop()
+   jit.off()
+   defer jit.on() end
+
+   local equality_mt = {
+      __eq = function(Other:table!):bool return &id is Other.id end
+   }
+   local first = setmetatable({ id=1 }, equality_mt)
+   local second = setmetatable({ id=2 }, equality_mt)
+   local probe = setmetatable({ id=2 }, equality_mt)
+   local items = array<any> { first, second }
+
+   assert(interpreted_variant_membership(items, probe),
+      'Interpreted variant membership should enter re-entrant equality with a valid VM top')
+end
+
 @Test function LegacyBuiltinMembershipApisAreUnavailable()
    assert(array.contains is nil and string.contains is nil and range.contains is nil,
       'Built-in membership APIs must not remain publicly callable')

--- a/src/tiri/tests/test_contains.tiri
+++ b/src/tiri/tests/test_contains.tiri
@@ -67,6 +67,33 @@ end
 
 end
 
+@Test function VariantArrayMembershipUsesEqualitySemantics()
+   local equality_mt = {
+      __eq = function(Other:table!):bool return &id is Other.id end
+   }
+   local first = setmetatable({ id=1 }, equality_mt)
+   local second = setmetatable({ id=2 }, equality_mt)
+   local probe = setmetatable({ id=2 }, equality_mt)
+   local values = array<any> { first, second }
+
+   assert(first in values, 'Variant array membership should find an identical reference')
+   assert(probe in values,
+      'Variant array membership should honour reference equality metamethods')
+   assert(not (setmetatable({ id=3 }, equality_mt) in values),
+      'Variant array membership should reject a non-matching reference')
+
+   local plain = { id=4 }
+   local plain_values = array<any> { plain }
+   assert(plain in plain_values and not ({ id=4 } in plain_values),
+      'Variant array membership should use identity when no equality metamethod exists')
+
+   local matches = 0
+   for _ in {0 to 100} do
+      if probe in values then matches++ end
+   end
+   assert(matches is 100, 'Variant array membership should remain correct after reaching the JIT threshold')
+end
+
 @Test function LegacyBuiltinMembershipApisAreUnavailable()
    assert(array.contains is nil and string.contains is nil and range.contains is nil,
       'Built-in membership APIs must not remain publicly callable')


### PR DESCRIPTION
* Evaluated variant array candidates using identity and compatible equality metamethods
* Preserved JIT behaviour by declining trace compilation when variant equality may re-enter the VM
* Added coverage for variant array membership and JIT execution