### PR TITLE
[Tiri] Preserve declared results for safe method calls

### DIFF
--- a/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
@@ -88,6 +88,7 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_pipe(
    ExpDesc receiver = receiver_result.value_ref();
    RegisterAllocator allocator(state);
    BCReg receiver_reg(0);
+   BCPOS field_nil_init = NO_JMP;
    if (Call.runtime_builtin_method->safe) {
       nil_guard = std::make_unique<NilShortCircuitGuard>(this, receiver);
       if (not nil_guard->ok()) return nil_guard->error<ExpDesc>();
@@ -210,6 +211,7 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_pipe(
       // the synthetic nil-result block; skip_nil carries both successful paths around it to the common continuation.
       ControlFlowEdge skip_nil = this->control_flow.make_unconditional(BCPos(bcemit_jmp(state)));
       field_nil_jump.patch_to(state->current_pc());
+      field_nil_init = state->pc;
       bcemit_nil(state, call_base.raw(), 1);
       skip_nil.patch_here();
    }
@@ -219,6 +221,7 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_pipe(
    if (not emitted.ok()) return emitted;
    ExpDesc result = emitted.value_ref();
    result.alternate_call = builtin_call.raw();
+   result.alternate_safe_nil_init = field_nil_init;
    result.u.s.aux = call_base.raw();
    result.static_results = Call.results;
    if (Call.results) {
@@ -635,6 +638,7 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_call(const CallExpr
    ExpDesc receiver = receiver_result.value_ref();
    RegisterAllocator allocator(state);
    BCReg receiver_reg(0);
+   BCPOS field_nil_init = NO_JMP;
    if (Payload.runtime_builtin_method->safe) {
       nil_guard = std::make_unique<NilShortCircuitGuard>(this, receiver);
       if (not nil_guard->ok()) return nil_guard->error<ExpDesc>();
@@ -747,6 +751,7 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_call(const CallExpr
       // into call_base before all paths rejoin for the existing receiver nil guard and result metadata handling.
       ControlFlowEdge skip_nil = this->control_flow.make_unconditional(BCPos(bcemit_jmp(state)));
       field_nil_jump.patch_to(state->current_pc());
+      field_nil_init = state->pc;
       bcemit_nil(state, call_base.raw(), 1);
       skip_nil.patch_here();
    }
@@ -757,6 +762,7 @@ ParserResult<ExpDesc> IrEmitter::emit_runtime_builtin_method_call(const CallExpr
 
    ExpDesc result = emitted.value_ref();
    result.alternate_call = builtin_call.raw();
+   result.alternate_safe_nil_init = field_nil_init;
    result.u.s.aux = call_base.raw();
    result.static_results = Payload.results;
    if (Payload.results) {
@@ -1066,12 +1072,14 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
 
    // For safe callable: emit the nil path and patch jumps
 
+   BCPos safe_nil_init = BCPos(NO_JMP);
    if (is_safe_callable) {
       ControlFlowEdge skip_nil = this->control_flow.make_unconditional(BCPos(bcemit_jmp(&this->func_state)));
 
       BCPos nil_path = BCPos(this->func_state.pc);
       nil_jump.patch_to(nil_path);
       if (not receiver_nil_jump.empty()) receiver_nil_jump.patch_to(nil_path);
+      safe_nil_init = nil_path;
       bcemit_nil(&this->func_state, is_contextual_call ? context_result_base.raw() : base.raw(), 1);
 
       skip_nil.patch_to(BCPos(this->func_state.pc));
@@ -1080,6 +1088,7 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
    ExpDesc result;
    result.init(ExpKind::Call, call_pc);
    result.u.s.aux = is_contextual_call ? context_result_base.raw() : base.raw();
+   result.safe_nil_init = safe_nil_init.raw();
    result.result_type = callee_return_type;  // Propagate known return type
    result.object_class_id = callee_object_class_id;  // Propagate object class ID for Object types
    result.struct_def = callee_struct_def;

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -558,6 +558,7 @@ public:
       ExpDesc result;
       result.init(ExpKind::Call, CallPc);
       result.u.s.aux = CallBase;
+      result.safe_nil_init = nil_path.raw();
       this->emitter->func_state.freereg = CallBase + 1;
       return ParserResult<ExpDesc>::success(result);
    }
@@ -692,6 +693,8 @@ static void snapshot_return_regs(FuncState* fs, BCIns* ins)
 // Exclusively used by ir_emitter for assignment statements, local declarations, and for loops.
 // TODO: May as well be a regular function instead of a LexState method.
 
+static void set_call_result_count(FuncState *State, const ExpDesc &Expression, BCREG Count);
+
 void LexState::assign_adjust(BCREG nvars, BCREG nexps, ExpDesc *Expr)
 {
    FuncState* fs = this->fs;
@@ -700,10 +703,7 @@ void LexState::assign_adjust(BCREG nvars, BCREG nexps, ExpDesc *Expr)
    if (Expr->k IS ExpKind::Call) {
       extra++;  // Compensate for the ExpKind::Call itself.
       if (extra < 0) extra = 0;
-      setbc_b(bcptr(fs, Expr), extra + 1);  // Fixup call results.
-      if (Expr->alternate_call != NO_JMP) {
-         setbc_b(&fs->bcbase[Expr->alternate_call].ins, extra + 1);
-      }
+      set_call_result_count(fs, *Expr, BCREG(extra + 1));
       if (extra > 1) allocator.reserve(BCReg(BCREG(extra) - 1));
    }
    else {
@@ -991,6 +991,17 @@ static void set_call_result_count(FuncState *State, const ExpDesc &Expression, B
    if (Expression.alternate_call != NO_JMP) {
       setbc_b(&State->bcbase[Expression.alternate_call].ins, Count);
    }
+   auto widen_nil_init = [&](BCPOS Position) {
+      if (Position IS NO_JMP or Count <= 1) return;
+      BCIns *nil_init = &State->bcbase[Position].ins;
+      BCREG first = bc_a(*nil_init);
+      lj_assertX(bc_op(*nil_init) IS BC_KPRI or bc_op(*nil_init) IS BC_KNIL,
+         "safe-call nil path does not start with a nil initialiser");
+      *nil_init = Count IS 2 ? BCINS_AD(BC_KPRI, first, ExpKind::Nil) :
+         BCINS_AD(BC_KNIL, first, first + Count - 2);
+   };
+   widen_nil_init(Expression.safe_nil_init);
+   widen_nil_init(Expression.alternate_safe_nil_init);
 }
 
 struct FalseyJumpOptions {
@@ -1733,18 +1744,18 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
                ins = BCINS_AD(bc_op(*ip) - BC_CALL + BC_CALLT, bc_a(*ip), bc_c(*ip));
             }
          }
-         else if (safe_call) {
-            // The nil short-circuit initialises only the consolidated first result, so it cannot use a return form
-            // that consumes MULTRES or exposes additional fixed registers.
-            set_call_result_count(&this->func_state, last, 2);
-            ins = BCINS_AD(BC_RET1, last.u.s.aux, 2);
-         }
          else if (truncate_return_results) {
             BCREG result_count = this->func_state.return_declared_count;
             set_call_result_count(&this->func_state, last, result_count + 1);
             ins = result_count > 0 ?
                BCINS_AD(BC_RET, last.u.s.aux, result_count + 1) :
                BCINS_AD(BC_RET0, 0, 1);
+         }
+         else if (safe_call) {
+            // An unconstrained nil short-circuit has no dynamic MULTRES value, so consolidate it to one result.
+            // Fixed return declarations are handled above and widen the nil path to the declared result count.
+            set_call_result_count(&this->func_state, last, 2);
+            ins = BCINS_AD(BC_RET1, last.u.s.aux, 2);
          }
          else if (not this->func_state.runtime_scopes.empty()) {
             // DISABLE TAIL-CALL inside try blocks: use CALL + RET instead of CALLT.
@@ -1797,11 +1808,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
       else {
          // Multiple return values
          if (last.k IS ExpKind::Call) {
-            if (is_safe_call_expression(*Payload.values.back())) {
-               set_call_result_count(&this->func_state, last, 2);
-               ins = BCINS_AD(BC_RET, return_base, count + 1);
-            }
-            else if (truncate_return_results) {
+            if (truncate_return_results) {
                BCREG result_count = this->func_state.return_declared_count;
                BCREG fixed_count = last.u.s.aux - return_base;
                BCREG call_count = result_count > fixed_count ? result_count - fixed_count : 0;
@@ -1809,6 +1816,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
                ins = result_count > 0 ?
                   BCINS_AD(BC_RET, return_base, result_count + 1) :
                   BCINS_AD(BC_RET0, 0, 1);
+            }
+            else if (is_safe_call_expression(*Payload.values.back())) {
+               set_call_result_count(&this->func_state, last, 2);
+               ins = BCINS_AD(BC_RET, return_base, count + 1);
             }
             else {
                set_call_result_count(&this->func_state, last, 0);

--- a/src/tiri/jit/src/parser/parse_types.h
+++ b/src/tiri/jit/src/parser/parse_types.h
@@ -251,6 +251,8 @@ struct ExpDesc {
    StaticResultSetHandle static_results = 0;
    uint32_t struct_field_index = 0xFFFFFFFFu; // Pre-resolved field index for STGETF/STSETF
    BCPOS alternate_call = NO_JMP; // Alternate call block used by runtime built-in method dispatch
+   BCPOS safe_nil_init = NO_JMP; // Nil initialiser for a skipped safe call; widened with fixed result requests
+   BCPOS alternate_safe_nil_init = NO_JMP; // Additional nil block used by runtime method fallback dispatch
    BCPOS t;        // True condition jump list.
    BCPOS f;        // False condition jump list.
 
@@ -314,6 +316,8 @@ struct ExpDesc {
       this->static_value = 0;
       this->static_results = 0;
       this->alternate_call = NO_JMP;
+      this->safe_nil_init = NO_JMP;
+      this->alternate_safe_nil_init = NO_JMP;
       this->f = this->t = NO_JMP;
    }
 

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -7200,9 +7200,22 @@ static bool test_tail_call_eligibility(kt::Log &Log)
       "end\n"
       "return checked_safe_fixed\n";
    auto checked_safe_fixed = compile_snapshot(L, checked_safe_fixed_source, true, error);
-   if (not checked_safe_fixed or count_opcode_tree(*checked_safe_fixed, BC_RET1) IS 0 or
-       count_opcode_tree(*checked_safe_fixed, BC_RET) != 0 or count_opcode_tree(*checked_safe_fixed, BC_RETM) != 0) {
-      Log.error("a contracted checked safe-call return did not lower to one fixed result: %s", error.c_str());
+   if (not checked_safe_fixed or count_opcode_tree(*checked_safe_fixed, BC_RET) IS 0 or
+       count_opcode_tree(*checked_safe_fixed, BC_RETM) != 0) {
+      Log.error("a contracted checked safe-call return did not lower to its fixed result count: %s", error.c_str());
+      return false;
+   }
+
+   constexpr std::string_view safe_fixed_source =
+      "local holder = { pair = function():<num, num> return 1, 2 end }\n"
+      "local function safe_fixed():<num, num>\n"
+      "   return holder?.pair()\n"
+      "end\n"
+      "return safe_fixed\n";
+   auto safe_fixed = compile_snapshot(L, safe_fixed_source, true, error);
+   if (not safe_fixed or count_opcode_tree(*safe_fixed, BC_RET) IS 0 or
+       count_opcode_tree(*safe_fixed, BC_RETM) != 0) {
+      Log.error("a multi-result safe call did not lower to its fixed result count: %s", error.c_str());
       return false;
    }
 

--- a/src/tiri/tests/test_safe_nav.tiri
+++ b/src/tiri/tests/test_safe_nav.tiri
@@ -87,6 +87,32 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
+@Test function testSafeMethodFixedMultiResultReturn()
+   target = {}
+   function target.pair():<num, num>
+      return 1, 2
+   end
+
+   function pairFrom(Target):<num, num>
+      return Target?.pair()
+   end
+
+   first, second = pairFrom(target)
+   assert(first is 1 and second is 2, "A present safe-call receiver should preserve every declared result")
+
+   first, second = pairFrom(nil)
+   assert(first is nil and second is nil, "A missing safe-call receiver should initialise every declared result")
+
+   local local_first, local_second = target?.pair()
+   assert(local_first is 1 and local_second is 2, "A local assignment should preserve every safe-call result")
+
+   missing = nil
+   local nil_first, nil_second = missing?.pair()
+   assert(nil_first is nil and nil_second is nil, "A local declaration should clear every skipped safe-call result")
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
 @Test function testCheckedSafeCallReturnOnNil()
    holder = nil
    try


### PR DESCRIPTION
* Widen skipped-call nil initialisers to match fixed result requests
* Cover fixed multi-result safe calls in parser and Tiri tests