### PR TITLE
[Tiri] Fixed implicit local attributes on later names

### DIFF
--- a/src/tiri/jit/src/parser/ast/builder.cpp
+++ b/src/tiri/jit/src/parser/ast/builder.cpp
@@ -810,9 +810,6 @@ ParserResult<std::unique_ptr<BlockStmt>> AstBuilder::parse_block(std::span<const
 
 //********************************************************************************************************************
 // Check if any identifier in a comma-separated name list has a type annotation or recognised declaration attribute.
-// Due to lexer lookahead complexities, the attribute name appears before '<' when special '<identifier' handling has
-// been triggered.
-//
 // Patterns: `name:type`, `name <attr>`, `name, name:type`, `name, name <attr>`
 // Returns true if this looks like an implicit local declaration.
 
@@ -825,12 +822,13 @@ static bool is_implicit_local_declaration(TokenStreamAdapter &Tokens)
       Token next = Tokens.peek(pos);
       if (next.kind() IS TokenKind::Colon) return true;
 
-      if (next.kind() IS TokenKind::Identifier) {
-         GCstr *attribute = next.identifier();
+      if (next.raw() IS '<') {
+         Token attribute_token = Tokens.peek(pos + 1);
+         GCstr *attribute = attribute_token.kind() IS TokenKind::Identifier ? attribute_token.identifier() : nullptr;
          if (attribute) {
             std::string_view name(strdata(attribute), attribute->len);
             if ((name IS "const" or name IS "close" or name IS "view") and
-                  Tokens.peek(pos + 1).raw() IS '<' and Tokens.peek(pos + 2).raw() IS '>') return true;
+                  Tokens.peek(pos + 2).raw() IS '>') return true;
          }
       }
 

--- a/src/tiri/jit/src/parser/lexer.cpp
+++ b/src/tiri/jit/src/parser/lexer.cpp
@@ -1961,7 +1961,19 @@ LexState::BufferedToken LexState::scan_buffered_token()
 void LexState::ensure_lookahead(size_t count)
 {
    while (this->available_lookahead() < count) {
-      this->buffered_tokens.push_back(this->scan_buffered_token());
+      size_t buffered_count = this->buffered_tokens.size();
+      BufferedToken buffered = this->scan_buffered_token();
+
+      // Scanning '<identifier' temporarily pushes the identifier to the front so direct token consumption can return
+      // '<' first.  Preserve tokens already gathered by lookahead and normalise this expansion to '<', identifier.
+
+      if (buffered.token IS '<' and this->buffered_tokens.size() IS buffered_count + 1) {
+         BufferedToken identifier = std::move(this->buffered_tokens.front());
+         this->buffered_tokens.pop_front();
+         this->buffered_tokens.push_back(std::move(buffered));
+         this->buffered_tokens.push_back(std::move(identifier));
+      }
+      else this->buffered_tokens.push_back(std::move(buffered));
    }
 }
 

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1178,6 +1178,61 @@ static bool test_typed_assignment_name_resolution(kt::Log &Log)
 
 //********************************************************************************************************************
 
+static bool test_implicit_later_name_attributes(kt::Log &Log)
+{
+   struct AttributeCase {
+      std::string_view source;
+      bool has_const;
+      bool has_close;
+      TiriType type;
+   };
+
+   constexpr std::array<AttributeCase, 3> cases = { {
+      { "first, second <const> = 1, 2", true, false, TiriType::Unknown },
+      { "first, second <close> = nil, nil", false, true, TiriType::Unknown },
+      { "first, second <const>:num = 1, 2", true, false, TiriType::Num }
+   } };
+
+   for (const AttributeCase &test_case : cases) {
+      auto result = build_ast_from_source(test_case.source, true);
+      if (not result.chunk.ok() or not result.diagnostics.empty()) {
+         Log.error("a declaration attribute on a later implicit-local name did not parse");
+         log_diagnostics(result.diagnostics, Log);
+         return false;
+      }
+
+      StatementListView statements = result.chunk.value_ref()->view();
+      const auto *declaration = statements.size() IS 1 and statements[0].kind IS AstNodeKind::LocalDeclStmt ?
+         std::get_if<LocalDeclStmtPayload>(&statements[0].data) : nullptr;
+      if (not declaration or declaration->names.size() != 2 or declaration->values.size() != 2 or
+          declaration->names[0].has_const or declaration->names[0].has_close or
+          declaration->names[1].has_const != test_case.has_const or
+          declaration->names[1].has_close != test_case.has_close or declaration->names[1].type != test_case.type) {
+         Log.error("a declaration attribute on a later implicit-local name produced the wrong AST");
+         return false;
+      }
+   }
+
+   auto invalid_view = build_ast_from_source("first, second <view> = 1, 2", true);
+   bool has_view_diagnostic = false;
+   bool has_expression_diagnostic = false;
+   for (const ParserDiagnostic &diagnostic : invalid_view.diagnostics) {
+      if (diagnostic.message.find("requires exactly one local name") != std::string::npos) {
+         has_view_diagnostic = true;
+      }
+      if (diagnostic.message.find("Expected expression") != std::string::npos) has_expression_diagnostic = true;
+   }
+   if (not has_view_diagnostic or has_expression_diagnostic) {
+      Log.error("a later <view> attribute did not reach declaration validation");
+      log_diagnostics(invalid_view.diagnostics, Log);
+      return false;
+   }
+
+   return true;
+}
+
+//********************************************************************************************************************
+
 static bool test_ternary_colon_separators(kt::Log &Log)
 {
    auto result = build_ast_from_source("return true ? 1 : 2, false ?? 3 : 4");
@@ -9507,7 +9562,7 @@ static bool test_defer_runtime_registration_state(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 88> tests = { {
+   constexpr std::array<TestCase, 89> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -9530,6 +9585,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "deprecated_numeric_for_rejected", test_deprecated_numeric_for_rejected },
       { "colon_method_syntax_rejected", test_colon_method_syntax_rejected },
       { "typed_assignment_name_resolution", test_typed_assignment_name_resolution },
+      { "implicit_later_name_attributes", test_implicit_later_name_attributes },
       { "ternary_colon_separators", test_ternary_colon_separators },
       { "extended_ternary_annotation_lookahead", test_extended_ternary_annotation_lookahead },
       { "array_length_range_for_ast", test_array_length_range_for_ast },

--- a/src/tiri/tests/test_const.tiri
+++ b/src/tiri/tests/test_const.tiri
@@ -84,6 +84,27 @@ end
    assert(b is 20, 'Non-const should be reassignable')
 end
 
+@Test function ConstAttributeOnLaterImplicitName()
+   mutable_value, fixed_value <const> = 1, 2
+   mutable_value = 3
+
+   assert(mutable_value is 3, 'Earlier mutable name should remain assignable')
+   assert(fixed_value is 2, 'Later const name should retain its initial value')
+   assert(debug.locality('mutable_value') is 'local', 'Earlier name should be an implicit local')
+   assert(debug.locality('fixed_value') is 'local', 'Later const name should be an implicit local')
+
+   typed_mutable, typed_fixed <const>:num = 4, 5
+   typed_mutable = 6
+   assert(typed_mutable is 6, 'Earlier name should remain mutable when the later const has a type annotation')
+   assert(typed_fixed is 5, 'Later typed const should retain its initial value')
+
+   try
+      exec('mutable_value, fixed_value <const> = 1, 2; fixed_value = 3')
+   success
+      error('Reassigning a later const name should fail')
+   end
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- Test const with nil value (should fail - const requires initialiser)
 -- This is tested via compile error in separate tests below


### PR DESCRIPTION
* Preserved declaration attribute token order during parser lookahead
* Added parser and runtime regression coverage for later-name attributes