### PR TITLE
[Tiri] Rejected ambiguous implicit attribute shadowing

### DIFF
--- a/src/tiri/jit/src/lib/lib_debug.cpp
+++ b/src/tiri/jit/src/lib/lib_debug.cpp
@@ -1053,6 +1053,7 @@ static CSTRING diagnostic_code_name(ParserErrorCode Code)
       case ParserErrorCode::RecursiveFunctionNeedsType: return "RecursiveFunctionNeedsType";
       case ParserErrorCode::TooManyReturnTypes:     return "TooManyReturnTypes";
       case ParserErrorCode::RecoverySkippedTokens:  return "RecoverySkippedTokens";
+      case ParserErrorCode::InvalidAssignment:      return "InvalidAssignment";
       case ParserErrorCode::UnresolvedMethodReceiver: return "UnresolvedMethodReceiver";
       default: return "Unknown";
    }

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -743,6 +743,7 @@ struct LocalDeclStmtPayload {
    AssignmentOperator op = AssignmentOperator::Plain;  // Supports ??= conditional assignment
    std::vector<Identifier> names;
    ExprNodeList values;
+   bool implicit_declaration = false; // Source omitted the explicit 'local' keyword
    uint32_t module_dependency = UINT32_MAX; // Descriptor ordinal for compiler-generated module activation
    ~LocalDeclStmtPayload();
 };

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -150,6 +150,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_local()
 
    auto stmt = std::make_unique<StmtNode>(AstNodeKind::LocalDeclStmt, local_token.span());
    stmt->data.emplace<LocalDeclStmtPayload>(assign_op, std::move(name_list), std::move(values));
+   std::get<LocalDeclStmtPayload>(stmt->data).implicit_declaration = implicit_local;
    return ParserResult<StmtNodePtr>::success(std::move(stmt));
 }
 

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1286,7 +1286,7 @@ static bool test_implicit_attribute_shadowing(kt::Log &Log)
       bool add_environment_global = false;
    };
 
-   constexpr std::array<RejectedCase, 16> rejected = { {
+   constexpr std::array<RejectedCase, 17> rejected = { {
       { "nested close", "thing = 'goodbye'\ndo\n   thing <close> = 'hello'\nend" },
       { "nested const", "thing = 1\ndo\n   thing <const> = 2\nend" },
       { "nested view", "thing = {}\ndo\n   thing <view> = {}\nend" },
@@ -1300,6 +1300,7 @@ static bool test_implicit_attribute_shadowing(kt::Log &Log)
       { "protected global", "print <const> = 2", true, false },
       { "registered constant", "enum SHADOW { VALUE }\nSHADOW_VALUE <const> = 2" },
       { "mixed sibling", "thing = 1\nfresh, thing <const> = 2, 3" },
+      { "duplicate sibling", "fresh, fresh <const> = 1, 2" },
       { "constant-false branch", "thing = 1\nif false then\n   thing <const> = 2\nend" },
       { "clause after constant-true", "thing = 1\nif true then\n   fresh = 2\nelseif true then\n"
          "   thing <const> = 3\nend" },
@@ -1353,12 +1354,13 @@ static bool test_implicit_attribute_shadowing(kt::Log &Log)
       return false;
    }
 
-   constexpr std::array<std::string_view, 7> accepted = { {
+   constexpr std::array<std::string_view, 8> accepted = { {
       "thing = 1\ndo\n   local thing <const> = 2\nend",
       "thing = nil\ndo\n   local thing <close> = nil\nend",
       "thing = {}\ndo\n   local thing <view> = {}\nend",
       "fresh <const> = 1",
       "first, second <close> = nil, nil",
+      "local fresh, fresh <const> = 1, 2",
       "_, fresh <const> = 1, 2",
       "if false then\n   fresh <const> = 1\nend"
    } };

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1286,7 +1286,7 @@ static bool test_implicit_attribute_shadowing(kt::Log &Log)
       bool add_environment_global = false;
    };
 
-   constexpr std::array<RejectedCase, 13> rejected = { {
+   constexpr std::array<RejectedCase, 16> rejected = { {
       { "nested close", "thing = 'goodbye'\ndo\n   thing <close> = 'hello'\nend" },
       { "nested const", "thing = 1\ndo\n   thing <const> = 2\nend" },
       { "nested view", "thing = {}\ndo\n   thing <view> = {}\nend" },
@@ -1299,7 +1299,11 @@ static bool test_implicit_attribute_shadowing(kt::Log &Log)
       { "environment global", "host_existing <const> = 2", false, true },
       { "protected global", "print <const> = 2", true, false },
       { "registered constant", "enum SHADOW { VALUE }\nSHADOW_VALUE <const> = 2" },
-      { "mixed sibling", "thing = 1\nfresh, thing <const> = 2, 3" }
+      { "mixed sibling", "thing = 1\nfresh, thing <const> = 2, 3" },
+      { "constant-false branch", "thing = 1\nif false then\n   thing <const> = 2\nend" },
+      { "clause after constant-true", "thing = 1\nif true then\n   fresh = 2\nelseif true then\n"
+         "   thing <const> = 3\nend" },
+      { "earlier unreachable local", "if false then\n   local thing = 1\n   thing <const> = 2\nend" }
    } };
 
    for (const RejectedCase &test_case : rejected) {
@@ -1349,13 +1353,14 @@ static bool test_implicit_attribute_shadowing(kt::Log &Log)
       return false;
    }
 
-   constexpr std::array<std::string_view, 6> accepted = { {
+   constexpr std::array<std::string_view, 7> accepted = { {
       "thing = 1\ndo\n   local thing <const> = 2\nend",
       "thing = nil\ndo\n   local thing <close> = nil\nend",
       "thing = {}\ndo\n   local thing <view> = {}\nend",
       "fresh <const> = 1",
       "first, second <close> = nil, nil",
-      "_, fresh <const> = 1, 2"
+      "_, fresh <const> = 1, 2",
+      "if false then\n   fresh <const> = 1\nend"
    } };
    for (std::string_view source : accepted) {
       auto result = discover_bindings_from_source(source);

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1205,6 +1205,7 @@ static bool test_implicit_later_name_attributes(kt::Log &Log)
       const auto *declaration = statements.size() IS 1 and statements[0].kind IS AstNodeKind::LocalDeclStmt ?
          std::get_if<LocalDeclStmtPayload>(&statements[0].data) : nullptr;
       if (not declaration or declaration->names.size() != 2 or declaration->values.size() != 2 or
+          not declaration->implicit_declaration or
           declaration->names[0].has_const or declaration->names[0].has_close or
           declaration->names[1].has_const != test_case.has_const or
           declaration->names[1].has_close != test_case.has_close or declaration->names[1].type != test_case.type) {
@@ -1225,6 +1226,157 @@ static bool test_implicit_later_name_attributes(kt::Log &Log)
    if (not has_view_diagnostic or has_expression_diagnostic) {
       Log.error("a later <view> attribute did not reach declaration validation");
       log_diagnostics(invalid_view.diagnostics, Log);
+      return false;
+   }
+
+   return true;
+}
+
+//********************************************************************************************************************
+
+struct BindingDiscoveryResult {
+   ParserResult<std::unique_ptr<BlockStmt>> chunk;
+   std::vector<ParserDiagnostic> diagnostics;
+   std::unique_ptr<LuaStateHolder> state;
+};
+
+static BindingDiscoveryResult discover_bindings_from_source(std::string_view Source,
+   bool EnableTypeAnalysis = true, bool OpenLibraries = false, bool AddEnvironmentGlobal = false)
+{
+   BindingDiscoveryResult result;
+   result.state = std::make_unique<LuaStateHolder>();
+   lua_State *L = result.state->get();
+   if (OpenLibraries) luaL_openlibs(L);
+   if (AddEnvironmentGlobal) {
+      lua_pushnumber(L, 1);
+      lua_setglobal(L, "host_existing");
+   }
+
+   StringReaderCtx reader{ Source.data(), Source.size() };
+   LexState lex(L, unit_reader, &reader, "implicit-attribute-shadowing", std::nullopt);
+   FuncState &fs = lex.fs_init();
+   ParserContext context = ParserContext::from(lex, fs, ParserAllocator::from(L));
+   ParserConfig config;
+   config.abort_on_error = false;
+   config.max_diagnostics = 32;
+   config.enable_type_analysis = EnableTypeAnalysis;
+   ParserSession session(context, config);
+
+   lex.next();
+   AstBuilder builder(context);
+   result.chunk = builder.parse_chunk();
+   if (result.chunk.ok()) {
+      discover_static_bindings(context, *result.chunk.value_ref());
+      if (EnableTypeAnalysis) run_type_analysis(context, *result.chunk.value_ref());
+   }
+
+   auto diagnostics = context.diagnostics().entries();
+   result.diagnostics.assign(diagnostics.begin(), diagnostics.end());
+   return result;
+}
+
+//********************************************************************************************************************
+
+static bool test_implicit_attribute_shadowing(kt::Log &Log)
+{
+   struct RejectedCase {
+      std::string_view name;
+      std::string_view source;
+      bool open_libraries = false;
+      bool add_environment_global = false;
+   };
+
+   constexpr std::array<RejectedCase, 13> rejected = { {
+      { "nested close", "thing = 'goodbye'\ndo\n   thing <close> = 'hello'\nend" },
+      { "nested const", "thing = 1\ndo\n   thing <const> = 2\nend" },
+      { "nested view", "thing = {}\ndo\n   thing <view> = {}\nend" },
+      { "same block", "thing = 1\nthing <const> = 2" },
+      { "parameter", "function test(thing)\n   thing <const> = 2\nend" },
+      { "captured local", "thing = 1\nfunction test()\n   thing <const> = 2\nend" },
+      { "declared global", "global thing = 1\nthing <const> = 2" },
+      { "global function", "global function thing() end\nthing <const> = 2" },
+      { "extern", "extern thing\nthing <const> = 2" },
+      { "environment global", "host_existing <const> = 2", false, true },
+      { "protected global", "print <const> = 2", true, false },
+      { "registered constant", "enum SHADOW { VALUE }\nSHADOW_VALUE <const> = 2" },
+      { "mixed sibling", "thing = 1\nfresh, thing <const> = 2, 3" }
+   } };
+
+   for (const RejectedCase &test_case : rejected) {
+      auto result = discover_bindings_from_source(test_case.source, true,
+         test_case.open_libraries, test_case.add_environment_global);
+      size_t matching = 0;
+      for (const ParserDiagnostic &diagnostic : result.diagnostics) {
+         if (diagnostic.code IS ParserErrorCode::InvalidAssignment and
+             diagnostic.message.find("requires explicit 'local'") != std::string::npos) matching++;
+      }
+      if (not result.chunk.ok() or matching != 1) {
+         Log.error("implicit attributed %.*s shadow produced %zu targeted diagnostics",
+            int(test_case.name.size()), test_case.name.data(), matching);
+         log_diagnostics(result.diagnostics, Log);
+         return false;
+      }
+   }
+
+   auto unannotated_sibling = discover_bindings_from_source(
+      "thing = 1\nthing, fresh <const> = 2, 3");
+   if (unannotated_sibling.diagnostics.size() != 1 or
+       unannotated_sibling.diagnostics[0].code != ParserErrorCode::InvalidAssignment or
+       unannotated_sibling.diagnostics[0].token.span().line.lineNumber() != 2 or
+       unannotated_sibling.diagnostics[0].token.span().column.lineNumber() != 1) {
+      Log.error("an unannotated conflicting sibling did not report at its identifier");
+      log_diagnostics(unannotated_sibling.diagnostics, Log);
+      return false;
+   }
+
+   auto multiple = discover_bindings_from_source(
+      "first = 1\nsecond = 2\nfirst, second <const> = second, first");
+   if (not multiple.chunk.ok() or multiple.diagnostics.size() != 2) {
+      Log.error("multiple implicit attribute conflicts did not produce one diagnostic per name");
+      log_diagnostics(multiple.diagnostics, Log);
+      return false;
+   }
+   StatementListView multiple_statements = multiple.chunk.value_ref()->view();
+   const auto &first_assignment = std::get<AssignmentStmtPayload>(multiple_statements[0].data);
+   const auto &second_assignment = std::get<AssignmentStmtPayload>(multiple_statements[1].data);
+   const auto &declaration = std::get<LocalDeclStmtPayload>(multiple_statements[2].data);
+   const auto &first_rhs = std::get<NameRef>(declaration.values[0]->data);
+   const auto &second_rhs = std::get<NameRef>(declaration.values[1]->data);
+   const auto &first_original = std::get<NameRef>(first_assignment.targets[0]->data);
+   const auto &second_original = std::get<NameRef>(second_assignment.targets[0]->data);
+   if (first_rhs.binding_id != second_original.binding_id or second_rhs.binding_id != first_original.binding_id) {
+      Log.error("an invalid declaration changed right-hand-side binding resolution");
+      return false;
+   }
+
+   constexpr std::array<std::string_view, 6> accepted = { {
+      "thing = 1\ndo\n   local thing <const> = 2\nend",
+      "thing = nil\ndo\n   local thing <close> = nil\nend",
+      "thing = {}\ndo\n   local thing <view> = {}\nend",
+      "fresh <const> = 1",
+      "first, second <close> = nil, nil",
+      "_, fresh <const> = 1, 2"
+   } };
+   for (std::string_view source : accepted) {
+      auto result = discover_bindings_from_source(source);
+      if (not result.chunk.ok() or not result.diagnostics.empty()) {
+         Log.error("valid explicit shadow or new implicit attributed local was rejected");
+         log_diagnostics(result.diagnostics, Log);
+         return false;
+      }
+   }
+
+   auto without_types = discover_bindings_from_source("thing = 1\nthing <const> = 2", false);
+   if (without_types.diagnostics.size() != 1 or
+       without_types.diagnostics[0].code != ParserErrorCode::InvalidAssignment) {
+      Log.error("implicit attribute shadowing depended on optional type analysis");
+      log_diagnostics(without_types.diagnostics, Log);
+      return false;
+   }
+
+   LocalDeclStmtPayload generated(AssignmentOperator::Plain, {}, {});
+   if (generated.implicit_declaration) {
+      Log.error("compiler-generated local declarations defaulted to implicit source provenance");
       return false;
    }
 
@@ -9635,7 +9787,7 @@ static bool test_defer_runtime_registration_state(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 89> tests = { {
+   constexpr std::array<TestCase, 90> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -9659,6 +9811,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "colon_method_syntax_rejected", test_colon_method_syntax_rejected },
       { "typed_assignment_name_resolution", test_typed_assignment_name_resolution },
       { "implicit_later_name_attributes", test_implicit_later_name_attributes },
+      { "implicit_attribute_shadowing", test_implicit_attribute_shadowing },
       { "ternary_colon_separators", test_ternary_colon_separators },
       { "extended_ternary_annotation_lookahead", test_extended_ternary_annotation_lookahead },
       { "array_length_range_for_ast", test_array_length_range_for_ast },

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -3,6 +3,7 @@
 #include "static_descriptor_analysis.h"
 
 #include <algorithm>
+#include <shared_mutex>
 #include <string>
 #include <utility>
 
@@ -78,6 +79,42 @@ private:
    [[nodiscard]] bool is_declared_global(GCstr *Name) const
    {
       return std::find(this->global_names_.begin(), this->global_names_.end(), Name) != this->global_names_.end();
+   }
+
+   [[nodiscard]] bool is_registered_constant(GCstr *Name) const
+   {
+      if (not Name) return false;
+
+      std::shared_lock lock(glConstantMutex);
+      return glConstantRegistry.contains(Name->hash);
+   }
+
+   [[nodiscard]] bool implicit_declaration_conflicts(GCstr *Name) const
+   {
+      if (not Name) return false;
+      if (this->resolve(Name) or this->is_declared_global(Name) or this->is_registered_constant(Name)) return true;
+      if ((Name->flags & STRFLAG_PROTECTED_GLOBAL) != 0) return true;
+
+      cTValue *global = lj_tab_getstr(tabref(this->context_.lua().env), Name);
+      return global and not tvisnil(global);
+   }
+
+   void validate_implicit_declaration(const LocalDeclStmtPayload &Payload)
+   {
+      if (not Payload.implicit_declaration) return;
+
+      for (const Identifier &name : Payload.names) {
+         if (name.is_blank or not this->implicit_declaration_conflicts(name.symbol)) continue;
+
+         std::string_view name_view(strdata(name.symbol), name.symbol->len);
+         ParserDiagnostic diagnostic;
+         diagnostic.severity = ParserDiagnosticSeverity::Error;
+         diagnostic.code = ParserErrorCode::InvalidAssignment;
+         diagnostic.message = std::format(
+            "declaration attribute on existing variable '{}' requires explicit 'local'", name_view);
+         diagnostic.token = Token::from_span(name.span, TokenKind::Identifier);
+         this->context_.diagnostics().report(diagnostic);
+      }
    }
 
    StaticBindingID declare(Identifier &Name, const ExprNode *Initialiser, uint8_t ResultPosition,
@@ -264,6 +301,7 @@ private:
          case AstNodeKind::LocalDeclStmt: {
             auto &payload = std::get<LocalDeclStmtPayload>(Statement.data);
             for (auto &value : payload.values) if (value) this->discover_expression(*value);
+            this->validate_implicit_declaration(payload);
             for (size_t i = 0; i < payload.names.size(); ++i) {
                const ExprNode *initialiser = i < payload.values.size() ? payload.values[i].get() :
                   (payload.values.empty() ? nullptr : payload.values.back().get());

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -105,8 +105,14 @@ private:
    {
       if (not Payload.implicit_declaration) return;
 
+      std::vector<GCstr *> declared_names;
+      declared_names.reserve(Payload.names.size());
       for (const Identifier &name : Payload.names) {
-         if (name.is_blank or not this->implicit_declaration_conflicts(name.symbol)) continue;
+         if (name.is_blank or not name.symbol) continue;
+
+         bool duplicate = std::find(declared_names.begin(), declared_names.end(), name.symbol) != declared_names.end();
+         declared_names.push_back(name.symbol);
+         if (not duplicate and not this->implicit_declaration_conflicts(name.symbol)) continue;
 
          std::string_view name_view(strdata(name.symbol), name.symbol->len);
          ParserDiagnostic diagnostic;

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -42,8 +42,10 @@ static bool is_builtin_interface_namespace(uint32_t Hash)
 
 class StaticDescriptorAnalyser {
 public:
-   explicit StaticDescriptorAnalyser(ParserContext &Context, bool NativeCallsOnly = false)
-      : context_(Context), catalogue_(Context.descriptors()), native_calls_only_(NativeCallsOnly) {}
+   explicit StaticDescriptorAnalyser(
+      ParserContext &Context, bool NativeCallsOnly = false, bool ValidationOnly = false)
+      : context_(Context), catalogue_(Context.descriptors()), native_calls_only_(NativeCallsOnly),
+        validation_only_(ValidationOnly) {}
 
    void discover(BlockStmt &Module)
    {
@@ -120,6 +122,14 @@ private:
    StaticBindingID declare(Identifier &Name, const ExprNode *Initialiser, uint8_t ResultPosition,
       const FunctionExprPayload *Function = nullptr, bool IsParameter = false)
    {
+      if (this->validation_only_) {
+         StaticBindingID placeholder(1);
+         if (Name.symbol and not Name.is_blank) {
+            this->scopes_.back().entries.emplace_back(Name.symbol, placeholder);
+         }
+         return placeholder;
+      }
+
       StaticBindingDescriptor binding;
       binding.name = Name.symbol;
       binding.initialiser = Initialiser;
@@ -137,6 +147,8 @@ private:
 
    void reference(NameRef &Reference, bool Write = false)
    {
+      if (this->validation_only_) return;
+
       StaticBindingID id = this->resolve(Reference.identifier.symbol);
       Reference.binding_id = id;
       Reference.identifier.binding_id = id;
@@ -295,6 +307,22 @@ private:
       if (NewScope) this->scopes_.pop_back();
    }
 
+   void validate_unreachable_expression(ExprNode &Expression)
+   {
+      StaticDescriptorAnalyser validator(this->context_, this->native_calls_only_, true);
+      validator.scopes_ = this->scopes_;
+      validator.global_names_ = this->global_names_;
+      validator.discover_expression(Expression);
+   }
+
+   void validate_unreachable_block(BlockStmt &Block)
+   {
+      StaticDescriptorAnalyser validator(this->context_, this->native_calls_only_, true);
+      validator.scopes_ = this->scopes_;
+      validator.global_names_ = this->global_names_;
+      validator.discover_block(Block);
+   }
+
    void discover_statement(StmtNode &Statement)
    {
       switch (Statement.kind) {
@@ -333,8 +361,8 @@ private:
                         (payload.values.empty() ? nullptr : payload.values.back().get());
                      uint8_t position = i < payload.values.size() ? 0 :
                         uint8_t(i - payload.values.size() + 1);
-                     reference.binding_id = this->declare(
-                        reference.identifier, initialiser, position);
+                     StaticBindingID binding = this->declare(reference.identifier, initialiser, position);
+                     if (not this->validation_only_) reference.binding_id = binding;
                      continue;
                   }
                }
@@ -376,13 +404,24 @@ private:
             break;
          }
          case AstNodeKind::IfStmt: {
-            for (auto &clause : std::get<IfStmtPayload>(Statement.data).clauses) {
+            auto &clauses = std::get<IfStmtPayload>(Statement.data).clauses;
+            for (size_t i = 0; i < clauses.size(); ++i) {
+               auto &clause = clauses[i];
                if (clause.condition) {
                   this->discover_expression(*clause.condition);
                   auto truth = this->constant_truth(*clause.condition);
-                  if (truth and not *truth) continue;
+                  if (truth and not *truth) {
+                     if (clause.block) this->validate_unreachable_block(*clause.block);
+                     continue;
+                  }
                   if (clause.block) this->discover_block(*clause.block);
-                  if (truth and *truth) break;
+                  if (truth and *truth) {
+                     for (++i; i < clauses.size(); ++i) {
+                        if (clauses[i].condition) this->validate_unreachable_expression(*clauses[i].condition);
+                        if (clauses[i].block) this->validate_unreachable_block(*clauses[i].block);
+                     }
+                     break;
+                  }
                }
                else {
                   if (clause.block) this->discover_block(*clause.block);
@@ -2534,6 +2573,7 @@ private:
    const BlockStmt *enclosing_body_ = nullptr;
    uint16_t function_depth_ = 0;
    bool native_calls_only_ = false;
+   bool validation_only_ = false;
 };
 
 } // namespace

--- a/src/tiri/tests/test_malformed_syntax.tiri
+++ b/src/tiri/tests/test_malformed_syntax.tiri
@@ -114,6 +114,47 @@ end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Implicit declaration attribute shadowing
+
+@Test function ValidateImplicitAttributeShadowing()
+   local cases = {
+      {
+         name = 'close',
+         source = "thing = 'goodbye'\ndo\n   thing <close> = 'hello'\nend"
+      },
+      {
+         name = 'const',
+         source = "thing = 1\ndo\n   thing <const> = 2\nend"
+      },
+      {
+         name = 'view',
+         source = "thing = {}\ndo\n   thing <view> = {}\nend"
+      }
+   }
+
+   for case in values(cases) do
+      local result = debug.validate(case.source)
+      assert(result.success is false, case.name .. ' shadow should fail validation')
+      assert(#result.diagnostics > 0, case.name .. ' shadow should report a diagnostic')
+      local found_shadowing_diagnostic = false
+      for diagnostic in values(result.diagnostics) do
+         if diagnostic.code is 'InvalidAssignment' and
+            diagnostic.message.find("requires explicit 'local'") then
+            found_shadowing_diagnostic = true
+         end
+      end
+      assert(found_shadowing_diagnostic,
+         case.name .. ' shadow should report InvalidAssignment and explain how to make the declaration explicit')
+   end
+
+   local explicit_shadow = debug.validate("thing = 1\ndo\n   local thing <const> = 2\nend")
+   assert(explicit_shadow.success is true, 'explicit local attributed shadow should validate')
+
+   local new_declaration = debug.validate("fresh <const> = 1")
+   assert(new_declaration.success is true, 'new bare attributed local should validate')
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Malformed type declarations and annotations
 
 @Test function ValidateMalformedTypeDeclarations()

--- a/src/tiri/tests/test_malformed_syntax.tiri
+++ b/src/tiri/tests/test_malformed_syntax.tiri
@@ -133,6 +133,10 @@ end
       {
          name = 'constant-false branch',
          source = "thing = 1\nif false then\n   thing <const> = 2\nend"
+      },
+      {
+         name = 'duplicate sibling',
+         source = "fresh, fresh <const> = 1, 2"
       }
    }
 
@@ -153,6 +157,9 @@ end
 
    local explicit_shadow = debug.validate("thing = 1\ndo\n   local thing <const> = 2\nend")
    assert(explicit_shadow.success is true, 'explicit local attributed shadow should validate')
+
+   local explicit_duplicate = debug.validate("local fresh, fresh <const> = 1, 2")
+   assert(explicit_duplicate.success is true, 'explicit local duplicate should validate')
 
    local new_declaration = debug.validate("fresh <const> = 1")
    assert(new_declaration.success is true, 'new bare attributed local should validate')

--- a/src/tiri/tests/test_malformed_syntax.tiri
+++ b/src/tiri/tests/test_malformed_syntax.tiri
@@ -129,6 +129,10 @@ end
       {
          name = 'view',
          source = "thing = {}\ndo\n   thing <view> = {}\nend"
+      },
+      {
+         name = 'constant-false branch',
+         source = "thing = 1\nif false then\n   thing <const> = 2\nend"
       }
    }
 


### PR DESCRIPTION
* Track whether attributed local declarations omit the explicit local keyword
* Reject bare attributed declarations that resolve to existing lexical, global, environment, protected, or constant bindings
* Add parser and Flute coverage for shadowing diagnostics, accepted declarations, and binding recovery