### PR TITLE
[Tiri] Preserved all results from checked expressions

### DIFF
--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -449,6 +449,19 @@ static array_count_span array_clamped_count_span(lua_State *L, int32_t Start, in
    return { start, count };
 }
 
+static array_count_span array_clamped_half_open_span(lua_State *L, int32_t Start, int32_t Stop, MSize Length)
+{
+   if (Start < 0 or Stop < 0) lj_err_caller(L, ErrMsg::IDXRNG);
+
+   auto start = MSize(Start);
+   if (start >= Length) return { Length, 0 };
+
+   auto stop = MSize(Stop);
+   if (stop > Length) stop = Length;
+   if (stop <= start) return { start, 0 };
+   return { start, stop - start };
+}
+
 static array_range_span array_range_to_span(lua_State *L, const tiri_range *Range, MSize Length)
 {
    tiri_index_range index_range;
@@ -1452,19 +1465,19 @@ static void fill_array_elements(lua_State *L, GCarray *Arr, cTValue *Value, int3
 }
 
 //********************************************************************************************************************
-// Usage: array.fill(arr, value [, start [, count]]) or array.fill(arr, value, range)
+// Usage: array.fill(arr, value [, start [, stop]]) or array.fill(arr, value, range)
 //
 // Fills array elements with a value.
 //
 // Parameters (integer form):
 //   arr: the array (must not be read-only)
-//   value: value to fill with (number)
+//   value: value satisfying the array's element contract
 //   start: starting index (0-based, default 0)
-//   count: number of elements to fill (default: all remaining)
+//   stop: exclusive stopping index (default: array length)
 //
 // Parameters (range form):
 //   arr: the array (must not be read-only)
-//   value: value to fill with (number)
+//   value: value satisfying the array's element contract
 //   range: range object specifying which elements to fill
 
 LJLIB_CF(array_fill)
@@ -1488,10 +1501,10 @@ LJLIB_CF(array_fill)
       return 0;
    }
 
-   // Original integer-based fill
+   // Positional half-open span
    auto start = lj_lib_optint(L, 3, 0);
-   auto count = lj_lib_optint(L, 4, array_default_remaining(arr->len, start));
-   auto span = array_clamped_count_span(L, start, count, arr->len);
+   auto stop = lj_lib_optint(L, 4, int32_t(arr->len));
+   auto span = array_clamped_half_open_span(L, start, stop, arr->len);
 
    if (span.count IS 0) return 0;
 

--- a/src/tiri/jit/src/lj_asm.cpp
+++ b/src/tiri/jit/src/lj_asm.cpp
@@ -2044,7 +2044,8 @@ static void asm_tail_link(ASMState* as)
             pc = retpc;
       }
       emit_loadu64(as, RID_LPC, u64ptr(pc));
-      if (bc_op(*pc) IS BC_JMP) mres = int32_t(snap->multres);
+      // BC_CHECK can separate a multi-result call from BC_RETM; its interpreter handoff must retain that count.
+      if (bc_op(*pc) IS BC_JMP or bc_op(*pc) IS BC_CHECK) mres = int32_t(snap->multres);
       else {
          mres = (int32_t)(snap->nslots - baseslot - LJ_FR2);
          switch (bc_op(*pc)) {

--- a/src/tiri/jit/src/lj_trace.cpp
+++ b/src/tiri/jit/src/lj_trace.cpp
@@ -1127,7 +1127,8 @@ int lj_trace_exit(jit_State *J, void *exptr)
    }
    // Return MULTRES or 0.
    ERRNO_RESTORE
-      if (bc_op(*pc) IS BC_JMP) return int(snapshot_multres);
+      // BC_CHECK can separate a multi-result call from BC_RETM; its interpreter handoff must retain that count.
+      if (bc_op(*pc) IS BC_JMP or bc_op(*pc) IS BC_CHECK) return int(snapshot_multres);
       switch (bc_op(*pc)) {
       case BC_CALLM: case BC_CALLMT: case BC_CTXCALLM:
          return (int)((BCREG)(L->top - L->base) - bc_a(*pc) - bc_c(*pc) - LJ_FR2);

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -385,13 +385,22 @@ ParserResult<ExprNodePtr> AstBuilder::parse_expression(uint8_t precedence)
 }
 
 //********************************************************************************************************************
-// Parses unary expressions (not, negation, length, bit not, prefix increment).
+// Parses unary expressions (check, not, negation, length, bit not, prefix increment).
 
 ParserResult<ExprNodePtr> AstBuilder::parse_unary()
 {
    constexpr uint8_t unary_precedence = 10;
 
    Token current = this->ctx.tokens().current();
+   if (current.kind() IS TokenKind::CheckToken) {
+      this->ctx.tokens().advance();
+      auto operand = this->parse_expression();
+      if (not operand.ok()) return operand;
+
+      operand.value_ref()->is_checked = true;
+      return operand;
+   }
+
    if (current.kind() IS TokenKind::NotToken) {
       this->ctx.tokens().advance();
       auto operand = this->parse_expression(unary_precedence);

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -692,6 +692,7 @@ struct ExprNode {
    AstNodeKind kind = AstNodeKind::LiteralExpr;
    SourceSpan span{};
    bool is_grouped = false;
+   bool is_checked = false; // Promote an unsafe first result while preserving the expression's complete result set
    mutable StaticValueHandle static_value = 0;
    mutable StaticResultSetHandle static_results = 0;
    std::variant<LiteralValue, NameRef, CurrentContextExprPayload, VarArgExprPayload, UnaryExprPayload,

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -3075,15 +3075,21 @@ ParserResult<ExpDesc> IrEmitter::emit_expression(const ExprNode& expr)
 
    this->lex_state.lastline = expr.span.line;
 
+   BCReg checkall_base = BCReg(0);
+   if (expr.is_checked) {
+      checkall_base = BCReg(this->func_state.freereg);
+      bcemit_AD(&this->func_state, BC_CHECKALLENTER, checkall_base, BCReg(0));
+      this->func_state.runtime_scopes.push_back(RuntimeScope{ RuntimeScopeKind::Checkall, checkall_base });
+   }
+
    // Attempting the fold at every node means a non-constant subtree can be re-walked once per ancestor,
    // giving O(depth^2) behaviour on deep chains; evaluation bails at the first non-constant operand, which
    // keeps the cost negligible for hand-written code.  Memoise per-node if generated code makes this hot.
-   if (auto constant = this->constant_evaluator.evaluate(expr)) {
-      return this->emit_literal_expr(constant->to_literal());
-   }
-
    ParserResult<ExpDesc> result;
-   switch (expr.kind) {
+   if (auto constant = this->constant_evaluator.evaluate(expr)) {
+      result = this->emit_literal_expr(constant->to_literal());
+   }
+   else switch (expr.kind) {
       case AstNodeKind::LiteralExpr:
          result = this->emit_literal_expr(std::get<LiteralValue>(expr.data));
          break;
@@ -3163,6 +3169,22 @@ ParserResult<ExpDesc> IrEmitter::emit_expression(const ExprNode& expr)
 
    if (result.ok()) {
       ExpDesc &emitted = result.value_ref();
+      if (expr.is_checked) {
+         BCReg error_reg;
+         if (emitted.k IS ExpKind::Call) error_reg = BCReg(emitted.u.s.aux);
+         else {
+            expr_toanyreg(&this->func_state, &emitted);
+            error_reg = BCReg(emitted.u.s.info);
+         }
+
+         bcemit_AD(&this->func_state, BC_CHECKALLLEAVE, checkall_base, BCReg(0));
+         this->func_state.runtime_scopes.pop_back();
+
+         int32_t raw_column = expr.span.column.lineNumber();
+         BCReg source_column = BCReg(raw_column > int32_t(BCMAX_D) ? BCMAX_D : raw_column);
+         bcemit_AD(&this->func_state, BC_CHECK, error_reg, source_column);
+      }
+
       if (expr.static_value) {
          emitted.static_value = expr.static_value;
          const auto &descriptor = this->ctx.descriptors().value(expr.static_value);

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1744,6 +1744,12 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
             set_call_result_count(&this->func_state, last, 0);
             ins = BCINS_AD(BC_RETM, return_base, last.u.s.aux - return_base);
          }
+         else if (has_post_call_control_flow and Payload.values.back()->is_checked) {
+            // A checked call retains its complete result set after promoting a failing first result. The inserted
+            // check instructions prevent tail-call conversion, but do not consolidate the successful results.
+            set_call_result_count(&this->func_state, last, 0);
+            ins = BCINS_AD(BC_RETM, return_base, last.u.s.aux - return_base);
+         }
          else if (has_post_call_control_flow) {
             // Safe calls and other call expressions with post-call control flow cannot be converted to CALLT: the
             // conversion removes the final emitted instruction rather than the earlier CALL.  Such expressions

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1645,6 +1645,15 @@ static bool tail_call_preserves_checkall_boundary(const ParserContext &Context, 
    return Context.descriptors().callable(call.callable).source != StaticCallableSource::NativePrototype;
 }
 
+static bool is_safe_call_expression(const ExprNode &Expression)
+{
+   // Parsed safe calls currently retain CallExpr and identify the nil short-circuit through their dispatch mode.
+   if (Expression.kind IS AstNodeKind::SafeCallExpr) return true;
+   if (Expression.kind != AstNodeKind::CallExpr) return false;
+   const auto &call = std::get<CallExprPayload>(Expression.data);
+   return call.dispatch IS CallDispatch::SafeMemberNamed or call.dispatch IS CallDispatch::SafeMemberComputed;
+}
+
 ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Payload)
 {
    BCIns ins;
@@ -1744,7 +1753,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
             set_call_result_count(&this->func_state, last, 0);
             ins = BCINS_AD(BC_RETM, return_base, last.u.s.aux - return_base);
          }
-         else if (has_post_call_control_flow and Payload.values.back()->is_checked) {
+         else if (has_post_call_control_flow and Payload.values.back()->is_checked and
+                  not is_safe_call_expression(*Payload.values.back())) {
             // A checked call retains its complete result set after promoting a failing first result. The inserted
             // check instructions prevent tail-call conversion, but do not consolidate the successful results.
             set_call_result_count(&this->func_state, last, 0);

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1701,6 +1701,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
          auto expected_end = last.u.s.info + (has_context_leave ? 2 : 1);
          bool has_post_call_control_flow = expected_end != this->func_state.pc;
          bool has_user_cleanup = cleanup_temp_regs > 0;
+         bool safe_call = is_safe_call_expression(*Payload.values.back());
          bool forwards_current_contract = tail_call_forwards_current_contract(
             this->ctx, this->current_callable, *Payload.values.back());
          bool direct_tail_call = call_op IS BC_CALL or call_op IS BC_CALLM;
@@ -1732,6 +1733,12 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
                ins = BCINS_AD(bc_op(*ip) - BC_CALL + BC_CALLT, bc_a(*ip), bc_c(*ip));
             }
          }
+         else if (safe_call) {
+            // The nil short-circuit initialises only the consolidated first result, so it cannot use a return form
+            // that consumes MULTRES or exposes additional fixed registers.
+            set_call_result_count(&this->func_state, last, 2);
+            ins = BCINS_AD(BC_RET1, last.u.s.aux, 2);
+         }
          else if (truncate_return_results) {
             BCREG result_count = this->func_state.return_declared_count;
             set_call_result_count(&this->func_state, last, result_count + 1);
@@ -1753,17 +1760,15 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
             set_call_result_count(&this->func_state, last, 0);
             ins = BCINS_AD(BC_RETM, return_base, last.u.s.aux - return_base);
          }
-         else if (has_post_call_control_flow and Payload.values.back()->is_checked and
-                  not is_safe_call_expression(*Payload.values.back())) {
+         else if (has_post_call_control_flow and Payload.values.back()->is_checked) {
             // A checked call retains its complete result set after promoting a failing first result. The inserted
             // check instructions prevent tail-call conversion, but do not consolidate the successful results.
             set_call_result_count(&this->func_state, last, 0);
             ins = BCINS_AD(BC_RETM, return_base, last.u.s.aux - return_base);
          }
          else if (has_post_call_control_flow) {
-            // Safe calls and other call expressions with post-call control flow cannot be converted to CALLT: the
-            // conversion removes the final emitted instruction rather than the earlier CALL.  Such expressions
-            // represent one consolidated value, so retain that result and return it normally.
+            // Calls with post-call control flow cannot be converted to CALLT: the conversion removes the final emitted
+            // instruction rather than the earlier CALL. Such expressions represent one consolidated value.
             set_call_result_count(&this->func_state, last, 2);
             ins = BCINS_AD(BC_RET1, last.u.s.aux, 2);
          }
@@ -1792,7 +1797,11 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
       else {
          // Multiple return values
          if (last.k IS ExpKind::Call) {
-            if (truncate_return_results) {
+            if (is_safe_call_expression(*Payload.values.back())) {
+               set_call_result_count(&this->func_state, last, 2);
+               ins = BCINS_AD(BC_RET, return_base, count + 1);
+            }
+            else if (truncate_return_results) {
                BCREG result_count = this->func_state.return_declared_count;
                BCREG fixed_count = last.u.s.aux - return_base;
                BCREG call_count = result_count > fixed_count ? result_count - fixed_count : 0;

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -7162,6 +7162,20 @@ static bool test_tail_call_eligibility(kt::Log &Log)
       return false;
    }
 
+   constexpr std::string_view checked_safe_source =
+      "extern obj\n"
+      "try global checked_safe_object = obj.new('time') end\n"
+      "local function checked_safe()\n"
+      "   return check checked_safe_object?.acQuery()\n"
+      "end\n"
+      "return checked_safe\n";
+   auto checked_safe = compile_snapshot(L, checked_safe_source, true, error);
+   if (not checked_safe or count_opcode_tree(*checked_safe, BC_RET1) IS 0 or
+       count_opcode_tree(*checked_safe, BC_RETM) != 0) {
+      Log.error("a checked safe-call return did not lower to one fixed result: %s", error.c_str());
+      return false;
+   }
+
    constexpr std::string_view cleanup_source =
       "local function source():<num, str> return 7, 'cleanup' end\n"
       "local function cleaned()\n"

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -7176,6 +7176,50 @@ static bool test_tail_call_eligibility(kt::Log &Log)
       return false;
    }
 
+   constexpr std::string_view checked_safe_try_source =
+      "extern obj\n"
+      "try global checked_safe_try_object = obj.new('time') end\n"
+      "local function checked_safe_try()\n"
+      "   try\n"
+      "      return check checked_safe_try_object?.acQuery()\n"
+      "   end\n"
+      "end\n"
+      "return checked_safe_try\n";
+   auto checked_safe_try = compile_snapshot(L, checked_safe_try_source, true, error);
+   if (not checked_safe_try or count_opcode_tree(*checked_safe_try, BC_RET1) IS 0 or
+       count_opcode_tree(*checked_safe_try, BC_RETM) != 0) {
+      Log.error("a checked safe-call return inside try did not lower to one fixed result: %s", error.c_str());
+      return false;
+   }
+
+   constexpr std::string_view checked_safe_fixed_source =
+      "extern obj\n"
+      "try global checked_safe_fixed_object = obj.new('time') end\n"
+      "local function checked_safe_fixed():<any, any>\n"
+      "   return check checked_safe_fixed_object?.acQuery()\n"
+      "end\n"
+      "return checked_safe_fixed\n";
+   auto checked_safe_fixed = compile_snapshot(L, checked_safe_fixed_source, true, error);
+   if (not checked_safe_fixed or count_opcode_tree(*checked_safe_fixed, BC_RET1) IS 0 or
+       count_opcode_tree(*checked_safe_fixed, BC_RET) != 0 or count_opcode_tree(*checked_safe_fixed, BC_RETM) != 0) {
+      Log.error("a contracted checked safe-call return did not lower to one fixed result: %s", error.c_str());
+      return false;
+   }
+
+   constexpr std::string_view checked_safe_list_source =
+      "extern obj\n"
+      "try global checked_safe_list_object = obj.new('time') end\n"
+      "local function checked_safe_list()\n"
+      "   return 'prefix', check checked_safe_list_object?.acQuery()\n"
+      "end\n"
+      "return checked_safe_list\n";
+   auto checked_safe_list = compile_snapshot(L, checked_safe_list_source, true, error);
+   if (not checked_safe_list or count_opcode_tree(*checked_safe_list, BC_RET) IS 0 or
+       count_opcode_tree(*checked_safe_list, BC_RETM) != 0) {
+      Log.error("a trailing checked safe-call return did not lower to fixed results: %s", error.c_str());
+      return false;
+   }
+
    constexpr std::string_view cleanup_source =
       "local function source():<num, str> return 7, 'cleanup' end\n"
       "local function cleaned()\n"

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -1491,13 +1491,15 @@ static bool test_lib_array_fill(kt::Log &Log)
    }
    luaL_openlibs(L);
 
-   // Test array.fill
+   // Test array.fill, including its half-open positional span.
    const char* code = R"(
       local arr:array<int> = array.new(10, "int")
-      array.fill(arr, 42)
+      array.fill(arr, 0)
+      array.fill(arr, 42, 3, 7)
       local ok = true
-      for i in {0 into 9} do
-         if arr[i] != 42 then ok = false end
+      for i in {0 to 10} do
+         local expected = (i >= 3 and i < 7) ? 42 :> 0
+         if arr[i] != expected then ok = false end
       end
       return ok
    )";

--- a/src/tiri/tests/test_array_element_validation.tiri
+++ b/src/tiri/tests/test_array_element_validation.tiri
@@ -114,7 +114,7 @@ end
    values.push(false)
    values.insert(0, 'first')
    values[1] = table_value
-   values.fill(array_value, 2, 1)
+   values.fill(array_value, 2, 3)
    local mapped = values.mapSame(Value => any: Value)
    assert(mapped[0] is 'first' and mapped[1] is table_value and mapped[2] is array_value,
       'Any writers did not preserve mixed categories')

--- a/src/tiri/tests/test_array_manip.tiri
+++ b/src/tiri/tests/test_array_manip.tiri
@@ -97,7 +97,7 @@ end
    assert(bytes[0] is 255 and bytes[1] is 0 and bytes[2] is 1, 'uint8 construction did not wrap and truncate')
    bytes.push(2)
    bytes.insert(1, 257)
-   bytes.fill(-1, 2, 1)
+   bytes.fill(-1, 2, 3)
    assert(bytes[1] is 1 and bytes[2] is 255, 'uint8 mutation did not preserve modulo conversion')
 
    local values = array<uint> { 2147483648, 3, 4294967295 }
@@ -1469,25 +1469,63 @@ end
    arr.fill(22, {20 to 30})
    assert(arr[0] is 11 and arr[1] is 11 and arr[2] is 0 and arr[3] is 0 and arr[4] is 0,
       "empty clipped fill ranges should leave the array unchanged")
-
-   arr.fill(33, 4, 10)
-   assert(arr[4] is 33, "integer fill should clamp count to the remaining span")
-
-   arr.fill(44, 5, 10)
-   assert(arr[4] is 33, "integer fill starting at the end should be a no-op")
 end
 
-@Test function ArrayFillOriginalSyntax()
-   -- Verify original syntax still works
+@Test function ArrayFillWithPositionalSpan()
    arr = array<int, 10>
-   arr.fill(0)  -- Zero-initialize first
+   arr.fill(0)
 
-   -- Fill starting at index 3, 4 elements
-   arr.fill(42, 3, 4)
-   assert(arr[2] is 0, "fill original: arr[2] should be 0")
-   assert(arr[3] is 42, "fill original: arr[3] should be 42")
-   assert(arr[4] is 42, "fill original: arr[4] should be 42")
-   assert(arr[5] is 42, "fill original: arr[5] should be 42")
-   assert(arr[6] is 42, "fill original: arr[6] should be 42")
-   assert(arr[7] is 0, "fill original: arr[7] should be 0")
+   arr.fill(42, 3, 7)
+   assert(arr[2] is 0, "positional fill should not change the element before Start")
+   assert(arr[3] is 42 and arr[6] is 42, "positional fill should include Start through Stop - 1")
+   assert(arr[7] is 0, "positional fill should exclude Stop")
+end
+
+@Test function ArrayFillPositionalMatchesRange()
+   positional = array<int, 8>
+   ranged = array<int, 8>
+   positional.fill(0)
+   ranged.fill(0)
+
+   positional.fill(17, 2, 6)
+   ranged.fill(17, {2 to 6})
+
+   for i in {0 to 8} do
+      assert(positional[i] is ranged[i], "positional and range fill should select the same elements")
+   end
+end
+
+@Test function ArrayFillPositionalDefaultsAndClipping()
+   arr = array<int, 5>
+   arr.fill(7, 0, 5)
+   assert(arr[0] is 7 and arr[4] is 7, "Stop equal to the array length should include the final element")
+   arr.fill(0)
+
+   arr.fill(11, 3)
+   assert(arr[2] is 0 and arr[3] is 11 and arr[4] is 11, "omitted Stop should fill to the array length")
+
+   arr.fill(22, 4, 10)
+   assert(arr[3] is 11 and arr[4] is 22, "Stop beyond the array length should be clipped")
+
+   arr.fill('invalid', 2, 2)
+   arr.fill('invalid', 4, 3)
+   arr.fill('invalid', 5, 10)
+   arr.fill('invalid', 8, 10)
+   assert(arr[2] is 0 and arr[3] is 11 and arr[4] is 22, "empty positional spans should be no-ops")
+end
+
+@Test function ArrayFillPositionalRejectsNegativeBounds()
+   arr = array<int, 5>
+
+   try
+      arr.fill(1, -1, 2)
+   success
+      error("Positional fill should reject a negative Start")
+   end
+
+   try
+      arr.fill(1, 0, -1)
+   success
+      error("Positional fill should reject a negative Stop")
+   end
 end

--- a/src/tiri/tests/test_safe_nav.tiri
+++ b/src/tiri/tests/test_safe_nav.tiri
@@ -87,6 +87,36 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
+@Test function testCheckedSafeCallReturnOnNil()
+   holder = nil
+   try
+      holder = obj.new('time')
+   end
+
+   function checkedSafeReturn()
+      return check holder?.acQuery()
+   end
+
+   result, extra = checkedSafeReturn()
+   assert(result is ERR_Okay, 'A checked safe call should return its first successful result')
+   assert(extra is nil, 'A checked safe call should consolidate a successful call to one result')
+
+   holder.free()
+   holder = nil
+
+   function priorResults():<any, str>
+      return nil, 'captured'
+   end
+   _, captured = priorResults()
+   assert(captured is 'captured', 'The stale-result seed should retain its second result')
+
+   result, extra = checkedSafeReturn()
+   assert(result is nil, 'A checked safe call should return nil for a missing receiver')
+   assert(extra is nil, 'A checked safe call should not return stale results for a missing receiver')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
 @Test function testSafeMethodChain()
    account = { profile = { email = "user@example.com" } }
    function account.getProfile(Self):table

--- a/src/tiri/tests/test_safe_nav.tiri
+++ b/src/tiri/tests/test_safe_nav.tiri
@@ -97,9 +97,36 @@ end
       return check holder?.acQuery()
    end
 
+   function checkedSafeReturnInTry()
+      try
+         return check holder?.acQuery()
+      end
+   end
+
+   function checkedSafeFixedReturn():<any, any>
+      return check holder?.acQuery()
+   end
+
+   function checkedSafeListReturn()
+      return 'prefix', check holder?.acQuery()
+   end
+
    result, extra = checkedSafeReturn()
    assert(result is ERR_Okay, 'A checked safe call should return its first successful result')
    assert(extra is nil, 'A checked safe call should consolidate a successful call to one result')
+
+   result, extra = checkedSafeReturnInTry()
+   assert(result is ERR_Okay, 'A checked safe call inside try should return its first successful result')
+   assert(extra is nil, 'A checked safe call inside try should consolidate a successful call to one result')
+
+   result, extra = checkedSafeFixedReturn()
+   assert(result is ERR_Okay, 'A contracted checked safe call should return its first successful result')
+   assert(extra is nil, 'A contracted checked safe call should initialise its additional result to nil')
+
+   prefix, result, extra = checkedSafeListReturn()
+   assert(prefix is 'prefix', 'A trailing checked safe call should preserve earlier return values')
+   assert(result is ERR_Okay, 'A trailing checked safe call should return its first successful result')
+   assert(extra is nil, 'A trailing checked safe call should consolidate to one result')
 
    holder.free()
    holder = nil
@@ -113,6 +140,25 @@ end
    result, extra = checkedSafeReturn()
    assert(result is nil, 'A checked safe call should return nil for a missing receiver')
    assert(extra is nil, 'A checked safe call should not return stale results for a missing receiver')
+
+   _, captured = priorResults()
+   assert(captured is 'captured', 'The active-scope stale-result seed should retain its second result')
+   result, extra = checkedSafeReturnInTry()
+   assert(result is nil, 'A checked safe call inside try should return nil for a missing receiver')
+   assert(extra is nil, 'A checked safe call inside try should not return stale results')
+
+   _, captured = priorResults()
+   assert(captured is 'captured', 'The contracted stale-result seed should retain its second result')
+   result, extra = checkedSafeFixedReturn()
+   assert(result is nil, 'A contracted checked safe call should return nil for a missing receiver')
+   assert(extra is nil, 'A contracted checked safe call should initialise its additional result to nil')
+
+   _, captured = priorResults()
+   assert(captured is 'captured', 'The trailing-call stale-result seed should retain its second result')
+   prefix, result, extra = checkedSafeListReturn()
+   assert(prefix is 'prefix', 'A nil trailing checked safe call should preserve earlier return values')
+   assert(result is nil, 'A trailing checked safe call should return nil for a missing receiver')
+   assert(extra is nil, 'A trailing checked safe call should not return stale results')
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_try_except.tiri
+++ b/src/tiri/tests/test_try_except.tiri
@@ -1444,6 +1444,40 @@ end
    error("check with expression should have thrown")
 end
 
+@Test(priority=66) function CheckExpressionFallsThroughResults()
+   function checked_results(Fail)
+      return Fail ? ERR_Args : ERR_Okay, 37, 'captured'
+   end
+
+   err, count, text = check checked_results(false)
+   assert(err is ERR_Okay, "check expression should preserve the successful error result")
+   assert(count is 37, "check expression should preserve the second result")
+   assert(text is 'captured', "check expression should preserve the third result")
+
+   file = obj.new('file', { path='string:native result' })
+   buffer = string.alloc(32)
+   err, bytes = check file.acRead(buffer)
+   assert(err is ERR_Okay, "check expression should preserve a successful native error result")
+   assert(bytes is 13, "check expression should preserve a native action's result")
+   assert(buffer.sub(0, bytes) is 'native result', "checked native action should populate its output buffer")
+
+   missing_path = 'no_such_volume_for_checked_expression:'
+   try
+      err, path_type = check mSys.AnalysePath(missing_path)
+   except e when ERR_FileNotFound
+      assert(e.message.find('AnalysePath()'), "checked native expression should retain the call diagnostic")
+   success
+      error("checked native expression should promote a failing first result")
+   end
+
+   try
+      err, count, text = check checked_results(true)
+   except e when ERR_Args
+      return
+   end
+   error("check expression assignment should promote a failing first result")
+end
+
 @Test(priority=0.5,hotpath=false) function CheckIncludesLocationAndTraceback()
    expected_line = @SourceLine + 3
 

--- a/src/tiri/tests/test_try_except.tiri
+++ b/src/tiri/tests/test_try_except.tiri
@@ -1445,14 +1445,23 @@ end
 end
 
 @Test(priority=66) function CheckExpressionFallsThroughResults()
-   function checked_results(Fail)
+   function checked_results(Fail):<num, num, str>
       return Fail ? ERR_Args : ERR_Okay, 37, 'captured'
+   end
+
+   function inferred_checked_results()
+      return check checked_results(false)
    end
 
    err, count, text = check checked_results(false)
    assert(err is ERR_Okay, "check expression should preserve the successful error result")
    assert(count is 37, "check expression should preserve the second result")
    assert(text is 'captured', "check expression should preserve the third result")
+
+   err, count, text = inferred_checked_results()
+   assert(err is ERR_Okay, "inferred checked return should preserve the successful error result")
+   assert(count is 37, "inferred checked return should preserve the second result")
+   assert(text is 'captured', "inferred checked return should preserve the third result")
 
    file = obj.new('file', { path='string:native result' })
    buffer = string.alloc(32)

--- a/src/tiri/tiri_async.cpp
+++ b/src/tiri/tiri_async.cpp
@@ -390,7 +390,7 @@ static int async_wait(lua_State *Lua)
 
       error = AsyncWait(ids, timeout_ms);
 
-      if ((error != ERR::Okay) and (in_checkall_immediate_scope(Lua))) luaL_error(Lua, error);
+      if ((error >= ERR::ExceptionThreshold) and (in_checkall_immediate_scope(Lua))) luaL_error(Lua, error);
    }
 
    lua_pushinteger(Lua, int(error));
@@ -425,7 +425,7 @@ static int async_cancel(lua_State *Lua)
    ERR error = ERR::Okay;
    if (not ids.empty()) {
       error = AsyncCancel(ids);
-      if ((error != ERR::Okay) and (in_checkall_immediate_scope(Lua))) luaL_error(Lua, error);
+      if ((error >= ERR::ExceptionThreshold) and (in_checkall_immediate_scope(Lua))) luaL_error(Lua, error);
    }
 
    lua_pushinteger(Lua, int(error));

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -235,7 +235,7 @@ static int processing_sleep(lua_State *Lua)
    else error = ProcessMessages(PMF::NIL, 0);
 
    // Promote errors to exceptions
-   if ((error != ERR::Okay) and (in_checkall_immediate_scope(Lua))) luaL_error(Lua, error);
+   if ((error >= ERR::ExceptionThreshold) and (in_checkall_immediate_scope(Lua))) luaL_error(Lua, error);
 
    lua_pushinteger(Lua, int(error));
    return 1;


### PR DESCRIPTION
* Extended the JIT parser and emitter to promote failing first results without discarding subsequent results
* Updated async and processing error promotion to preserve ordinary error results
* Added Tiri coverage for checked script and native multi-result expressions