### PR TITLE
[Tiri] Added defer support during error unwinding

### DIFF
--- a/src/tiri/jit/src/bytecode/lj_bc.h
+++ b/src/tiri/jit/src/bytecode/lj_bc.h
@@ -304,7 +304,10 @@ constexpr uint8_t  NO_REG = BCMAX_A;
   _(ISNIN,     var,  ___, var, contains) \
   /* Lexical automatic native error promotion. */ \
   _(CHECKALLENTER, base, ___, ___, ___) \
-  _(CHECKALLLEAVE, base, ___, ___, ___)
+  _(CHECKALLLEAVE, base, ___, ___, ___) \
+  /* Runtime defer registration. Appended to preserve existing opcode numbers. */ \
+  _(DEFERARM,      var,  lit, lit, ___) \
+  _(DEFERCONSUME,  var,  ___, ___, ___)
 
 // Bytecode opcode numbers.
 // Explicitly enumerated for debugger visibility and easy value lookup.
@@ -486,8 +489,10 @@ typedef enum {
    BC_ISNIN = 137,
    BC_CHECKALLENTER = 138,
    BC_CHECKALLLEAVE = 139,
+   BC_DEFERARM = 140,
+   BC_DEFERCONSUME = 141,
 
-   BC__MAX   = 140
+   BC__MAX   = 142
 } BCOp;
 
 [[nodiscard]] inline constexpr bool bc_is_func_header(BCOp Op) noexcept

--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -51,10 +51,10 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // identities with uint8, uint16, uint32 and uint64.  Version 0x93 gives int8 its own signed array member identity.
 // Version 0x96 adds BC_ISIN and BC_ISNIN. Version 0x97 adds rawtype and shifts the generated fast-function ordering.
 // Version 0x98 adds forEach and shifts the generated fast-function ordering.  Version 0x99 adds the Stage A array
-// and range collection compatibility callables. Version 0x9a adds BC_CHECKALLENTER and BC_CHECKALLLEAVE. Older chunks
-// are rejected rather than retaining compatibility shims.
+// and range collection compatibility callables. Version 0x9a adds BC_CHECKALLENTER and BC_CHECKALLLEAVE. Version 0x9b
+// adds BC_DEFERARM and BC_DEFERCONSUME. Older chunks are rejected rather than retaining compatibility shims.
 
-constexpr uint8_t BCDUMP_VERSION = 0x9a;
+constexpr uint8_t BCDUMP_VERSION = 0x9b;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/bytecode/lj_bcread.cpp
+++ b/src/tiri/jit/src/bytecode/lj_bcread.cpp
@@ -342,6 +342,18 @@ static void bcread_bytecode(LexState *State, GCproto *pt, MSize sizebc)
          BCREG slot = bc_a(bc[i]);
          if (slot >= pt->framesize or slot >= 64) bcread_error(State, ErrMsg::BCBAD);
       }
+      else if (op IS BC_DEFERARM) {
+         BCREG callable_slot = bc_a(bc[i]);
+         BCREG scope_base = bc_b(bc[i]);
+         BCREG argument_count = bc_c(bc[i]);
+         if (callable_slot >= pt->framesize or scope_base > callable_slot or
+             callable_slot + argument_count >= pt->framesize) {
+            bcread_error(State, ErrMsg::BCBAD);
+         }
+      }
+      else if (op IS BC_DEFERCONSUME) {
+         if (bc_a(bc[i]) >= pt->framesize) bcread_error(State, ErrMsg::BCBAD);
+      }
       else if (op IS BC_VIEW) {
          if (bc_a(bc[i]) != 0 or bc_d(bc[i]) > 1) bcread_error(State, ErrMsg::BCBAD);
       }

--- a/src/tiri/jit/src/debug/lj_err.cpp
+++ b/src/tiri/jit/src/debug/lj_err.cpp
@@ -139,34 +139,34 @@ extern "C" void lj_err_prepare_foreign_exception(lua_State *L, const char *Messa
 }
 
 //********************************************************************************************************************
-// Call __close handlers for to-be-closed locals during error unwinding.
+// Call cleanup handlers for locals during error unwinding.
 // The active error is held in protected per-thread state while each handler runs. Normal bytecode scope exits use the
-// dedicated BC_CLOSE path, while error unwinding calls lj_meta_close() directly with this value.
-// Returns the error object to propagate (may be updated if a __close handler throws).
-// Per Lua 5.4: if a __close handler throws, that error replaces the original,
-// but all other pending __close handlers are still called.
+// dedicated cleanup bytecodes, while error unwinding invokes protected close and defer helpers directly.
+// Per Lua 5.4-style cleanup semantics, a handler error replaces the original, but remaining handlers still run.
 
-static TValue* unwind_close_try_block(
+static TValue* unwind_close_range(
+   lua_State *L, TValue *Frame, TValue *ErrorObject, int MinimumSlotIndex, int MaximumSlotIndex);
+static TValue* unwind_cleanup_range(
    lua_State *L, TValue *Frame, TValue *ErrorObject, int MinimumSlotIndex, int MaximumSlotIndex);
 
-static TValue * unwind_close_handlers(lua_State *L, TValue *frame, TValue *errobj)
+static TValue * unwind_cleanup_handlers(lua_State *L, TValue *Frame, TValue *ErrorObject)
 {
-   GCfunc *fn = frame_func(frame);
-   if (not isluafunc(fn)) return errobj;
+   GCfunc *fn = frame_func(Frame);
+   if (not isluafunc(fn)) return ErrorObject;
 
-   ptrdiff_t owner_base = savestack(L, frame + 1);
+   ptrdiff_t owner_base = savestack(L, Frame + 1);
    int upper = LJ_MAX_SLOTS;
    while (not L->context_stack.empty()) {
       const lua_State::ContextFrame &context = L->context_stack.back();
       if (context.owner_kind != lua_State::ContextFrame::OwnerKind::Block or
           context.owner_base != owner_base) break;
-      frame = restorestack(L, owner_base) - 1;
-      errobj = unwind_close_try_block(L, frame, errobj, context.entry_slots, upper);
+      Frame = restorestack(L, owner_base) - 1;
+      ErrorObject = unwind_cleanup_range(L, Frame, ErrorObject, context.entry_slots, upper);
       upper = context.entry_slots;
       lj_context_restore_depth(L, L->context_stack.size() - 1);
    }
-   frame = restorestack(L, owner_base) - 1;
-   return unwind_close_try_block(L, frame, errobj, 0, upper);
+   Frame = restorestack(L, owner_base) - 1;
+   return unwind_cleanup_range(L, Frame, ErrorObject, 0, upper);
 }
 
 //********************************************************************************************************************
@@ -174,7 +174,7 @@ static TValue * unwind_close_handlers(lua_State *L, TValue *frame, TValue *errob
 // (slots created after the try started).  min_slot_index is the slot index (relative to function base) above which
 // to close.  Returns the error object to propagate (may be updated if a __close handler throws).
 
-static TValue* unwind_close_try_block(
+static TValue* unwind_close_range(
    lua_State *L, TValue* Frame, TValue* ErrorObject, int MinimumSlotIndex, int MaximumSlotIndex)
 {
    const ptrdiff_t frame_offset = savestack(L, Frame);
@@ -189,9 +189,9 @@ static TValue* unwind_close_try_block(
    if (closeslots IS 0) return ErrorObject;
 
    lj_assertL(MinimumSlotIndex >= 0,
-      "unwind_close_try_block: min_slot_index negative (%d)", MinimumSlotIndex);
+      "unwind_close_range: min_slot_index negative (%d)", MinimumSlotIndex);
    lj_assertL(MinimumSlotIndex <= LJ_MAX_SLOTS,
-      "unwind_close_try_block: min_slot_index too large (%d)", MinimumSlotIndex);
+      "unwind_close_range: min_slot_index too large (%d)", MinimumSlotIndex);
 
    // A close handler can trigger and catch nested unwinding. Preserve the outer pending value so the enclosing close
    // sequence remains isolated when the nested handler returns.
@@ -207,8 +207,9 @@ static TValue* unwind_close_try_block(
    TValue *base = restorestack(L, frame_offset) + 1;
    Frame = restorestack(L, frame_offset);
    lj_assertL(Frame >= tvref(L->stack) and Frame < tvref(L->maxstack),
-      "unwind_close_try_block: frame out of range (%p)", Frame);
-   lj_assertL(base >= tvref(L->stack) and base <= tvref(L->maxstack), "unwind_close_try_block: base out of range (%p)", base);
+      "unwind_close_range: frame out of range (%p)", Frame);
+   lj_assertL(base >= tvref(L->stack) and base <= tvref(L->maxstack),
+      "unwind_close_range: base out of range (%p)", base);
 
    uint64_t pending_slots = lj_close_take_armed(
       L, restorestack(L, frame_offset) + 1, uint32_t(MinimumSlotIndex), uint32_t(MaximumSlotIndex));
@@ -239,10 +240,70 @@ static TValue* unwind_close_try_block(
 }
 
 //********************************************************************************************************************
-// Call __close handlers for all frames from 'from' down to 'to'.  This must be called BEFORE L->base is modified
-// during unwinding.  If a __close handler throws, the new error replaces the original at L->top - 1.
+// Invoke the registered defers owned by one lexical scope in reverse registration order.
 
-static void unwind_close_all(lua_State *L, TValue *From, TValue *To)
+static TValue * unwind_defer_scope(lua_State *L, TValue *Frame, TValue *ErrorObject, uint32_t MinimumSlotIndex,
+   uint32_t MaximumSlotIndex, uint32_t ScopeBase)
+{
+   ptrdiff_t frame_offset = savestack(L, Frame);
+   bool has_current_err = ErrorObject != nullptr;
+   ptrdiff_t current_err_offset = has_current_err ? savestack(L, ErrorObject) : 0;
+
+   TValue saved_cleanup_error;
+   copyTV(L, &saved_cleanup_error, &L->pending_close_error);
+   if (ErrorObject) copyTV(L, &L->pending_close_error, ErrorObject);
+   else setnilV(&L->pending_close_error);
+
+   DeferRegistration registration;
+   TValue *owner_base = restorestack(L, frame_offset) + 1;
+   while (lj_defer_peek_scope(L, owner_base, MinimumSlotIndex, MaximumSlotIndex, ScopeBase, &registration)) {
+      owner_base = restorestack(L, frame_offset) + 1;
+      int errcode = lj_meta_defer(L, owner_base, registration);
+      if (errcode != 0) {
+         has_current_err = true;
+         current_err_offset = savestack(L, L->top - 1);
+         copyTV(L, &L->pending_close_error, restorestack(L, current_err_offset));
+      }
+      owner_base = restorestack(L, frame_offset) + 1;
+   }
+
+   copyTV(L, &L->pending_close_error, &saved_cleanup_error);
+   return has_current_err ? restorestack(L, current_err_offset) : nullptr;
+}
+
+//********************************************************************************************************************
+// Process lexical cleanup groups from inner to outer.  Each group closes its resources before invoking its defers.
+
+static TValue* unwind_cleanup_range(
+   lua_State *L, TValue *Frame, TValue *ErrorObject, int MinimumSlotIndex, int MaximumSlotIndex)
+{
+   ptrdiff_t frame_offset = savestack(L, Frame);
+   uint32_t minimum_slot = uint32_t(MinimumSlotIndex);
+   uint32_t upper_slot = uint32_t(MaximumSlotIndex);
+   uint32_t scope_base;
+   TValue *error_object = ErrorObject;
+
+   TValue *owner_base = restorestack(L, frame_offset) + 1;
+   while (lj_defer_find_scope(L, owner_base, minimum_slot, uint32_t(MaximumSlotIndex), &scope_base)) {
+      uint32_t lower_slot = scope_base < minimum_slot ? minimum_slot : scope_base;
+      Frame = restorestack(L, frame_offset);
+      error_object = unwind_close_range(L, Frame, error_object, int(lower_slot), int(upper_slot));
+      Frame = restorestack(L, frame_offset);
+      error_object = unwind_defer_scope(
+         L, Frame, error_object, minimum_slot, uint32_t(MaximumSlotIndex), scope_base);
+      upper_slot = lower_slot;
+      owner_base = restorestack(L, frame_offset) + 1;
+   }
+
+   Frame = restorestack(L, frame_offset);
+   return unwind_close_range(L, Frame, error_object, MinimumSlotIndex, int(upper_slot));
+}
+
+//********************************************************************************************************************
+// Call cleanup handlers for all frames from 'from' down to 'to'.  This must be called before L->base is modified.
+// If a handler throws, the new error replaces the original at L->top - 1.
+
+static void unwind_cleanup_all(lua_State *L, TValue *From, TValue *To)
 {
    const ptrdiff_t to_offset = savestack(L, To);
    ptrdiff_t frame_offset = savestack(L, From);
@@ -265,13 +326,13 @@ static void unwind_close_all(lua_State *L, TValue *From, TValue *To)
 
       lj_context_unwind(L, frame + 1);
 
-      // unwind_close_handlers may return a different error if a __close threw
+      // A cleanup handler may return a different error.
 
-      TValue *new_err = unwind_close_handlers(L, frame, errobj);
+      TValue *new_err = unwind_cleanup_handlers(L, frame, errobj);
       const bool has_new_error = new_err != nullptr;
       const ptrdiff_t new_error_offset = has_new_error ? savestack(L, new_err) : 0;
       if (has_new_error and has_error and new_error_offset != error_offset) {
-         // A __close handler threw - update the error at the original location
+         // A cleanup handler threw - update the error at the original location.
          errobj = restorestack(L, error_offset);
          copyTV(L, errobj, new_err);
       }
@@ -295,7 +356,7 @@ static void unwind_close_all(lua_State *L, TValue *From, TValue *To)
    // If we hit the limit, the frame chain is likely corrupt. Log an assertion
    // in debug builds to help diagnose the issue.
 
-   lj_assertL(count < LUAI_MAXCSTACK, "frame chain exceeded LUAI_MAXCSTACK during __close unwinding");
+   lj_assertL(count < LUAI_MAXCSTACK, "frame chain exceeded LUAI_MAXCSTACK during cleanup unwinding");
 
 }
 
@@ -305,6 +366,7 @@ static void unwind_close_all(lua_State *L, TValue *From, TValue *To)
 LJ_NOINLINE static void unwindstack(lua_State *L, TValue *Top)
 {
    lj_context_unwind(L, Top);
+   lj_defer_unwind(L, Top);
    lj_func_closeuv(L, Top);
    if (Top < L->top - 1) {
       copyTV(L, Top, L->top - 1);
@@ -511,17 +573,15 @@ extern "C" void setup_try_handler(lua_State *L)
       try_frame->context_depth <= L->context_stack.size(),
       "saved try context depth is outside the active context stack");
 
-   // Call __close handlers for <close> locals in ALL frames between current position and try block.
-   // This handles <close> variables in nested function calls (e.g., inner() called from try block).
-   // Without this, only the try block's frame would be processed, missing nested frames.
+   // Run cleanup in all nested frames between the current position and the try block.
 
    TValue *errobj = (L->top > saved_top) ? L->top - 1 : nullptr;
-   unwind_close_all(L, L->base - 1, saved_base);  // Close nested frames first
+   unwind_cleanup_all(L, L->base - 1, saved_base);  // Clean nested frames first.
    saved_base = restorestack(L, try_frame->frame_base);
    saved_top = restorestack(L, try_frame->saved_top);
+   lj_defer_unwind(L, saved_base);
 
-   // After unwind_close_all(), re-read the error from L->top - 1 as it may have been updated
-   // by a __close handler that threw. unwind_close_all() updates the error in-place via copyTV().
+   // Re-read the error after nested cleanup because a handler may have replaced it in place.
 
    errobj = (L->top > saved_top) ? L->top - 1 : nullptr;
 
@@ -538,14 +598,16 @@ extern "C" void setup_try_handler(lua_State *L)
          context.owner_base IS try_frame->frame_base,
          "try unwind crossed an unrelated contextual activation");
       try_frame_ptr = restorestack(L, try_frame->frame_base) - 1;
-      errobj = unwind_close_try_block(
+      errobj = unwind_cleanup_range(
          L, try_frame_ptr, errobj, context.entry_slots, upper_slot_index);
       upper_slot_index = context.entry_slots;
       lj_context_restore_depth(L, L->context_stack.size() - 1);
    }
    try_frame_ptr = restorestack(L, try_frame->frame_base) - 1;
-   TValue *final_err = unwind_close_try_block(
+   TValue *final_err = unwind_cleanup_range(
       L, try_frame_ptr, errobj, min_slot_index, upper_slot_index);
+   saved_base = restorestack(L, try_frame->frame_base);
+   lj_defer_discard(L, saved_base, uint32_t(min_slot_index));
    lj_assertL(L->context_stack.size() IS try_frame->context_depth,
       "try handler did not restore the saved contextual depth");
    const bool has_final_err = final_err != nullptr;
@@ -555,11 +617,11 @@ extern "C" void setup_try_handler(lua_State *L)
    saved_top = restorestack(L, try_frame->saved_top);
    lj_meta_multres_unwind(L, saved_base);
 
-   // After all __close handlers have run, extract the final error message.
-   // The error may have been updated by handlers in nested frames (unwind_close_all)
-   // or in the try block's frame (unwind_close_try_block).
+   // After all cleanup handlers have run, extract the final error message.
+   // The error may have been updated by handlers in nested frames or in the try block's frame.
 
    TValue *current_err = has_final_err ? restorestack(L, final_err_offset) : errobj;
+   if (L->CaughtError >= ERR::ExceptionThreshold) err_code = L->CaughtError;
    GCstr *error_msg = nullptr;
    GCstr *error_source = nullptr;
    int line = 0;
@@ -641,7 +703,7 @@ void * err_unwind(lua_State *L, void *StopCatchFrame, int errcode)
                const ptrdiff_t frame_offset = savestack(L, frame);
                const ptrdiff_t top_offset = savestack(L, top);
                lj_checkall_cleanup_to_base(L, top);
-               unwind_close_all(L, L->base - 1, top);
+               unwind_cleanup_all(L, L->base - 1, top);
                frame = restorestack(L, frame_offset);
                top = restorestack(L, top_offset);
                lj_meta_multres_unwind(L, top);
@@ -669,7 +731,7 @@ void * err_unwind(lua_State *L, void *StopCatchFrame, int errcode)
                const ptrdiff_t frame_offset = savestack(L, frame);
                const ptrdiff_t target_offset = savestack(L, target);
                lj_checkall_cleanup_to_base(L, target);
-               unwind_close_all(L, L->base - 1, target);
+               unwind_cleanup_all(L, L->base - 1, target);
                frame = restorestack(L, frame_offset);
                target = restorestack(L, target_offset);
                lj_meta_multres_unwind(L, target);
@@ -702,7 +764,12 @@ void * err_unwind(lua_State *L, void *StopCatchFrame, int errcode)
 
             if (errcode) {
                TValue *target = frame_prevd(frame) + 1;
+               const ptrdiff_t frame_offset = savestack(L, frame);
+               const ptrdiff_t target_offset = savestack(L, target);
                lj_checkall_cleanup_to_base(L, target);
+               if (lj_defer_has_owner_above(L, target)) unwind_cleanup_all(L, L->base - 1, target);
+               frame = restorestack(L, frame_offset);
+               target = restorestack(L, target_offset);
                lj_meta_multres_unwind(L, target);
                L->base = target;
                L->cframe = cframe_prev(cf);
@@ -726,12 +793,12 @@ void * err_unwind(lua_State *L, void *StopCatchFrame, int errcode)
 
                if (frame_typep(frame) IS FRAME_PCALL) hook_leave(G(L));
 
-               // Call __close handlers BEFORE modifying L->base
+               // Run cleanup handlers before modifying L->base.
 
                TValue *target = frame_prevd(frame) + 1;
                const ptrdiff_t target_offset = savestack(L, target);
                lj_checkall_cleanup_to_base(L, target);
-               unwind_close_all(L, L->base - 1, target);
+               unwind_cleanup_all(L, L->base - 1, target);
                target = restorestack(L, target_offset);
                lj_meta_multres_unwind(L, target);
                L->base = target;
@@ -749,7 +816,7 @@ void * err_unwind(lua_State *L, void *StopCatchFrame, int errcode)
       TValue* target = tvref(L->stack) + 1 + LJ_FR2;
       const ptrdiff_t target_offset = savestack(L, target);
       lj_checkall_cleanup_to_base(L, target);
-      unwind_close_all(L, L->base - 1, target);
+      unwind_cleanup_all(L, L->base - 1, target);
       target = restorestack(L, target_offset);
       lj_meta_multres_unwind(L, target);
       L->base = target;

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -4908,6 +4908,30 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_next
     break;
 
+  case BC_DEFERARM:
+    |  ldr L, SAVE_L
+    |  str BASE, L->base
+    |  mov CARG1, L
+    |  mov CARG2, BASE
+    |  decode_RA CARG3w, INS
+    |  decode_RC CARG4w, INS
+    |  decode_RB CARG5w, INS
+    |  bl extern lj_defer_arm
+    |  ldr BASE, L->base
+    |  ins_next
+    break;
+
+  case BC_DEFERCONSUME:
+    |  ldr L, SAVE_L
+    |  str BASE, L->base
+    |  mov CARG1, L
+    |  mov CARG2, BASE
+    |  mov CARG3w, RAw
+    |  bl extern lj_defer_consume
+    |  ldr BASE, L->base
+    |  ins_next
+    break;
+
   case BC_VIEW:
     |  ldr L, SAVE_L
     |  str BASE, L->base

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -6972,6 +6972,32 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_next
     break;
 
+  case BC_DEFERARM:
+    |  lwz L, SAVE_L
+    |  stp BASE, L->base
+    |  mr CARG1, L
+    |  mr CARG2, BASE
+    |  srwi CARG3, RA, 3
+    |  decode_RC8 CARG4, INS
+    |  srwi CARG4, CARG4, 3
+    |  decode_RB8 CARG5, INS
+    |  srwi CARG5, CARG5, 3
+    |  bl extern lj_defer_arm
+    |  lp BASE, L->base
+    |  ins_next
+    break;
+
+  case BC_DEFERCONSUME:
+    |  lwz L, SAVE_L
+    |  stp BASE, L->base
+    |  mr CARG1, L
+    |  mr CARG2, BASE
+    |  srwi CARG3, RA, 3
+    |  bl extern lj_defer_consume
+    |  lp BASE, L->base
+    |  ins_next
+    break;
+
   case BC_VIEW:
     |  lwz L, SAVE_L
     |  stp BASE, L->base

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -5926,6 +5926,38 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_next
     break;
 
+  case BC_DEFERARM:
+    |  ins_ABC
+    |.if X64WIN
+    |  mov CARG3d, RAd
+    |  mov CARG4d, RCd
+    |  mov ARG5d, RBd
+    |.else
+    |  mov CARG5d, RBd
+    |  mov CARG2, BASE
+    |  mov CARG3d, RAd
+    |  mov CARG4d, RCd
+    |.endif
+    |  mov L:RB, SAVE_L
+    |  mov L:RB->base, CARG2
+    |  mov L:CARG1, L:RB
+    |  call extern lj_defer_arm
+    |  mov BASE, L:RB->base
+    |  ins_next
+    break;
+
+  case BC_DEFERCONSUME:
+    |  ins_AD
+    |  mov CARG2, BASE
+    |  mov CARG3d, RAd
+    |  mov L:RB, SAVE_L
+    |  mov L:RB->base, CARG2
+    |  mov L:CARG1, L:RB
+    |  call extern lj_defer_consume
+    |  mov BASE, L:RB->base
+    |  ins_next
+    break;
+
   case BC_VIEW:
     |  ins_AD
     |  mov L:RB, SAVE_L

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -233,6 +233,9 @@ typedef struct CCallInfo {
   _(ANY,        lj_try_leave,      1,  FS, NIL, CCI_L) \
   _(ANY,        lj_checkall_enter,  3,  FS, NIL, CCI_L) \
   _(ANY,        lj_checkall_leave,  1,  FS, NIL, CCI_L) \
+  /* Deferred cleanup registration */ \
+  _(ANY,        lj_defer_arm,         5, S, NIL, CCI_L) \
+  _(ANY,        lj_defer_consume_jit, 3, S, NIL, CCI_L) \
   /* State-local table context */ \
   _(ANY,        lj_context_current_jit,  1, FS, TAB, CCI_L) \
   _(ANY,        lj_context_enter_jit,    3,  S, NIL, CCI_L) \
@@ -291,6 +294,9 @@ extern "C" void lj_try_enter(lua_State *L, GCfunc *Func, TValue *Base, uint16_t 
 extern "C" void lj_try_leave(lua_State *L);
 extern "C" void lj_checkall_enter(lua_State *L, GCfunc *Func, TValue *Base);
 extern "C" void lj_checkall_leave(lua_State *L);
+extern "C" void lj_defer_arm(lua_State *L, TValue *OwnerBase, uint32_t CallableSlot,
+   uint32_t ArgumentCount, uint32_t ScopeBase);
+extern "C" void lj_defer_consume_jit(lua_State *L, TValue *OwnerBase, uint32_t CallableSlot);
 
 // Permanent contextual designation of a recorded table (see lj_state.cpp).
 extern "C" void lj_tab_mark_contextual_jit(GCtab *Table) noexcept;

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -61,13 +61,15 @@ static TRef rec_tmpref(jit_State *J, TRef tr, int mode)
 
 static TRef sload(jit_State *J, int32_t Slot);
 
+#define getslot(J, s)   (J->base[(s)] ? J->base[(s)] : sload(J, (int32_t)(s)))
+
 //********************************************************************************************************************
 // Materialise live trace slots back to the Lua stack before a throwable helper runs inside a recorded try block.
 
 static TRef rec_stack_slot_addr(jit_State *J, IRBuilder& Ir, int32_t AbsoluteSlot)
 {
    lj_assertJ(AbsoluteSlot >= 0 and AbsoluteSlot < LJ_MAX_JSLOTS + LJ_STACK_EXTRA,
-      "try materialisation slot out of range");
+      "stack materialisation slot out of range");
    int32_t byte_offset = 8 * (AbsoluteSlot - 1 - LJ_FR2);
    return Ir.emit(IRT(IR_ADD, IRT_PGC), REF_BASE, Ir.kint(byte_offset));
 }
@@ -113,37 +115,49 @@ static void rec_emit_tvalue_store(jit_State *J, TRef SlotAddr, TRef ValueRef)
    }
 }
 
-static void rec_try_materialise_slots(jit_State *J, bool ForceLoad, BCREG SlotLimit)
+static void rec_materialise_slot_range(
+   jit_State *J, BCREG FirstSlot, BCREG SlotLimit, bool ForceLoad, bool TrackTryStores)
 {
    BCREG slot_limit = SlotLimit;
    if (slot_limit > J->maxslot) slot_limit = J->maxslot;
-   if (slot_limit IS 0) return;
+   if (FirstSlot >= slot_limit) return;
 
    IRBuilder ir(J);
    bool stored = false;
 
-   for (BCREG slot = 0; slot < slot_limit; slot++) {
-      TRef value_ref = J->base[slot];
-      if (not value_ref and ForceLoad) value_ref = sload(J, slot);
+   for (BCREG slot = FirstSlot; slot < slot_limit; slot++) {
+      TRef value_ref = ForceLoad ? getslot(J, slot) : J->base[slot];
       if (not value_ref or (value_ref & (TREF_FRAME | TREF_CONT))) continue;
 
       int32_t absolute_slot = int32_t(J->baseslot) + int32_t(slot);
       lj_assertJ(absolute_slot >= 0 and absolute_slot < LJ_MAX_JSLOTS + LJ_STACK_EXTRA,
-         "try materialisation slot out of range");
-      if (not ForceLoad and J->trymat[absolute_slot] IS value_ref) {
+         "stack materialisation slot out of range");
+      if (TrackTryStores and not ForceLoad and J->trymat[absolute_slot] IS value_ref) {
          J->try_skipped_stores++;
          continue;
       }
 
       TRef slot_addr = rec_stack_slot_addr(J, ir, absolute_slot);
       rec_emit_tvalue_store(J, slot_addr, value_ref);
-      J->trymat[absolute_slot] = value_ref;
-      J->try_stores++;
-      if (ForceLoad) J->try_enter_stores++;
+      if (TrackTryStores) {
+         J->trymat[absolute_slot] = value_ref;
+         J->try_stores++;
+         if (ForceLoad) J->try_enter_stores++;
+      }
       stored = true;
    }
 
    if (stored) emitir_raw(IRT(IR_XBAR, IRT_NIL), 0, 0);
+}
+
+static void rec_try_materialise_slots(jit_State *J, bool ForceLoad, BCREG SlotLimit)
+{
+   rec_materialise_slot_range(J, 0, SlotLimit, ForceLoad, true);
+}
+
+static void rec_defer_materialise_slots(jit_State *J, BCREG CallableSlot, BCREG ArgumentCount)
+{
+   rec_materialise_slot_range(J, CallableSlot, BCREG(CallableSlot + ArgumentCount + 1), true, false);
 }
 
 void lj_record_try_materialise(jit_State *J)
@@ -389,7 +403,6 @@ static TRef sload(jit_State *J, int32_t slot)
 //********************************************************************************************************************
 // Get TRef from slot. Load slot and specialise if not done already.
 
-#define getslot(J, s)   (J->base[(s)] ? J->base[(s)] : sload(J, (int32_t)(s)))
 // Note: getslot macro retained for compatibility; SlotView can be used for new code:
 //   SlotView slots(J); TRef tr = slots.is_loaded(s) ? slots[s] : sload(J, s);
 
@@ -5331,6 +5344,42 @@ void lj_record_ins(jit_State *J)
       if (J->checkalldepth > 0) J->checkalldepth--;
       J->needsnap = 1;
       break;
+
+   case BC_DEFERARM: {
+      BCREG callable_slot = bc_a(ins);
+      BCREG argument_count = bc_c(ins);
+      BCREG scope_base = bc_b(ins);
+      uint32_t slot_limit = uint32_t(callable_slot) + uint32_t(argument_count) + 1;
+      uint32_t absolute_limit = uint32_t(J->baseslot) + slot_limit;
+      if (scope_base > callable_slot or slot_limit > J->maxslot or
+          absolute_limit > LJ_MAX_JSLOTS + LJ_STACK_EXTRA) {
+         setintV(&J->errinfo, int32_t(op));
+         lj_trace_err_info(J, LJ_TRERR_NYIBC);
+      }
+
+      rec_defer_materialise_slots(J, callable_slot, argument_count);
+      IRBuilder ir(J);
+      TRef owner_base = rec_stack_slot_addr(J, ir, int32_t(J->baseslot));
+      lj_ir_call(J, IRCALL_lj_defer_arm, owner_base, ir.kint(callable_slot), ir.kint(argument_count),
+         ir.kint(scope_base));
+      J->needsnap = 1;
+      break;
+   }
+
+   case BC_DEFERCONSUME: {
+      BCREG callable_slot = bc_a(ins);
+      if (callable_slot >= J->maxslot or uint32_t(J->baseslot) + uint32_t(callable_slot) >=
+          LJ_MAX_JSLOTS + LJ_STACK_EXTRA) {
+         setintV(&J->errinfo, int32_t(op));
+         lj_trace_err_info(J, LJ_TRERR_NYIBC);
+      }
+
+      IRBuilder ir(J);
+      TRef owner_base = rec_stack_slot_addr(J, ir, int32_t(J->baseslot));
+      lj_ir_call(J, IRCALL_lj_defer_consume_jit, owner_base, ir.kint(callable_slot));
+      J->needsnap = 1;
+      break;
+   }
 
    case BC_CHECK:
    case BC_RAISE:

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -2790,6 +2790,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_defer_stmt(const DeferStmtPayload &Payl
    if (not Payload.callable) return this->unsupported_stmt(AstNodeKind::DeferStmt, SourceSpan{});
 
    FuncState* fs = &this->func_state;
+   BCREG scope_base = fs->bl->nactvar;
    auto reg = fs->free_reg();
    this->lex_state.var_new(0, NAME_BLANK);
    RegisterAllocator allocator(fs);
@@ -2829,6 +2830,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_defer_stmt(const DeferStmtPayload &Payl
       }
    }
 
+   bcemit_ABC(fs, BC_DEFERARM, reg.raw(), scope_base, nargs);
    fs->reset_freereg();
    return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
 }

--- a/src/tiri/jit/src/parser/parse_scope.cpp
+++ b/src/tiri/jit/src/parser/parse_scope.cpp
@@ -398,6 +398,7 @@ static void execute_defers(FuncState *State, BCREG Limit, BCREG Upper)
          BCREG j;
          RegisterAllocator allocator(State);
          allocator.reserve(BCReg(argc + 1 + LJ_FR2));
+         bcemit_AD(State, BC_DEFERCONSUME, v->slot, 0);
          bcemit_AD(State, BC_MOV, callbase, v->slot);
          for (j = 0; j < argc; j++) {
             BCREG src = argslots[argc - 1 - j];

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -8871,11 +8871,221 @@ static bool test_checkall_syntax_and_bytecode(kt::Log &Log)
    return true;
 }
 
+//********************************************************************************************************************
+// Defer error-unwind registration is intentionally test-first.  Resolve the planned opcodes by name so this test
+// remains compileable until the bytecode definitions land, while still failing clearly when either opcode is absent.
+
+static bool test_defer_unwind_registration_bytecode(kt::Log &Log)
+{
+   auto find_opcode = [](std::string_view Name) -> std::optional<BCOp> {
+      for (uint32_t i = 0; i < uint32_t(BC__MAX); ++i) {
+         if (Name IS glBcNames[i]) return BCOp(i);
+      }
+      return std::nullopt;
+   };
+
+   const auto arm_opcode = find_opcode("DEFERARM");
+   const auto consume_opcode = find_opcode("DEFERCONSUME");
+   if (not arm_opcode or not consume_opcode) {
+      Log.error("defer unwind registration bytecodes have not been implemented");
+      return false;
+   }
+
+   LuaStateHolder holder;
+   lua_State *lua = holder.get();
+   constexpr std::string_view source =
+      "function subject(ReturnEarly)\n"
+      "   defer(Value) local snapshot = Value end(42)\n"
+      "   if ReturnEarly then return end\n"
+      "end\n";
+
+   if (lua_load(lua, source, "defer-registration-bytecode")) {
+      Log.error("failed to compile defer registration fixture: %s", lua_tostring(lua, -1));
+      return false;
+   }
+
+   GCproto *root = funcproto(funcV(lua->top - 1));
+   GCproto *subject = first_child_proto(root);
+   if (not subject) {
+      Log.error("defer registration fixture did not emit its subject prototype");
+      return false;
+   }
+
+   BCIns *bytecode = proto_bc(subject);
+   MSize arm_position = subject->sizebc;
+   std::vector<MSize> consume_positions;
+   for (MSize i = 1; i < subject->sizebc; ++i) {
+      if (bc_op(bytecode[i]) IS *arm_opcode) {
+         if (arm_position != subject->sizebc) {
+            Log.error("a single defer emitted more than one DEFERARM");
+            return false;
+         }
+         arm_position = i;
+      }
+      else if (bc_op(bytecode[i]) IS *consume_opcode) {
+         consume_positions.push_back(i);
+      }
+   }
+
+   if (arm_position IS subject->sizebc or consume_positions.empty()) {
+      Log.error("defer lowering omitted DEFERARM or DEFERCONSUME");
+      return false;
+   }
+
+   BCIns arm = bytecode[arm_position];
+   BCREG callable_slot = bc_a(arm);
+   BCREG argument_count = bc_c(arm);
+   if (argument_count != 1 or bc_b(arm) > callable_slot or callable_slot + argument_count >= subject->framesize) {
+      Log.error("DEFERARM encoded invalid callable, scope or argument operands");
+      return false;
+   }
+
+   bool callable_ready = false;
+   bool argument_ready = false;
+   for (MSize i = 1; i < arm_position; ++i) {
+      callable_ready |= bc_op(bytecode[i]) IS BC_FNEW and bc_a(bytecode[i]) IS callable_slot;
+      argument_ready |= bc_op(bytecode[i]) IS BC_KSHORT and
+         bc_a(bytecode[i]) IS callable_slot + argument_count;
+   }
+   if (not callable_ready or not argument_ready) {
+      Log.error("DEFERARM did not follow callable and argument materialisation");
+      return false;
+   }
+
+   size_t call_count = 0;
+   for (MSize i = 1; i < subject->sizebc; ++i) {
+      if (bc_op(bytecode[i]) IS BC_CALL) call_count++;
+   }
+   if (call_count != consume_positions.size()) {
+      Log.error("defer cleanup calls and DEFERCONSUME operations were not paired on every edge");
+      return false;
+   }
+
+   for (MSize consume_position : consume_positions) {
+      if (consume_position + 2 >= subject->sizebc or consume_position < arm_position or
+          bc_a(bytecode[consume_position]) != callable_slot or bc_op(bytecode[consume_position + 1]) != BC_MOV) {
+         Log.error("normal defer cleanup did not consume its registration immediately before call setup");
+         return false;
+      }
+
+      bool call_found = false;
+      for (MSize i = consume_position + 2; i < subject->sizebc; ++i) {
+         if (bc_op(bytecode[i]) IS *consume_opcode) break;
+         if (bc_op(bytecode[i]) IS BC_CALL) {
+            call_found = true;
+            break;
+         }
+      }
+      if (not call_found) {
+         Log.error("DEFERCONSUME was not followed by the existing defer call sequence");
+         return false;
+      }
+   }
+
+   auto malformed_rejected = [&](MSize Position, BCIns Invalid, std::string_view Label) {
+      BCIns saved = bytecode[Position];
+      bytecode[Position] = Invalid;
+      std::string dump;
+      bool wrote = lj_bcwrite(lua, subject, bytecode_writer, &dump, 1) IS 0;
+      bytecode[Position] = saved;
+      if (not wrote) {
+         Log.error("failed to write malformed %.*s fixture", int(Label.size()), Label.data());
+         return false;
+      }
+
+      if (lua_load(lua, std::string_view(dump.data(), dump.size()), "malformed-defer-bytecode")) {
+         lua_pop(lua, 1);
+         return true;
+      }
+
+      lua_pop(lua, 1);
+      Log.error("bytecode reader accepted malformed %.*s operands", int(Label.size()), Label.data());
+      return false;
+   };
+
+   if (not malformed_rejected(arm_position,
+         BCINS_ABC(*arm_opcode, subject->framesize, bc_b(arm), argument_count), "DEFERARM callable") or
+       not malformed_rejected(arm_position,
+         BCINS_ABC(*arm_opcode, callable_slot, callable_slot + 1, argument_count), "DEFERARM scope") or
+       not malformed_rejected(arm_position,
+         BCINS_ABC(*arm_opcode, callable_slot, bc_b(arm), subject->framesize - callable_slot),
+         "DEFERARM arguments") or
+       not malformed_rejected(consume_positions.front(),
+         BCINS_AD(*consume_opcode, subject->framesize, 0), "DEFERCONSUME callable")) {
+      return false;
+   }
+
+   return true;
+}
+
+//********************************************************************************************************************
+
+static bool test_defer_runtime_registration_state(kt::Log &Log)
+{
+   LuaStateHolder holder;
+   lua_State *lua = holder.get();
+   if (not lua) {
+      Log.error("failed to create a state for defer registration testing");
+      return false;
+   }
+
+   ptrdiff_t owner_offset = savestack(lua, lua->base);
+   lj_defer_arm(lua, lua->base, 3, 2, 1);
+   lj_defer_arm(lua, lua->base, 7, 1, 1);
+   if (lua->defer_frames.size() != 1 or lua->defer_frames[0].owner_base != owner_offset or
+       lua->defer_frames[0].registrations.size() != 2) {
+      Log.error("defer registrations were not appended to their owning frame");
+      return false;
+   }
+
+   const DeferRegistration &first = lua->defer_frames[0].registrations[0];
+   if (first.callable_slot != 3 or first.argument_count != 2 or first.scope_base != 1) {
+      Log.error("defer registration metadata was not retained");
+      return false;
+   }
+
+   lj_state_growstack(lua, 64);
+   TValue *owner = restorestack(lua, owner_offset);
+   if (lua->defer_frames[0].owner_base != savestack(lua, owner) or
+       not lj_defer_consume(lua, owner, 7) or lua->defer_frames[0].registrations.size() != 1) {
+      Log.error("defer ownership did not survive stack relocation or consume in LIFO order");
+      return false;
+   }
+   if (not lj_defer_consume(lua, owner, 3) or not lua->defer_frames.empty()) {
+      Log.error("consuming the last defer did not remove its empty frame state");
+      return false;
+   }
+
+   TValue *inner_owner = owner + 8;
+   lj_defer_arm(lua, owner, 2, 0, 1);
+   lj_defer_arm(lua, owner, 5, 1, 4);
+   lj_defer_arm(lua, inner_owner, 1, 0, 0);
+   lj_defer_unwind(lua, owner);
+   if (lua->defer_frames.size() != 1 or lua->defer_frames[0].owner_base != owner_offset or
+       lua->defer_frames[0].registrations.size() != 2) {
+      Log.error("unwinding did not discard only frame states above the surviving owner");
+      return false;
+   }
+
+   lj_defer_discard(lua, owner, 4);
+   if (lua->defer_frames.size() != 1 or lua->defer_frames[0].registrations.size() != 1 or
+       lua->defer_frames[0].registrations[0].callable_slot != 2) {
+      Log.error("lexical defer discard removed registrations outside the abandoned slot range");
+      return false;
+   }
+   if (not lj_defer_consume(lua, owner, 2) or not lua->defer_frames.empty()) {
+      Log.error("surviving defer registration could not be consumed after a partial unwind");
+      return false;
+   }
+
+   return true;
+}
+
 }  // namespace
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 83> tests = { {
+   constexpr std::array<TestCase, 85> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -8889,6 +9099,8 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "local_function_table_ast", test_local_function_table_ast },
       { "ast_statement_matrix", test_ast_statement_matrix },
       { "checkall_syntax_and_bytecode", test_checkall_syntax_and_bytecode },
+      { "defer_unwind_registration_bytecode", test_defer_unwind_registration_bytecode },
+      { "defer_runtime_registration_state", test_defer_runtime_registration_state },
       { "range_for_ast", test_range_for_ast },
       { "current_context_range_operands", test_current_context_range_operands },
       { "deprecated_numeric_for_rejected", test_deprecated_numeric_for_rejected },

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -1664,6 +1664,62 @@ int lj_meta_close(lua_State *L, TValue *o, TValue *err)
 }
 
 //********************************************************************************************************************
+// Invoke one snapshotted defer registration through a protected call.  Consumption immediately before the call makes
+// the registration exactly-once even when its handler throws and starts a nested unwind.
+
+int lj_meta_defer(lua_State *L, TValue *OwnerBase, const DeferRegistration &Registration)
+{
+   [[maybe_unused]] size_t context_depth = lj_context_depth(L);
+   ptrdiff_t owner_offset = savestack(L, OwnerBase);
+   if (not lj_defer_consume(L, OwnerBase, Registration.callable_slot)) return 0;
+   lj_state_checkstack(L, MSize(Registration.argument_count + 1 + LJ_FR2));
+
+   OwnerBase = restorestack(L, owner_offset);
+   const BCIns *saved_try_handler = L->try_handler_pc;
+   int saved_try_depth = L->try_stack.depth;
+   int saved_checkall_depth = L->checkall_stack->depth;
+   std::array<TryFrame, LJ_MAX_TRY_DEPTH> saved_try_frames;
+   std::array<CheckallFrame, LJ_MAX_CHECKALL_DEPTH> saved_checkall_frames;
+   std::copy_n(L->try_stack.frames, saved_try_depth, saved_try_frames.begin());
+   std::copy_n(L->checkall_stack->frames, saved_checkall_depth, saved_checkall_frames.begin());
+
+   global_State *g = G(L);
+   uint8_t oldh = hook_save(g);
+   int errcode;
+   lj_trace_abort(g);
+   hook_entergc(g);
+   if (LJ_HASPROFILE and (oldh & HOOK_PROFILE)) lj_dispatch_update(g);
+
+   {
+      GCPauseGuard pause_gc(g);
+      TValue *top = L->top;
+      copyTV(L, top++, OwnerBase + Registration.callable_slot);
+      if (LJ_FR2) setnilV(top++);
+      TValue *argbase = top;
+      for (uint32_t i = 0; i < Registration.argument_count; ++i) {
+         copyTV(L, top++, OwnerBase + Registration.callable_slot + i + 1);
+      }
+      L->top = top;
+
+      L->try_stack.depth = 0;
+      L->checkall_stack->depth = 0;
+      L->try_handler_pc = nullptr;
+      errcode = lj_vm_pcall(L, argbase, 1, -1);
+      lj_assertL(lj_context_depth(L) IS context_depth,
+         "defer returned with unbalanced contextual activations");
+      std::copy_n(saved_try_frames.begin(), saved_try_depth, L->try_stack.frames);
+      std::copy_n(saved_checkall_frames.begin(), saved_checkall_depth, L->checkall_stack->frames);
+      L->try_stack.depth = saved_try_depth;
+      L->checkall_stack->depth = saved_checkall_depth;
+      L->try_handler_pc = saved_try_handler;
+   }
+
+   hook_restore(g, oldh);
+   if (LJ_HASPROFILE and (oldh & HOOK_PROFILE)) lj_dispatch_update(g);
+   return errcode;
+}
+
+//********************************************************************************************************************
 // Helper for FORI. Coercion.
 
 void lj_meta_for(lua_State *L, TValue *o)

--- a/src/tiri/jit/src/runtime/lj_meta.h
+++ b/src/tiri/jit/src/runtime/lj_meta.h
@@ -53,6 +53,7 @@ extern "C" void lj_meta_for(lua_State* L, TValue* o);
 
 // Helper for __close metamethod during scope exit. Returns error code (0 = success).
 extern "C" int lj_meta_close(lua_State* L, TValue* o, TValue* err);
+LJ_FUNC int lj_meta_defer(lua_State *L, TValue *OwnerBase, const DeferRegistration &Registration);
 extern "C" void lj_meta_multres_save(lua_State *L, TValue *Base, uint32_t Count);
 extern "C" uint32_t lj_meta_multres_restore(lua_State *L, TValue *Base);
 extern "C" void lj_meta_multres_unwind(lua_State *L, TValue *TargetBase);

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -1651,6 +1651,17 @@ inline void hook_restore(global_State *g, uint8_t h) noexcept { g->hookmask = (g
 
 // Per-thread state object.  See lua_newstate() in lj_state.cpp for initialisation.
 
+struct DeferRegistration {
+   uint8_t callable_slot = 0;
+   uint8_t argument_count = 0;
+   uint8_t scope_base = 0;
+};
+
+struct DeferFrameState {
+   ptrdiff_t owner_base = 0;
+   std::vector<DeferRegistration> registrations;
+};
+
 struct lua_State {
    GCHeader;            // NB: C++ placement new can trash any preset values here.
    uint8_t dummy_ffid;  //  Fake FF_C for curr_funcisL() on dummy frames.
@@ -1714,6 +1725,7 @@ struct lua_State {
       uint64_t armed_slots = 0;
    };
    std::vector<CloseFrameState> close_frames;
+   std::vector<DeferFrameState> defer_frames;
 
    struct SavedMultresFrame {
       ptrdiff_t frame_base = 0;

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -455,6 +455,186 @@ extern "C" void lj_close_arm(lua_State *L, uint32_t Slot)
    state->armed_slots |= uint64_t(1) << Slot;
 }
 
+//********************************************************************************************************************
+// Register a defer only after its callable and snapshotted arguments have been materialised.  The values remain rooted
+// in the owning Lua frame; this side state records only stable stack offsets and compact slot metadata.
+
+extern "C" void lj_defer_arm(lua_State *L, TValue *OwnerBase, uint32_t CallableSlot,
+   uint32_t ArgumentCount, uint32_t ScopeBase)
+{
+   lj_assertL(L and OwnerBase, "invalid defer registration owner");
+   if (not L or not OwnerBase) return;
+
+   TValue *stack = tvref(L->stack);
+   TValue *stack_end = tvref(L->maxstack);
+   lj_assertL(OwnerBase >= stack and OwnerBase <= stack_end, "defer owner is outside the state stack allocation");
+   lj_assertL(CallableSlot < LJ_MAX_SLOTS, "defer callable slot exceeds the frame limit");
+   lj_assertL(ArgumentCount < LJ_MAX_SLOTS, "defer argument count exceeds the frame limit");
+   lj_assertL(CallableSlot + ArgumentCount < LJ_MAX_SLOTS, "defer arguments exceed the frame limit");
+   lj_assertL(ScopeBase <= CallableSlot, "defer scope begins after its callable slot");
+   if (OwnerBase < stack or OwnerBase > stack_end or CallableSlot >= LJ_MAX_SLOTS or
+       ArgumentCount >= LJ_MAX_SLOTS or CallableSlot + ArgumentCount >= LJ_MAX_SLOTS or ScopeBase > CallableSlot) {
+      return;
+   }
+
+   ptrdiff_t owner_base = savestack(L, OwnerBase);
+   auto frame = std::find_if(L->defer_frames.rbegin(), L->defer_frames.rend(),
+      [owner_base](const DeferFrameState &Frame) { return Frame.owner_base IS owner_base; });
+   if (frame IS L->defer_frames.rend()) {
+      L->defer_frames.push_back(DeferFrameState{ .owner_base = owner_base });
+      frame = L->defer_frames.rbegin();
+   }
+
+   auto duplicate = std::find_if(frame->registrations.rbegin(), frame->registrations.rend(),
+      [CallableSlot](const DeferRegistration &Registration) {
+         return Registration.callable_slot IS CallableSlot;
+      });
+   lj_assertL(duplicate IS frame->registrations.rend(), "defer callable slot armed more than once");
+   if (duplicate != frame->registrations.rend()) return;
+
+   frame->registrations.push_back(DeferRegistration{
+      .callable_slot = uint8_t(CallableSlot),
+      .argument_count = uint8_t(ArgumentCount),
+      .scope_base = uint8_t(ScopeBase)
+   });
+}
+
+//********************************************************************************************************************
+// Consume before entering user code so a throwing normal-exit handler cannot be discovered again during unwinding.
+
+extern "C" bool lj_defer_consume(lua_State *L, TValue *OwnerBase, uint32_t CallableSlot)
+{
+   lj_assertL(L and OwnerBase, "invalid defer consumption owner");
+   if (not L or not OwnerBase) return false;
+
+   TValue *stack = tvref(L->stack);
+   TValue *stack_end = tvref(L->maxstack);
+   lj_assertL(OwnerBase >= stack and OwnerBase <= stack_end,
+      "defer consumption owner is outside the state stack allocation");
+   lj_assertL(CallableSlot < LJ_MAX_SLOTS, "defer consumption slot exceeds the frame limit");
+   if (OwnerBase < stack or OwnerBase > stack_end or CallableSlot >= LJ_MAX_SLOTS) return false;
+
+   ptrdiff_t owner_base = savestack(L, OwnerBase);
+   auto frame = std::find_if(L->defer_frames.rbegin(), L->defer_frames.rend(),
+      [owner_base](const DeferFrameState &Frame) { return Frame.owner_base IS owner_base; });
+   lj_assertL(frame != L->defer_frames.rend(), "defer consumption has no owning frame state");
+   if (frame IS L->defer_frames.rend()) return false;
+
+   auto registration = std::find_if(frame->registrations.rbegin(), frame->registrations.rend(),
+      [CallableSlot](const DeferRegistration &Registration) {
+         return Registration.callable_slot IS CallableSlot;
+      });
+   lj_assertL(registration != frame->registrations.rend(), "defer callable slot is not armed");
+   if (registration IS frame->registrations.rend()) return false;
+
+   lj_assertL(registration IS frame->registrations.rbegin(), "defer registrations consumed out of LIFO order");
+   frame->registrations.erase(std::next(registration).base());
+   if (frame->registrations.empty()) L->defer_frames.erase(std::next(frame).base());
+   return true;
+}
+
+//********************************************************************************************************************
+// Find the innermost active lexical defer scope in a callable-slot range.
+
+bool lj_defer_find_scope(lua_State *State, const TValue *OwnerBase, uint32_t LowerCallableSlot,
+   uint32_t UpperCallableSlot, uint32_t *ScopeBase) noexcept
+{
+   if (not State or not OwnerBase or not ScopeBase or LowerCallableSlot > UpperCallableSlot) return false;
+
+   ptrdiff_t owner_base = savestack(State, OwnerBase);
+   auto frame = std::find_if(State->defer_frames.rbegin(), State->defer_frames.rend(),
+      [owner_base](const DeferFrameState &Frame) { return Frame.owner_base IS owner_base; });
+   if (frame IS State->defer_frames.rend()) return false;
+
+   bool found = false;
+   uint32_t scope_base = 0;
+   for (const DeferRegistration &registration : frame->registrations) {
+      if (registration.callable_slot < LowerCallableSlot or registration.callable_slot >= UpperCallableSlot) continue;
+      if (not found or registration.scope_base > scope_base) {
+         found = true;
+         scope_base = registration.scope_base;
+      }
+   }
+   if (found) *ScopeBase = scope_base;
+   return found;
+}
+
+//********************************************************************************************************************
+// Copy the newest active registration in one lexical scope.  The caller must consume it before invoking user code.
+
+bool lj_defer_peek_scope(lua_State *State, const TValue *OwnerBase, uint32_t LowerCallableSlot,
+   uint32_t UpperCallableSlot, uint32_t ScopeBase, DeferRegistration *Registration) noexcept
+{
+   if (not State or not OwnerBase or not Registration or LowerCallableSlot > UpperCallableSlot) return false;
+
+   ptrdiff_t owner_base = savestack(State, OwnerBase);
+   auto frame = std::find_if(State->defer_frames.rbegin(), State->defer_frames.rend(),
+      [owner_base](const DeferFrameState &Frame) { return Frame.owner_base IS owner_base; });
+   if (frame IS State->defer_frames.rend()) return false;
+
+   auto registration = std::find_if(frame->registrations.rbegin(), frame->registrations.rend(),
+      [LowerCallableSlot, UpperCallableSlot, ScopeBase](const DeferRegistration &Candidate) {
+         return Candidate.callable_slot >= LowerCallableSlot and Candidate.callable_slot < UpperCallableSlot and
+            Candidate.scope_base IS ScopeBase;
+      });
+   if (registration IS frame->registrations.rend()) return false;
+   *Registration = *registration;
+   return true;
+}
+
+//********************************************************************************************************************
+// Report whether a protected boundary is abandoning any frame that owns active defers.
+
+bool lj_defer_has_owner_above(lua_State *State, const TValue *SurvivingBase) noexcept
+{
+   if (not State or not SurvivingBase) return false;
+   ptrdiff_t surviving_base = savestack(State, SurvivingBase);
+   return std::any_of(State->defer_frames.begin(), State->defer_frames.end(),
+      [surviving_base](const DeferFrameState &Frame) { return Frame.owner_base > surviving_base; });
+}
+
+//********************************************************************************************************************
+// Discard registrations belonging to an abandoned lexical range after its cleanup handlers have had an opportunity
+// to run.  The owner frame can survive when a try handler resumes within the same function.
+
+void lj_defer_discard(lua_State *State, const TValue *OwnerBase, uint32_t MinimumCallableSlot) noexcept
+{
+   if (not State or not OwnerBase) return;
+   TValue *stack = tvref(State->stack);
+   TValue *stack_end = tvref(State->maxstack);
+   lj_assertG_(G(State), OwnerBase >= stack and OwnerBase <= stack_end,
+      "defer discard owner is outside the state stack allocation");
+   lj_assertG_(G(State), MinimumCallableSlot <= LJ_MAX_SLOTS,
+      "defer discard slot exceeds the frame limit");
+   if (OwnerBase < stack or OwnerBase > stack_end or MinimumCallableSlot > LJ_MAX_SLOTS) return;
+
+   ptrdiff_t owner_base = savestack(State, OwnerBase);
+   auto frame = std::find_if(State->defer_frames.begin(), State->defer_frames.end(),
+      [owner_base](const DeferFrameState &Frame) { return Frame.owner_base IS owner_base; });
+   if (frame IS State->defer_frames.end()) return;
+
+   frame->registrations.erase(std::remove_if(frame->registrations.begin(), frame->registrations.end(),
+      [MinimumCallableSlot](const DeferRegistration &Registration) {
+         return Registration.callable_slot >= MinimumCallableSlot;
+      }), frame->registrations.end());
+   if (frame->registrations.empty()) State->defer_frames.erase(frame);
+}
+
+void lj_defer_unwind(lua_State *State, const TValue *SurvivingBase) noexcept
+{
+   if (not State or not SurvivingBase) return;
+   TValue *stack = tvref(State->stack);
+   TValue *stack_end = tvref(State->maxstack);
+   lj_assertG_(G(State), SurvivingBase >= stack and SurvivingBase <= stack_end,
+      "defer unwind boundary is outside the state stack allocation");
+   if (SurvivingBase < stack or SurvivingBase > stack_end) return;
+
+   ptrdiff_t surviving_base = savestack(State, SurvivingBase);
+   State->defer_frames.erase(std::remove_if(State->defer_frames.begin(), State->defer_frames.end(),
+      [surviving_base](const DeferFrameState &Frame) { return Frame.owner_base > surviving_base; }),
+      State->defer_frames.end());
+}
+
 extern "C" void lj_array_view_mode(lua_State *L, uint32_t Enabled)
 {
    if (Enabled) {
@@ -762,6 +942,7 @@ static void close_state(lua_State *L)
 {
    global_State *g = G(L);
    // Teardown also covers states terminated while an activation or asynchronous root boundary is still live.
+   L->defer_frames.clear();
    L->context_stack.clear();
    L->context_active = 0;
    L->context_root_floors.clear();
@@ -921,6 +1102,7 @@ void lj_state_free(global_State* g, lua_State *L)
    if (obj2gco(L) IS gcref(g->cur_L)) setgcrefnull(g->cur_L);
    lj_assertG(L->context_stack.empty(), "state freed with active contextual activations");
    lj_assertG(L->context_root_floors.empty(), "state freed with active asynchronous root boundaries");
+   L->defer_frames.clear();
 
    if (L->parser_diagnostics) { delete (ParserDiagnostics*)L->parser_diagnostics; L->parser_diagnostics = nullptr; }
    if (L->parser_tips) { delete L->parser_tips; L->parser_tips = nullptr; }

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -533,6 +533,12 @@ extern "C" bool lj_defer_consume(lua_State *L, TValue *OwnerBase, uint32_t Calla
    return true;
 }
 
+extern "C" void lj_defer_consume_jit(lua_State *L, TValue *OwnerBase, uint32_t CallableSlot)
+{
+   [[maybe_unused]] bool consumed = lj_defer_consume(L, OwnerBase, CallableSlot);
+   lj_assertL(consumed, "recorded defer callable slot is not armed");
+}
+
 //********************************************************************************************************************
 // Find the innermost active lexical defer scope in a callable-slot range.
 

--- a/src/tiri/jit/src/runtime/lj_state.h
+++ b/src/tiri/jit/src/runtime/lj_state.h
@@ -68,6 +68,20 @@ extern "C" LJ_FUNC void lj_context_end_block_jit(
    lua_State *L, TValue *OwnerBase, uint32_t BlockIndex) noexcept;
 extern "C" LJ_FUNC void lj_close_arm(lua_State *L, uint32_t Slot);
 extern "C" LJ_FUNC void lj_close_consume(lua_State *L, uint32_t Slot);
+extern "C" LJ_FUNC void lj_defer_arm(lua_State *State, TValue *OwnerBase, uint32_t CallableSlot,
+   uint32_t ArgumentCount, uint32_t ScopeBase);
+extern "C" LJ_FUNC [[nodiscard]] bool lj_defer_consume(
+   lua_State *State, TValue *OwnerBase, uint32_t CallableSlot);
+LJ_FUNC [[nodiscard]] bool lj_defer_find_scope(lua_State *State, const TValue *OwnerBase,
+   uint32_t LowerCallableSlot, uint32_t UpperCallableSlot, uint32_t *ScopeBase) noexcept;
+LJ_FUNC [[nodiscard]] bool lj_defer_peek_scope(lua_State *State, const TValue *OwnerBase,
+   uint32_t LowerCallableSlot, uint32_t UpperCallableSlot, uint32_t ScopeBase,
+   DeferRegistration *Registration) noexcept;
+LJ_FUNC [[nodiscard]] bool lj_defer_has_owner_above(
+   lua_State *State, const TValue *SurvivingBase) noexcept;
+LJ_FUNC void lj_defer_discard(
+   lua_State *State, const TValue *OwnerBase, uint32_t MinimumCallableSlot) noexcept;
+LJ_FUNC void lj_defer_unwind(lua_State *State, const TValue *SurvivingBase) noexcept;
 extern "C" LJ_FUNC void lj_array_view_mode(lua_State *L, uint32_t Enabled);
 LJ_FUNC [[nodiscard]] bool lj_array_take_view_mode(lua_State *L) noexcept;
 LJ_FUNC uint64_t lj_close_take_armed(

--- a/src/tiri/jit/src/runtime/lj_state.h
+++ b/src/tiri/jit/src/runtime/lj_state.h
@@ -72,6 +72,8 @@ extern "C" LJ_FUNC void lj_defer_arm(lua_State *State, TValue *OwnerBase, uint32
    uint32_t ArgumentCount, uint32_t ScopeBase);
 extern "C" LJ_FUNC [[nodiscard]] bool lj_defer_consume(
    lua_State *State, TValue *OwnerBase, uint32_t CallableSlot);
+extern "C" LJ_FUNC void lj_defer_consume_jit(
+   lua_State *State, TValue *OwnerBase, uint32_t CallableSlot);
 LJ_FUNC [[nodiscard]] bool lj_defer_find_scope(lua_State *State, const TValue *OwnerBase,
    uint32_t LowerCallableSlot, uint32_t UpperCallableSlot, uint32_t *ScopeBase) noexcept;
 LJ_FUNC [[nodiscard]] bool lj_defer_peek_scope(lua_State *State, const TValue *OwnerBase,

--- a/src/tiri/tests/test_context_blocks.tiri
+++ b/src/tiri/tests/test_context_blocks.tiri
@@ -112,7 +112,7 @@ end
    assert(&name is nil, 'Loop exits should leave crossed temporary contexts')
 end
 
-@Test function ErrorCleanupUsesLexicalContextAndSkipsDefers()
+@Test function ErrorCleanupRunsCloseThenDeferBeforeLeavingContext()
    local outer = { name = 'outer' }
    local inner = { name = 'inner' }
    local events = {}
@@ -127,7 +127,7 @@ end
       try
          using inner do
             defer
-               events.insert('defer')
+               events.insert('defer:' .. &name)
             end
             local resource <close> = setmetatable({ name = 'resource' }, mt)
             error('block failure')
@@ -137,8 +137,8 @@ end
       end
    end
 
-   assert(events[0] is 'close:resource' and #events is 1,
-      'Error cleanup should run close under dispatch context and retain unsupported defer semantics')
+   assert(events[0] is 'close:resource' and events[1] is 'defer:inner' and #events is 2,
+      'Error cleanup should use dispatch context for close, then lexical context for defer')
    assert(&name is nil)
 end
 

--- a/src/tiri/tests/test_defer.tiri
+++ b/src/tiri/tests/test_defer.tiri
@@ -273,7 +273,263 @@ end
 end
 
 @Test function HandlerError()
-   -- Phase 3 placeholder: deferred handler error propagation to be implemented.
+   local events = {}
+   local caught_message = nil
+
+   function subject()
+      defer
+         events.insert('defer')
+      end
+      events.insert('body')
+      error('body failure')
+   end
+
+   try
+      subject()
+   except e
+      caught_message = e.message
+   success
+      error('Expected the body error to propagate')
+   end
+
+   assert(join(events) is 'body,defer',
+      "A body error should run its armed defer: '" .. join(events) .. "'")
+   assert(caught_message.find('body failure') != nil,
+      'The original body error should propagate when cleanup succeeds: ' .. caught_message)
+end
+
+@Test function UnwindPreservesLifoOrder()
+   local events = {}
+
+   function subject()
+      defer events.insert('first') end
+      defer events.insert('second') end
+      defer events.insert('third') end
+      events.insert('body')
+      error('body failure')
+   end
+
+   try
+      subject()
+   except e
+      assert(e.message.find('body failure') != nil, 'The body error should survive successful cleanup')
+   success
+      error('Expected the body error to propagate')
+   end
+
+   assert(join(events) is 'body,third,second,first',
+      "Error unwinding should run defers in LIFO order: '" .. join(events) .. "'")
+end
+
+@Test function NestedBlockAndFunctionUnwindOrder()
+   local events = {}
+
+   function inner()
+      defer events.insert('inner-function') end
+      do
+         defer events.insert('inner-block') end
+         events.insert('body')
+         error('nested failure')
+      end
+   end
+
+   function outer()
+      defer events.insert('outer-function') end
+      inner()
+   end
+
+   try
+      outer()
+   except e
+      assert(e.message.find('nested failure') != nil, 'The nested body error should propagate')
+   success
+      error('Expected the nested body error to propagate')
+   end
+
+   assert(join(events) is 'body,inner-block,inner-function,outer-function',
+      "Nested scopes and frames should unwind from inner to outer: '" .. join(events) .. "'")
+end
+
+@Test function ArgumentSnapshotDuringUnwind()
+   local events = {}
+   local caught_message = nil
+
+   function subject()
+      local value = 5
+      defer(Snapshot)
+         events.insert('defer-' .. tostring(Snapshot))
+      end(value)
+
+      value = 15
+      events.insert('body-' .. tostring(value))
+      error('snapshot failure')
+   end
+
+   try
+      subject()
+   except e
+      caught_message = e.message
+   success
+      error('Expected the snapshot body error to propagate')
+   end
+
+   assert(join(events) is 'body-15,defer-5',
+      "Error cleanup should retain snapshotted arguments: '" .. join(events) .. "'")
+   assert(caught_message.find('snapshot failure') != nil, 'Successful cleanup should preserve the snapshot body error')
+end
+
+@Test function CloseBeforeDeferDuringUnwind()
+   local events = {}
+   local caught_message = nil
+
+   function close_handler(Name:str):table
+      return setmetatable({}, {
+         __close = function(Error)
+            assert(Error != nil, 'Error unwinding should pass the active error to close handlers')
+            events.insert(Name)
+         end
+      })
+   end
+
+   function subject()
+      defer events.insert('outer-defer') end
+      local outer_close <close> = close_handler('outer-close')
+
+      do
+         defer events.insert('inner-defer') end
+         local inner_close <close> = close_handler('inner-close')
+         events.insert('body')
+         error('ordered cleanup failure')
+      end
+   end
+
+   try
+      subject()
+   except e
+      caught_message = e.message
+   success
+      error('Expected the ordered cleanup body error to propagate')
+   end
+
+   assert(join(events) is 'body,inner-close,inner-defer,outer-close,outer-defer',
+      "Each scope should close resources before running defers: '" .. join(events) .. "'")
+   assert(caught_message.find('ordered cleanup failure') != nil,
+      'Successful close and defer handlers should preserve the body error')
+end
+
+@Test function RemainingDefersRunAfterHandlerError()
+   local events = {}
+   local caught_message = nil
+
+   function subject()
+      defer events.insert('outer') end
+      defer
+         events.insert('throwing')
+         error('cleanup failure')
+      end
+      defer events.insert('inner') end
+      error('body failure')
+   end
+
+   try
+      subject()
+   except e
+      caught_message = e.message
+   end
+
+   assert(join(events) is 'inner,throwing,outer',
+      "A throwing defer must not skip remaining cleanup: '" .. join(events) .. "'")
+   assert(caught_message.find('cleanup failure') != nil,
+      'A cleanup error should replace the body error: ' .. caught_message)
+end
+
+@Test function LastCleanupErrorWins()
+   local events = {}
+   local caught_message = nil
+
+   function subject()
+      defer
+         events.insert('first')
+         error('first cleanup failure')
+      end
+      defer
+         events.insert('second')
+         error('second cleanup failure')
+      end
+      defer
+         events.insert('third')
+         error('third cleanup failure')
+      end
+      error('body failure')
+   end
+
+   try
+      subject()
+   except e
+      caught_message = e.message
+   end
+
+   assert(join(events) is 'third,second,first',
+      "Every throwing defer should still run in LIFO order: '" .. join(events) .. "'")
+   assert(caught_message.find('first cleanup failure') != nil,
+      'The last cleanup error should reach the handler: ' .. caught_message)
+end
+
+@Test function NormalCleanupHandlerErrorRunsOnce()
+   local calls = 0
+   local caught_message = nil
+
+   function subject()
+      defer
+         calls++
+         error('normal cleanup failure')
+      end
+   end
+
+   try
+      subject()
+   except e
+      caught_message = e.message
+   success
+      error('Expected the defer handler to fail')
+   end
+
+   assert(calls is 1, 'A defer that throws during normal cleanup must not run again during unwind')
+   assert(caught_message.find('normal cleanup failure') != nil, 'The defer error should propagate to the handler')
+end
+
+@Test function FailedArgumentEvaluationLeavesDeferUnarmed()
+   local events = {}
+   local caught_message = nil
+
+   function snapshot(Value:str):str
+      events.insert('evaluate-' .. Value)
+      return Value
+   end
+
+   function fail_argument():str
+      events.insert('evaluate-failing')
+      error('argument failure')
+      return 'unreachable'
+   end
+
+   function subject()
+      defer(First, Second)
+         events.insert('defer-' .. First .. '-' .. Second)
+      end(snapshot('first'), fail_argument())
+   end
+
+   try
+      subject()
+   except e
+      caught_message = e.message
+   success
+      error('Expected deferred argument evaluation to fail')
+   end
+
+   assert(join(events) is 'evaluate-first,evaluate-failing',
+      "A defer must remain unarmed until every argument succeeds: '" .. join(events) .. "'")
+   assert(caught_message.find('argument failure') != nil, 'The argument error should propagate unchanged')
 end
 
 function recurse(n, order)
@@ -292,6 +548,169 @@ end
    recurse(3, order)
 
    assert(join(order) is 'enter-3,enter-2,enter-1,leave-1,defer-1,leave-2,defer-2,leave-3,defer-3', "Unexpected recursive defer order: '" .. join(order) .. "'")
+end
+
+@Test function RepeatedLoopAndRecursiveUnwind()
+   local events = {}
+   local caught_message = nil
+
+   function loop_subject()
+      for i in {0 to 4} do
+         defer events.insert('loop-defer-' .. tostring(i)) end
+         events.insert('loop-body-' .. tostring(i))
+         if i is 2 then error('loop failure') end
+      end
+   end
+
+   try
+      loop_subject()
+   except e
+      caught_message = e.message
+   success
+      error('Expected the loop body error to propagate')
+   end
+
+   assert(join(events) is
+      'loop-body-0,loop-defer-0,loop-body-1,loop-defer-1,loop-body-2,loop-defer-2',
+      "Repeated loop registrations should unwind the active iteration: '" .. join(events) .. "'")
+   assert(caught_message.find('loop failure') != nil, 'Loop cleanup should preserve the body error')
+
+   events.clear()
+   caught_message = nil
+
+   function recursive_subject(Depth:num)
+      defer events.insert('recursive-defer-' .. tostring(Depth)) end
+      events.insert('recursive-body-' .. tostring(Depth))
+      if Depth > 0 then
+         recursive_subject(Depth - 1)
+      else
+         error('recursive failure')
+      end
+   end
+
+   try
+      recursive_subject(2)
+   except e
+      caught_message = e.message
+   success
+      error('Expected the recursive body error to propagate')
+   end
+
+   assert(join(events) is
+      'recursive-body-2,recursive-body-1,recursive-body-0,recursive-defer-0,recursive-defer-1,recursive-defer-2',
+      "Recursive activations should own independent registrations: '" .. join(events) .. "'")
+   assert(caught_message.find('recursive failure') != nil, 'Recursive cleanup should preserve the body error')
+end
+
+@Test function CheckallPromotionRunsDefer()
+   local events = {}
+   local caught_code = ERR_Okay
+
+   function subject()
+      defer events.insert('defer') end
+      events.insert('body')
+      checkall
+         mSys.AllocResource(-1024, 0)
+      end
+   end
+
+   try
+      subject()
+   except e when ERR_Args
+      caught_code = e.code
+   success
+      error('Expected checkall to promote ERR_Args')
+   end
+
+   assert(caught_code is ERR_Args, 'The promoted native error should reach the filtered handler')
+   assert(join(events) is 'body,defer',
+      "A checkall promotion should unwind armed defers: '" .. join(events) .. "'")
+end
+
+@Test(hotpath=false) function ProtectedCallUnwindRunsDefer()
+   local events = {}
+   local caught_message = nil
+   rawset(_G, 'glDeferProtectedEvents', events)
+
+   try
+      exec([[
+         function protected_subject()
+            defer
+               _G['glDeferProtectedEvents'].insert('defer')
+            end
+            _G['glDeferProtectedEvents'].insert('body')
+            error('protected failure')
+         end
+         protected_subject()
+      ]])
+   except e
+      caught_message = e.message
+   end
+
+   rawset(_G, 'glDeferProtectedEvents', nil)
+   assert(caught_message != nil, 'Expected exec() to propagate its protected-call error')
+   assert(join(events) is 'body,defer',
+      "A protected-call boundary should observe cleanup first: '" .. join(events) .. "'")
+   assert(caught_message.find('protected failure') != nil, 'The protected call should preserve the body error')
+end
+
+@Test function RegistrationSurvivesStackRelocation()
+   local events = {}
+   local caught_message = nil
+
+   function grow_stack(Depth:num):any
+      if Depth > 0 then return grow_stack(Depth - 1) end
+      processing.collect('full')
+      error('relocated failure')
+   end
+
+   function subject()
+      local token = { name = 'snapshot' }
+      defer(Snapshot)
+         events.insert('defer-' .. Snapshot.name)
+      end(token)
+      grow_stack(180)
+   end
+
+   try
+      subject()
+   except e
+      caught_message = e.message
+   success
+      error('Expected the relocated body error to propagate')
+   end
+
+   assert(join(events) is 'defer-snapshot',
+      "Stack relocation should preserve the defer registration and its arguments: '" .. join(events) .. "'")
+   assert(caught_message.find('relocated failure') != nil, 'Relocated cleanup should preserve the body error')
+end
+
+@Test function AbandonedFramesLeaveNoStaleRegistrations()
+   local events = {}
+   local caught_message = nil
+
+   function abandoned()
+      defer events.insert('abandoned') end
+      error('abandon frame')
+   end
+
+   function survivor()
+      defer events.insert('survivor') end
+      events.insert('survivor-body')
+   end
+
+   try
+      abandoned()
+   except e
+      caught_message = e.message
+   success
+      error('Expected the abandoned frame error to propagate')
+   end
+   survivor()
+
+   assert(join(events) is 'abandoned,survivor-body,survivor',
+      "An abandoned frame should not leak registrations into a later call: '" .. join(events) .. "'")
+   assert(caught_message.find('abandon frame') != nil, 'Abandoning a frame should preserve the body error')
 end
 
 @Test function ClosureReturn()

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -16,6 +16,8 @@ local ir_conv <const> = 91  -- IRDEF order; numeric and integer conversions.
 local ir_bufput <const> = 86
 local ir_bufstr <const> = 87
 local ir_calln <const> = 95  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
+global glBcDeferArm = 140
+global glBcDeferConsume = 141
 local ir_calla <const> = 96
 local ir_calll <const> = 97
 local ir_calls <const> = 98
@@ -3460,6 +3462,173 @@ end
       t[i % 8] = i
    end
    assert(#t is 8, f"A numerically addressed table should keep its length, got {tostring(#t)}")
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Deferred cleanup registrations are physical VM state.  These workloads exercise normal consumption, side exits and
+-- error unwinding while the surrounding loop is recorded.
+
+function defer_ordering_workload(Count:num):str
+   local events = {}
+   for iteration in {0 to Count} do
+      defer(Value)
+         events.insert('outer-' .. tostring(Value))
+      end(iteration)
+      defer(Value)
+         events.insert('inner-' .. tostring(Value))
+      end(iteration)
+      events.insert('body-' .. tostring(iteration))
+   end
+   return events.concat(',')
+end
+
+function defer_side_exit_workload(Count:num, ChangedAt:num):str
+   local events = {}
+   for iteration in {0 to Count} do
+      defer(Value)
+         events.insert('defer-' .. tostring(Value))
+      end(iteration)
+      if iteration >= ChangedAt then events.insert('changed-' .. tostring(iteration)) end
+   end
+   return events.concat(',')
+end
+
+function defer_cleanup_error_workload(FailAt:num):<str, str>
+   local events = {}
+   local caught = ''
+
+   try
+      for iteration in {0 to 40} do
+         defer(Value)
+            events.insert('remaining-' .. tostring(Value))
+         end(iteration)
+         defer(Value, ShouldFail)
+            events.insert('first-' .. tostring(Value))
+            if ShouldFail then error('traced cleanup failure') end
+         end(iteration, iteration is FailAt)
+      end
+   except e
+      caught = e.message
+   end
+
+   return events.concat(','), caught
+end
+
+function defer_throwing_once(Value:num, State:table)
+   defer(Captured)
+      State.calls++
+      error('defer body failure ' .. tostring(Captured))
+   end(Value)
+end
+
+function defer_throwing_body_workload(Count:num):<num, str>
+   local state = { calls = 0 }
+   local caught = ''
+   for iteration in {0 to Count} do
+      try
+         defer_throwing_once(iteration, state)
+      except e
+         caught = e.message
+      end
+   end
+   return state.calls, caught
+end
+
+function run_defer_trace(Workload, Count):<str, str, num, num, num>
+   jit.off()
+   local expected = Workload(Count)
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=2', 'hotexit=1', 'minstitch=0')
+   local compiled = 0
+   local aborted = 0
+   local defer_aborts = 0
+   local function trace_event(Event, TraceNo, Function, BytecodePosition, Error, Detail)
+      if Event is 'stop' then compiled++
+      elseif Event is 'abort' then
+         aborted++
+         if Detail is glBcDeferArm or Detail is glBcDeferConsume then defer_aborts++ end
+      end
+   end
+
+   jit.attach(trace_event, 'trace')
+   local result = Workload(Count)
+   jit.attach(trace_event)
+   jit.opt.start()
+   return expected, result, compiled, aborted, defer_aborts
+end
+
+@Test function JITDeferNormalCleanupAndOrdering()
+   local expected, result, compiled, aborted, defer_aborts = run_defer_trace(defer_ordering_workload, 80)
+   assert(result is expected, 'Recorded defer cleanup should match complete interpreter event ordering')
+   assert(compiled > 0, 'A hot loop containing defer registration and consumption should compile')
+   assert(defer_aborts is 0,
+      f'DEFERARM and DEFERCONSUME should not abort trace recording (total aborts={aborted}, defer aborts={defer_aborts})')
+end
+
+@Test function JITDeferRegistrationSurvivesSideExit()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=2', 'hotexit=1', 'minstitch=0')
+   local compiled = 0
+   local function trace_event(Event)
+      if Event is 'stop' then compiled++ end
+   end
+
+   jit.attach(trace_event, 'trace')
+   local result = defer_side_exit_workload(80, 35)
+   jit.attach(trace_event)
+   local expected = ''
+   jit.off()
+   expected = defer_side_exit_workload(80, 35)
+   jit.on()
+
+   assert(result is expected, 'A branch side exit after DEFERARM should retain each captured value and registration')
+   assert(result.find('changed-35,defer-35') != nil,
+      'The first changed branch should still run the defer armed before its side exit')
+   assert(compiled > 0, 'The post-arm branch workload should execute through compiled code')
+   jit.opt.start()
+end
+
+@Test function JITDeferCleanupErrorLeavesEarlierRegistrationArmed()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=2', 'hotexit=1', 'minstitch=0')
+   local compiled = 0
+   local function trace_event(Event)
+      if Event is 'stop' then compiled++ end
+   end
+   jit.attach(trace_event, 'trace')
+   local events, caught = defer_cleanup_error_workload(25)
+   jit.attach(trace_event)
+
+   assert(caught.find('traced cleanup failure') != nil, 'The cleanup error should propagate through try-except')
+   assert(events.endsWith('first-25,remaining-25'),
+      'The throwing defer should be consumed once and the earlier registration should unwind afterwards')
+   assert(events.count('first-25') is 1, 'The consumed throwing defer must run exactly once')
+   assert(compiled > 0, 'The cleanup-error workload should compile before its changed error edge')
+   jit.opt.start()
+end
+
+@Test function JITThrowingDeferBodyMatchesInterpreter()
+   jit.off()
+   local expected_calls, expected_error = defer_throwing_body_workload(80)
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=2', 'hotexit=1', 'minstitch=0')
+   local compiled = 0
+   local function trace_event(Event)
+      if Event is 'stop' then compiled++ end
+   end
+   jit.attach(trace_event, 'trace')
+   local calls, caught = defer_throwing_body_workload(80)
+   jit.attach(trace_event)
+
+   assert(calls is expected_calls, f'Expected {expected_calls} throwing defer calls, got {calls}')
+   assert(caught is expected_error, f"Expected final defer error '{expected_error}', got '{caught}'")
+   assert(compiled > 0, 'Repeated throwing defer bodies should produce recorded code')
+   jit.opt.start()
 end
 
 -----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces support for runtime `defer` semantics in the LuaJIT bytecode system, adding new bytecodes and updating the error handling and unwinding logic to support both close and defer cleanup handlers. The changes also generalize and refactor the cleanup process during error unwinding, replacing the previous focus on `__close` handlers with a more unified "cleanup" system that includes both close and defer handlers.

**New bytecode and versioning:**

* Added two new bytecodes, `BC_DEFERARM` and `BC_DEFERCONSUME`, to support runtime defer registration and consumption. Updated the `BCOp` enum and increased the bytecode version to `0x9b` to reflect these additions. [[1]](diffhunk://#diff-fdc1fd034986c3ed01ec954183639217472b5dfadf17a64d3cb7f8a72151ab64L307-R310) [[2]](diffhunk://#diff-fdc1fd034986c3ed01ec954183639217472b5dfadf17a64d3cb7f8a72151ab64R492-R495) [[3]](diffhunk://#diff-af40a0b4d460a64a503f4668619da0bca27f4b93d37d056d9788e72fe2fb0cabL54-R57)

**Bytecode validation:**

* Updated bytecode reader (`lj_bcread.cpp`) to validate the new defer bytecodes, ensuring correct slot ranges and argument counts for `BC_DEFERARM` and `BC_DEFERCONSUME`.

**Error unwinding and cleanup refactor:**

* Refactored error unwinding logic to generalize cleanup handling: replaced all references to `__close` handlers with a unified cleanup handler system that processes both close and defer registrations. Introduced new helper functions like `unwind_defer_scope`, `unwind_cleanup_range`, and `unwind_cleanup_all`, and updated all unwinding code paths to use these. [[1]](diffhunk://#diff-027421fa34f66ceecb56aaf7f7ddde11723add3816700784481bb4eefb933bcaL142-R177) [[2]](diffhunk://#diff-027421fa34f66ceecb56aaf7f7ddde11723add3816700784481bb4eefb933bcaL242-R306) [[3]](diffhunk://#diff-027421fa34f66ceecb56aaf7f7ddde11723add3816700784481bb4eefb933bcaL268-R335) [[4]](diffhunk://#diff-027421fa34f66ceecb56aaf7f7ddde11723add3816700784481bb4eefb933bcaR369) [[5]](diffhunk://#diff-027421fa34f66ceecb56aaf7f7ddde11723add3816700784481bb4eefb933bcaL514-R584) [[6]](diffhunk://#diff-027421fa34f66ceecb56aaf7f7ddde11723add3816700784481bb4eefb933bcaL541-R610) [[7]](diffhunk://#diff-027421fa34f66ceecb56aaf7f7ddde11723add3816700784481bb4eefb933bcaL644-R706) [[8]](diffhunk://#diff-027421fa34f66ceecb56aaf7f7ddde11723add3816700784481bb4eefb933bcaL672-R734) [[9]](diffhunk://#diff-027421fa34f66ceecb56aaf7f7ddde11723add3816700784481bb4eefb933bcaR767-R772) [[10]](diffhunk://#diff-027421fa34f66ceecb56aaf7f7ddde11723add3816700784481bb4eefb933bcaL729-R801) [[11]](diffhunk://#diff-027421fa34f66ceecb56aaf7f7ddde11723add3816700784481bb4eefb933bcaL752-R819)

**Semantics and comments:**

* Updated comments throughout the error handling code to clarify that both close and defer handlers are now supported, and to describe the new cleanup semantics and control flow. [[1]](diffhunk://#diff-027421fa34f66ceecb56aaf7f7ddde11723add3816700784481bb4eefb933bcaL142-R177) [[2]](diffhunk://#diff-027421fa34f66ceecb56aaf7f7ddde11723add3816700784481bb4eefb933bcaL242-R306) [[3]](diffhunk://#diff-027421fa34f66ceecb56aaf7f7ddde11723add3816700784481bb4eefb933bcaL268-R335)

These changes lay the groundwork for robust runtime defer support in LuaJIT, ensuring that both close and defer handlers are properly registered, validated, and executed during normal scope exit and error unwinding.