### PR TITLE
[Tiri] Removed extern wildcard declarations

### DIFF
--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -762,7 +762,6 @@ struct GlobalDeclStmtPayload {
 };
 
 struct ExternDeclStmtPayload {
-   ExternDeclStmtPayload() = default;
    explicit ExternDeclStmtPayload(std::vector<Identifier> Names)
       : names(std::move(Names)) {}
    ExternDeclStmtPayload(const ExternDeclStmtPayload&) = delete;
@@ -770,7 +769,6 @@ struct ExternDeclStmtPayload {
    ExternDeclStmtPayload(ExternDeclStmtPayload&&) noexcept = default;
    ExternDeclStmtPayload& operator=(ExternDeclStmtPayload&&) noexcept = default;
    std::vector<Identifier> names;
-   bool all_symbols = false;
    ~ExternDeclStmtPayload();
 };
 

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -286,24 +286,8 @@ ParserResult<StmtNodePtr> AstBuilder::parse_extern()
    this->ctx.tokens().advance();
 
    if (this->ctx.check(TokenKind::Multiply)) {
-      this->ctx.tokens().advance();
-
-      if (this->ctx.check(TokenKind::Comma)) {
-         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-            "Extern wildcard cannot be combined with named symbols");
-      }
-
-      if (this->ctx.check(TokenKind::Equals) or
-            token_to_assignment_op(this->ctx.tokens().current().kind()).has_value()) {
-         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-            "Extern declarations cannot have an initialiser");
-      }
-
-      auto stmt = std::make_unique<StmtNode>(AstNodeKind::ExternStmt, extern_token.span());
-      ExternDeclStmtPayload payload;
-      payload.all_symbols = true;
-      stmt->data = std::move(payload);
-      return ParserResult<StmtNodePtr>::success(std::move(stmt));
+      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
+         "Extern wildcard '*' is not supported; list external symbols by name");
    }
 
    auto names = this->parse_name_list();

--- a/src/tiri/jit/src/parser/func_state.h
+++ b/src/tiri/jit/src/parser/func_state.h
@@ -66,7 +66,6 @@ struct FuncState {
 
    // Track externally supplied symbols for this parse so strict identifier reads can allow cross-file references.
    ankerl::unordered_dense::set<GCstr*> external_symbols;
-   bool allow_external_symbol_reads = false;
 
    // Function name for named function declarations (used for tostring() output).
    // Set before fs_finish() is called. nullptr for anonymous functions.

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -107,7 +107,6 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
    // Inherit declared globals from parent so nested functions recognize them
    child_state.declared_globals = parent_state->declared_globals;
    child_state.external_symbols = parent_state->external_symbols;
-   child_state.allow_external_symbol_reads = parent_state->allow_external_symbol_reads;
 
    // Set linedefined to the earliest line that bytecode might reference.
    // Note: SourceSpan.line represents the END line of a span (due to combine_spans behavior),

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -2114,11 +2114,6 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
 
 ParserResult<IrEmitUnit> IrEmitter::emit_extern_decl_stmt(const ExternDeclStmtPayload &Payload)
 {
-   if (Payload.all_symbols) {
-      this->func_state.allow_external_symbol_reads = true;
-      return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
-   }
-
    for (const Identifier &identifier : Payload.names) {
       if (is_blank_symbol(identifier)) continue;
       if (identifier.symbol) this->func_state.external_symbols.insert(identifier.symbol);
@@ -2146,7 +2141,6 @@ bool IrEmitter::can_elide_expression(const ExprNode &Expression) const
          if (lookup_constant(reference.identifier.symbol)) return true;
          if (this->func_state.declared_globals.contains(reference.identifier.symbol)) return true;
          if (this->func_state.external_symbols.contains(reference.identifier.symbol)) return true;
-         if (this->func_state.allow_external_symbol_reads) return true;
 
          cTValue *global = lj_tab_getstr(tabref(this->lex_state.L->env), reference.identifier.symbol);
          return (global and not tvisnil(global)) or is_named_external_global(reference.identifier.symbol);
@@ -3362,9 +3356,6 @@ ParserResult<ExpDesc> IrEmitter::emit_identifier_expr(const NameRef& reference, 
          resolved.k = ExpKind::Global;
       }
       else if (this->func_state.external_symbols.count(reference.identifier.symbol) > 0) {
-         resolved.k = ExpKind::Global;
-      }
-      else if (this->func_state.allow_external_symbol_reads) {
          resolved.k = ExpKind::Global;
       }
       else if (reference.identifier.symbol) {

--- a/src/tiri/tests/test_malformed_syntax.tiri
+++ b/src/tiri/tests/test_malformed_syntax.tiri
@@ -98,17 +98,21 @@ end
    assertInvalidCode("local something = externalValue", 'UndefinedVariable',
       'extern symbols should not leak between validation runs')
 
-   result = debug.validate("extern *\nlocal value = anyMissingSymbol")
-   assert(result.success is true, "Extern wildcard read should validate")
+   result = debug.validate("extern *")
+   assert(result.success is false, "Extern wildcard should fail validation")
+   assert(result.diagnostics[0].code is 'UnexpectedToken',
+      "Extern wildcard should report an UnexpectedToken diagnostic")
+   assert(result.diagnostics[0].message.find('list external symbols by name') != nil,
+      "Extern wildcard diagnostic should explain the named-symbol migration")
 
-   result = debug.validate("extern *\nfunction nested():any\n   return anyMissingSymbol\nend")
-   assert(result.success is true, "Extern wildcard read inside nested function should validate")
+   result = debug.validate("extern *\nlocal value = anyMissingSymbol")
+   assert(result.success is false, "Extern wildcard should remain invalid before an unresolved read")
+   assert(result.diagnostics[0].message.find('list external symbols by name') != nil,
+      "Extern wildcard with a following read should retain the migration diagnostic")
 
    assertInvalidCode("local value = anyMissingSymbol", 'UndefinedVariable',
-      'extern wildcard should not leak between validation runs')
+      'removed extern wildcard should not affect later validation runs')
 
-   assertInvalid("extern * = value", 'extern wildcard with initialiser')
-   assertInvalid("extern *, namedSymbol", 'extern wildcard combined with named symbols')
    assertInvalid("extern externalValue:num", 'extern declaration with type annotation')
    assertInvalid("extern externalValue <const>", 'extern declaration with attribute')
 end

--- a/tools/tiri_lsp/include/lsp_defs.tiri
+++ b/tools/tiri_lsp/include/lsp_defs.tiri
@@ -202,7 +202,7 @@ glKeywords = {
    ['local'] = { comment = 'Declares a local variable (block-scoped).' },
    ['global'] = { comment = 'Declares a global variable.' },
    ['extern'] = {
-      comment = 'Declares that a symbol is supplied externally and should be resolved as a global.'
+      comment = 'Declares one or more named symbols supplied externally and resolves them as globals.'
    },
    ['import'] = {
       comment = 'Inlines one or more Tiri script libraries at parse time. List entries must be string literals; ' ..

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -170,6 +170,15 @@ end
    result = computeDiagnostics(doc)
 
    assert(#result.diagnostics is 0, 'LSP diagnostics should accept extern declarations.')
+
+   doc = makeDoc('extern *\nlocal runner = missingRunner\n')
+   result = computeDiagnostics(doc)
+
+   assert(#result.diagnostics > 0, 'LSP diagnostics should reject the removed extern wildcard.')
+   assert(result.diagnostics[0].code is 'UnexpectedToken',
+      'LSP diagnostics should preserve the extern wildcard parser code.')
+   assert(result.diagnostics[0].message.find('list external symbols by name') != nil,
+      'LSP diagnostics should explain how to replace the extern wildcard.')
 end
 
 @Test function RangeSeparatorsReceiveContextualSemanticTokens()


### PR DESCRIPTION
* Rejected extern * with an explicit migration diagnostic and removed wildcard parser state
* Added parser and LSP regressions while preserving named extern declarations
* [LSP] Clarified that extern declarations require named symbols