### PR TITLE
[Tiri] Added recursive typed array support

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -863,7 +863,8 @@ endif ()
 set (TIRI_TESTS
    defer debuglog io object regex struct async async_actions async_wait xml strings math array array_any array_manip
    array_element_validation array_view
-   array_functional array_typed_syntax bitshift bitwise has_operator approx if_empty if_empty_guard presence blank ternary table stress unit_tests
+   array_functional array_typed_syntax recursive_array_types bitshift bitwise has_operator approx if_empty if_empty_guard
+   presence blank ternary table stress unit_tests
    jitoptions fstring const const_optimisation import_scope unicode ellipsis safe_nav close type_annotations type_fixing
    type_inference jit jit_try_regex pipe for_each arrow_functions result_filter thunks deferred_expr shadow_assert
    ranges contains bare_iteration compiler_intrinsics

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -109,15 +109,21 @@ static OBJECTID object_uid_from_value(lua_State *L, int ArgIndex)
 static std::string_view array_struct_name(lua_State *L, int NArg);
 bool lj_array_struct_is_trivial(const struct_record &Def);
 
-static AET parse_elemtype(lua_State *L, int NArg)
+static ArrayAllocationDescriptor parse_elemtype(lua_State *L, int NArg)
 {
    GCstr *type_str = lj_lib_checkstr(L, NArg);
    std::string_view type_name(strdata(type_str), type_str->len);
    if (type_name IS "obj") type_name = "object";
-   if (auto descriptor = describe_array_element(type_name, L)) return descriptor->storage;
+   if (auto element = parse_array_element_type(type_name, L)) {
+      ArrayAllocationDescriptor descriptor;
+      descriptor.storage = element->storage;
+      descriptor.struct_def = element->struct_def;
+      descriptor.canonical_identity = std::format("array<{}>", array_element_name(*element));
+      return descriptor;
+   }
 
    lj_err_argv(L, NArg, ErrMsg::BADTYPE, "valid array type", strdata(type_str));
-   return AET(0);  // unreachable
+   return {};  // unreachable
 }
 
 //********************************************************************************************************************
@@ -129,9 +135,9 @@ GCarray * lj_array_new_map_result(lua_State *L, MSize Length, int TypeArg)
 {
    if (TypeArg <= 0 or lua_isnoneornil(L, TypeArg)) return lj_array_new(L, Length, AET::ANY);
 
-   auto elem_type = parse_elemtype(L, TypeArg);
-   if (elem_type IS AET::PTR) lj_err_argv(L, TypeArg, ErrMsg::ARRTYPE);
-   if (elem_type != AET::STRUCT) return lj_array_new(L, Length, elem_type);
+   auto descriptor = parse_elemtype(L, TypeArg);
+   if (descriptor.storage IS AET::PTR) lj_err_argv(L, TypeArg, ErrMsg::ARRTYPE);
+   if (descriptor.storage != AET::STRUCT) return lj_array_new(L, Length, descriptor);
 
    auto struct_name = array_struct_name(L, TypeArg);
    if (struct_name.empty()) lj_err_argv(L, TypeArg, ErrMsg::ARRTYPE);
@@ -139,7 +145,8 @@ GCarray * lj_array_new_map_result(lua_State *L, MSize Length, int TypeArg)
    if ((not struct_def) or (not lj_array_struct_is_trivial(*struct_def))) {
       lj_err_argv(L, TypeArg, ErrMsg::ARRTYPE);
    }
-   return lj_array_new(L, Length, elem_type, nullptr, 0, struct_name, struct_def);
+   descriptor.struct_def = struct_def;
+   return lj_array_new(L, Length, descriptor);
 }
 
 static std::string_view array_struct_name(lua_State *L, int NArg)
@@ -321,19 +328,20 @@ LJLIB_CF(array_new)      LJLIB_REC(.)
    else {
       auto size = lj_lib_checkint(L, 1);
       if (size < 0) lj_err_argv(L, 1, ErrMsg::NUMRNG, "non-negative", "negative");
-      auto elem_type = parse_elemtype(L, 2);
+      auto descriptor = parse_elemtype(L, 2);
 
-      if (elem_type IS AET::PTR) lj_err_argv(L, 2, ErrMsg::ARRTYPE); // For Kotuku functions only
-      else if (elem_type IS AET::STRUCT) {
+      if (descriptor.storage IS AET::PTR) lj_err_argv(L, 2, ErrMsg::ARRTYPE); // For Kotuku functions only
+      else if (descriptor.storage IS AET::STRUCT) {
          auto struct_name = array_struct_name(L, 2);
          if (struct_name.empty()) lj_err_argv(L, 2, ErrMsg::ARRTYPE);
          auto struct_def = find_struct(L, struct_name);
          if ((not struct_def) or (not lj_array_struct_is_trivial(*struct_def))) {
             lj_err_argv(L, 2, ErrMsg::ARRTYPE);
          }
-         arr = lj_array_new(L, uint32_t(size), elem_type, nullptr, 0, struct_name, struct_def);
+         descriptor.struct_def = struct_def;
+         arr = lj_array_new(L, uint32_t(size), descriptor);
       }
-      else arr = lj_array_new(L, uint32_t(size), elem_type);
+      else arr = lj_array_new(L, uint32_t(size), descriptor);
    }
 
    // Per-instance metatable is null - base metatable will be used automatically
@@ -355,9 +363,9 @@ LJLIB_CF(array_new)      LJLIB_REC(.)
 
 LJLIB_CF(array_of)
 {
-   auto elem_type = parse_elemtype(L, 1);
+   auto descriptor = parse_elemtype(L, 1);
 
-   if (elem_type IS AET::PTR) lj_err_argv(L, 1, ErrMsg::BADTYPE, "non-pointer type", "pointer");
+   if (descriptor.storage IS AET::PTR) lj_err_argv(L, 1, ErrMsg::BADTYPE, "non-pointer type", "pointer");
 
    // Count number of values provided (all arguments after the type string)
 
@@ -365,16 +373,17 @@ LJLIB_CF(array_of)
    if (num_values < 1) luaL_error(L, ERR::Args, "array.of() requires at least one value");
 
    GCarray *arr;
-   if (elem_type IS AET::STRUCT) {
+   if (descriptor.storage IS AET::STRUCT) {
       auto struct_name = array_struct_name(L, 1);
       if (struct_name.empty()) lj_err_argv(L, 1, ErrMsg::ARRTYPE);
       auto struct_def = find_struct(L, struct_name);
       if ((not struct_def) or (not lj_array_struct_is_trivial(*struct_def))) {
          lj_err_argv(L, 1, ErrMsg::ARRTYPE);
       }
-      arr = lj_array_new(L, uint32_t(num_values), elem_type, nullptr, 0, struct_name, struct_def);
+      descriptor.struct_def = struct_def;
+      arr = lj_array_new(L, uint32_t(num_values), descriptor);
    }
-   else arr = lj_array_new(L, uint32_t(num_values), elem_type);
+   else arr = lj_array_new(L, uint32_t(num_values), descriptor);
    setarrayV(L, L->top++, arr);
 
    lj_array_store_new_values(L, arr, L->base + 1, MSize(num_values));
@@ -1222,10 +1231,7 @@ LJLIB_CF(array_copy)
       auto src_idx  = lj_lib_optint(L, 4, 0);
       auto count = lj_lib_optint(L, 5, array_default_remaining(src->len, src_idx));
 
-      if (not (dest->elemtype IS src->elemtype)) lj_err_caller(L, ErrMsg::ARRTYPE);
       auto span = array_copy_span(L, dest_idx, dest->len, src_idx, src->len, count, false);
-      if (span.count IS 0) return 0;
-
       lj_array_copy(L, dest, span.start, src, MSize(src_idx), span.count);
       return 0;
    }
@@ -1259,9 +1265,7 @@ LJLIB_CF(array_copy)
       auto span = array_copy_span(L, dest_idx, dest->len, src_idx, table_len, copy_total, true);
       if (span.count IS 0) return 0;
 
-      GCarray *staged = dest->elemtype IS AET::STRUCT ?
-         lj_array_new(L, span.count, dest->elemtype, nullptr, 0, dest->structdef->Name, dest->structdef) :
-         lj_array_new(L, span.count, dest->elemtype);
+      GCarray *staged = lj_array_new_like(L, dest, span.count);
       setarrayV(L, L->top++, staged);
 
       for (MSize i = 0; i < span.count; i++) {
@@ -2221,21 +2225,13 @@ LJLIB_CF(array_each)
 }
 
 //********************************************************************************************************************
-static GCarray * array_new_like(lua_State *L, GCarray *Source, MSize Length)
-{
-   if (Source->elemtype IS AET::STRUCT) {
-      return lj_array_new(L, Length, Source->elemtype, nullptr, 0, Source->structdef->Name, Source->structdef);
-   }
-   return lj_array_new(L, Length, Source->elemtype);
-}
-
 static int array_map_same(lua_State *L)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
    luaL_checktype(L, 2, LUA_TFUNCTION);
    MSize count = arr->len;
 
-   GCarray *result = array_new_like(L, arr, count);
+   GCarray *result = lj_array_new_like(L, arr, count);
    setarrayV(L, L->top++, result);
 
    for (MSize i = 0; i < count; i++) {
@@ -2354,7 +2350,7 @@ LJLIB_CF(array_filter)
    MSize count = arr->len;
 
    // Create result array with zero length (will grow dynamically)
-   GCarray *result = array_new_like(L, arr, 0);
+   GCarray *result = lj_array_new_like(L, arr, 0);
    setarrayV(L, L->top++, result);
 
    // Single pass: filter and copy matching elements
@@ -2628,7 +2624,7 @@ LJLIB_CF(array_clone)
    if (arr->elemtype IS AET::STRUCT) luaL_error(L, ERR::NoSupport, "array.clone() does not support struct types.");
 
    // Create new array with same type and length
-   GCarray *result = lj_array_new(L, arr->len, arr->elemtype);
+   GCarray *result = lj_array_new_like(L, arr, arr->len);
    setarrayV(L, L->top++, result);
 
    if (arr->len IS 0) return 1;

--- a/src/tiri/jit/src/lib/lib_range.cpp
+++ b/src/tiri/jit/src/lib/lib_range.cpp
@@ -983,7 +983,7 @@ static int range_slice_impl(lua_State *L)
 
       // Check for empty/invalid ranges
       if (len IS 0 or (forward and start > effective_stop) or (not forward and start < effective_stop)) {
-         GCarray *new_arr = lj_array_new(L, 0, arr->elemtype);
+         GCarray *new_arr = lj_array_new_like(L, arr, 0);
          // Per-instance metatable is null - base metatable will be used automatically
          setarrayV(L, L->top++, new_arr);
          return 1;
@@ -995,22 +995,19 @@ static int range_slice_impl(lua_State *L)
       else result_size = ((start - effective_stop) / (-step)) + 1;
 
       // Create result array
-      GCarray *new_arr = lj_array_new(L, MSize(result_size), arr->elemtype);
-      auto src_base = arr->get<uint8_t>();
-      auto dst_base = new_arr->get<uint8_t>();
-      MSize elemsize = arr->elemsize;
+      GCarray *new_arr = lj_array_new_like(L, arr, MSize(result_size));
 
       // Copy elements
       int32_t dst_idx = 0;
       if (forward) {
          for (int32_t i = start; i <= effective_stop; i += step) {
-            memcpy(dst_base + dst_idx * elemsize, src_base + i * elemsize, elemsize);
+            lj_array_copy(L, new_arr, MSize(dst_idx), arr, MSize(i), 1);
             dst_idx++;
          }
       }
       else {
          for (int32_t i = start; i >= effective_stop; i += step) {
-            memcpy(dst_base + dst_idx * elemsize, src_base + i * elemsize, elemsize);
+            lj_array_copy(L, new_arr, MSize(dst_idx), arr, MSize(i), 1);
             dst_idx++;
          }
       }

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -351,7 +351,12 @@ static void recff_rawtype(jit_State* J, RecordFFData* Data)
       IRBuilder ir(J);
       TRef element_type_ref = ir.fload(value_ref, IRFL_ARRAY_ELEMTYPE, IRT_U8);
       ir.guard_eq_int(element_type_ref, ir.kint(int32_t(array->elemtype)));
-      if (array->elemtype IS AET::STRUCT) {
+      if (gcref(array->type_identity)) {
+         GCstr *identity = strref(array->type_identity);
+         TRef identity_ref = ir.fload(value_ref, IRFL_ARRAY_IDENTITY, IRT_STR);
+         ir.guard_eq(identity_ref, ir.kstr(identity), IRT_STR);
+      }
+      else if (array->elemtype IS AET::STRUCT) {
          TRef definition_ref = ir.fload(value_ref, IRFL_ARRAY_STRUCTDEF, IRT_PTR);
          TRef definition = array->structdef ? ir.kkptr(array->structdef) : ir.knull(IRT_PTR);
          ir.guard_eq(definition_ref, definition, IRT_PTR);

--- a/src/tiri/jit/src/lj_ir.h
+++ b/src/tiri/jit/src/lj_ir.h
@@ -222,6 +222,7 @@ typedef enum {
   _(TAB_GCONTRACTS, offsetof(GCtab, global_type_contracts)) \
   _(OBJ_CLASSPTR, offsetof(GCobject, classptr)) \
   _(ARRAY_STRUCTDEF, offsetof(GCarray, structdef)) \
+  _(ARRAY_IDENTITY, offsetof(GCarray, type_identity)) \
   _(TAB_FLAGS, offsetof(GCtab, flags))
 
 typedef enum {

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -529,6 +529,14 @@ static RecordedContract rec_contract_guard_array(
       TRef definition_ref = ir.fload(ValueRef, IRFL_ARRAY_STRUCTDEF, IRT_PTR);
       ir.guard_eq(definition_ref, ir.kkptr(definition), IRT_PTR);
    }
+   else if (Entry.array_element_type IS AET::ARRAY and not Entry.constraint_name.empty()) {
+      if (not lj_array_member_identity_matches(array, Entry.constraint_name)) return RecordedContract::Mismatch;
+      std::string expected_identity = std::format("array<{}>", Entry.constraint_name);
+      if (not lj_array_identity_matches(array, expected_identity)) return RecordedContract::Complex;
+      GCstr *identity = strref(array->type_identity);
+      TRef identity_ref = ir.fload(ValueRef, IRFL_ARRAY_IDENTITY, IRT_STR);
+      ir.guard_eq(identity_ref, ir.kstr(identity), IRT_STR);
+   }
 
    return RecordedContract::Basic;
 }
@@ -664,6 +672,13 @@ static TRef rec_type_test(jit_State *J, BCREG Slot, GCstr *Encoded)
          observed.array_element_type = arrayV(value)->elemtype;
          if (arrayV(value)->elemtype IS AET::STRUCT and arrayV(value)->structdef) {
             observed.constraint_name = arrayV(value)->structdef->Name;
+         }
+         else if (arrayV(value)->elemtype IS AET::ARRAY and gcref(arrayV(value)->type_identity)) {
+            GCstr *identity = strref(arrayV(value)->type_identity);
+            std::string_view outer(strdata(identity), identity->len);
+            if (outer.starts_with("array<") and outer.ends_with('>')) {
+               observed.constraint_name = outer.substr(6, outer.size() - 7);
+            }
          }
          if (rec_contract_guard_array(J, value_ref, value, observed) != RecordedContract::Basic) return 0;
       }

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -811,7 +811,17 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          Token start = this->ctx.tokens().current();
          GCstr *type_str = start.payload().as_string();
          std::string_view element_name(strdata(type_str), type_str->len);
-         if (element_name.starts_with("array<")) type_str = this->ctx.lex().keepstr("array");
+         if (element_name.starts_with("array<") and element_name.find(',') != std::string_view::npos) {
+            return this->fail<ExprNodePtr>(ParserErrorCode::UnexpectedToken, start,
+               "Nested array element types cannot declare a size");
+         }
+         auto element = parse_array_element_type(
+            element_name IS "obj" ? "object" : element_name, &this->ctx.lua(), &this->ctx.lex());
+         if (not element or element->storage IS AET::PTR or
+             (element->storage IS AET::STRUCT and not element->struct_def)) {
+            return this->fail<ExprNodePtr>(ParserErrorCode::UnknownTypeName, start,
+               std::format("Unknown or malformed array element type '{}'", element_name));
+         }
          ArrayTypedSize specified_size = this->ctx.lex().array_typed_size;
          this->ctx.tokens().advance();
 

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -180,15 +180,16 @@ ParserResult<Token> AstBuilder::parse_type_annotation(
       }
       GCstr *element_symbol = type_token.payload().as_string();
       std::string_view element_name(strdata(element_symbol), element_symbol->len);
-      if (element_name.starts_with("array<")) {
+      if (element_name.starts_with("array<") and element_name.find(',') != std::string_view::npos) {
          return this->fail<Token>(ParserErrorCode::UnexpectedToken, type_token,
-            "Nested array specialisation is not supported; use array<array>");
+            "Array type annotations cannot declare a nested size");
       }
       if (element_name IS "object") {
          return this->fail<Token>(ParserErrorCode::UnknownTypeName, type_token,
             "Unknown array element type 'object'; use 'obj'");
       }
-      auto element = describe_array_element(element_name IS "obj" ? "object" : element_name, &this->ctx.lua());
+      auto element = parse_array_element_type(
+         element_name IS "obj" ? "object" : element_name, &this->ctx.lua(), &this->ctx.lex());
       if (not element or element->storage IS AET::PTR or
           (element->storage IS AET::STRUCT and not element->struct_def)) {
          return this->fail<Token>(ParserErrorCode::UnknownTypeName, type_token,
@@ -242,8 +243,13 @@ ParserResult<Token> AstBuilder::parse_type_annotation(
             this->ctx.tokens().advance();
          }
          else if (element_token.kind() IS TokenKind::ArrayTyped) {
-            return this->fail<Token>(ParserErrorCode::UnexpectedToken, element_token,
-               "Nested array specialisation is not supported; use array<array>");
+            GCstr *name = element_token.payload().as_string();
+            element_storage.assign(strdata(name), name->len);
+            if (not this->ctx.lex().array_typed_size.is_absent()) {
+               return this->fail<Token>(ParserErrorCode::UnexpectedToken, element_token,
+                  "Array type annotations cannot declare a nested size");
+            }
+            this->ctx.tokens().advance();
          }
          else if (element_token.kind() IS TokenKind::Identifier) {
             GCstr *name = element_token.identifier();
@@ -266,7 +272,8 @@ ParserResult<Token> AstBuilder::parse_type_annotation(
             return this->fail<Token>(ParserErrorCode::UnknownTypeName, element_token,
                "Unknown array element type 'object'; use 'obj'");
          }
-         auto element = describe_array_element(element_storage IS "obj" ? "object" : element_storage, &this->ctx.lua());
+         auto element = parse_array_element_type(
+            element_storage IS "obj" ? "object" : element_storage, &this->ctx.lua(), &this->ctx.lex());
          if (not element or element->storage IS AET::PTR or
              (element->storage IS AET::STRUCT and not element->struct_def)) {
             return this->fail<Token>(ParserErrorCode::UnknownTypeName, element_token,

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -343,19 +343,32 @@ ParserResult<TypeTestDescriptor> AstBuilder::parse_type_test_descriptor()
          return this->fail<TypeTestDescriptor>(ParserErrorCode::UnexpectedToken, constraint_token,
             std::format("Type-test descriptor '<{}>' does not accept an inner name", type_name_view));
       }
-      if (constraint_token.kind() != TokenKind::Identifier) {
+
+      std::string constraint_name;
+      if (constraint_token.kind() IS TokenKind::Identifier) {
+         GCstr *constraint_symbol = constraint_token.identifier();
+         constraint_name.assign(strdata(constraint_symbol), constraint_symbol->len);
+      }
+      else if (descriptor.type IS TiriType::Array and constraint_token.kind() IS TokenKind::ArrayTyped) {
+         if (not this->ctx.lex().array_typed_size.is_absent()) {
+            return this->fail<TypeTestDescriptor>(ParserErrorCode::UnexpectedToken, constraint_token,
+               "Array type-test descriptors cannot declare a size");
+         }
+         GCstr *constraint_symbol = constraint_token.payload().as_string();
+         constraint_name = std::format("array<{}>",
+            std::string_view(strdata(constraint_symbol), constraint_symbol->len));
+      }
+      else {
          return this->fail<TypeTestDescriptor>(ParserErrorCode::ExpectedIdentifier, constraint_token,
             "Expected one inner name in type-test descriptor");
       }
 
-      GCstr *constraint_symbol = constraint_token.identifier();
-      std::string_view constraint_name(strdata(constraint_symbol), constraint_symbol->len);
       this->ctx.tokens().advance();
       descriptor.constrained = true;
 
       if (descriptor.type IS TiriType::Array) {
-         auto element = describe_array_element(constraint_name IS "obj" ? "object" : constraint_name,
-            &this->ctx.lua());
+         auto element = parse_array_element_type(constraint_name IS "obj" ? "object" : constraint_name,
+            &this->ctx.lua(), &this->ctx.lex());
          if (element and element->storage != AET::PTR and
              (element->storage != AET::STRUCT or element->struct_def)) descriptor.array_element = *element;
          else if (struct_record *definition = find_struct(&this->ctx.lua(), constraint_name)) {

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -3548,15 +3548,19 @@ ParserResult<ExpDesc> IrEmitter::emit_type_test_expr(const TypeTestExprPayload &
    if (type_test.type IS TiriType::Array) {
       AET element_type = type_test.constrained ? type_test.array_element.storage : AET::ANY;
       descriptor.push_back(char(uint8_t(element_type)));
-      std::string_view element_struct_name;
+      std::string_view element_constraint_name;
       if (element_type IS AET::STRUCT and type_test.array_element.struct_def) {
-         element_struct_name = type_test.array_element.struct_def->Name;
+         element_constraint_name = type_test.array_element.struct_def->Name;
       }
-      if (element_struct_name.size() > UINT8_MAX) {
+      else if (element_type IS AET::ARRAY and type_test.array_element.nested_array_identity) {
+         GCstr *identity = type_test.array_element.nested_array_identity;
+         element_constraint_name = std::string_view(strdata(identity), identity->len);
+      }
+      if (element_constraint_name.size() > UINT8_MAX) {
          return ParserResult<ExpDesc>::failure(this->make_error(
-            ParserErrorCode::UnexpectedToken, "Type-test array structure name is too long"));
+            ParserErrorCode::UnexpectedToken, "Type-test array constraint is too long"));
       }
-      append_text(descriptor, element_struct_name);
+      append_text(descriptor, element_constraint_name);
    }
    append_text(descriptor, {});
 

--- a/src/tiri/jit/src/parser/lexer.cpp
+++ b/src/tiri/jit/src/parser/lexer.cpp
@@ -1086,10 +1086,9 @@ static LexToken lex_array_typed(LexState *State, TValue *tv)
 
    lex_skip_inline_ws(State);
 
-   // Preserve a nested array spelling so annotation parsing can reject unsupported recursive specialisation.
-   // Constructor parsing deliberately reduces it to the existing immediate array member identity.
+   // Preserve the complete nested array spelling for central validation and canonicalisation.
 
-   if (type_str == "array" and State->c IS '<') {
+   if (type_str IS "array" and State->c IS '<') {
       int depth = 1;
       lex_next(State);  // Consume inner '<'
       std::string inner;

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -605,6 +605,10 @@ static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeCo
          descriptor.push_back(char(uint8_t(contract.array_element.storage)));
          std::string_view array_struct_name;
          if (contract.array_element.struct_def) array_struct_name = contract.array_element.struct_def->Name;
+         else if (contract.array_element.storage IS AET::ARRAY and contract.array_element.nested_array_identity) {
+            GCstr *identity = contract.array_element.nested_array_identity;
+            array_struct_name = std::string_view(strdata(identity), identity->len);
+         }
          contract_append_text(fs, descriptor, array_struct_name, "runtime array contract structure name");
       }
 

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -46,6 +46,7 @@
 #include "parser.h"
 #include "static_descriptor_analysis.h"
 #include "table_ownership.h"
+#include "../runtime/lj_array.h"
 #include "../../../defs.h"
 
 static extTiri *glTestScript = nullptr;
@@ -2222,7 +2223,8 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
       "function required(Value:num!):num! return Value end\n"
       "local value = obj.new('time')\n"
       "value = dynamic(value)\n"
-      "local numbers:array<int> = dynamic(array<int> {})\n";
+      "local numbers:array<int> = dynamic(array<int> {})\n"
+      "local matrix:array<array<int>> = dynamic(array<array<int>> {})\n";
    if (lua_load(L, source, "contract-roundtrip")) {
       Log.error("failed to compile contract source: %s", lua_tostring(L, -1));
       return false;
@@ -2287,6 +2289,25 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
       return false;
    };
    bool array_survived = has_int_array_contract(has_int_array_contract, restored_proto);
+   auto has_recursive_array_contract = [](auto &Self, GCproto *Proto) -> bool {
+      for (uint32_t i = 1; i < Proto->sizebc; ++i) {
+         BCIns instruction = proto_bc(Proto)[i];
+         if (bc_op(instruction) != BC_CONTRACT) continue;
+         GCstr *encoded = gco_to_string(proto_kgc(Proto, ~(ptrdiff_t)bc_d(instruction)));
+         RuntimeContractDescriptor descriptor;
+         if (decode_runtime_contract(encoded, descriptor) and descriptor.contract_count > 0 and
+             descriptor.entries[0].type IS TiriType::Array and
+             descriptor.entries[0].array_element_type IS AET::ARRAY and
+             descriptor.entries[0].constraint_name IS "array<int>") return true;
+      }
+      GCRef *constant = mref<GCRef>(Proto->k) - 1;
+      for (uint32_t i = 0; i < Proto->sizekgc; ++i, --constant) {
+         GCobj *child = gcref(*constant);
+         if (child->gch.gct IS ~LJ_TPROTO and Self(Self, gco_to_proto(child))) return true;
+      }
+      return false;
+   };
+   bool recursive_array_survived = has_recursive_array_contract(has_recursive_array_contract, restored_proto);
    auto has_required_contract = [](auto &Self, GCproto *Proto) -> bool {
       for (uint32_t i = 1; i < Proto->sizebc; ++i) {
          BCIns instruction = proto_bc(Proto)[i];
@@ -2306,7 +2327,7 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
    };
    bool required_survived = has_required_contract(has_required_contract, restored_proto);
    lua_pop(L, 1);
-   if (not class_survived or not array_survived or not required_survived) {
+   if (not class_survived or not array_survived or not recursive_array_survived or not required_survived) {
       Log.error("reloaded bytecode lost an object, array member or required constraint in BC_CONTRACT");
       return false;
    }
@@ -2412,6 +2433,23 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
        array_decoded.entries[0].array_element_type != AET::STRUCT or
        array_decoded.entries[0].constraint_name != "Point") {
       Log.error("named-structure array constraint did not round-trip through the shared decoder");
+      return false;
+   }
+
+   std::string recursive_array_encoded = build_descriptor(
+      TiriType::Array, CLASSID::NIL, {}, "Matrix", const_flags, AET::ARRAY, "array<int>");
+   GCstr *recursive_array_descriptor = lj_str_new(
+      lua, recursive_array_encoded.data(), recursive_array_encoded.size());
+   if (not decode_runtime_contract(recursive_array_descriptor, array_decoded) or
+       array_decoded.entries[0].array_element_type != AET::ARRAY or
+       array_decoded.entries[0].constraint_name != "array<int>") {
+      Log.error("recursive array constraint did not round-trip through the shared decoder");
+      return false;
+   }
+   std::string malformed_recursive_array = build_descriptor(
+      TiriType::Array, CLASSID::NIL, {}, "Matrix", const_flags, AET::ARRAY, "array<int");
+   if (not rejected(malformed_recursive_array)) {
+      Log.error("runtime contract decoder accepted a malformed recursive array identity");
       return false;
    }
 
@@ -4661,6 +4699,45 @@ static bool test_static_descriptor_model(kt::Log &Log)
    }
    if (describe_array_element("unsupported", nullptr)) {
       Log.error("unsupported array storage name unexpectedly produced a descriptor");
+      return false;
+   }
+
+   LuaStateHolder recursive_state;
+   lua_State *recursive_lua = recursive_state.get();
+   auto recursive = parse_array_element_type(" array < array < char > > ", recursive_lua);
+   auto recursive_name = canonical_array_type_name(" array < array < char > > ", recursive_lua);
+   if (not recursive or recursive->storage != AET::ARRAY or
+       not recursive->nested_array_identity or
+       std::string_view(strdata(recursive->nested_array_identity), recursive->nested_array_identity->len) !=
+          "array<array<byte>>" or
+       not recursive_name or *recursive_name != "array<array<byte>>") {
+      Log.error("recursive array type parsing did not preserve and canonicalise the complete identity");
+      return false;
+   }
+   auto exact = parse_array_element_type("array<array<int>>", recursive_lua);
+   auto mismatch = parse_array_element_type("array<array<str>>", recursive_lua);
+   auto wildcard = parse_array_element_type("array<array<any>>", recursive_lua);
+   if (not exact or not mismatch or not wildcard or array_element_matches(*exact, *mismatch) or
+       not array_element_matches(*wildcard, *exact)) {
+      Log.error("recursive array descriptor comparison lost exact or wildcard semantics");
+      return false;
+   }
+   ArrayAllocationDescriptor matching_array {
+      .storage = AET::ARRAY,
+      .canonical_identity = "array<array<int>>"
+   };
+   ArrayAllocationDescriptor mismatched_array {
+      .storage = AET::ARRAY,
+      .canonical_identity = "array<array<str>>"
+   };
+   if (not array_element_matches(*exact, lj_array_new(recursive_lua, 0, matching_array)) or
+       array_element_matches(*exact, lj_array_new(recursive_lua, 0, mismatched_array))) {
+      Log.error("runtime arrays did not compare through their canonical recursive identities");
+      return false;
+   }
+   if (parse_array_element_type("array<array<int, 4>>") or parse_array_element_type("array<>") or
+       parse_array_element_type("array<array<int>")) {
+      Log.error("malformed recursive array type spelling was accepted");
       return false;
    }
    return true;

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -4717,8 +4717,11 @@ static bool test_static_descriptor_model(kt::Log &Log)
    auto exact = parse_array_element_type("array<array<int>>", recursive_lua);
    auto mismatch = parse_array_element_type("array<array<str>>", recursive_lua);
    auto wildcard = parse_array_element_type("array<array<any>>", recursive_lua);
+   auto deep_exact = parse_array_element_type("array<array<array<int>>>", recursive_lua);
+   auto deep_wildcard = parse_array_element_type("array<array<array>>", recursive_lua);
    if (not exact or not mismatch or not wildcard or array_element_matches(*exact, *mismatch) or
-       not array_element_matches(*wildcard, *exact)) {
+       not array_element_matches(*wildcard, *exact) or not deep_exact or not deep_wildcard or
+       not array_element_matches(*deep_wildcard, *deep_exact)) {
       Log.error("recursive array descriptor comparison lost exact or wildcard semantics");
       return false;
    }

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -1113,7 +1113,8 @@ private:
          result.nullable = false;
       }
       else if (auto array_type = this->array_constructor_type(Call)) {
-         auto element = describe_array_element(array_type->first, &this->context_.lua());
+         auto element = parse_array_element_type(
+            array_type->first, &this->context_.lua(), &this->context_.lex());
          if (element) {
             result.primary = TiriType::Array;
             result.array_element = *element;
@@ -1296,7 +1297,8 @@ private:
             const auto &literal = std::get<LiteralValue>(type_expression.data);
             if (literal.kind IS LiteralKind::String and literal.string_value) {
                std::string_view type_name(strdata(literal.string_value), literal.string_value->len);
-               if (auto element = describe_array_element(type_name, &this->context_.lua())) {
+               if (auto element = parse_array_element_type(
+                      type_name, &this->context_.lua(), &this->context_.lex())) {
                   StaticValueDescriptor result;
                   result.primary = TiriType::Array;
                   result.array_element = *element;
@@ -1416,13 +1418,24 @@ private:
       return {};
    }
 
-   [[nodiscard]] static StaticValueDescriptor array_element_value(
-      const ArrayElementDescriptor &Element)
+   [[nodiscard]] StaticValueDescriptor array_element_value(
+      const ArrayElementDescriptor &Element) const
    {
       StaticValueDescriptor result;
       result.primary = Element.logical_type;
       result.object_class_id = Element.object_class_id;
       result.struct_def = Element.struct_def;
+      if (Element.storage IS AET::ARRAY and Element.nested_array_identity) {
+         std::string_view identity(
+            strdata(Element.nested_array_identity), Element.nested_array_identity->len);
+         if (identity.starts_with("array<") and identity.ends_with('>')) {
+            std::string_view member = identity.substr(6, identity.size() - 7);
+            if (auto nested = parse_array_element_type(
+                   member, &this->context_.lua(), &this->context_.lex())) {
+               result.array_element = *nested;
+            }
+         }
+      }
       result.proof = StaticProof::Trusted;
       result.nullable = Element.storage IS AET::STR_GC or Element.storage IS AET::OBJECT or
          Element.storage IS AET::TABLE or Element.storage IS AET::ARRAY;

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -40,13 +40,16 @@ bool StaticValueDescriptor::proved() const noexcept
 [[nodiscard]] static bool recursive_array_identity_matches(std::string_view Expected, std::string_view Actual)
 {
    if (Expected IS Actual) return true;
-   if (Expected IS "array<any>") return Actual.starts_with("array<") and Actual.ends_with('>');
+   if (Expected IS "array" or Expected IS "array<any>") {
+      return Actual.starts_with("array<") and Actual.ends_with('>');
+   }
    if (not Expected.starts_with("array<") or not Expected.ends_with('>') or
        not Actual.starts_with("array<") or not Actual.ends_with('>')) return false;
    std::string_view expected_member = Expected.substr(6, Expected.size() - 7);
    std::string_view actual_member = Actual.substr(6, Actual.size() - 7);
    if (expected_member IS "any") return true;
-   if (expected_member.starts_with("array<") and actual_member.starts_with("array<")) {
+   if ((expected_member IS "array" or expected_member.starts_with("array<")) and
+       actual_member.starts_with("array<")) {
       return recursive_array_identity_matches(expected_member, actual_member);
    }
    return false;

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -41,7 +41,7 @@ bool StaticValueDescriptor::proved() const noexcept
 {
    if (Expected IS Actual) return true;
    if (Expected IS "array" or Expected IS "array<any>") {
-      return Actual.starts_with("array<") and Actual.ends_with('>');
+      return Actual IS "array" or (Actual.starts_with("array<") and Actual.ends_with('>'));
    }
    if (not Expected.starts_with("array<") or not Expected.ends_with('>') or
        not Actual.starts_with("array<") or not Actual.ends_with('>')) return false;
@@ -49,7 +49,7 @@ bool StaticValueDescriptor::proved() const noexcept
    std::string_view actual_member = Actual.substr(6, Actual.size() - 7);
    if (expected_member IS "any") return true;
    if ((expected_member IS "array" or expected_member.starts_with("array<")) and
-       actual_member.starts_with("array<")) {
+       (actual_member IS "array" or actual_member.starts_with("array<"))) {
       return recursive_array_identity_matches(expected_member, actual_member);
    }
    return false;

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -3,6 +3,7 @@
 #include "static_type_descriptor.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include <format>
 #include <string>
@@ -11,6 +12,7 @@
 #include <kotuku/objects.h>
 
 #include "ast/nodes.h"
+#include "lexer.h"
 #include "parse_types.h"
 #include "../runtime/lj_array.h"
 #include "../runtime/lj_struct.h"
@@ -35,16 +37,37 @@ bool StaticValueDescriptor::proved() const noexcept
    return Storage;
 }
 
+[[nodiscard]] static bool recursive_array_identity_matches(std::string_view Expected, std::string_view Actual)
+{
+   if (Expected IS Actual) return true;
+   if (Expected IS "array<any>") return Actual.starts_with("array<") and Actual.ends_with('>');
+   if (not Expected.starts_with("array<") or not Expected.ends_with('>') or
+       not Actual.starts_with("array<") or not Actual.ends_with('>')) return false;
+   std::string_view expected_member = Expected.substr(6, Expected.size() - 7);
+   std::string_view actual_member = Actual.substr(6, Actual.size() - 7);
+   if (expected_member IS "any") return true;
+   if (expected_member.starts_with("array<") and actual_member.starts_with("array<")) {
+      return recursive_array_identity_matches(expected_member, actual_member);
+   }
+   return false;
+}
+
 bool array_element_matches(
-   const ArrayElementDescriptor &Expected, const ArrayElementDescriptor &Actual) noexcept
+   const ArrayElementDescriptor &Expected, const ArrayElementDescriptor &Actual)
 {
    if (not Expected.known or Expected.storage IS AET::ANY) return Actual.known;
    if (not Actual.known or public_array_storage(Expected.storage) != public_array_storage(Actual.storage)) return false;
    if (Expected.storage IS AET::STRUCT and Expected.struct_def) return Expected.struct_def IS Actual.struct_def;
+   if (Expected.storage IS AET::ARRAY and Expected.nested_array_identity) {
+      if (not Actual.nested_array_identity) return false;
+      std::string_view expected_name(strdata(Expected.nested_array_identity), Expected.nested_array_identity->len);
+      std::string_view actual_name(strdata(Actual.nested_array_identity), Actual.nested_array_identity->len);
+      return recursive_array_identity_matches(expected_name, actual_name);
+   }
    return true;
 }
 
-ArrayElementDescriptor describe_array_element(const GCarray *Array) noexcept
+ArrayElementDescriptor describe_array_element(const GCarray *Array)
 {
    if (not Array) return {};
    ArrayElementDescriptor result;
@@ -78,8 +101,15 @@ ArrayElementDescriptor describe_array_element(const GCarray *Array) noexcept
    return result;
 }
 
-bool array_element_matches(const ArrayElementDescriptor &Expected, const GCarray *Actual) noexcept
+bool array_element_matches(const ArrayElementDescriptor &Expected, const GCarray *Actual)
 {
+   if (Expected.storage IS AET::ARRAY and Expected.nested_array_identity) {
+      if (not Actual or Actual->elemtype != AET::ARRAY or not gcref(Actual->type_identity)) return false;
+      GCstr *actual_identity = strref(Actual->type_identity);
+      std::string_view expected_name(strdata(Expected.nested_array_identity), Expected.nested_array_identity->len);
+      std::string_view actual_name(strdata(actual_identity), actual_identity->len);
+      return recursive_array_identity_matches(expected_name, actual_name);
+   }
    return array_element_matches(Expected, describe_array_element(Actual));
 }
 
@@ -88,7 +118,134 @@ std::string array_element_name(const ArrayElementDescriptor &Element)
    if (not Element.known) return "array";
    AET storage = public_array_storage(Element.storage);
    if (storage IS AET::STRUCT and Element.struct_def) return std::format("struct<{}>", Element.struct_def->Name);
+   if (storage IS AET::ARRAY and Element.nested_array_identity) {
+      return std::string(strdata(Element.nested_array_identity), Element.nested_array_identity->len);
+   }
    return std::string(lj_array_elemtype_name(storage));
+}
+
+namespace {
+
+class RecursiveArrayTypeParser {
+public:
+   RecursiveArrayTypeParser(std::string_view Text, lua_State *State, LexState *Lexer)
+      : text_(Text), state_(State), lexer_(Lexer) { }
+
+   std::optional<ArrayElementDescriptor> parse_element()
+   {
+      auto result = this->parse_member(0, nullptr);
+      this->skip_space();
+      if (not result or this->position_ != this->text_.size()) return std::nullopt;
+      return result;
+   }
+
+   std::optional<std::string> canonical_name()
+   {
+      std::string canonical;
+      auto result = this->parse_member(0, &canonical);
+      this->skip_space();
+      if (not result or this->position_ != this->text_.size()) return std::nullopt;
+      if (result->storage IS AET::ARRAY) return canonical;
+      return std::format("array<{}>", canonical);
+   }
+
+private:
+   static constexpr size_t MAX_DEPTH = 32;
+
+   void skip_space()
+   {
+      while (this->position_ < this->text_.size() and
+             std::isspace(uint8_t(this->text_[this->position_]))) this->position_++;
+   }
+
+   bool consume(char Character)
+   {
+      this->skip_space();
+      if (this->position_ >= this->text_.size() or this->text_[this->position_] != Character) return false;
+      this->position_++;
+      return true;
+   }
+
+   std::string_view identifier()
+   {
+      this->skip_space();
+      size_t start = this->position_;
+      while (this->position_ < this->text_.size()) {
+         char character = this->text_[this->position_];
+         if (not std::isalnum(uint8_t(character)) and character != '_') break;
+         this->position_++;
+      }
+      return this->text_.substr(start, this->position_ - start);
+   }
+
+   std::optional<ArrayElementDescriptor> parse_member(size_t Depth, std::string *Canonical)
+   {
+      if (Depth >= MAX_DEPTH) return std::nullopt;
+      std::string_view name = this->identifier();
+      if (name.empty()) return std::nullopt;
+
+      if (name IS "array") {
+         ArrayElementDescriptor result { AET::ARRAY, TiriType::Array, CLASSID::NIL, nullptr, true };
+         this->skip_space();
+         if (this->position_ >= this->text_.size() or this->text_[this->position_] != '<') {
+            if (Canonical) *Canonical = "array";
+            return result;
+         }
+         this->position_++;
+         std::string member_name;
+         auto member = this->parse_member(Depth + 1, &member_name);
+         if (not member or member->storage IS AET::PTR or
+             (this->state_ and member->storage IS AET::STRUCT and not member->struct_def) or
+             not this->consume('>')) {
+            return std::nullopt;
+         }
+         std::string identity = std::format("array<{}>", member_name);
+         if (this->lexer_) result.nested_array_identity = this->lexer_->keepstr(identity);
+         else if (this->state_) {
+            result.nested_array_identity = lj_str_new(this->state_, identity.data(), identity.size());
+         }
+         if (Canonical) *Canonical = identity;
+         return result;
+      }
+
+      if (name IS "struct") {
+         if (not this->consume('<')) {
+            if (Canonical) *Canonical = "struct";
+            return describe_array_element("struct", this->state_);
+         }
+         std::string_view structure_name = this->identifier();
+         if (structure_name.empty() or not this->consume('>')) return std::nullopt;
+         if (Canonical) *Canonical = std::format("struct<{}>", structure_name);
+         auto result = describe_array_element(std::format("struct<{}>", structure_name), this->state_);
+         if (this->state_ and result and not result->struct_def) return std::nullopt;
+         return result;
+      }
+
+      if (name IS "object") name = "obj";
+      if (name IS "string") name = "str";
+      auto result = describe_array_element(name IS "obj" ? "object" : name, this->state_);
+      if (result and result->storage IS AET::PTR) return std::nullopt;
+      if (result and Canonical) *Canonical = array_element_name(*result);
+      return result;
+   }
+
+   std::string_view text_;
+   lua_State *state_ = nullptr;
+   LexState *lexer_ = nullptr;
+   size_t position_ = 0;
+};
+
+} // namespace
+
+std::optional<ArrayElementDescriptor> parse_array_element_type(
+   std::string_view Name, lua_State *State, LexState *Lexer)
+{
+   return RecursiveArrayTypeParser(Name, State, Lexer).parse_element();
+}
+
+std::optional<std::string> canonical_array_type_name(std::string_view Name, lua_State *State)
+{
+   return RecursiveArrayTypeParser(Name, State, nullptr).canonical_name();
 }
 
 StaticValueDescriptor StaticResultSet::value_at(size_t Position) const

--- a/src/tiri/jit/src/parser/static_type_descriptor.h
+++ b/src/tiri/jit/src/parser/static_type_descriptor.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -16,6 +17,7 @@
 struct ExprNode;
 struct FunctionField;
 struct FunctionExprPayload;
+class LexState;
 struct struct_field;
 struct struct_record;
 struct RuntimeContract;
@@ -40,15 +42,20 @@ struct ArrayElementDescriptor {
    CLASSID object_class_id = CLASSID::NIL;
    struct_record *struct_def = nullptr;
    bool known = false;
+   GCstr *nested_array_identity = nullptr;
 
    [[nodiscard]] bool operator==(const ArrayElementDescriptor &) const = default;
 };
 
 [[nodiscard]] bool array_element_matches(
-   const ArrayElementDescriptor &Expected, const ArrayElementDescriptor &Actual) noexcept;
-[[nodiscard]] bool array_element_matches(const ArrayElementDescriptor &Expected, const GCarray *Actual) noexcept;
-[[nodiscard]] ArrayElementDescriptor describe_array_element(const GCarray *) noexcept;
+   const ArrayElementDescriptor &Expected, const ArrayElementDescriptor &Actual);
+[[nodiscard]] bool array_element_matches(const ArrayElementDescriptor &Expected, const GCarray *Actual);
+[[nodiscard]] ArrayElementDescriptor describe_array_element(const GCarray *);
 [[nodiscard]] std::string array_element_name(const ArrayElementDescriptor &);
+[[nodiscard]] std::optional<ArrayElementDescriptor> parse_array_element_type(
+   std::string_view, lua_State *State = nullptr, LexState *Lexer = nullptr);
+[[nodiscard]] std::optional<std::string> canonical_array_type_name(
+   std::string_view, lua_State *State = nullptr);
 
 // Whether a table value is known to establish context when one of its members is called.  `Unknown` is the sound
 // classification wherever the analysed function cannot see every designation of the table, because a designation

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -547,7 +547,7 @@ static bool array_identity_text_matches(std::string_view Expected, std::string_v
 {
    if (Expected IS Actual) return true;
    if (Expected IS "array" or Expected IS "array<any>") {
-      return Actual.starts_with("array<") and Actual.ends_with('>');
+      return Actual IS "array" or (Actual.starts_with("array<") and Actual.ends_with('>'));
    }
    if (not Expected.starts_with("array<") or not Expected.ends_with('>') or
        not Actual.starts_with("array<") or not Actual.ends_with('>')) return false;
@@ -556,7 +556,7 @@ static bool array_identity_text_matches(std::string_view Expected, std::string_v
    std::string_view actual_member = Actual.substr(6, Actual.size() - 7);
    if (expected_member IS "any") return true;
    if ((expected_member IS "array" or expected_member.starts_with("array<")) and
-       actual_member.starts_with("array<")) {
+       (actual_member IS "array" or actual_member.starts_with("array<"))) {
       return array_identity_text_matches(expected_member, actual_member);
    }
    return false;

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -555,7 +555,8 @@ static bool array_identity_text_matches(std::string_view Expected, std::string_v
    std::string_view expected_member = Expected.substr(6, Expected.size() - 7);
    std::string_view actual_member = Actual.substr(6, Actual.size() - 7);
    if (expected_member IS "any") return true;
-   if (expected_member.starts_with("array<") and actual_member.starts_with("array<")) {
+   if ((expected_member IS "array" or expected_member.starts_with("array<")) and
+       actual_member.starts_with("array<")) {
       return array_identity_text_matches(expected_member, actual_member);
    }
    return false;

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -18,7 +18,9 @@
 #include <cfloat>
 #include <climits>
 #include <cmath>
+#include <format>
 #include <limits>
+#include <string_view>
 #include <kotuku/main.h>
 #include <kotuku/modules/tiri.h>
 #include <kotuku/strings.hpp>
@@ -193,7 +195,8 @@ static LJ_AINLINE ArrayElementResult array_validate_element(GCarray *Array, cTVa
       case AET::TABLE:
          return tvistab(Value) ? ArrayElementResult::OK : ArrayElementResult::INVALID_TYPE;
       case AET::ARRAY:
-         return tvisarray(Value) ? ArrayElementResult::OK : ArrayElementResult::INVALID_TYPE;
+         return tvisarray(Value) and lj_array_identity_accepts(Array, arrayV(Value)) ?
+            ArrayElementResult::OK : ArrayElementResult::INVALID_TYPE;
       case AET::OBJECT:
          return tvisobject(Value) ? ArrayElementResult::OK : ArrayElementResult::INVALID_TYPE;
       case AET::PTR:
@@ -534,6 +537,78 @@ static void array_attach_basemt(lua_State *L, GCarray *Arr)
 // - String content is copied into a vector<char> owned by the array
 // - The storage area stores CSTRING pointers into the vector
 
+std::string lj_array_default_identity(AET Type, const struct_record *StructDef)
+{
+   if (Type IS AET::STRUCT and StructDef) return std::format("array<struct<{}>>", StructDef->Name);
+   return std::format("array<{}>", lj_array_elemtype_name(Type));
+}
+
+static bool array_identity_text_matches(std::string_view Expected, std::string_view Actual)
+{
+   if (Expected IS Actual) return true;
+   if (Expected IS "array" or Expected IS "array<any>") {
+      return Actual.starts_with("array<") and Actual.ends_with('>');
+   }
+   if (not Expected.starts_with("array<") or not Expected.ends_with('>') or
+       not Actual.starts_with("array<") or not Actual.ends_with('>')) return false;
+
+   std::string_view expected_member = Expected.substr(6, Expected.size() - 7);
+   std::string_view actual_member = Actual.substr(6, Actual.size() - 7);
+   if (expected_member IS "any") return true;
+   if (expected_member.starts_with("array<") and actual_member.starts_with("array<")) {
+      return array_identity_text_matches(expected_member, actual_member);
+   }
+   return false;
+}
+
+bool lj_array_identity_accepts(const GCarray *Destination, const GCarray *Value)
+{
+   if (not Destination or not Value or Destination->elemtype != AET::ARRAY) return false;
+   if (not gcref(Destination->type_identity)) return true;
+
+   GCstr *destination_identity = strref(Destination->type_identity);
+   std::string_view destination_name(strdata(destination_identity), destination_identity->len);
+   if (destination_name IS "array<array>") return true;
+   if (not destination_name.starts_with("array<") or not destination_name.ends_with('>') or
+       not gcref(Value->type_identity)) return false;
+
+   std::string_view expected_member = destination_name.substr(6, destination_name.size() - 7);
+   GCstr *value_identity = strref(Value->type_identity);
+   std::string_view actual_name(strdata(value_identity), value_identity->len);
+   return array_identity_text_matches(expected_member, actual_name);
+}
+
+bool lj_array_identity_matches(const GCarray *Array, std::string_view Expected)
+{
+   if (not Array or not gcref(Array->type_identity)) return false;
+   GCstr *identity = strref(Array->type_identity);
+   return array_identity_text_matches(Expected, std::string_view(strdata(identity), identity->len));
+}
+
+bool lj_array_member_identity_matches(const GCarray *Array, std::string_view ExpectedMember)
+{
+   if (not Array or not gcref(Array->type_identity)) return false;
+   GCstr *identity = strref(Array->type_identity);
+   std::string_view actual(strdata(identity), identity->len);
+   if (not actual.starts_with("array<") or not actual.ends_with('>')) return false;
+   return array_identity_text_matches(ExpectedMember, actual.substr(6, actual.size() - 7));
+}
+
+static bool array_copy_identity_compatible(const GCarray *Destination, const GCarray *Source)
+{
+   if (Destination->elemtype != AET::ARRAY) return true;
+   if (not gcref(Destination->type_identity)) return true;
+
+   GCstr *destination_identity = strref(Destination->type_identity);
+   std::string_view destination_name(strdata(destination_identity), destination_identity->len);
+   if (destination_name IS "array<array>") return true;
+   if (not gcref(Source->type_identity)) return false;
+
+   GCstr *source_identity = strref(Source->type_identity);
+   std::string_view source_name(strdata(source_identity), source_identity->len);
+   return array_identity_text_matches(destination_name, source_name);
+}
+
 extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Data, uint8_t Flags,
    std::string_view StructName, struct_record *StructDef)
 {
@@ -553,6 +628,9 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
    }
    else elem_size = lj_array_elemsize(Type);
 
+   std::string identity = lj_array_default_identity(Type, sdef);
+   GCstr *type_identity = lj_str_new(L, identity.data(), identity.size());
+
    lj_assertL(elem_size > 0, "invalid element size for array creation");
 
    if (Data or (Flags & ARRAY_EXTERNAL)) {
@@ -560,7 +638,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
          // External data - caller manages lifetime (no storage allocation needed)
          // External arrays have capacity = length and cannot grow
          auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-         arr->init(Data, Type, elem_size, Length, Length, Flags, sdef);
+         arr->init(Data, Type, elem_size, Length, Length, Flags, sdef, type_identity);
          array_attach_basemt(L, arr);
          return arr;
       }
@@ -571,7 +649,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
             size_t byte_size = Length * sizeof(CSTRING);
             void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
             auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-            arr->init(storage, AET::CSTR, sizeof(CSTRING), Length, Length, 0, sdef);
+            arr->init(storage, AET::CSTR, sizeof(CSTRING), Length, Length, 0, sdef, type_identity);
             array_attach_basemt(L, arr);
 
             // Calculate total string content size
@@ -631,7 +709,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
             size_t byte_size = Length * elem_size;
             void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
             auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-            arr->init(storage, Type, elem_size, Length, Length, Flags, sdef);
+            arr->init(storage, Type, elem_size, Length, Length, Flags, sdef, type_identity);
             array_attach_basemt(L, arr);
 
             auto refs = arr->get<GCRef>();
@@ -653,7 +731,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
             size_t byte_size = Length * elem_size;
             void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
             auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-            arr->init(storage, Type, elem_size, Length, Length, Flags, sdef);
+            arr->init(storage, Type, elem_size, Length, Length, Flags, sdef, type_identity);
             array_attach_basemt(L, arr);
             if (byte_size > 0) {
                if (Type IS AET::ANY) lj_bulk_copy_tvalue((TValue *)storage, (const TValue *)Data, Length);
@@ -669,7 +747,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
       size_t byte_size = Length * elem_size;
       void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
       auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-      arr->init(storage, Type, elem_size, Length, Length, Flags & ~(ARRAY_EXTERNAL|ARRAY_CACHED), sdef);
+      arr->init(storage, Type, elem_size, Length, Length, Flags & ~(ARRAY_EXTERNAL|ARRAY_CACHED), sdef, type_identity);
       array_attach_basemt(L, arr);
       if (storage) {
          if (Type IS AET::ANY) {
@@ -680,6 +758,33 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
       }
       return arr;
    }
+}
+
+GCarray * lj_array_new(lua_State *L, uint32_t Length, const ArrayAllocationDescriptor &Descriptor, void *Data,
+   uint8_t Flags)
+{
+   std::string_view struct_name = Descriptor.storage IS AET::STRUCT and Descriptor.struct_def ?
+      std::string_view(Descriptor.struct_def->Name) : std::string_view{};
+   GCarray *array = lj_array_new(
+      L, Length, Descriptor.storage, Data, Flags, struct_name, Descriptor.struct_def);
+   if (not Descriptor.canonical_identity.empty()) {
+      GCstr *identity = lj_str_new(L, Descriptor.canonical_identity.data(), Descriptor.canonical_identity.size());
+      setgcref(array->type_identity, obj2gco(identity));
+      lj_gc_objbarrier(L, array, identity);
+   }
+   return array;
+}
+
+GCarray * lj_array_new_like(lua_State *L, const GCarray *Source, uint32_t Length)
+{
+   ArrayAllocationDescriptor descriptor;
+   descriptor.storage = Source->elemtype;
+   descriptor.struct_def = Source->structdef;
+   if (gcref(Source->type_identity)) {
+      GCstr *identity = strref(Source->type_identity);
+      descriptor.canonical_identity.assign(strdata(identity), identity->len);
+   }
+   return lj_array_new(L, Length, descriptor);
 }
 
 //********************************************************************************************************************
@@ -768,7 +873,9 @@ void lj_array_copy(lua_State *L, GCarray *Dest, uint32_t DstIdx, GCarray *Src, u
       lj_err_caller(L, ErrMsg::IDXRNG);
    }
    if (Dest->is_readonly()) lj_err_caller(L, ErrMsg::ARRRO);
-   if (not (Dest->elemtype IS Src->elemtype)) lj_err_caller(L, ErrMsg::ARRTYPE);
+   if (not (Dest->elemtype IS Src->elemtype) or not array_copy_identity_compatible(Dest, Src)) {
+      lj_err_caller(L, ErrMsg::ARRTYPE);
+   }
    if (Count IS 0) return;
 
    void *dst_ptr = lj_array_index(Dest, DstIdx);

--- a/src/tiri/jit/src/runtime/lj_array.h
+++ b/src/tiri/jit/src/runtime/lj_array.h
@@ -5,8 +5,21 @@
 
 #include "lj_obj.h"
 
+struct ArrayAllocationDescriptor {
+   AET storage = AET::ANY;
+   struct_record *struct_def = nullptr;
+   std::string canonical_identity;
+};
+
 extern GCarray * lj_array_new(lua_State *, uint32_t, AET, void *Data = nullptr, uint8_t Flags = 0,
    std::string_view StructName = {}, struct_record *StructDef = nullptr);
+extern GCarray * lj_array_new(lua_State *, uint32_t, const ArrayAllocationDescriptor &, void *Data = nullptr,
+   uint8_t Flags = 0);
+[[nodiscard]] extern std::string lj_array_default_identity(AET, const struct_record * = nullptr);
+[[nodiscard]] extern bool lj_array_identity_accepts(const GCarray *, const GCarray *);
+[[nodiscard]] extern bool lj_array_identity_matches(const GCarray *, std::string_view);
+[[nodiscard]] extern bool lj_array_member_identity_matches(const GCarray *, std::string_view);
+[[nodiscard]] extern GCarray * lj_array_new_like(lua_State *, const GCarray *, uint32_t);
 extern void lj_array_free(global_State *, GCarray *);
 [[nodiscard]] extern uint8_t lj_array_elemsize(AET);
 [[nodiscard]] extern CSTRING lj_array_elemtype_name(AET) noexcept;

--- a/src/tiri/jit/src/runtime/lj_contract.h
+++ b/src/tiri/jit/src/runtime/lj_contract.h
@@ -50,7 +50,7 @@ struct RuntimeContractEntry {
    uint8_t flags = 0;
    uint8_t position = 0;
    CLASSID object_class_id = CLASSID::NIL;
-   std::string_view constraint_name; // Named structure, or the structure member of array<struct<Name>>.
+   std::string_view constraint_name; // Structure name or canonical nested-array member identity.
    std::string_view label;
 };
 
@@ -86,7 +86,7 @@ struct RuntimeContractDescriptor {
 struct CachedRuntimeContractEntry {
    union {
       uint32_t object_class_id;
-      uint16_t constraint_offset; // Structure or array-member structure name, selected by type.
+      uint16_t constraint_offset; // Structure name or canonical nested-array identity, selected by type.
    };
    uint16_t label_offset;
    TiriType type;
@@ -272,6 +272,40 @@ private:
    const uint8_t *end_;
 };
 
+[[nodiscard]] inline bool runtime_array_identity_is_canonical(std::string_view Identity) noexcept
+{
+   auto identifier = [](std::string_view Text) {
+      if (Text.empty()) return false;
+      bool first_alpha = (Text[0] >= 'a' and Text[0] <= 'z') or
+         (Text[0] >= 'A' and Text[0] <= 'Z') or Text[0] IS '_';
+      if (not first_alpha) return false;
+      for (char character : Text.substr(1)) {
+         bool alpha = (character >= 'a' and character <= 'z') or
+            (character >= 'A' and character <= 'Z') or character IS '_';
+         bool digit = character >= '0' and character <= '9';
+         if (not alpha and not digit) return false;
+      }
+      return true;
+   };
+   auto member_valid = [&identifier](auto &Self, std::string_view Member, uint8_t Depth) -> bool {
+      if (Depth >= 32 or Member.empty()) return false;
+      if (Member.starts_with("array<") and Member.ends_with('>')) {
+         return Self(Self, Member.substr(6, Member.size() - 7), uint8_t(Depth + 1));
+      }
+      if (Member.starts_with("struct<") and Member.ends_with('>')) {
+         return identifier(Member.substr(7, Member.size() - 8));
+      }
+      constexpr std::array<std::string_view, 16> names = {
+         "any", "array", "byte", "double", "float", "int", "int8", "int16", "int64", "obj",
+         "str", "table", "uint", "uint8", "uint16", "uint64"
+      };
+      for (std::string_view name : names) if (Member IS name) return true;
+      return false;
+   };
+   return Identity.starts_with("array<") and Identity.ends_with('>') and
+      member_valid(member_valid, Identity.substr(6, Identity.size() - 7), 0);
+}
+
 // Result is usable only when decoding succeeds.  Avoid clearing the fixed-capacity entry array here because callers
 // already default-initialise it and every live entry is overwritten below.
 [[nodiscard]] inline bool decode_runtime_contract(
@@ -324,6 +358,10 @@ private:
             return fail(RuntimeContractDecodeError::Entry);
          }
          entry.array_element_type = AET(array_element_type);
+         if (entry.array_element_type IS AET::ARRAY and not array_struct_name.empty() and
+             not runtime_array_identity_is_canonical(array_struct_name)) {
+            return fail(RuntimeContractDecodeError::Entry);
+         }
       }
       if (not reader.read_text(entry.label)) return fail(RuntimeContractDecodeError::Entry);
       bool is_const = contract_entry_is_const(entry);
@@ -347,7 +385,9 @@ private:
          if (entry.array_element_type IS AET::STRUCT) {
             if (array_struct_name.empty()) return fail(RuntimeContractDecodeError::Entry);
          }
-         else if (not array_struct_name.empty()) return fail(RuntimeContractDecodeError::Entry);
+         else if (entry.array_element_type != AET::ARRAY and not array_struct_name.empty()) {
+            return fail(RuntimeContractDecodeError::Entry);
+         }
       }
       if (entry.type IS TiriType::Object) entry.object_class_id = CLASSID(object_class_id);
       else if (entry.type IS TiriType::Struct) entry.constraint_name = struct_name;

--- a/src/tiri/jit/src/runtime/lj_gc.cpp
+++ b/src/tiri/jit/src/runtime/lj_gc.cpp
@@ -495,6 +495,7 @@ static void gc_traverse_array(global_State *g, GCarray *Arr)
 {
    GCtab *mt = tabref(Arr->metatable);
    if (mt) gc_markobj(g, mt);
+   if (gcref(Arr->type_identity)) gc_markobj(g, gcref(Arr->type_identity));
 
    if (Arr->elemtype IS AET::STR_GC or Arr->elemtype IS AET::TABLE or Arr->elemtype IS AET::ARRAY or Arr->elemtype IS AET::OBJECT) {
       GCRef *refs = Arr->get<GCRef>();

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -200,7 +200,11 @@ void lj_meta_raw_type_text(lua_State *L, cTValue *Value, char *Buffer, size_t Si
 
    if (tvisarray(Value)) {
       GCarray *array = arrayV(Value);
-      if (array->elemtype IS AET::STRUCT and array->structdef) {
+      if (gcref(array->type_identity)) {
+         GCstr *identity = strref(array->type_identity);
+         std::snprintf(Buffer, Size, "%.*s", int(identity->len), strdata(identity));
+      }
+      else if (array->elemtype IS AET::STRUCT and array->structdef) {
          std::snprintf(Buffer, Size, "array<struct<%s>>", array->structdef->Name.c_str());
       }
       else std::snprintf(Buffer, Size, "array<%s>", lj_array_elemtype_name(array->elemtype));
@@ -938,9 +942,14 @@ namespace {
    bool string_match = expected IS AET::STR_GC and
       (actual IS AET::STR_GC or actual IS AET::CSTR or actual IS AET::STR_CPP);
    if (not string_match and actual != expected) return false;
-   if (expected != AET::STRUCT) return true;
-   struct_record *definition = find_struct(L, Entry.constraint_name);
-   return definition and Array->structdef IS definition;
+   if (expected IS AET::STRUCT) {
+      struct_record *definition = find_struct(L, Entry.constraint_name);
+      return definition and Array->structdef IS definition;
+   }
+   if (expected IS AET::ARRAY and not Entry.constraint_name.empty()) {
+      return lj_array_member_identity_matches(Array, Entry.constraint_name);
+   }
+   return true;
 }
 
 [[nodiscard]] static bool contract_matches(lua_State *L, cTValue *Value, const RuntimeContractEntry &Entry)
@@ -1006,6 +1015,11 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
    if (Entry.type IS TiriType::Array) {
       if (Entry.array_element_type IS AET::STRUCT and not Entry.constraint_name.empty()) {
          std::snprintf(Buffer, Size, "array<struct<%.*s>>", int(Entry.constraint_name.size()),
+            Entry.constraint_name.data());
+         return;
+      }
+      if (Entry.array_element_type IS AET::ARRAY and not Entry.constraint_name.empty()) {
+         std::snprintf(Buffer, Size, "array<%.*s>", int(Entry.constraint_name.size()),
             Entry.constraint_name.data());
          return;
       }
@@ -1140,7 +1154,8 @@ static void apply_cached_contract(lua_State *L, TValue *Base, uint32_t DynamicCo
          .position = cached.position,
          .object_class_id = cached.type IS TiriType::Object ? CLASSID(cached.object_class_id) : CLASSID::NIL,
          .constraint_name = (cached.type IS TiriType::Struct or
-            (cached.type IS TiriType::Array and cached.array_element_type IS AET::STRUCT)) ?
+            (cached.type IS TiriType::Array and
+             (cached.array_element_type IS AET::STRUCT or cached.array_element_type IS AET::ARRAY))) ?
             cached_contract_text(Descriptor, cached.constraint_offset) : std::string_view{},
          .label = cached_contract_text(Descriptor, cached.label_offset)
       };
@@ -1192,7 +1207,8 @@ extern "C" void lj_meta_type_test_pc(lua_State *L, const BCIns *PC)
       decoded_entry.position = cached.position;
       if (cached.type IS TiriType::Object) decoded_entry.object_class_id = CLASSID(cached.object_class_id);
       else if (cached.type IS TiriType::Struct or
-               (cached.type IS TiriType::Array and cached.array_element_type IS AET::STRUCT)) {
+               (cached.type IS TiriType::Array and
+                (cached.array_element_type IS AET::STRUCT or cached.array_element_type IS AET::ARRAY))) {
          decoded_entry.constraint_name = cached_contract_text(encoded, cached.constraint_offset);
       }
       decoded_entry.label = cached_contract_text(encoded, cached.label_offset);
@@ -1291,7 +1307,8 @@ void lj_contract_build_cache(lua_State *L, GCproto *Prototype)
          CachedRuntimeContractEntry &target = entries[entry_index++];
          if (source.type IS TiriType::Object) target.object_class_id = uint32_t(source.object_class_id);
          else if (source.type IS TiriType::Struct or
-                  (source.type IS TiriType::Array and source.array_element_type IS AET::STRUCT)) {
+                  (source.type IS TiriType::Array and
+                   (source.array_element_type IS AET::STRUCT or source.array_element_type IS AET::ARRAY))) {
             target.constraint_offset = cached_contract_text_offset(encoded, source.constraint_name);
          }
          else target.object_class_id = 0;
@@ -1464,7 +1481,9 @@ static void env_check_contract(lua_State *L, GCtab *Environment, GCstr *Name, cT
          .object_class_id = cached->entry.type IS TiriType::Object ?
             CLASSID(cached->entry.object_class_id) : CLASSID::NIL,
          .constraint_name = (cached->entry.type IS TiriType::Struct or
-            (cached->entry.type IS TiriType::Array and cached->entry.array_element_type IS AET::STRUCT)) ?
+            (cached->entry.type IS TiriType::Array and
+             (cached->entry.array_element_type IS AET::STRUCT or
+              cached->entry.array_element_type IS AET::ARRAY))) ?
             cached_contract_text(cached->descriptor, cached->entry.constraint_offset) : std::string_view{},
          .label = cached_contract_text(cached->descriptor, cached->entry.label_offset)
       };

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -1384,6 +1384,7 @@ struct GCarray {
    struct struct_record *structdef;  // Optional: struct definition for struct arrays
    std::vector<char> *strcache; // Optional: cached string content for CSTRING/STRING_CPP arrays
    RESOURCEID resource_id; // Optional Core resource pin owned by an external view
+   GCRef type_identity; // Interned complete public type name, appended to preserve fixed field offsets
 
 public:
    // Initialise the array structure. Storage must be pre-allocated by the caller using lj_mem_new()
@@ -1391,7 +1392,7 @@ public:
    // them! We avoid member initialiser lists to prevent GCC from zero-initializing the GCHeader
    // fields (nextgc, marked) that were set by lj_mem_newgco().
    void init(void *Data, AET Type, MSize ElemSize, MSize Length, MSize Capacity, uint8_t Flags,
-             struct struct_record *StructDef = nullptr) noexcept
+             struct struct_record *StructDef = nullptr, GCstr *TypeIdentity = nullptr) noexcept
    {
       gct       = ~LJ_TARRAY;
       luatype   = glArrayConversion[size_t(Type)].type;
@@ -1408,6 +1409,7 @@ public:
       structdef = StructDef;
       strcache  = nullptr;
       resource_id = 0;
+      type_identity.gcptr64 = uint64_t(TypeIdentity);
    }
 
    // Destructor only handles strcache. Storage is freed by lj_array_free() for proper GC tracking.

--- a/src/tiri/jit/src/runtime/lj_tab.cpp
+++ b/src/tiri/jit/src/runtime/lj_tab.cpp
@@ -750,7 +750,8 @@ void lj_tab_set_global_contract(lua_State *L, GCtab *Environment, const GCstr *N
       replacement.descriptor = Descriptor;
       if (source.type IS TiriType::Object) replacement.entry.object_class_id = uint32_t(source.object_class_id);
       else if (source.type IS TiriType::Struct or
-               (source.type IS TiriType::Array and source.array_element_type IS AET::STRUCT)) {
+               (source.type IS TiriType::Array and
+                (source.array_element_type IS AET::STRUCT or source.array_element_type IS AET::ARRAY))) {
          ptrdiff_t offset = source.constraint_name.data() - strdata(Descriptor);
          lj_assertX(offset > 0 and uint64_t(offset) <= UINT16_MAX,
             "global contract constraint offset is out of range");

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -214,6 +214,22 @@ static bool test_array_recursive_identity(kt::Log &Log)
       Log.error("a recursive wildcard rejected a valid inner array");
       return false;
    }
+
+   ArrayAllocationDescriptor deep_wildcard_descriptor {
+      .storage = AET::ARRAY,
+      .canonical_identity = "array<array<array>>"
+   };
+   ArrayAllocationDescriptor specialised_matrix_descriptor {
+      .storage = AET::ARRAY,
+      .canonical_identity = "array<array<int>>"
+   };
+   GCarray *deep_wildcard = lj_array_new(lua, 0, deep_wildcard_descriptor);
+   GCarray *specialised_matrix = lj_array_new(lua, 0, specialised_matrix_descriptor);
+   setarrayV(lua, &value, specialised_matrix);
+   if (lj_array_validate_element(deep_wildcard, &value) != ArrayElementResult::OK) {
+      Log.error("a deeply recursive bare array wildcard rejected a valid specialisation");
+      return false;
+   }
    return true;
 }
 

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -164,6 +164,59 @@ static bool test_array_creation_int32(kt::Log &Log)
    return true;
 }
 
+static bool test_array_recursive_identity(kt::Log &Log)
+{
+   LuaStateHolder holder;
+   lua_State *lua = holder.get();
+   if (not lua) return false;
+
+   GCarray *ordinary = lj_array_new(lua, 0, AET::ARRAY);
+   if (not gcref(ordinary->type_identity) or
+       std::string_view(strdata(strref(ordinary->type_identity)), strref(ordinary->type_identity)->len) !=
+          "array<array>") {
+      Log.error("the C++ convenience allocator did not derive an unconstrained canonical identity");
+      return false;
+   }
+
+   ArrayAllocationDescriptor descriptor {
+      .storage = AET::ARRAY,
+      .canonical_identity = "array<array<double>>"
+   };
+   GCarray *matrix = lj_array_new(lua, 0, descriptor);
+   setarrayV(lua, lua->top++, matrix);
+   lua_gc(lua, LUA_GCCOLLECT);
+   GCstr *identity = strref(matrix->type_identity);
+   if (not identity or std::string_view(strdata(identity), identity->len) != "array<array<double>>") {
+      Log.error("a descriptor-aware array allocation lost its identity during GC traversal");
+      return false;
+   }
+
+   GCarray *matching = lj_array_new(lua, 0, AET::DOUBLE);
+   GCarray *mismatch = lj_array_new(lua, 0, AET::STR_GC);
+   TValue value;
+   setarrayV(lua, &value, matching);
+   if (lj_array_validate_element(matrix, &value) != ArrayElementResult::OK) {
+      Log.error("recursive array storage rejected a matching inner identity");
+      return false;
+   }
+   setarrayV(lua, &value, mismatch);
+   if (lj_array_validate_element(matrix, &value) != ArrayElementResult::INVALID_TYPE) {
+      Log.error("recursive array storage accepted a mismatched inner identity");
+      return false;
+   }
+
+   ArrayAllocationDescriptor wildcard_descriptor {
+      .storage = AET::ARRAY,
+      .canonical_identity = "array<array<any>>"
+   };
+   GCarray *wildcard = lj_array_new(lua, 0, wildcard_descriptor);
+   if (lj_array_validate_element(wildcard, &value) != ArrayElementResult::OK) {
+      Log.error("a recursive wildcard rejected a valid inner array");
+      return false;
+   }
+   return true;
+}
+
 //********************************************************************************************************************
 
 static bool test_unsigned_array_types(kt::Log &Log)
@@ -1588,10 +1641,11 @@ static bool test_lib_array_double_type(kt::Log &Log)
 
 void array_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 38> Tests = { {
+   constexpr std::array<TestCase, 39> Tests = { {
       // Core Data Structures
       { "array_creation_byte", test_array_creation_byte },
       { "array_creation_int32", test_array_creation_int32 },
+      { "array_recursive_identity", test_array_recursive_identity },
       { "unsigned_array_types", test_unsigned_array_types },
       { "struct_pointer_array_sentinel", test_struct_pointer_array_sentinel },
       { "struct_to_table_string_vector", test_struct_to_table_string_vector },

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -230,6 +230,13 @@ static bool test_array_recursive_identity(kt::Log &Log)
       Log.error("a deeply recursive bare array wildcard rejected a valid specialisation");
       return false;
    }
+
+   GCarray *bare_matrix = lj_array_new(lua, 0, AET::ARRAY);
+   if (not lj_array_member_identity_matches(bare_matrix, "array<any>") or
+       not lj_array_identity_matches(bare_matrix, "array<array<any>>")) {
+      Log.error("an array<any> wildcard rejected a bare array identity");
+      return false;
+   }
    return true;
 }
 

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -1490,7 +1490,7 @@ end
 
 @Test function ArrayOfInvalidType()
    try
-      t = array<invalid> { 1, 2, 3 }
+      exec('t = array<invalid> { 1, 2, 3 }')
    success
       error("array.of() with invalid type should fail")
    end
@@ -1498,7 +1498,7 @@ end
 
 @Test function ArrayOfPointerRejected()
    try
-      t = array<pointer> { 1, 2, 3 }
+      exec('t = array<pointer> { 1, 2, 3 }')
    success
       error("array.of() with pointer type should be rejected")
    end
@@ -1506,7 +1506,7 @@ end
 
 @Test function ArrayOfStructRejected()
    try
-      t = array<struct> { 1, 2, 3 }
+      exec('t = array<struct> { 1, 2, 3 }')
    success
       error("array.of() with struct type should be rejected")
    end

--- a/src/tiri/tests/test_array_element_validation.tiri
+++ b/src/tiri/tests/test_array_element_validation.tiri
@@ -58,7 +58,8 @@ end
    expect_failure(() => do array.of('str', 12) end, 'String constructor accepted a number')
    expect_failure(() => do indexed.copy({ [0]=12 }) end, 'String table copy accepted a number')
    expect_failure(() => do indexed.mapSame(Value => num: 12) end, 'String map accepted a number')
-   expect_failure(() => do array.new(0, 'string') end, "Legacy 'string' element name was accepted")
+   local legacy_string = array.new(0, 'string')
+   assert(legacy_string.type() is 'str', "The canonical 'string' alias did not produce string storage")
 end
 
 @Test function ReferenceCategoriesAreExact()

--- a/src/tiri/tests/test_recursive_array_types.tiri
+++ b/src/tiri/tests/test_recursive_array_types.tiri
@@ -12,6 +12,10 @@ function identity_matrix(Matrix:array<array<double>>):array<array<double>>
    return Matrix
 end
 
+function deep_wildcard_parameter(Value:array<array<array>>!):num
+   return #Value
+end
+
 @Test function RecursiveConstructorsAndAnnotations()
    local integers:array<array<int>> = array<array<int>> {
       array<int> { 3, 5 },
@@ -64,6 +68,21 @@ end
    }
    assert(broad[0][0] is 1 and broad[1][0] is 'two',
       'array<array> should remain an unconstrained inner-array annotation')
+end
+
+@Test function DeepUnconstrainedInnerArrayRemainsValid()
+   local row = array<int> { 1 }
+   local matrix = array<array<int>> { row }
+   local constructed = array<array<array>> { matrix }
+   local specialised = array<array<array<int>>> { matrix }
+   local assigned:array<array<array>> = specialised
+
+   assert(constructed[0][0][0] is 1,
+      'a deeply nested bare array wildcard was rejected during construction')
+   assert(deep_wildcard_parameter(specialised) is 1,
+      'a deeply nested bare array wildcard was rejected by a parameter contract')
+   assert(assigned[0][0][0] is 1,
+      'a deeply nested bare array wildcard was rejected by typed assignment')
 end
 
 @Test function RecursiveIdentityIsPubliclyVisible()

--- a/src/tiri/tests/test_recursive_array_types.tiri
+++ b/src/tiri/tests/test_recursive_array_types.tiri
@@ -99,6 +99,17 @@ end
    end
 end
 
+@Test function RecursiveRuntimeTypeTests()
+   local matrix:any = array<array<int>> { array<int> { 1 } }
+   local cube:any = array<array<array<int>>> { array<array<int>> { array<int> { 2 } } }
+
+   assert(matrix is <array array<int>>, 'a matching recursive array type test was rejected')
+   assert(matrix is not <array array<str>>, 'a recursive array type test accepted a mismatching member type')
+   assert(matrix is <array array<any>>, 'a recursive array type test rejected an any wildcard')
+   assert(cube is <array array<array<int>>>, 'a matching deeply recursive array type test was rejected')
+   assert(cube is <array array<array>>, 'a deep bare-array wildcard type test was rejected')
+end
+
 function expect_recursive_store_failure(Operation:func, Message:str)
    try
       Operation()
@@ -292,4 +303,5 @@ end
    assert_rejected('local values = array<array<int, 4>> {}', 'declare a size')
    assert_rejected('local values = array<array<missing>> {}', 'Unknown or malformed array element type')
    assert_rejected('local values = array<array<int> {}', "'>' expected")
+   assert_rejected('return array<array<int>> {} is <array array<int, 4>>', 'cannot declare a size')
 end

--- a/src/tiri/tests/test_recursive_array_types.tiri
+++ b/src/tiri/tests/test_recursive_array_types.tiri
@@ -1,0 +1,276 @@
+-- Parser, constructor and static-analysis coverage for recursive array element types.
+
+struct RecursiveArrayPoint
+   Value: int
+end
+
+function first_value(Matrix:array<array<int>>!):num
+   return Matrix[0][0]
+end
+
+function identity_matrix(Matrix:array<array<double>>):array<array<double>>
+   return Matrix
+end
+
+@Test function RecursiveConstructorsAndAnnotations()
+   local integers:array<array<int>> = array<array<int>> {
+      array<int> { 3, 5 },
+      array<int> { 7, 11 }
+   }
+   local fixed = array<array<int>, 3> { array<int> { 13 }, array<int> { 17 } }
+   local captured:array<array<int>> = integers
+   local function captured_value():num
+      return captured[1][0]
+   end
+   global glRecursiveDoubles:array<array<double>> = array<array<double>> {
+      array<double> { 1.0, 0.0 },
+      array<double> { 0.0, 1.0 }
+   }
+
+   assert(first_value(integers) is 3, 'chained indexing lost the innermost numeric type')
+   assert(captured_value() is 7, 'captured recursive descriptors were not preserved through upvalues')
+   assert(#fixed is 3 and fixed[1][0] is 17 and fixed[2] is nil,
+      'a size on the constructed outer array should remain valid')
+   assert(identity_matrix(glRecursiveDoubles)[1][1] is 1.0,
+      'recursive descriptors were not preserved through parameters, results and globals')
+end
+
+@Test function CanonicalAliasesAndWhitespaceRemainStable()
+   local matrix:array< array < char > > = array< array < char > > {
+      array<char> { 65 }
+   }
+
+   assert(rawtype(matrix) is 'array<array<byte>>',
+      'recursive identities should remain rooted after whitespace and alias canonicalisation')
+   assert(matrix[0][0] is 65, 'a canonical recursive descriptor lost its element type')
+end
+
+@Test function ThreeDimensionalAndNamedStructureTypes()
+   local cube:array<array<array<int>>> = array<array<array<int>>> {
+      array<array<int>> { array<int> { 17 } }
+   }
+   local points:array<array<struct<RecursiveArrayPoint>>> = array<array<struct<RecursiveArrayPoint>>> {
+      array<struct<RecursiveArrayPoint>> { struct<RecursiveArrayPoint> { Value=23 } }
+   }
+
+   assert(cube[0][0][0] is 17, 'three-dimensional indexing lost recursive element descriptors')
+   assert(points[0][0].Value is 23, 'nested named structure identity was not retained')
+end
+
+@Test function UnconstrainedInnerArrayRemainsValid()
+   local broad:array<array> = array<array> {
+      array<int> { 1 },
+      array<str> { 'two' }
+   }
+   assert(broad[0][0] is 1 and broad[1][0] is 'two',
+      'array<array> should remain an unconstrained inner-array annotation')
+end
+
+@Test function RecursiveIdentityIsPubliclyVisible()
+   local matrix = array<array<int>> { array<int> { 1 } }
+   local cube = array<array<array<double>>> { array<array<double>> { array<double> { 1.0 } } }
+
+   assert(type(matrix) is 'array', 'type() should continue to report the public array category')
+   assert(matrix.type() is 'array', 'array.type() should continue to report the immediate public category')
+   assert(rawtype(matrix) is 'array<array<int>>', 'rawtype() lost the complete recursive array identity')
+   assert(rawtype(cube) is 'array<array<array<double>>>', 'rawtype() lost a three-dimensional identity')
+
+   for _ in {0 to 200} do
+      assert(rawtype(matrix) is 'array<array<int>>', 'traced rawtype() lost the recursive array identity')
+   end
+end
+
+function expect_recursive_store_failure(Operation:func, Message:str)
+   try
+      Operation()
+      error(Message)
+   except e
+      assert(e.message.find('element type') != nil, 'Unexpected recursive array runtime diagnostic: ' .. e.message)
+   end
+end
+
+function recursive_dynamic(Value:any):any
+   return Value
+end
+
+function recursive_parameter(Matrix:array<array<int>>!):num
+   return #Matrix
+end
+
+function recursive_wildcard_parameter(Matrix:array<array<any>>!):num
+   return #Matrix
+end
+
+function recursive_result(Value:any):array<array<int>>!
+   return Value
+end
+
+function expect_recursive_contract_failure(Operation:func, Message:str)
+   try
+      Operation()
+      error(Message)
+   except e
+      assert(e.message.find('array<array<int>>') != nil,
+         'Recursive contract diagnostic lost the complete expected type: ' .. e.message)
+   end
+end
+
+@Test function RecursiveRuntimeContractsAreExact()
+   local matching:any = array<array<int>> { array<int> { 1 } }
+   local mismatch:any = array<array<str>> { array<str> { 'wrong' } }
+
+   assert(recursive_parameter(matching) is 1, 'a matching recursive parameter contract was rejected')
+   expect_recursive_contract_failure(() => recursive_parameter(mismatch),
+      'a recursive parameter contract accepted an incompatible array')
+   expect_recursive_contract_failure(() => recursive_result(mismatch),
+      'a recursive result contract accepted an incompatible array')
+
+   expect_recursive_contract_failure(() => do
+      local matrix:array<array<int>> = matching
+      matrix = recursive_dynamic(mismatch)
+   end, 'a recursive local contract accepted an incompatible array')
+
+   local captured:array<array<int>> = matching
+   local function update(Value:any):nil
+      captured = Value
+   end
+   expect_recursive_contract_failure(() => update(mismatch),
+      'a recursive upvalue contract accepted an incompatible array')
+
+   global glRecursiveContract:array<array<int>> = matching
+   expect_recursive_contract_failure(() => do glRecursiveContract = mismatch end,
+      'a persisted recursive global contract accepted an incompatible array')
+   assert(glRecursiveContract is matching, 'a failed recursive global contract changed the stored value')
+
+   exec('global glRecursiveCrossChunk:array<array<int>> = array<array<int>> { array<int> { 2 } }')
+   expect_recursive_contract_failure(
+      () => exec("glRecursiveCrossChunk = array<array<str>> { array<str> { 'wrong' } }"),
+      'a separately compiled chunk bypassed a persisted recursive global contract')
+end
+
+@Test function RecursiveContractsRemainSafeOnTraces()
+   local matching:any = array<array<int>> { array<int> { 1 } }
+   local mismatch:any = array<array<str>> { array<str> { 'wrong' } }
+   for _ in {0 to 200} do
+      assert(recursive_parameter(matching) is 1, 'a traced recursive parameter rejected a matching value')
+   end
+   expect_recursive_contract_failure(() => recursive_parameter(mismatch),
+      'a traced recursive parameter contract accepted an incompatible array')
+   assert(recursive_parameter(matching) is 1,
+      'a recursive contract trace was unstable after rejecting an incompatible array')
+
+   local destination = array<array<int>, 1>
+   for _ in {0 to 200} do destination[0] = matching[0] end
+   expect_recursive_store_failure(() => do destination[0] = mismatch[0] end,
+      'a traced recursive indexed store accepted an incompatible inner array')
+   assert(destination[0] is matching[0], 'a traced recursive indexed store corrupted its destination')
+end
+
+@Test function RecursiveWildcardContractsGuardObservedIdentity()
+   defer
+      jit.flush()
+      jit.opt.start()
+   end
+
+   local matching:any = array<array<int>> { array<int> { 1 } }
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1')
+   for _ in {0 to 200} do
+      assert(recursive_wildcard_parameter(matching) is 1,
+         'a traced recursive wildcard rejected a compatible specialisation')
+   end
+
+   local found_identity = false
+   for trace_no in {1 into 20} do
+      local info = jit.util.traceInfo(trace_no)
+      if info != nil then
+         for instruction in {1 into info.nins} do
+            local _, _, operand_1, operand_2 = jit.util.traceIR(trace_no, instruction)
+            if operand_1 != nil and operand_1 < 0 then
+               local constant = jit.util.traceK(trace_no, operand_1)
+               if constant is 'array<array<int>>' then found_identity = true end
+            end
+            if operand_2 != nil and operand_2 < 0 then
+               local constant = jit.util.traceK(trace_no, operand_2)
+               if constant is 'array<array<int>>' then found_identity = true end
+            end
+         end
+      end
+   end
+   assert(found_identity,
+      'a recursive wildcard trace should guard the compatible identity observed during recording')
+end
+
+@Test function RecursiveRuntimeStoresAreValidatedAtomically()
+   local matching:any = array<int> { 5 }
+   local mismatch:any = array<str> { 'wrong' }
+
+   expect_recursive_store_failure(() => do
+      local values = array<array<int>> { matching }
+      values[0] = mismatch
+   end, 'Indexed assignment accepted an incompatible inner array')
+
+   local values = array<array<int>> { matching, matching }
+   expect_recursive_store_failure(() => values.push(mismatch),
+      'push() accepted an incompatible inner array')
+   expect_recursive_store_failure(() => values.insert(1, matching, mismatch),
+      'insert() accepted an incompatible inner array')
+   expect_recursive_store_failure(() => values.fill(mismatch),
+      'fill() accepted an incompatible inner array')
+   assert(#values is 2 and values[0] is matching and values[1] is matching,
+      'a failed recursive store partially mutated its destination')
+
+   local staged = array<array<int>> { matching, matching }
+   expect_recursive_store_failure(() => array.copy(staged, { matching, mismatch }),
+      'table-backed copy accepted an incompatible inner array')
+   assert(staged[0] is matching and staged[1] is matching,
+      'table-backed copy exposed a partial mutation')
+
+   local incompatible = array<array<str>> { mismatch, mismatch }
+   expect_recursive_store_failure(() => array.copy(staged, incompatible),
+      'bulk array copy accepted an incompatible recursive identity')
+   assert(staged[0] is matching and staged[1] is matching,
+      'bulk array copy mutated its destination before rejecting the source identity')
+end
+
+@Test function DerivedArraysPreserveRecursiveIdentity()
+   local row = array<int> { 3 }
+   local mismatch:any = array<str> { 'wrong' }
+   local source = array<array<int>> { row, row }
+   local derived = {
+      source.clone(),
+      source.filter(Value => bool: true),
+      source.slice({0 into 1}),
+      source.mapSame(Value => array: Value),
+      source.map(Value => array: Value, 'array<int>')
+   }
+
+   for _, value in derived do
+      expect_recursive_store_failure(() => do value[0] = mismatch end,
+         'an array-producing operation lost its recursive identity')
+      assert(value[0] is row, 'a derived array changed after rejecting an incompatible row')
+   end
+
+   local wildcard = array<array<any>> { row }
+   wildcard[0] = mismatch
+   assert(wildcard[0] is mismatch, 'array<array<any>> did not retain wildcard runtime semantics')
+end
+
+@Test function MalformedRecursiveTypesAreRejected()
+   function assert_rejected(Source:str, Expected:str)
+      try
+         exec(Source)
+         error('Expected recursive array type syntax to be rejected')
+      except e
+         assert(e.message.find(Expected) != nil, 'Unexpected recursive array diagnostic: ' .. e.message)
+      end
+   end
+
+   assert_rejected('function invalid(Value:array<array<int, 4>>) end', 'nested size')
+   assert_rejected('function invalid(Value:array<array<missing>>) end', 'Unknown array element type')
+   assert_rejected('function invalid(Value:array<array<struct<Missing>>>) end', 'Unknown array element type')
+   assert_rejected('function invalid(Value:array<array<pointer>>) end', 'Unknown array element type')
+   assert_rejected('local values = array<array<int, 4>> {}', 'declare a size')
+   assert_rejected('local values = array<array<missing>> {}', 'Unknown or malformed array element type')
+   assert_rejected('local values = array<array<int> {}', "'>' expected")
+end

--- a/src/tiri/tests/test_recursive_array_types.tiri
+++ b/src/tiri/tests/test_recursive_array_types.tiri
@@ -131,6 +131,23 @@ function recursive_wildcard_parameter(Matrix:array<array<any>>!):num
    return #Matrix
 end
 
+@Test function BareArrayIdentityMatchesAnyWildcard()
+   local integer_row = array<int> { 1 }
+   local string_row = array<str> { 'two' }
+   local broad:any = array<array> { integer_row, string_row }
+
+   assert(recursive_wildcard_parameter(broad) is 2,
+      'an array<array<any>> parameter rejected a bare array member identity')
+   local assigned:array<array<any>> = broad
+   assert(assigned[0] is integer_row and assigned[1] is string_row,
+      'an array<array<any>> local contract rejected a bare array member identity')
+
+   local copied = array<array<any>, 2>
+   array.copy(copied, broad)
+   assert(copied[0] is integer_row and copied[1] is string_row,
+      'array.copy() rejected a bare array identity accepted by individual element stores')
+end
+
 function recursive_result(Value:any):array<array<int>>!
    return Value
 end

--- a/src/tiri/tests/test_type_annotations.tiri
+++ b/src/tiri/tests/test_type_annotations.tiri
@@ -131,10 +131,18 @@ end
       return Values
    end
 
+   function accept_nested(Values:array<array<str>>):array<array<str>>
+      return Values
+   end
+
    local values:array<int> = array<int> { 3, 5 }
+   local string_alias:array<string> = array<string> { 'canonical' }
    global glAnnotatedWords:array<str> = array<str> { 'one' }
    assert(accept_ints(values)[1] is 5, 'Concrete array annotations should work in parameters, locals and results')
+   assert(accept_nested(array<array<str>> { array<str> { 'nested' } })[0][0] is 'nested',
+      'Recursive array annotations should work in parameters and results')
    assert(glAnnotatedWords[0] is 'one', 'Concrete array annotations should work for globals')
+   assert(string_alias[0] is 'canonical', 'String array aliases should canonicalise to str storage')
 
    function assert_rejected(Source:str, Message:str)
       try
@@ -146,11 +154,10 @@ end
    end
 
    assert_rejected('function invalid(Value:array) end', 'element type')
-   assert_rejected('function invalid(Value:array<string>) end', 'Unknown array element type')
    assert_rejected('function invalid(Value:array<missing>) end', 'Unknown array element type')
    assert_rejected('function invalid(Value:array<pointer>) end', 'Unknown array element type')
-   assert_rejected('function invalid(Value:array<array<str>>) end', 'Nested array specialisation')
    assert_rejected('function invalid(Value:array<int, 4>) end', 'cannot declare a size')
+   assert_rejected('function invalid(Value:array<array<int, 4>>) end', 'nested size')
 end
 
 @Test function MistypedArrayArgumentRaisesCleanly()

--- a/src/tiri/tests/test_type_guided_emission.tiri
+++ b/src/tiri/tests/test_type_guided_emission.tiri
@@ -87,7 +87,7 @@ end
    local numbers = array<int> { 3, 7 }
    local strings = array<str> { 'a', 'b' }
    local tables = array<table> { { value=11 } }
-   local nested = array<array> { array<int> { 19 } }
+   local nested = array<array<int>> { array<int> { 19 } }
    local points = array<struct<EmissionPoint>> { struct<EmissionPoint> { Value=29 } }
    local clock = obj.new('time')
    local objects = array<obj> { clock }
@@ -95,10 +95,20 @@ end
    assert(numbers[1] is 7, 'array<int> indexing should return a number')
    assert(strings[0] is 'a', 'array<str> indexing should return a string')
    assert(tables[0].value is 11, 'array<table> indexing should retain table behaviour')
-   assert(nested[0][0] is 19, 'array<array> indexing should retain nested array behaviour')
+   assert(nested[0][0] is 19, 'recursive array indexing should retain the innermost descriptor')
    assert(points[0].Value is 29, 'named struct-array indexing should retain its layout')
    assert(objects[0].id is clock.id, 'array<obj> indexing should retain object behaviour')
    clock.free()
+end
+
+@Test function RecursiveArrayPropagationPaths()
+   local nested = array<array<int>> { array<int> { 2, 3 }, array<int> { 5, 7 } }
+   local clone = nested.clone()
+   local total = 0
+   for _, row in clone do total += row[0] end
+
+   assert(clone[1][1] is 7, 'array-preserving intrinsics should retain recursive descriptors')
+   assert(total is 7, 'generic iteration should expose the recursively typed row descriptor')
 end
 
 @Test function ArrayPropagationPaths()

--- a/src/tiri/tiri_regex.cpp
+++ b/src/tiri/tiri_regex.cpp
@@ -406,7 +406,11 @@ static int regex_search(lua_State *Lua)
    auto text = luaL_checklstring(Lua, 1, &text_len);
    auto flags = RMATCH(luaL_optint(Lua, 2, int(RMATCH::NIL)));
 
-   GCarray *results = lj_array_new(Lua, 0, AET::ARRAY);
+   ArrayAllocationDescriptor descriptor {
+      .storage = AET::ARRAY,
+      .canonical_identity = "array<array<str>>"
+   };
+   GCarray *results = lj_array_new(Lua, 0, descriptor);
    setarrayV(Lua, Lua->top++, results); // Root results to prevent GC during callbacks
 
    // Use match_many() to populate the array with the matches.

--- a/tools/tiri_lsp/tests/test_hover.tiri
+++ b/tools/tiri_lsp/tests/test_hover.tiri
@@ -140,6 +140,20 @@ result = greet|('Ada')
    assertContains(hover, '`Name: str` - Person to greet', 'Call hover should include parameter documentation.')
 end
 
+@Test function RecursiveArrayFunctionHover()
+   hover, token = hoverAt([=[
+function matrixFirst(Matrix:array<array<int>>!):array<array<double>>
+   return array<array<double>> {}
+end
+
+value = matrixF|irst(array<array<int>> {})
+]=])
+
+   assert(token and token.text is 'matrixFirst', 'Hover should identify the recursively typed function call.')
+   assertContains(hover, 'matrixFirst(Matrix: array<array<int>>!):array<array<double>>',
+      'Hover should preserve complete recursive array annotations.')
+end
+
 @Test function DocAnnotatedFunctionCallHoverAfterRelativeImport()
    hover, token = hoverAt([=[
 import './relative_symbol_helper'

--- a/tools/tiri_lsp/tests/test_signature_help.tiri
+++ b/tools/tiri_lsp/tests/test_signature_help.tiri
@@ -154,6 +154,23 @@ mix(123, |)
    assert(help.activeParameter is 1, 'Second argument should be active.')
 end
 
+@Test function RecursiveArraySignature()
+   help = signatureAt([=[
+function matrixFirst(Matrix:array<array<int>>!):array<array<double>>
+   return array<array<double>> {}
+end
+
+matrixFirst(|)
+]=])
+
+   signature = firstSignature(help)
+   assert(signature.label is
+      'matrixFirst(Matrix: array<array<int>>!):array<array<double>>',
+      'Signature help should preserve balanced recursive array annotations.')
+   assert(signature.parameters[0].label is 'Matrix: array<array<int>>!',
+      'Signature parameter metadata should preserve the complete recursive type.')
+end
+
 @Test function NestedCallsStringsAndTablesDoNotAdvanceOuterParameter()
    help = signatureAt([=[
 function target(First, Second, Third)


### PR DESCRIPTION
* Preserved nested array type identities across parsing, runtime operations and JIT contracts
* Added recursive array coverage for constructors, annotations, contracts, mutations and LSP tooling