### PR TITLE
[Tiri] Standardised array element type spellings

### DIFF
--- a/apps/tests/test_proximity.tiri
+++ b/apps/tests/test_proximity.tiri
@@ -54,7 +54,7 @@ function rawProxyRequestOnPort(ProxyPort:num, Request:str, Timeout:num):str
    })
    defer socket.free() end
 
-   local proc = processing.new({ timeout = Timeout, signals = array<object> { socket } })
+   local proc = processing.new({ timeout = Timeout, signals = array<obj> { socket } })
    check socket.mtConnect('127.0.0.1', ProxyPort, 3.0)
    local err = proc.sleep()
    assert(err is ERR_Okay, 'Proxy request timed out or failed: ' .. mSys.GetErrorMsg(err))
@@ -313,7 +313,7 @@ function connectTunnelRoundTripOnProxy(ProxyPort:num, Port:num, Payload:str, Coa
    })
    defer socket.free() end
 
-   local proc = processing.new({ timeout = 8.0, signals = array<object> { socket } })
+   local proc = processing.new({ timeout = 8.0, signals = array<obj> { socket } })
    check socket.mtConnect('127.0.0.1', ProxyPort, 3.0)
    local err = proc.sleep()
    assert(err is ERR_Okay, 'CONNECT tunnel request timed out or failed: ' .. mSys.GetErrorMsg(err))
@@ -772,7 +772,7 @@ function ConnectTunnelPassesSSLHandshake()
    })
    defer socket.free() end
 
-   local proc = processing.new({ timeout = 8.0, signals = array<object> { socket } })
+   local proc = processing.new({ timeout = 8.0, signals = array<obj> { socket } })
    check socket.mtConnect('127.0.0.1', PROXY_PORT, 3.0)
    local err = proc.sleep()
 

--- a/apps/tests/test_tuku_server.tiri
+++ b/apps/tests/test_tuku_server.tiri
@@ -145,7 +145,7 @@ function sendHttpRequest(Host:str, Port:num, Request:str):str
       end
    })
 
-   local proc = processing.new({ timeout = 5.0, signals = array<object> { client } })
+   local proc = processing.new({ timeout = 5.0, signals = array<obj> { client } })
    err = client.mtConnect(Host, Port, 3.0)
    if err != ERR_Okay then
       client.free()

--- a/apps/tuku.tiri
+++ b/apps/tuku.tiri
@@ -789,7 +789,7 @@ function fetchOnce(Args:table!):table
    local http = obj.new('http', makeRequestConfig(Args))
    applyTransferHeaders(http, Args)
    applyRequestHeaders(http, Args)
-   proc = processing.new({ timeout = Args.timeout, signals = array<object> { http } })
+   proc = processing.new({ timeout = Args.timeout, signals = array<obj> { http } })
 
    err = http.acActivate() -- Send asynchronous request
    if err is ERR_Okay then

--- a/examples/benchmark_particles.tiri
+++ b/examples/benchmark_particles.tiri
@@ -336,7 +336,7 @@ end
 
       glSurface.mtAddCallback(drawDirectVector)
 
-      global glVectorColours = array<object> {
+      global glVectorColours = array<obj> {
         obj.new('VectorColour', { red=0.8,   green=0,   blue=0 }),
         obj.new('VectorColour', { red=1.0,   green=0.8, blue=0 }),
         obj.new('VectorColour', { red=0.666, green=1.0, blue=0 }),

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -113,7 +113,6 @@ static ArrayAllocationDescriptor parse_elemtype(lua_State *L, int NArg)
 {
    GCstr *type_str = lj_lib_checkstr(L, NArg);
    std::string_view type_name(strdata(type_str), type_str->len);
-   if (type_name IS "obj") type_name = "object";
    if (auto element = parse_array_element_type(type_name, L)) {
       ArrayAllocationDescriptor descriptor;
       descriptor.storage = element->storage;

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -815,8 +815,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
             return this->fail<ExprNodePtr>(ParserErrorCode::UnexpectedToken, start,
                "Nested array element types cannot declare a size");
          }
-         auto element = parse_array_element_type(
-            element_name IS "obj" ? "object" : element_name, &this->ctx.lua(), &this->ctx.lex());
+         auto element = parse_array_element_type(element_name, &this->ctx.lua(), &this->ctx.lex());
          if (not element or element->storage IS AET::PTR or
              (element->storage IS AET::STRUCT and not element->struct_def)) {
             return this->fail<ExprNodePtr>(ParserErrorCode::UnknownTypeName, start,

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -188,8 +188,7 @@ ParserResult<Token> AstBuilder::parse_type_annotation(
          return this->fail<Token>(ParserErrorCode::UnknownTypeName, type_token,
             "Unknown array element type 'object'; use 'obj'");
       }
-      auto element = parse_array_element_type(
-         element_name IS "obj" ? "object" : element_name, &this->ctx.lua(), &this->ctx.lex());
+      auto element = parse_array_element_type(element_name, &this->ctx.lua(), &this->ctx.lex());
       if (not element or element->storage IS AET::PTR or
           (element->storage IS AET::STRUCT and not element->struct_def)) {
          return this->fail<Token>(ParserErrorCode::UnknownTypeName, type_token,
@@ -272,8 +271,7 @@ ParserResult<Token> AstBuilder::parse_type_annotation(
             return this->fail<Token>(ParserErrorCode::UnknownTypeName, element_token,
                "Unknown array element type 'object'; use 'obj'");
          }
-         auto element = parse_array_element_type(
-            element_storage IS "obj" ? "object" : element_storage, &this->ctx.lua(), &this->ctx.lex());
+         auto element = parse_array_element_type(element_storage, &this->ctx.lua(), &this->ctx.lex());
          if (not element or element->storage IS AET::PTR or
              (element->storage IS AET::STRUCT and not element->struct_def)) {
             return this->fail<Token>(ParserErrorCode::UnknownTypeName, element_token,
@@ -330,7 +328,7 @@ ParserResult<TypeTestDescriptor> AstBuilder::parse_type_test_descriptor()
    }
 
    TypeTestDescriptor descriptor;
-   descriptor.type = type_name_view IS "object" ? TiriType::Object : parse_type_name(type_name_view);
+   descriptor.type = parse_type_name(type_name_view);
    if (descriptor.type IS TiriType::Unknown) {
       return this->fail<TypeTestDescriptor>(ParserErrorCode::UnknownTypeName, type_token,
          std::format("Unknown type-test name '{}'; expected a Tiri type", type_name_view));
@@ -367,8 +365,7 @@ ParserResult<TypeTestDescriptor> AstBuilder::parse_type_test_descriptor()
       descriptor.constrained = true;
 
       if (descriptor.type IS TiriType::Array) {
-         auto element = parse_array_element_type(constraint_name IS "obj" ? "object" : constraint_name,
-            &this->ctx.lua(), &this->ctx.lex());
+         auto element = parse_array_element_type(constraint_name, &this->ctx.lua(), &this->ctx.lex());
          if (element and element->storage != AET::PTR and
              (element->storage != AET::STRUCT or element->struct_def)) descriptor.array_element = *element;
          else if (struct_record *definition = find_struct(&this->ctx.lua(), constraint_name)) {

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -4684,7 +4684,7 @@ static bool test_static_descriptor_model(kt::Log &Log)
       { "str", AET::STR_GC, TiriType::Str },
       { "table", AET::TABLE, TiriType::Table },
       { "array", AET::ARRAY, TiriType::Array },
-      { "object", AET::OBJECT, TiriType::Object },
+      { "obj", AET::OBJECT, TiriType::Object },
       { "any", AET::ANY, TiriType::Any },
       { "pointer", AET::PTR, TiriType::Any },
       { "struct<Missing>", AET::STRUCT, TiriType::Struct }
@@ -4717,10 +4717,13 @@ static bool test_static_descriptor_model(kt::Log &Log)
    auto exact = parse_array_element_type("array<array<int>>", recursive_lua);
    auto mismatch = parse_array_element_type("array<array<str>>", recursive_lua);
    auto wildcard = parse_array_element_type("array<array<any>>", recursive_lua);
+   auto immediate_wildcard = parse_array_element_type("array<any>", recursive_lua);
+   auto bare_array = parse_array_element_type("array", recursive_lua);
    auto deep_exact = parse_array_element_type("array<array<array<int>>>", recursive_lua);
    auto deep_wildcard = parse_array_element_type("array<array<array>>", recursive_lua);
-   if (not exact or not mismatch or not wildcard or array_element_matches(*exact, *mismatch) or
-       not array_element_matches(*wildcard, *exact) or not deep_exact or not deep_wildcard or
+   if (not exact or not mismatch or not wildcard or not immediate_wildcard or not bare_array or
+       array_element_matches(*exact, *mismatch) or not array_element_matches(*wildcard, *exact) or
+       not array_element_matches(*immediate_wildcard, *bare_array) or not deep_exact or not deep_wildcard or
        not array_element_matches(*deep_wildcard, *deep_exact)) {
       Log.error("recursive array descriptor comparison lost exact or wildcard semantics");
       return false;
@@ -4739,7 +4742,9 @@ static bool test_static_descriptor_model(kt::Log &Log)
       return false;
    }
    if (parse_array_element_type("array<array<int, 4>>") or parse_array_element_type("array<>") or
-       parse_array_element_type("array<array<int>")) {
+       parse_array_element_type("array<array<int>") or parse_array_element_type("string") or
+       parse_array_element_type("object") or parse_array_element_type("array<string>") or
+       parse_array_element_type("array<object>")) {
       Log.error("malformed recursive array type spelling was accepted");
       return false;
    }

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -62,9 +62,12 @@ bool array_element_matches(
    if (not Actual.known or public_array_storage(Expected.storage) != public_array_storage(Actual.storage)) return false;
    if (Expected.storage IS AET::STRUCT and Expected.struct_def) return Expected.struct_def IS Actual.struct_def;
    if (Expected.storage IS AET::ARRAY and Expected.nested_array_identity) {
-      if (not Actual.nested_array_identity) return false;
       std::string_view expected_name(strdata(Expected.nested_array_identity), Expected.nested_array_identity->len);
-      std::string_view actual_name(strdata(Actual.nested_array_identity), Actual.nested_array_identity->len);
+      std::string_view actual_name = "array";
+      if (Actual.nested_array_identity) {
+         actual_name = std::string_view(
+            strdata(Actual.nested_array_identity), Actual.nested_array_identity->len);
+      }
       return recursive_array_identity_matches(expected_name, actual_name);
    }
    return true;
@@ -224,9 +227,7 @@ private:
          return result;
       }
 
-      if (name IS "object") name = "obj";
-      if (name IS "string") name = "str";
-      auto result = describe_array_element(name IS "obj" ? "object" : name, this->state_);
+      auto result = describe_array_element(name, this->state_);
       if (result and result->storage IS AET::PTR) return std::nullopt;
       if (result and Canonical) *Canonical = array_element_name(*result);
       return result;
@@ -777,7 +778,7 @@ std::optional<ArrayElementDescriptor> describe_array_element(std::string_view Na
    else if (Name IS "str") result = { AET::STR_GC, TiriType::Str, CLASSID::NIL, nullptr, true };
    else if (Name IS "table") result = { AET::TABLE, TiriType::Table, CLASSID::NIL, nullptr, true };
    else if (Name IS "array") result = { AET::ARRAY, TiriType::Array, CLASSID::NIL, nullptr, true };
-   else if (Name IS "object") result = { AET::OBJECT, TiriType::Object, CLASSID::NIL, nullptr, true };
+   else if (Name IS "obj") result = { AET::OBJECT, TiriType::Object, CLASSID::NIL, nullptr, true };
    else if (Name IS "any") result = { AET::ANY, TiriType::Any, CLASSID::NIL, nullptr, true };
    else if (Name IS "pointer") result = { AET::PTR, TiriType::Any, CLASSID::NIL, nullptr, true };
    else if (Name IS "struct") result = { AET::STRUCT, TiriType::Struct, CLASSID::NIL, nullptr, true };

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -1233,7 +1233,7 @@ end
 @Test function ObjectArrayToTable()
    obj_one = obj.new('time')
    obj_two = obj.new('file')
-   arr = array<object, 2>
+   arr = array<obj, 2>
    arr[0] = obj_one
    arr[1] = obj_two
 

--- a/src/tiri/tests/test_array_element_validation.tiri
+++ b/src/tiri/tests/test_array_element_validation.tiri
@@ -58,8 +58,8 @@ end
    expect_failure(() => do array.of('str', 12) end, 'String constructor accepted a number')
    expect_failure(() => do indexed.copy({ [0]=12 }) end, 'String table copy accepted a number')
    expect_failure(() => do indexed.mapSame(Value => num: 12) end, 'String map accepted a number')
-   local legacy_string = array.new(0, 'string')
-   assert(legacy_string.type() is 'str', "The canonical 'string' alias did not produce string storage")
+   expect_failure(() => array.new(0, 'string'), "array.new() accepted the removed 'string' alias")
+   expect_failure(() => array.of('string', 'value'), "array.of() accepted the removed 'string' alias")
 end
 
 @Test function ReferenceCategoriesAreExact()
@@ -69,7 +69,7 @@ end
 
    local tables = array<table, 1>
    local arrays = array<array, 1>
-   local objects = array<object, 1>
+   local objects = array<obj, 1>
    tables[0] = table_value
    arrays[0] = array_value
    objects[0] = object_value
@@ -81,6 +81,11 @@ end
    expect_failure(() => do objects[0] = table_value end, 'Object array accepted a table')
 
    object_value.free()
+end
+
+@Test function RemovedObjectAliasIsRejectedByFactories()
+   expect_failure(() => array.new(0, 'object'), "array.new() accepted the removed 'object' alias")
+   expect_failure(() => array.of('object'), "array.of() accepted the removed 'object' alias")
 end
 
 @Test function NilUsesTheTypedEmptyValue()

--- a/src/tiri/tests/test_recursive_array_types.tiri
+++ b/src/tiri/tests/test_recursive_array_types.tiri
@@ -135,12 +135,16 @@ end
    local integer_row = array<int> { 1 }
    local string_row = array<str> { 'two' }
    local broad:any = array<array> { integer_row, string_row }
+   local statically_visible = array<array> { integer_row, string_row }
 
    assert(recursive_wildcard_parameter(broad) is 2,
       'an array<array<any>> parameter rejected a bare array member identity')
    local assigned:array<array<any>> = broad
    assert(assigned[0] is integer_row and assigned[1] is string_row,
       'an array<array<any>> local contract rejected a bare array member identity')
+   local statically_assigned:array<array<any>> = statically_visible
+   assert(statically_assigned[0] is integer_row and statically_assigned[1] is string_row,
+      'static analysis rejected a bare array identity accepted by the runtime wildcard contract')
 
    local copied = array<array<any>, 2>
    array.copy(copied, broad)

--- a/src/tiri/tests/test_type_annotations.tiri
+++ b/src/tiri/tests/test_type_annotations.tiri
@@ -80,12 +80,21 @@ end
 end
 
 @Test function RemovedStringTypeRejected()
-   try
-      exec("local value:string = 'text'")
-   success
-      error("Expected string type name to be rejected")
+   function assert_rejected(Source:str, Context:str)
+      try
+         exec(Source)
+      success
+         error(f"Expected string type name to be rejected in {Context}")
+      end
    end
 
+   assert_rejected("local value:string = 'text'", "a local annotation")
+   assert_rejected("local values:array<string> = array<str> {}", "an array element annotation")
+   assert_rejected("local values:array<array<string>> = array<array<str>> {}", "a nested array annotation")
+   assert_rejected("local values = array<string> {}", "an array constructor")
+   assert_rejected("local values = array<array<string>> {}", "a nested array constructor")
+   assert_rejected("return array<str> {} is <array string>", "an array type-test descriptor")
+   assert_rejected("return array<array<str>> {} is <array array<string>>", "a nested array type-test descriptor")
    assert(type('text') is 'string', "type() must continue to return the string runtime name")
 end
 
@@ -101,7 +110,13 @@ end
    assert_rejected("local value:object = nil", "a local annotation")
    assert_rejected("local function rejected(Value:object) return Value end", "a parameter annotation")
    assert_rejected("local function rejected():object return nil end", "a return annotation")
+   assert_rejected("return nil is <object>", "a type-test descriptor")
    assert_rejected("local values:array<object> = array<obj> {}", "an array element annotation")
+   assert_rejected("local values:array<array<object>> = array<array<obj>> {}", "a nested array annotation")
+   assert_rejected("local values = array<object> {}", "an array constructor")
+   assert_rejected("local values = array<array<object>> {}", "a nested array constructor")
+   assert_rejected("return array<obj> {} is <array object>", "an array type-test descriptor")
+   assert_rejected("return array<array<obj>> {} is <array array<object>>", "a nested array type-test descriptor")
 end
 
 @Test function RemovedBooleanTypeRejected()
@@ -136,13 +151,11 @@ end
    end
 
    local values:array<int> = array<int> { 3, 5 }
-   local string_alias:array<string> = array<string> { 'canonical' }
    global glAnnotatedWords:array<str> = array<str> { 'one' }
    assert(accept_ints(values)[1] is 5, 'Concrete array annotations should work in parameters, locals and results')
    assert(accept_nested(array<array<str>> { array<str> { 'nested' } })[0][0] is 'nested',
       'Recursive array annotations should work in parameters and results')
    assert(glAnnotatedWords[0] is 'one', 'Concrete array annotations should work for globals')
-   assert(string_alias[0] is 'canonical', 'String array aliases should canonicalise to str storage')
 
    function assert_rejected(Source:str, Message:str)
       try

--- a/src/tiri/tests/test_type_tests.tiri
+++ b/src/tiri/tests/test_type_tests.tiri
@@ -68,7 +68,7 @@ end
    local rectangle = obj.new('VectorRectangle')
 
    assert(time_value is <obj>, 'unconstrained obj should match every object wrapper')
-   assert(time_value is <object Time>, 'object alias should be accepted')
+   assert(time_value is <obj Time>, 'named obj descriptors should match their object class')
    assert(time_value is not <obj File>, 'unrelated object classes should not match')
    assert(rectangle is <obj Vector>, 'derived objects should match their base class')
    assert(nil is not <obj>, 'nil should not match obj')

--- a/src/tiri/tiri_async.cpp
+++ b/src/tiri/tiri_async.cpp
@@ -360,13 +360,13 @@ static void collect_object_ids(lua_State *Lua, int ArgIndex, kt::vector<OBJECTID
             }
          }
       }
-      else luaL_argerror(Lua, ArgIndex, "Expected an array<object>.");
+      else luaL_argerror(Lua, ArgIndex, "Expected an array<obj>.");
    }
-   else luaL_argerror(Lua, ArgIndex, "Expected an object or array<object>.");
+   else luaL_argerror(Lua, ArgIndex, "Expected an object or array<obj>.");
 }
 
 //********************************************************************************************************************
-// Usage: error = async.wait(Object|array<object>, [Timeout])
+// Usage: error = async.wait(Object|array<obj>, [Timeout])
 //
 // Thin wrapper around the Core AsyncWait() API.  Collects object IDs from the Lua arguments and delegates to
 // AsyncWait().
@@ -412,7 +412,7 @@ static int async_pending(lua_State *Lua)
 }
 
 //********************************************************************************************************************
-// Usage: error = async.cancel(Object|array<object>)
+// Usage: error = async.cancel(Object|array<obj>)
 //
 // Cancel all pending asynchronous actions for the listed objects.  The in-flight thread (if any) is interrupted
 // and the remaining action queue is drained without execution.

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -95,7 +95,7 @@ static int processing_new(lua_State *Lua)
                      }
                      else {
                         return fail(ERR::InvalidType,
-                           std::format("The signals option requires an array<object> reference."));
+                           std::format("The signals option requires an array<obj> reference."));
                      }
                      break;
                   }


### PR DESCRIPTION
* Removed string and object aliases from array type parsing and factories
* Aligned static and runtime recursive-array wildcard matching
* Updated Tiri callers and coverage to use canonical array element types