### PR TITLE
[Tiri] Reserve safe-call frames for fixed multi-result returns

### DIFF
--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -997,6 +997,11 @@ static void set_call_result_count(FuncState *State, const ExpDesc &Expression, B
       BCREG first = bc_a(*nil_init);
       lj_assertX(bc_op(*nil_init) IS BC_KPRI or bc_op(*nil_init) IS BC_KNIL,
          "safe-call nil path does not start with a nil initialiser");
+      BCREG required_top = first + Count - 1;
+      if (State->freereg < required_top) {
+         RegisterAllocator allocator(State);
+         allocator.bump(BCReg(required_top - State->freereg));
+      }
       *nil_init = Count IS 2 ? BCINS_AD(BC_KPRI, first, ExpKind::Nil) :
          BCINS_AD(BC_KNIL, first, first + Count - 2);
    };

--- a/src/tiri/tests/test_safe_nav.tiri
+++ b/src/tiri/tests/test_safe_nav.tiri
@@ -1,5 +1,7 @@
 -- Flute tests for the safe navigation operators - ?., ?: and ?[
 
+global glSafeCallTripleTarget = nil
+
 @BeforeEach(hotpath=true)
 function enforce_hotpath() end
 
@@ -109,6 +111,17 @@ end
    missing = nil
    local nil_first, nil_second = missing?.pair()
    assert(nil_first is nil and nil_second is nil, "A local declaration should clear every skipped safe-call result")
+
+   function triple_from_missing():<num, num, num>
+      return glSafeCallTripleTarget?.values()
+   end
+
+   local triple_info = jit.util.funcInfo(triple_from_missing, 0)
+   assert(triple_info.stackSlots >= 3,
+      "A three-result safe-call return must reserve every result register in its frame")
+   local nil_one, nil_two, nil_three = triple_from_missing()
+   assert(nil_one is nil and nil_two is nil and nil_three is nil,
+      "A missing safe-call receiver should initialise all three declared results")
 end
 
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
* Grow function frames before widening safe-call nil result ranges
* Cover three-result safe-call returns with stack-slot validation