### PR TITLE
[Tiri] Treat native struct chars as unsigned bytes

### DIFF
--- a/src/tiri/jit/src/lib/lib_struct.cpp
+++ b/src/tiri/jit/src/lib/lib_struct.cpp
@@ -96,10 +96,10 @@ static bool write_primitive_field(lua_State *L, APTR Address, const struct_field
          }
          ((bool *)Address)[ElementIndex] = lua_toboolean(L, StackIndex);
          return true;
-      case NativeStructType::Char:
       case NativeStructType::Int8:
          write_integer_field<int8_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 8, true, CurrentFrame);
          return true;
+      case NativeStructType::Char:
       case NativeStructType::UInt8:
          write_integer_field<uint8_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 8, false, CurrentFrame);
          return true;
@@ -412,10 +412,12 @@ static bool read_primitive_field(lua_State *L, APTR Address, const struct_field 
       else lua_createarray(L, ArraySize, ff_to_aet(Type, Field.NativeType), (APTR *)Address, ARRAY_CACHED);
    }
    else if (Field.NativeType IS NativeStructType::Bool) lua_pushboolean(L, ((bool *)Address)[0]);
-   else if (Field.NativeType IS NativeStructType::Char or Field.NativeType IS NativeStructType::Int8) {
+   else if (Field.NativeType IS NativeStructType::Int8) {
       lua_pushinteger(L, ((int8_t *)Address)[0]);
    }
-   else if (Field.NativeType IS NativeStructType::UInt8) lua_pushinteger(L, ((uint8_t *)Address)[0]);
+   else if (Field.NativeType IS NativeStructType::Char or Field.NativeType IS NativeStructType::UInt8) {
+      lua_pushinteger(L, ((uint8_t *)Address)[0]);
+   }
    else if (Field.NativeType IS NativeStructType::Int16) lua_pushinteger(L, ((int16_t *)Address)[0]);
    else if (Field.NativeType IS NativeStructType::UInt16) lua_pushinteger(L, ((uint16_t *)Address)[0]);
    else if (Field.NativeType IS NativeStructType::Int32) lua_pushinteger(L, ((int32_t *)Address)[0]);

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -4332,7 +4332,6 @@ static TRef rec_struct_number_ref(jit_State *J, TRef ValueRef)
 static bool rec_struct_integer_signed(NativeStructType Type)
 {
    switch (Type) {
-      case NativeStructType::Char:
       case NativeStructType::Int8:
       case NativeStructType::Int16:
       case NativeStructType::Int32:
@@ -4446,7 +4445,7 @@ static TRef rec_struct_get(jit_State *J, RecordOps *ops)
       }
       else if (scalar_type IS NativeStructType::Char or scalar_type IS NativeStructType::Int8 or
             scalar_type IS NativeStructType::UInt8) {
-         IRType load_type = (scalar_type IS NativeStructType::UInt8) ? IRT_U8 : IRT_I8;
+         IRType load_type = scalar_type IS NativeStructType::Int8 ? IRT_I8 : IRT_U8;
          TRef result_ref = emitir(IRT(IR_XLOAD, load_type), addr_ref, 0);
          if (not LJ_DUALNUM) result_ref = emitir(IRTN(IR_CONV), result_ref, IRCONV_NUM_INT);
          return result_ref;

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -2743,6 +2743,10 @@ end
    assert(store_trace_found, 'Expected 15 direct stores in the declared all-scalar write trace')
    assert(load_trace_found, 'Expected 15 direct loads in the declared all-scalar read trace')
 
+   value.CharValue = 255
+   assert(traced_phase_five_scalar_read(value, 1) is 413.5,
+      'A hot char read should preserve values above the signed 8-bit range')
+
    value.Unsigned32 = 4294967295
    value.Unsigned64 = 18446744073709549568
    assert(traced_phase_five_unsigned32_read(value, 20) is 4294967295,

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -133,13 +133,13 @@ end
 
 @Test function NativeStructPrimitiveValidation()
    local value = struct<DeclaredLayout> {
-      Bool=true, Char=-128, Byte=255, Int8=127, UInt8=0, Int16=-32768, UInt16=65535,
+      Bool=true, Char=255, Byte=255, Int8=127, UInt8=0, Int16=-32768, UInt16=65535,
       Int=-2147483648, UInt=4294967295, Int32=2147483647, UInt32=0,
       Int64=-9223372036854775808, UInt64=9007199254740992, Float=1.25, Double=math.huge,
       String='valid', Buffer='buffer'
    }
 
-   assert(value.Bool is true and value.Char is -128 and value.Byte is 255,
+   assert(value.Bool is true and value.Char is 255 and value.Byte is 255,
       'Constructor assignment should preserve valid bool and byte-sized values')
    assert(value.Int16 is -32768 and value.UInt16 is 65535 and value.Int is -2147483648,
       'Constructor assignment should preserve valid signed and unsigned integer boundaries')
@@ -149,7 +149,7 @@ end
       'Constructor assignment should preserve floating, string and character-buffer values')
 
    value.Bool = false
-   value.Char = 127
+   value.Char = 255
    value.Byte = 0
    value.Int8 = -128
    value.UInt8 = 255
@@ -166,7 +166,7 @@ end
    value.Float = 0 / 0
    value.Double = -math.huge
    value.String = 'updated'
-   assert(value.Bool is false and value.Char is 127 and value.UInt8 is 255 and value.Int16 is 32767,
+   assert(value.Bool is false and value.Char is 255 and value.UInt8 is 255 and value.Int16 is 32767,
       'Later assignment should accept valid scalar boundaries')
    assert(value.UInt32 is 4294967295 and value.UInt64 is 18446744073709549568,
       'Later assignment should accept representable unsigned wide values below their exclusive upper bounds')
@@ -196,6 +196,11 @@ end
    expect_struct_error(() => do value.UInt8 = 256 end, ERR_OutOfRange, 'uint8 should reject overflow')
    value.UInt8 = 300 & 0xff
    assert(value.UInt8 is 44, 'Clients should be able to apply explicit wrapping before assignment')
+
+   expect_struct_error(() => do value.Char = -1 end, ERR_OutOfRange, 'char should reject underflow')
+   expect_struct_error(() => do value.Char = 256 end, ERR_OutOfRange, 'char should reject overflow')
+   value.Char = 300 & 0xff
+   assert(value.Char is 44, 'char should match byte after explicit wrapping')
 
    expect_struct_error(() => do value.Int16 = -32769 end, ERR_OutOfRange, 'int16 should reject underflow')
    expect_struct_error(() => do value.Int16 = 32768 end, ERR_OutOfRange, 'int16 should reject overflow')


### PR DESCRIPTION
* Corrected interpreted and JIT struct char reads and writes to preserve the full byte range
* Added Tiri and JIT regression coverage for char values above the signed byte range