### PR TITLE
[Tiri] Fixed global contract finalisers disabling JIT prototypes

### DIFF
--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -547,6 +547,14 @@ static RecordedContract rec_contract_record(jit_State *J, BCREG Base, GCstr *Enc
    if (not decode_runtime_contract(Encoded, descriptor)) return RecordedContract::Invalid;
    if (descriptor.dynamic_count()) return RecordedContract::Complex;
 
+   // A declaration finaliser can validate or publish environment policy, reject a conflicting redeclaration and
+   // enforce const lifecycle rules.  These effects are not pure value predicates and must remain interpreter-owned,
+   // even when an equivalent policy currently exists.  Other boundaries cannot match, declaration pre-contracts
+   // carry Initialising, and ordinary assignment hints carry GlobalHint.
+   if (descriptor.boundary IS ContractBoundary::Global and descriptor.contract_count IS 1 and
+       not contract_entry_is_initialising(descriptor.entries[0]) and
+       not contract_entry_is_global_hint(descriptor.entries[0])) return RecordedContract::SideEffect;
+
    if (descriptor.boundary IS ContractBoundary::Global and descriptor.contract_count IS 1 and
        contract_entry_is_global_hint(descriptor.entries[0])) {
       const RuntimeContractEntry &entry = descriptor.entries[0];

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -560,15 +560,12 @@ static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeCo
 {
    if (Contracts.empty()) return;
 
-   // Dynamic result counts still require interpreter-only MRSAVE/MRRESTORE handling.  Fixed contracts have exact
-   // recorder predicates, including callable values, named structures, ranges and userdata.
+   // Dynamic result counts still require interpreter-only MRSAVE/MRRESTORE handling.  Const contracts retain
+   // prototype-wide lifecycle semantics.  Ordinary global declaration finalisers are bytecode-local side-effect
+   // boundaries handled by the recorder; other fixed contracts have exact recorder predicates.
    if (DynamicCount) fs->flags |= PROTO_NOJIT;
    for (const RuntimeContract &contract : Contracts) {
-      // Global declaration finalisers publish environment policy after a store, or after a conditional declaration
-      // retains its existing value.  The recorder only emits type guards for BC_CONTRACT, so this side effect must
-      // remain interpreter-only.  Const contracts require the same treatment throughout their initialisation.
-      if (contract.is_const or (contract.boundary IS ContractBoundary::Global and not contract.initialising and
-          not contract.global_hint)) {
+      if (contract.is_const) {
          fs->flags |= PROTO_NOJIT;
          break;
       }

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -3107,79 +3107,83 @@ static bool test_complex_contract_jit_eligibility(kt::Log &Log)
 {
    LuaStateHolder state;
    lua_State *lua = state.get();
-   auto compile_child = [lua, &Log](std::string_view Source, const char *Label) -> GCproto * {
+   auto compile_proto = [lua, &Log](std::string_view Source, const char *Label, bool Child) -> GCproto * {
       if (lua_load(lua, Source, Label)) {
          Log.error("%s failed to compile: %s", Label, lua_tostring(lua, -1));
          lua_pop(lua, 1);
          return nullptr;
       }
 
-      GCproto *child = first_child_proto(funcproto(funcV(lua->top - 1)));
+      GCproto *root = funcproto(funcV(lua->top - 1));
+      GCproto *result = Child ? first_child_proto(root) : root;
       lua->top--;
-      return child;
+      return result;
    };
 
-   GCproto *fixed = compile_child(
+   GCproto *fixed = compile_proto(
       "return function(Value:func):func\n"
       "   return Value\n"
       "end\n",
-      "fixed-complex-contract");
+      "fixed-complex-contract", true);
    if (not fixed or (fixed->flags & PROTO_NOJIT)) {
       Log.error("a fixed complex contract remained interpreter-only");
       return false;
    }
 
-   GCproto *fixed_object_class = compile_child(
+   GCproto *fixed_object_class = compile_proto(
       "extern obj\n"
       "return function(Value:any)\n"
       "   local stored = obj.new('time')\n"
       "   stored = Value\n"
       "   return stored\n"
       "end\n",
-      "fixed-object-class-contract");
+      "fixed-object-class-contract", true);
    if (not fixed_object_class or (fixed_object_class->flags & PROTO_NOJIT)) {
       Log.error("a fixed object-class contract became interpreter-only");
       return false;
    }
 
-   GCproto *dynamic = compile_child(
+   GCproto *dynamic = compile_proto(
       "return function(...):<num, ...>\n"
       "   return ...\n"
       "end\n",
-      "dynamic-result-contract");
+      "dynamic-result-contract", true);
    if (not dynamic or not (dynamic->flags & PROTO_NOJIT)) {
       Log.error("a dynamic-result contract became JIT-eligible without exact multi-result recorder support");
       return false;
    }
 
-   GCproto *global_const = compile_child(
-      "return function()\n"
-      "   global glRecordedConst <const> = 1\n"
-      "end\n",
-      "global-const-contract");
-   if (not global_const or not (global_const->flags & PROTO_NOJIT)) {
-      Log.error("a global const contract became JIT-eligible despite its post-store policy side effect");
-      return false;
-   }
+   struct EligibilityCase {
+      const char *label;
+      const char *statement;
+      bool no_jit;
+   };
+   constexpr EligibilityCase cases[] = {
+      { "inferred-global-contract", "global glRecordedInferred = 'value'", false },
+      { "typed-global-contract", "global glRecordedTyped:str = 'value'", false },
+      { "any-global-contract", "global glRecordedAny:any = 'value'", false },
+      { "conditional-global-contract", "global glRecordedConditional:str ?= 'fallback'", false },
+      { "empty-conditional-global-contract", "global glRecordedEmptyConditional:str ?" "?= 'fallback'", false },
+      { "global-function-contract", "global function glRecordedFunction() return 1 end", false },
+      { "plain-global-store", "glRecordedStore = 1", false },
+      { "global-const-contract", "global glRecordedConst <const> = 1", true }
+   };
 
-   GCproto *conditional_global = compile_child(
-      "return function()\n"
-      "   global glRecordedConditional:str ?= 'fallback'\n"
-      "end\n",
-      "conditional-global-contract");
-   if (not conditional_global or not (conditional_global->flags & PROTO_NOJIT)) {
-      Log.error("a conditional global contract became JIT-eligible despite its policy-publication side effect");
-      return false;
-   }
+   for (const EligibilityCase &test : cases) {
+      std::string child_source = std::format("return function()\n   {}\nend\n", test.statement);
+      std::string child_label = std::format("{}-child", test.label);
+      GCproto *child = compile_proto(child_source, child_label.c_str(), true);
+      if (not child or bool(child->flags & PROTO_NOJIT) != test.no_jit) {
+         Log.error("%s had unexpected child prototype JIT eligibility", test.label);
+         return false;
+      }
 
-   GCproto *empty_conditional_global = compile_child(
-      "return function()\n"
-      "   global glRecordedEmptyConditional:str ?" "?= 'fallback'\n"
-      "end\n",
-      "empty-conditional-global-contract");
-   if (not empty_conditional_global or not (empty_conditional_global->flags & PROTO_NOJIT)) {
-      Log.error("an empty-conditional global contract became JIT-eligible despite its policy-publication side effect");
-      return false;
+      std::string main_label = std::format("{}-main", test.label);
+      GCproto *main = compile_proto(test.statement, main_label.c_str(), false);
+      if (not main or bool(main->flags & PROTO_NOJIT) != test.no_jit) {
+         Log.error("%s had unexpected main prototype JIT eligibility", test.label);
+         return false;
+      }
    }
    return true;
 }

--- a/src/tiri/tests/test_global_types.tiri
+++ b/src/tiri/tests/test_global_types.tiri
@@ -24,6 +24,43 @@ local function assert_global_contract_before_store(Statement, Context)
    return disasm
 end
 
+local function count_global_contract_traces():num
+   local count = 0
+   for trace_no in {1 into 100} do
+      if jit.util.traceInfo(trace_no) != nil then count++ end
+   end
+   return count
+end
+
+local function run_global_contract_jit_workload(Workload:func):<any, any, num, num, num>
+   local compiled = 0
+   local aborted = 0
+   local function trace_event(Event)
+      if Event is 'stop' then compiled++
+      elseif Event is 'abort' then aborted++
+      end
+   end
+
+   defer
+      jit.attach(trace_event)
+      jit.flush()
+      jit.opt.start()
+      jit.on()
+   end
+
+   jit.off()
+   jit.flush()
+   local expected = Workload()
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   jit.attach(trace_event, 'trace')
+   local result = Workload()
+   jit.attach(trace_event)
+   return expected, result, compiled, aborted, count_global_contract_traces()
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- Inferred scalar globals emit a declaration contract and retain a bootstrap hint for stores that may execute before
 -- declaration publication.  Once policy exists, the environment boundary owns semantic validation.
@@ -108,6 +145,165 @@ end
    exec([[global glGTFailedDeclaration = 42]])
    assert(glGTFailedDeclaration is 42,
       'A rejected declaration must not leave a stale type policy that prevents retry')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Non-const declaration finalisers are local recorder boundaries.  They must not disable later loops in the same
+-- prototype, while finalisers reached during recording must remain interpreter-owned so policy effects are preserved.
+
+@Test function OrdinaryGlobalDeclarationsRetainJitEligibility()
+   local function hot_loop_only():num
+      local total = 0
+      for _ in {0 to 120} do total++ end
+      return total
+   end
+
+   local function plain_store():num
+      glGTJitPlainStore = 'value'
+      local total = 0
+      for _ in {0 to 120} do total++ end
+      return total
+   end
+
+   local function inferred():num
+      global glGTJitInferred = 'value'
+      local total = 0
+      for _ in {0 to 120} do total++ end
+      return total
+   end
+
+   local function typed():num
+      global glGTJitTyped:str = 'value'
+      local total = 0
+      for _ in {0 to 120} do total++ end
+      return total
+   end
+
+   local function variant():num
+      global glGTJitAny:any = 'value'
+      local total = 0
+      for _ in {0 to 120} do total++ end
+      return total
+   end
+
+   local function conditional():num
+      global glGTJitConditional:str ?= 'value'
+      local total = 0
+      for _ in {0 to 120} do total++ end
+      return total
+   end
+
+   local function empty_conditional():num
+      global glGTJitEmptyConditional:str ??= 'value'
+      local total = 0
+      for _ in {0 to 120} do total++ end
+      return total
+   end
+
+   local function verify_case(CaseNo:num, Workload:func)
+      local expected, result, compiled, _, traces = run_global_contract_jit_workload(Workload)
+      assert(expected is 120 and result is expected,
+         f'Global declaration JIT case {CaseNo} diverged from the interpreter')
+      assert(compiled > 0 and traces > 0,
+         f'Global declaration JIT case {CaseNo} did not complete a trace')
+   end
+
+   verify_case(0, hot_loop_only)
+   verify_case(1, plain_store)
+   verify_case(2, inferred)
+   verify_case(3, typed)
+   verify_case(4, variant)
+   verify_case(5, conditional)
+   verify_case(6, empty_conditional)
+end
+
+@Test function MainChunkGlobalDeclarationRetainsJitEligibility()
+   local function run_main_chunk():num
+      return exec([[
+global glGTJitMainChunk = 'value'
+local total = 0
+for _ in {0 to 120} do total++ end
+return total
+]])
+   end
+
+   local expected, result, compiled, _, traces = run_global_contract_jit_workload(run_main_chunk)
+   assert(expected is 120 and result is expected,
+      'A dynamically compiled main chunk should preserve interpreter/JIT parity')
+   assert(compiled > 0 and traces > 0,
+      'An ordinary global declaration must not disable an unrelated top-level loop')
+end
+
+@Test function DeclarationFinaliserAbortsLocallyAndPublishesPolicy()
+   local function boundary_workload():num
+      local total = 0
+      for _ in {0 to 80} do
+         global glGTJitBoundary:str ?= 'retained'
+         total++
+      end
+      for _ in {0 to 120} do total++ end
+      return total
+   end
+
+   local expected, result, compiled, aborted, traces = run_global_contract_jit_workload(boundary_workload)
+   assert(expected is 200 and result is expected,
+      'Interpreter hand-off at a declaration finaliser changed the workload result')
+   assert(aborted > 0, 'Recording should abort when it reaches a policy-publishing declaration finaliser')
+   assert(compiled > 0 and traces > 0,
+      'A finaliser abort must not prevent a separate loop in the same prototype from compiling')
+   assert(glGTJitBoundary is 'retained', 'The interpreted finaliser should retain the existing global value')
+
+   local rejected = false
+   try
+      rawset(_G, 'glGTJitBoundary', 42)
+   except e
+      rejected = e.message.find('expected str') != nil
+   end
+   assert(rejected and glGTJitBoundary is 'retained',
+      'The interpreted finaliser should publish and preserve its string policy')
+end
+
+@Test function SkippedDeclarationsPublishCompatiblePolicies()
+   rawset(_G, 'glGTJitRetainedNil', 'nil-retained')
+   rawset(_G, 'glGTJitRetainedEmpty', 'empty-retained')
+   exec([[global glGTJitRetainedNil:str ?= 'fallback']])
+   exec([[global glGTJitRetainedEmpty:str ??= 'fallback']])
+
+   assert(glGTJitRetainedNil is 'nil-retained' and glGTJitRetainedEmpty is 'empty-retained',
+      'Compatible skipped declarations should retain their existing values')
+
+   local nil_rejected = false
+   local empty_rejected = false
+   try
+      rawset(_G, 'glGTJitRetainedNil', 1)
+   except e
+      nil_rejected = e.message.find('expected str') != nil
+   end
+   try
+      rawset(_G, 'glGTJitRetainedEmpty', 1)
+   except e
+      empty_rejected = e.message.find('expected str') != nil
+   end
+   assert(nil_rejected and empty_rejected,
+      'Both compatible retained-value paths should publish their string policies')
+end
+
+@Test function ConflictingSkippedDeclarationPreservesPolicyAndValue()
+   exec([[global glGTJitConflicting:str = 'original']])
+   local rejected = false
+   try
+      exec([[global glGTJitConflicting:num ?= 42]])
+   except e
+      rejected = e.message.find('cannot redeclare str as num') != nil
+   end
+
+   assert(rejected, 'A conflicting retained-value declaration should raise the redeclaration diagnostic')
+   assert(glGTJitConflicting is 'original',
+      'A conflicting retained-value declaration must preserve the original value')
+
+   rawset(_G, 'glGTJitConflicting', 'compatible')
+   assert(glGTJitConflicting is 'compatible',
+      'A rejected redeclaration must preserve the original string policy')
 end
 -----------------------------------------------------------------------------------------------------------------------
 -- Direct global callable declarations must publish the same persistent binding contract as global variables.


### PR DESCRIPTION
* Kept non-const global declaration prototypes JIT eligible while handing policy finalisers back to the interpreter
* Added parser eligibility matrices and runtime regressions for tracing, retained values and conflicting policies