### PR TITLE
[Tiri] Resolve assignment targets before analysis

### DIFF
--- a/apps/find.tiri
+++ b/apps/find.tiri
@@ -213,7 +213,7 @@ Examples:
 
    -- Build search options
 
-   options = {
+   local options = {
       maxDepth = glMaxDepth,
    }
 

--- a/src/tiri/jit/src/debug/lj_err.cpp
+++ b/src/tiri/jit/src/debug/lj_err.cpp
@@ -1483,7 +1483,7 @@ LJ_NOINLINE void lj_err_callermsg(lua_State *L, CSTRING msg)
 // Error in the context of the active Tiri frame.  VM helpers use this path because they execute C++ code without
 // adding the C frame that lj_err_callermsg() normally skips.
 
-LJ_NORET LJ_NOINLINE static void err_currentmsg(lua_State *L, CSTRING Message)
+LJ_NOINLINE void lj_err_currentmsg(lua_State *L, CSTRING Message)
 {
    auto frame = L->base - 1;
    err_record_pending_exception(L, Message, frame, nullptr);
@@ -1688,7 +1688,7 @@ static CSTRING luaL_push_error_string(lua_State *L, std::string &Message)
    va_start(argp, Format);
    auto msg = lj_strfmt_pushvf(L, Format, argp);
    va_end(argp);
-   err_currentmsg(L, msg);
+   lj_err_currentmsg(L, msg);
 }
 
 [[noreturn]] extern void luaL_error(lua_State *L, ERR ErrorCode, std::string Message)

--- a/src/tiri/jit/src/debug/lj_err.h
+++ b/src/tiri/jit/src/debug/lj_err.h
@@ -26,6 +26,7 @@ LJ_FUNC_NORET void lj_err_run(lua_State *L);
 LJ_FUNCA_NORET void lj_err_trace(lua_State *L, int errcode);
 LJ_FUNC_NORET void lj_err_msg(lua_State *L, ErrMsg em);
 LJ_FUNC_NORET void lj_err_msgv(lua_State *L, ErrMsg em, ...);
+LJ_FUNC_NORET void lj_err_currentmsg(lua_State *L, const char *);
 LJ_FUNC_NORET void lj_err_lex(lua_State *L, GCstr *src, const char *tok, BCLine line, ErrMsg em, va_list argp);
 LJ_FUNC_NORET void lj_err_optype(lua_State *L, cTValue *o, ErrMsg opm);
 LJ_FUNC_NORET void lj_err_comp(lua_State *L, cTValue *o1, cTValue *o2);

--- a/src/tiri/jit/src/parser/assignment_target_resolution.cpp
+++ b/src/tiri/jit/src/parser/assignment_target_resolution.cpp
@@ -1,0 +1,517 @@
+// Authoritative semantic resolution for identifier assignment targets.
+
+#include "assignment_target_resolution.h"
+
+#include <algorithm>
+#include <shared_mutex>
+#include <utility>
+#include <vector>
+
+#include "ast/nodes.h"
+#include "parser_context.h"
+#include "../../../defs.h"
+#include "../runtime/lj_tab.h"
+
+namespace {
+
+struct AssignmentBinding {
+   GCstr *name = nullptr;
+   StaticBindingID binding_id{};
+   uint16_t function_depth = 0;
+};
+
+struct AssignmentScope {
+   std::vector<AssignmentBinding> bindings;
+};
+
+class AssignmentTargetResolver {
+public:
+   explicit AssignmentTargetResolver(ParserContext &Context) : context_(Context) {}
+
+   void resolve(BlockStmt &Module)
+   {
+      this->scopes_.clear();
+      this->global_names_.clear();
+      this->function_depth_ = 0;
+      this->next_binding_id_ = StaticBindingID(1);
+      this->scopes_.push_back(AssignmentScope{});
+      this->resolve_block(Module, false);
+   }
+
+private:
+   [[nodiscard]] const AssignmentBinding *find_binding(GCstr *Name) const
+   {
+      if (not Name) return nullptr;
+      for (auto scope = this->scopes_.rbegin(); scope != this->scopes_.rend(); ++scope) {
+         for (auto binding = scope->bindings.rbegin(); binding != scope->bindings.rend(); ++binding) {
+            if (binding->name IS Name) return &*binding;
+         }
+      }
+      return nullptr;
+   }
+
+   [[nodiscard]] bool is_declared_global(GCstr *Name) const
+   {
+      return std::find(this->global_names_.begin(), this->global_names_.end(), Name) != this->global_names_.end();
+   }
+
+   [[nodiscard]] bool is_registered_constant(GCstr *Name) const
+   {
+      if (not Name) return false;
+      std::shared_lock lock(glConstantMutex);
+      return glConstantRegistry.contains(Name->hash);
+   }
+
+   [[nodiscard]] bool is_environment_global(GCstr *Name) const
+   {
+      if (not Name) return false;
+      GCtab *environment = tabref(this->context_.lua().env);
+      if (not environment) return false;
+      cTValue *value = lj_tab_getstr(environment, Name);
+      return (value and not tvisnil(value)) or lj_tab_get_global_contract(environment, Name) != nullptr;
+   }
+
+   [[nodiscard]] bool is_existing_global(GCstr *Name) const
+   {
+      if (not Name) return false;
+      // The glX/mX naming convention is a read-only fallback, not an assignment external policy.  Named source
+      // externs are recorded in global_names_, so a convention-shaped unknown assignment still creates a local.
+      if (this->is_declared_global(Name) or this->is_registered_constant(Name) or
+          (Name->flags & STRFLAG_PROTECTED_GLOBAL) != 0) return true;
+      return this->is_environment_global(Name);
+   }
+
+   [[nodiscard]] StaticBindingID allocate_binding_id()
+   {
+      StaticBindingID result = this->next_binding_id_;
+      ++this->next_binding_id_;
+      return result;
+   }
+
+   AssignmentBinding prepare_declaration(Identifier &Name)
+   {
+      AssignmentBinding binding;
+      binding.name = Name.symbol;
+      binding.function_depth = this->function_depth_;
+      if (Name.symbol and not Name.is_blank) {
+         binding.binding_id = this->allocate_binding_id();
+         Name.binding_id = binding.binding_id;
+      }
+      else Name.binding_id = {};
+      return binding;
+   }
+
+   void publish_declaration(AssignmentBinding Binding)
+   {
+      if (Binding.name and Binding.binding_id) this->scopes_.back().bindings.push_back(std::move(Binding));
+   }
+
+   void declare(Identifier &Name)
+   {
+      this->publish_declaration(this->prepare_declaration(Name));
+   }
+
+   void resolve_reference(NameRef &Reference)
+   {
+      const AssignmentBinding *binding = this->find_binding(Reference.identifier.symbol);
+      Reference.binding_id = binding ? binding->binding_id : StaticBindingID{};
+      Reference.identifier.binding_id = Reference.binding_id;
+   }
+
+   void resolve_identifier_target(NameRef &Reference, bool AllowsCreation,
+      std::vector<AssignmentBinding> *PendingDeclarations)
+   {
+      Reference.binding_id = {};
+      Reference.identifier.binding_id = {};
+
+      if (Reference.identifier.is_blank) {
+         Reference.assignment_resolution = AssignmentTargetResolution::Blank;
+         return;
+      }
+
+      if (const AssignmentBinding *binding = this->find_binding(Reference.identifier.symbol)) {
+         Reference.binding_id = binding->binding_id;
+         Reference.identifier.binding_id = binding->binding_id;
+         Reference.assignment_resolution = binding->function_depth IS this->function_depth_ ?
+            AssignmentTargetResolution::ExistingLocal : AssignmentTargetResolution::ExistingUpvalue;
+         return;
+      }
+
+      if (this->is_existing_global(Reference.identifier.symbol)) {
+         Reference.assignment_resolution = AssignmentTargetResolution::ExistingGlobal;
+         return;
+      }
+
+      if (AllowsCreation and PendingDeclarations) {
+         AssignmentBinding binding = this->prepare_declaration(Reference.identifier);
+         Reference.binding_id = binding.binding_id;
+         Reference.assignment_resolution = AssignmentTargetResolution::NewLocal;
+         PendingDeclarations->push_back(std::move(binding));
+         return;
+      }
+
+      Reference.assignment_resolution = AssignmentTargetResolution::Invalid;
+   }
+
+   void resolve_assignment_target(ExprNode &Target, bool AllowsCreation,
+      std::vector<AssignmentBinding> *PendingDeclarations = nullptr)
+   {
+      if (Target.kind IS AstNodeKind::IdentifierExpr) {
+         this->resolve_identifier_target(
+            std::get<NameRef>(Target.data), AllowsCreation, PendingDeclarations);
+         return;
+      }
+
+      // A member or index lvalue does not give its base identifier assignment-target semantics.  Its operands are
+      // ordinary reads and retain NameResolution for the later read/callable pipeline.
+      this->resolve_expression(Target);
+   }
+
+   void resolve_function(FunctionExprPayload &Function)
+   {
+      ++this->function_depth_;
+      this->scopes_.push_back(AssignmentScope{});
+      for (FunctionParameter &parameter : Function.parameters) this->declare(parameter.name);
+      if (Function.body) this->resolve_block(*Function.body, false);
+      this->scopes_.pop_back();
+      --this->function_depth_;
+   }
+
+   void resolve_expression(ExprNode &Expression)
+   {
+      switch (Expression.kind) {
+         case AstNodeKind::IdentifierExpr:
+            this->resolve_reference(std::get<NameRef>(Expression.data));
+            break;
+         case AstNodeKind::UnaryExpr: {
+            auto &payload = std::get<UnaryExprPayload>(Expression.data);
+            if (payload.operand) this->resolve_expression(*payload.operand);
+            break;
+         }
+         case AstNodeKind::UpdateExpr: {
+            auto &payload = std::get<UpdateExprPayload>(Expression.data);
+            if (payload.target) this->resolve_assignment_target(*payload.target, false);
+            break;
+         }
+         case AstNodeKind::TypeTestExpr: {
+            auto &payload = std::get<TypeTestExprPayload>(Expression.data);
+            if (payload.value) this->resolve_expression(*payload.value);
+            break;
+         }
+         case AstNodeKind::BinaryExpr: {
+            auto &payload = std::get<BinaryExprPayload>(Expression.data);
+            if (payload.left) this->resolve_expression(*payload.left);
+            if (payload.right) this->resolve_expression(*payload.right);
+            break;
+         }
+         case AstNodeKind::ComparisonChainExpr:
+            for (auto &operand : std::get<ComparisonChainExprPayload>(Expression.data).operands) {
+               if (operand) this->resolve_expression(*operand);
+            }
+            break;
+         case AstNodeKind::TernaryExpr: {
+            auto &payload = std::get<TernaryExprPayload>(Expression.data);
+            if (payload.condition) this->resolve_expression(*payload.condition);
+            if (payload.if_true) this->resolve_expression(*payload.if_true);
+            if (payload.if_false) this->resolve_expression(*payload.if_false);
+            break;
+         }
+         case AstNodeKind::PresenceExpr: {
+            auto &payload = std::get<PresenceExprPayload>(Expression.data);
+            if (payload.value) this->resolve_expression(*payload.value);
+            break;
+         }
+         case AstNodeKind::PipeExpr: {
+            auto &payload = std::get<PipeExprPayload>(Expression.data);
+            if (payload.lhs) this->resolve_expression(*payload.lhs);
+            if (payload.rhs_call) this->resolve_expression(*payload.rhs_call);
+            break;
+         }
+         case AstNodeKind::CallExpr:
+         case AstNodeKind::SafeCallExpr: {
+            auto &payload = std::get<CallExprPayload>(Expression.data);
+            if (auto *direct = std::get_if<DirectCallTarget>(&payload.target)) {
+               if (direct->callable) this->resolve_expression(*direct->callable);
+            }
+            for (auto &argument : payload.arguments) if (argument) this->resolve_expression(*argument);
+            break;
+         }
+         case AstNodeKind::MemberExpr: {
+            auto &payload = std::get<MemberExprPayload>(Expression.data);
+            if (payload.table) this->resolve_expression(*payload.table);
+            break;
+         }
+         case AstNodeKind::IndexExpr: {
+            auto &payload = std::get<IndexExprPayload>(Expression.data);
+            if (payload.table) this->resolve_expression(*payload.table);
+            if (payload.index) this->resolve_expression(*payload.index);
+            break;
+         }
+         case AstNodeKind::SafeMemberExpr: {
+            auto &payload = std::get<SafeMemberExprPayload>(Expression.data);
+            if (payload.table) this->resolve_expression(*payload.table);
+            break;
+         }
+         case AstNodeKind::SafeIndexExpr: {
+            auto &payload = std::get<SafeIndexExprPayload>(Expression.data);
+            if (payload.table) this->resolve_expression(*payload.table);
+            if (payload.index) this->resolve_expression(*payload.index);
+            break;
+         }
+         case AstNodeKind::ResultFilterExpr: {
+            auto &payload = std::get<ResultFilterPayload>(Expression.data);
+            if (payload.expression) this->resolve_expression(*payload.expression);
+            break;
+         }
+         case AstNodeKind::TableExpr:
+            for (auto &field : std::get<TableExprPayload>(Expression.data).fields) {
+               if (field.key) this->resolve_expression(*field.key);
+               if (field.value) this->resolve_expression(*field.value);
+            }
+            break;
+         case AstNodeKind::FunctionExpr:
+            this->resolve_function(std::get<FunctionExprPayload>(Expression.data));
+            break;
+         case AstNodeKind::DeferredExpr: {
+            auto &payload = std::get<DeferredExprPayload>(Expression.data);
+            if (payload.inner) this->resolve_expression(*payload.inner);
+            break;
+         }
+         case AstNodeKind::RangeExpr: {
+            auto &payload = std::get<RangeExprPayload>(Expression.data);
+            if (payload.start) this->resolve_expression(*payload.start);
+            if (payload.stop) this->resolve_expression(*payload.stop);
+            if (payload.step) this->resolve_expression(*payload.step);
+            break;
+         }
+         case AstNodeKind::ChooseExpr: {
+            auto &payload = std::get<ChooseExprPayload>(Expression.data);
+            if (payload.scrutinee) this->resolve_expression(*payload.scrutinee);
+            for (auto &item : payload.scrutinee_tuple) if (item) this->resolve_expression(*item);
+            for (auto &choice : payload.cases) {
+               if (choice.pattern) this->resolve_expression(*choice.pattern);
+               for (auto &item : choice.tuple_patterns) if (item) this->resolve_expression(*item);
+               if (choice.guard) this->resolve_expression(*choice.guard);
+               if (choice.result) this->resolve_expression(*choice.result);
+               if (choice.result_stmt) this->resolve_statement(*choice.result_stmt);
+            }
+            break;
+         }
+         default:
+            break;
+      }
+   }
+
+   void resolve_assignment(AssignmentStmtPayload &Payload)
+   {
+      // Assignment expressions execute against the pre-assignment scope.  Resolve every RHS and lvalue operand before
+      // publishing any implicit local so sibling targets cannot affect one another.
+      for (auto &value : Payload.values) if (value) this->resolve_expression(*value);
+
+      bool allows_creation = Payload.op IS AssignmentOperator::Plain or
+         Payload.op IS AssignmentOperator::IfEmpty or Payload.op IS AssignmentOperator::IfNil;
+      std::vector<AssignmentBinding> pending;
+      pending.reserve(Payload.targets.size());
+      for (auto &target : Payload.targets) {
+         if (target) this->resolve_assignment_target(*target, allows_creation, &pending);
+      }
+      for (AssignmentBinding &binding : pending) this->publish_declaration(std::move(binding));
+   }
+
+   void resolve_block(BlockStmt &Block, bool NewScope = true)
+   {
+      if (NewScope) this->scopes_.push_back(AssignmentScope{});
+      for (auto &statement : Block.statements) if (statement) this->resolve_statement(*statement);
+      if (NewScope) this->scopes_.pop_back();
+   }
+
+   void resolve_statement(StmtNode &Statement)
+   {
+      switch (Statement.kind) {
+         case AstNodeKind::LocalDeclStmt: {
+            auto &payload = std::get<LocalDeclStmtPayload>(Statement.data);
+            for (auto &value : payload.values) if (value) this->resolve_expression(*value);
+            std::vector<AssignmentBinding> pending;
+            pending.reserve(payload.names.size());
+            for (Identifier &name : payload.names) pending.push_back(this->prepare_declaration(name));
+            for (AssignmentBinding &binding : pending) this->publish_declaration(std::move(binding));
+            break;
+         }
+         case AstNodeKind::AssignmentStmt:
+            this->resolve_assignment(std::get<AssignmentStmtPayload>(Statement.data));
+            break;
+         case AstNodeKind::GlobalDeclStmt: {
+            auto &payload = std::get<GlobalDeclStmtPayload>(Statement.data);
+            for (auto &value : payload.values) if (value) this->resolve_expression(*value);
+            for (Identifier &name : payload.names) if (name.symbol) this->global_names_.push_back(name.symbol);
+            break;
+         }
+         case AstNodeKind::ExternStmt:
+            for (Identifier &name : std::get<ExternDeclStmtPayload>(Statement.data).names) {
+               if (name.symbol) this->global_names_.push_back(name.symbol);
+            }
+            break;
+         case AstNodeKind::LocalFunctionStmt: {
+            auto &payload = std::get<LocalFunctionStmtPayload>(Statement.data);
+            this->declare(payload.name);
+            if (payload.function) this->resolve_function(*payload.function);
+            break;
+         }
+         case AstNodeKind::FunctionStmt: {
+            auto &payload = std::get<FunctionStmtPayload>(Statement.data);
+            bool local = not payload.name.is_explicit_global and payload.name.segments.size() IS 1;
+            if (local) this->declare(payload.name.segments.front());
+            else if (payload.name.is_explicit_global and not payload.name.segments.empty() and
+                     payload.name.segments.front().symbol) {
+               this->global_names_.push_back(payload.name.segments.front().symbol);
+            }
+            else if (not payload.name.segments.empty()) {
+               const AssignmentBinding *binding = this->find_binding(payload.name.segments.front().symbol);
+               payload.name.segments.front().binding_id = binding ? binding->binding_id : StaticBindingID{};
+            }
+            if (payload.function) this->resolve_function(*payload.function);
+            break;
+         }
+         case AstNodeKind::IfStmt:
+            for (auto &clause : std::get<IfStmtPayload>(Statement.data).clauses) {
+               if (clause.condition) this->resolve_expression(*clause.condition);
+               if (clause.block) this->resolve_block(*clause.block);
+            }
+            break;
+         case AstNodeKind::WhileStmt: {
+            auto &payload = std::get<LoopStmtPayload>(Statement.data);
+            if (payload.condition) this->resolve_expression(*payload.condition);
+            if (payload.body) this->resolve_block(*payload.body);
+            break;
+         }
+         case AstNodeKind::RepeatStmt: {
+            auto &payload = std::get<LoopStmtPayload>(Statement.data);
+            this->scopes_.push_back(AssignmentScope{});
+            if (payload.body) this->resolve_block(*payload.body, false);
+            if (payload.condition) this->resolve_expression(*payload.condition);
+            this->scopes_.pop_back();
+            break;
+         }
+         case AstNodeKind::NumericForStmt: {
+            auto &payload = std::get<NumericForStmtPayload>(Statement.data);
+            if (payload.start) this->resolve_expression(*payload.start);
+            if (payload.stop) this->resolve_expression(*payload.stop);
+            if (payload.step) this->resolve_expression(*payload.step);
+            this->scopes_.push_back(AssignmentScope{});
+            this->declare(payload.control);
+            if (payload.body) this->resolve_block(*payload.body, false);
+            this->scopes_.pop_back();
+            break;
+         }
+         case AstNodeKind::RangeForStmt: {
+            auto &payload = std::get<RangeForStmtPayload>(Statement.data);
+            if (payload.start) this->resolve_expression(*payload.start);
+            if (payload.stop) this->resolve_expression(*payload.stop);
+            if (payload.step) this->resolve_expression(*payload.step);
+            this->scopes_.push_back(AssignmentScope{});
+            this->declare(payload.control);
+            if (payload.body) this->resolve_block(*payload.body, false);
+            this->scopes_.pop_back();
+            break;
+         }
+         case AstNodeKind::GenericForStmt: {
+            auto &payload = std::get<GenericForStmtPayload>(Statement.data);
+            for (auto &iterator : payload.iterators) if (iterator) this->resolve_expression(*iterator);
+            this->scopes_.push_back(AssignmentScope{});
+            for (Identifier &name : payload.names) this->declare(name);
+            if (payload.body) this->resolve_block(*payload.body, false);
+            this->scopes_.pop_back();
+            break;
+         }
+         case AstNodeKind::ReturnStmt:
+            for (auto &value : std::get<ReturnStmtPayload>(Statement.data).values) {
+               if (value) this->resolve_expression(*value);
+            }
+            break;
+         case AstNodeKind::DeferStmt: {
+            auto &payload = std::get<DeferStmtPayload>(Statement.data);
+            if (payload.callable) this->resolve_function(*payload.callable);
+            for (auto &argument : payload.arguments) if (argument) this->resolve_expression(*argument);
+            break;
+         }
+         case AstNodeKind::DoStmt: {
+            auto &payload = std::get<DoStmtPayload>(Statement.data);
+            if (payload.block) this->resolve_block(*payload.block);
+            break;
+         }
+         case AstNodeKind::ContextStmt: {
+            auto &payload = std::get<ContextStmtPayload>(Statement.data);
+            if (payload.reference) this->resolve_expression(*payload.reference);
+            if (payload.block) this->resolve_block(*payload.block);
+            break;
+         }
+         case AstNodeKind::ConditionalShorthandStmt: {
+            auto &payload = std::get<ConditionalShorthandStmtPayload>(Statement.data);
+            if (payload.condition) this->resolve_expression(*payload.condition);
+            if (payload.body) this->resolve_statement(*payload.body);
+            break;
+         }
+         case AstNodeKind::TryExceptStmt: {
+            auto &payload = std::get<TryExceptPayload>(Statement.data);
+            if (payload.try_block) this->resolve_block(*payload.try_block);
+            for (ExceptClause &clause : payload.except_clauses) {
+               for (auto &code : clause.filter_codes) if (code) this->resolve_expression(*code);
+               this->scopes_.push_back(AssignmentScope{});
+               if (clause.exception_var) this->declare(*clause.exception_var);
+               if (clause.block) this->resolve_block(*clause.block, false);
+               this->scopes_.pop_back();
+            }
+            if (payload.success_block) this->resolve_block(*payload.success_block);
+            break;
+         }
+         case AstNodeKind::CheckallStmt: {
+            auto &payload = std::get<CheckallStmtPayload>(Statement.data);
+            if (payload.block) this->resolve_block(*payload.block);
+            break;
+         }
+         case AstNodeKind::RaiseStmt: {
+            auto &payload = std::get<RaiseStmtPayload>(Statement.data);
+            if (payload.error_code) this->resolve_expression(*payload.error_code);
+            if (payload.message) this->resolve_expression(*payload.message);
+            break;
+         }
+         case AstNodeKind::CheckStmt: {
+            auto &payload = std::get<CheckStmtPayload>(Statement.data);
+            if (payload.error_code) this->resolve_expression(*payload.error_code);
+            break;
+         }
+         case AstNodeKind::ImportStmt:
+            for (ImportEntryPayload &entry : std::get<ImportStmtPayload>(Statement.data).entries) {
+               if (entry.inlined_body) this->resolve_block(*entry.inlined_body);
+               if (entry.namespace_name) this->declare(*entry.namespace_name);
+            }
+            break;
+         case AstNodeKind::WithStmt: {
+            auto &payload = std::get<WithStmtPayload>(Statement.data);
+            for (auto &object : payload.objects) if (object) this->resolve_expression(*object);
+            if (payload.block) this->resolve_block(*payload.block);
+            break;
+         }
+         case AstNodeKind::ExpressionStmt: {
+            auto &payload = std::get<ExpressionStmtPayload>(Statement.data);
+            if (payload.expression) this->resolve_expression(*payload.expression);
+            break;
+         }
+         default:
+            break;
+      }
+   }
+
+   ParserContext &context_;
+   std::vector<AssignmentScope> scopes_;
+   std::vector<GCstr *> global_names_;
+   StaticBindingID next_binding_id_{ 1 };
+   uint16_t function_depth_ = 0;
+};
+
+} // namespace
+
+void resolve_assignment_targets(ParserContext &Context, BlockStmt &Module)
+{
+   AssignmentTargetResolver(Context).resolve(Module);
+}

--- a/src/tiri/jit/src/parser/assignment_target_resolution.cpp
+++ b/src/tiri/jit/src/parser/assignment_target_resolution.cpp
@@ -305,7 +305,7 @@ private:
    void resolve_assignment(AssignmentStmtPayload &Payload)
    {
       // Assignment expressions execute against the pre-assignment scope.  Resolve every RHS and lvalue operand before
-      // publishing any implicit local so sibling targets cannot affect one another.
+      // publishing any new local so sibling targets cannot affect one another.
       for (auto &value : Payload.values) if (value) this->resolve_expression(*value);
 
       bool allows_creation = Payload.op IS AssignmentOperator::Plain or

--- a/src/tiri/jit/src/parser/assignment_target_resolution.cpp
+++ b/src/tiri/jit/src/parser/assignment_target_resolution.cpp
@@ -169,12 +169,14 @@ private:
 
    void resolve_function(FunctionExprPayload &Function)
    {
+      const size_t inherited_global_count = this->global_names_.size();
       ++this->function_depth_;
       this->scopes_.push_back(AssignmentScope{});
       for (FunctionParameter &parameter : Function.parameters) this->declare(parameter.name);
       if (Function.body) this->resolve_block(*Function.body, false);
       this->scopes_.pop_back();
       --this->function_depth_;
+      this->global_names_.resize(inherited_global_count);
    }
 
    void resolve_expression(ExprNode &Expression)

--- a/src/tiri/jit/src/parser/assignment_target_resolution.h
+++ b/src/tiri/jit/src/parser/assignment_target_resolution.h
@@ -1,0 +1,6 @@
+#pragma once
+
+class ParserContext;
+struct BlockStmt;
+
+void resolve_assignment_targets(ParserContext &, BlockStmt &);

--- a/src/tiri/jit/src/parser/ast/annotations.cpp
+++ b/src/tiri/jit/src/parser/ast/annotations.cpp
@@ -228,7 +228,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_annotated_statement()
       stmt = std::move(result.value_ref());
    }
    else if (current.kind() IS TokenKind::Local) {
-      auto result = this->parse_local();
+      auto result = this->parse_explicit_local_declaration();
       if (not result.ok()) return result;
       stmt = std::move(result.value_ref());
    }

--- a/src/tiri/jit/src/parser/ast/builder.cpp
+++ b/src/tiri/jit/src/parser/ast/builder.cpp
@@ -809,11 +809,10 @@ ParserResult<std::unique_ptr<BlockStmt>> AstBuilder::parse_block(std::span<const
 }
 
 //********************************************************************************************************************
-// Check if any identifier in a comma-separated name list has a type annotation or recognised declaration attribute.
-// Patterns: `name:type`, `name <attr>`, `name, name:type`, `name, name <attr>`
-// Returns true if this looks like an implicit local declaration.
+// Checks whether a bare comma-separated name list contains a type annotation or recognised declaration attribute.
+// Patterns: `name:type`, `name <attr>`, `name, name:type`, `name, name <attr>`.
 
-static bool is_implicit_local_declaration(TokenStreamAdapter &Tokens)
+static bool starts_bare_annotated_name_list(TokenStreamAdapter &Tokens)
 {
    if (Tokens.current().kind() != TokenKind::Identifier) return false;
 
@@ -866,7 +865,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_statement()
 
    switch (current.kind()) {
       case TokenKind::Annotate:      return this->parse_annotated_statement();
-      case TokenKind::Local:         return this->parse_local();
+      case TokenKind::Local:         return this->parse_explicit_local_declaration();
       case TokenKind::Global:        return this->parse_global();
       case TokenKind::ExternToken:   return this->parse_extern();
       case TokenKind::Enum:          return this->parse_enum(current);
@@ -910,9 +909,10 @@ ParserResult<StmtNodePtr> AstBuilder::parse_statement()
             }
          }
 
-         // A type annotation or declaration attribute does not change Tiri's local-by-default assignment semantics.
-         if (is_implicit_local_declaration(this->ctx.tokens())) {
-            return this->parse_local();
+         // This is syntax routing only.  Assignment target resolution decides whether a bare typed assignment creates
+         // a local or writes existing storage.  Declaration attributes retain their legacy declaration AST path.
+         if (starts_bare_annotated_name_list(this->ctx.tokens())) {
+            return this->parse_bare_annotated_assignment();
          }
          return this->parse_expression_stmt();
       }

--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -126,7 +126,9 @@ private:
 
    [[nodiscard]] ParserResult<std::unique_ptr<BlockStmt>> parse_block(std::span<const TokenKind> terminators);
    ParserResult<StmtNodePtr> parse_statement();
-   ParserResult<StmtNodePtr> parse_local();
+   ParserResult<StmtNodePtr> parse_explicit_local_declaration();
+   ParserResult<StmtNodePtr> parse_bare_annotated_assignment();
+   ParserResult<StmtNodePtr> parse_local_name_list(const Token &StartToken, bool BareAnnotatedSyntax);
    ParserResult<StmtNodePtr> parse_global();
    ParserResult<StmtNodePtr> parse_extern();
    ParserResult<StmtNodePtr> parse_enum(const Token &StartToken);

--- a/src/tiri/jit/src/parser/ast/nodes.cpp
+++ b/src/tiri/jit/src/parser/ast/nodes.cpp
@@ -619,6 +619,29 @@ ImportStmtPayload::~ImportStmtPayload() = default;
 WithStmtPayload::~WithStmtPayload() = default;
 BlockStmt::~BlockStmt() = default;
 
+//********************************************************************************************************************
+
+bool assignment_target_is_existing_lexical(AssignmentTargetResolution Resolution) noexcept
+{
+   return Resolution IS AssignmentTargetResolution::ExistingLocal or
+      Resolution IS AssignmentTargetResolution::ExistingUpvalue;
+}
+
+//********************************************************************************************************************
+
+bool assignment_target_is_existing_storage(AssignmentTargetResolution Resolution) noexcept
+{
+   return assignment_target_is_existing_lexical(Resolution) or
+      Resolution IS AssignmentTargetResolution::ExistingGlobal;
+}
+
+//********************************************************************************************************************
+
+bool assignment_target_creates_local(AssignmentTargetResolution Resolution) noexcept
+{
+   return Resolution IS AssignmentTargetResolution::NewLocal;
+}
+
 ExprNodePtr make_literal_expr(SourceSpan Span, const LiteralValue &Literal)
 {
    ExprNodePtr node = std::make_unique<ExprNode>();

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -187,6 +187,20 @@ enum class NameResolution : uint8_t {
    BuiltinCallable
 };
 
+enum class AssignmentTargetResolution : uint8_t {
+   Unresolved,
+   Blank,
+   ExistingLocal,
+   ExistingUpvalue,
+   ExistingGlobal,
+   NewLocal,
+   Invalid
+};
+
+[[nodiscard]] bool assignment_target_is_existing_lexical(AssignmentTargetResolution Resolution) noexcept;
+[[nodiscard]] bool assignment_target_is_existing_storage(AssignmentTargetResolution Resolution) noexcept;
+[[nodiscard]] bool assignment_target_creates_local(AssignmentTargetResolution Resolution) noexcept;
+
 enum class TableFieldKind : uint8_t {
    Array,
    Record,
@@ -274,6 +288,7 @@ struct Identifier {
 struct NameRef {
    Identifier identifier;
    NameResolution resolution = NameResolution::Unresolved;
+   AssignmentTargetResolution assignment_resolution = AssignmentTargetResolution::Unresolved;
    uint16_t slot = 0;
    mutable StaticBindingID binding_id{};
 };

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -10,50 +10,63 @@
 // - Expression statements
 
 //********************************************************************************************************************
-// Parses local variable declarations, local function statements and local thunk function statements.
-// Supports both explicit 'local' keyword and implicit local declarations with declaration attributes.
+// Parses an explicit local variable declaration, local function statement, or local thunk function statement.
 
-ParserResult<StmtNodePtr> AstBuilder::parse_local()
+ParserResult<StmtNodePtr> AstBuilder::parse_explicit_local_declaration()
 {
    Token local_token = this->ctx.tokens().current();
-   bool implicit_local = (local_token.kind() IS TokenKind::Identifier);
+   this->ctx.tokens().advance();  // Consume the 'local' keyword
 
-   if (not implicit_local) {
-      this->ctx.tokens().advance();  // Consume the 'local' keyword
-
-      if (this->ctx.check(TokenKind::Enum)) {
-         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-            "Local enum declarations are not supported");
-      }
-
-      bool is_thunk = false;
-      if (this->ctx.check(TokenKind::ThunkToken)) {
-         is_thunk = true;
-         this->ctx.tokens().advance();
-      }
-
-      if (this->ctx.check(TokenKind::Function) or is_thunk) {
-         if (not is_thunk) {
-            this->ctx.tokens().advance();
-         }
-         Token function_token = local_token;  // Use local_token as span start
-         auto name_token = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
-         if (not name_token.ok()) return ParserResult<StmtNodePtr>::failure(name_token.error_ref());
-         if (this->is_module_namespace_name(name_token.value_ref().identifier())) {
-            return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, name_token.value_ref(),
-               "Module namespaces cannot be declared as functions");
-         }
-         GCstr *funcname = name_token.value_ref().identifier();
-         auto fn = this->parse_function_literal(function_token, is_thunk, funcname);
-         if (not fn.ok()) return ParserResult<StmtNodePtr>::failure(fn.error_ref());
-         ExprNodePtr function_expr = std::move(fn.value_ref());
-         auto stmt = std::make_unique<StmtNode>(AstNodeKind::LocalFunctionStmt, this->span_from(local_token, name_token.value_ref()));
-         LocalFunctionStmtPayload payload(make_identifier(name_token.value_ref()), move_function_payload(function_expr));
-         stmt->data = std::move(payload);
-         return ParserResult<StmtNodePtr>::success(std::move(stmt));
-      }
+   if (this->ctx.check(TokenKind::Enum)) {
+      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
+         "Local enum declarations are not supported");
    }
 
+   bool is_thunk = false;
+   if (this->ctx.check(TokenKind::ThunkToken)) {
+      is_thunk = true;
+      this->ctx.tokens().advance();
+   }
+
+   if (this->ctx.check(TokenKind::Function) or is_thunk) {
+      if (not is_thunk) {
+         this->ctx.tokens().advance();
+      }
+      Token function_token = local_token;  // Use local_token as span start
+      auto name_token = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
+      if (not name_token.ok()) return ParserResult<StmtNodePtr>::failure(name_token.error_ref());
+      if (this->is_module_namespace_name(name_token.value_ref().identifier())) {
+         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, name_token.value_ref(),
+            "Module namespaces cannot be declared as functions");
+      }
+      GCstr *funcname = name_token.value_ref().identifier();
+      auto fn = this->parse_function_literal(function_token, is_thunk, funcname);
+      if (not fn.ok()) return ParserResult<StmtNodePtr>::failure(fn.error_ref());
+      ExprNodePtr function_expr = std::move(fn.value_ref());
+      auto stmt = std::make_unique<StmtNode>(AstNodeKind::LocalFunctionStmt,
+         this->span_from(local_token, name_token.value_ref()));
+      LocalFunctionStmtPayload payload(make_identifier(name_token.value_ref()), move_function_payload(function_expr));
+      stmt->data = std::move(payload);
+      return ParserResult<StmtNodePtr>::success(std::move(stmt));
+   }
+
+   return this->parse_local_name_list(local_token, false);
+}
+
+//********************************************************************************************************************
+// Parses a bare annotated name list.  Type-only syntax produces an assignment; declaration attributes retain the
+// legacy LocalDeclStmt representation and diagnostics.
+
+ParserResult<StmtNodePtr> AstBuilder::parse_bare_annotated_assignment()
+{
+   return this->parse_local_name_list(this->ctx.tokens().current(), true);
+}
+
+//********************************************************************************************************************
+// Parses the name list and optional initialiser shared by explicit locals and bare annotated syntax.
+
+ParserResult<StmtNodePtr> AstBuilder::parse_local_name_list(const Token &StartToken, bool BareAnnotatedSyntax)
+{
    auto names = this->parse_name_list();
    if (not names.ok()) return ParserResult<StmtNodePtr>::failure(names.error_ref());
 
@@ -130,7 +143,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_local()
       }
    }
 
-   if (implicit_local) {
+   if (BareAnnotatedSyntax) {
       bool has_declaration_attribute = std::ranges::any_of(name_list, [](const Identifier &Identifier) {
          return Identifier.has_close or Identifier.has_const or Identifier.has_view;
       });
@@ -144,13 +157,13 @@ ParserResult<StmtNodePtr> AstBuilder::parse_local()
             targets.push_back(make_identifier_expr(reference.identifier.span, reference));
          }
          return ParserResult<StmtNodePtr>::success(
-            make_assignment_stmt(local_token.span(), assign_op, std::move(targets), std::move(values)));
+            make_assignment_stmt(StartToken.span(), assign_op, std::move(targets), std::move(values)));
       }
    }
 
-   auto stmt = std::make_unique<StmtNode>(AstNodeKind::LocalDeclStmt, local_token.span());
+   auto stmt = std::make_unique<StmtNode>(AstNodeKind::LocalDeclStmt, StartToken.span());
    stmt->data.emplace<LocalDeclStmtPayload>(assign_op, std::move(name_list), std::move(values));
-   std::get<LocalDeclStmtPayload>(stmt->data).implicit_declaration = implicit_local;
+   std::get<LocalDeclStmtPayload>(stmt->data).implicit_declaration = BareAnnotatedSyntax;
    return ParserResult<StmtNodePtr>::success(std::move(stmt));
 }
 

--- a/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
@@ -350,9 +350,11 @@ ParserResult<IrEmitUnit> IrEmitter::emit_plain_assignment(std::vector<PreparedAs
       for (BCReg i = BCReg(0); i < nvars; ++i) {
          PreparedAssignment& target = targets[i.raw()];
          if (target.pending_symbol) {
+            VarInfo *info = &this->func_state.var_get((base + i).raw());
+            info->binding_id = target.binding_id;
             this->update_local_binding(target.pending_symbol, base + i);
 
-            if (i.raw() < values.size()) {
+            if (not this->apply_analysed_local_type(base + i, target.binding_id) and i.raw() < values.size()) {
                this->apply_inferred_local_type(base + i, *values[i.raw()]);
             }
          }
@@ -815,27 +817,6 @@ ParserResult<std::vector<PreparedAssignment>> IrEmitter::prepare_assignment_targ
             std::format("cannot override built-in '{}'",
                std::string_view(strdata(protected_name), protected_name->len)),
             node->span));
-      }
-
-      // A plain identifier target naming a host pre-registered global is an override unless an explicit
-      // local shadow is in scope.  Member and index stores (math.foo = 1) remain legal table mutations.
-
-      if (node->kind IS AstNodeKind::IdentifierExpr) {
-         if (const auto *name_ref = std::get_if<NameRef>(&node->data)) {
-            GCstr *symbol = name_ref->identifier.symbol;
-            if (symbol and not name_ref->identifier.is_blank and
-                ((symbol->flags & STRFLAG_PROTECTED_GLOBAL) != 0)) {
-               ExpDesc resolved;
-               this->lex_state.var_lookup_symbol(symbol, &resolved);
-               if (resolved.k != ExpKind::Local and resolved.k != ExpKind::Upval) {
-                  return ParserResult<std::vector<PreparedAssignment>>::failure(this->make_error(
-                     ParserErrorCode::OverrideProtectedGlobal,
-                     std::format("cannot override built-in '{}'",
-                        std::string_view(strdata(symbol), symbol->len)),
-                     node->span));
-               }
-            }
-         }
       }
 
       PreparedAssignment prepared;

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -106,6 +106,7 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
 
    // Inherit declared globals from parent so nested functions recognize them
    child_state.declared_globals = parent_state->declared_globals;
+   child_state.const_globals = parent_state->const_globals;
    child_state.external_symbols = parent_state->external_symbols;
 
    // Set linedefined to the earliest line that bytecode might reference.
@@ -394,7 +395,100 @@ ParserResult<ExpDesc> IrEmitter::emit_function_lvalue(const FunctionNamePath &pa
 // AllocNewLocal must be false when dealing with update operators like compound assignments (+=, -=) and (++, --)
 // where the variable must already exist.
 
-ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool AllocNewLocal, ControlFlowEdge* SafeNavSkip)
+ParserResult<ExpDesc> IrEmitter::emit_assignment_identifier(const NameRef &Reference, bool AllocNewLocal)
+{
+   const Identifier &identifier = Reference.identifier;
+   AssignmentTargetResolution category = Reference.assignment_resolution;
+   auto invariant = [&](std::string_view Message) {
+      return ParserResult<ExpDesc>::failure(
+         this->make_error(ParserErrorCode::InternalInvariant, Message, identifier.span));
+   };
+
+   if (category IS AssignmentTargetResolution::Unresolved) {
+      return invariant("assignment target reached IR emission without semantic resolution");
+   }
+
+   if (category IS AssignmentTargetResolution::Blank) {
+      if (not identifier.is_blank) return invariant("blank assignment category disagrees with its identifier");
+      ExpDesc blank;
+      blank.init(ExpKind::Global, 0);
+      blank.u.sval = NAME_BLANK;
+      return ParserResult<ExpDesc>::success(blank);
+   }
+
+   if (not identifier.symbol or identifier.is_blank) {
+      return invariant("resolved assignment category has no usable identifier");
+   }
+
+   if (assignment_target_is_existing_lexical(category)) {
+      ExpDesc resolved;
+      MSize variable_index = this->lex_state.var_lookup_symbol(identifier.symbol, &resolved);
+      ExpKind expected = category IS AssignmentTargetResolution::ExistingLocal ?
+         ExpKind::Local : ExpKind::Upval;
+      bool valid_binding = variable_index != MSize(-1) and Reference.binding_id and
+         identifier.binding_id IS Reference.binding_id and resolved.k IS expected and
+         this->lex_state.vstack[variable_index].binding_id IS Reference.binding_id;
+      if (not valid_binding) {
+         return invariant("lexical assignment target disagrees with its emitted binding");
+      }
+      if (resolved.k IS ExpKind::Local) resolved.u.s.aux = this->func_state.varmap[resolved.u.s.info];
+      return ParserResult<ExpDesc>::success(resolved);
+   }
+
+   if (category IS AssignmentTargetResolution::ExistingGlobal) {
+      if (Reference.binding_id or identifier.binding_id) {
+         return invariant("global assignment target unexpectedly has a lexical binding");
+      }
+      if ((identifier.symbol->flags & STRFLAG_PROTECTED_GLOBAL) != 0) {
+         return ParserResult<ExpDesc>::failure(this->make_error(ParserErrorCode::OverrideProtectedGlobal,
+            std::format("cannot override built-in '{}'",
+               std::string_view(strdata(identifier.symbol), identifier.symbol->len)), identifier.span));
+      }
+      if (lookup_constant(identifier.symbol) or this->func_state.const_globals.contains(identifier.symbol)) {
+         return ParserResult<ExpDesc>::failure(this->make_error(ParserErrorCode::AssignToConstant,
+            std::format("cannot assign to constant '{}'",
+               std::string_view(strdata(identifier.symbol), identifier.symbol->len)), identifier.span));
+      }
+
+      ExpDesc global;
+      global.init(ExpKind::Global, 0);
+      global.u.sval = identifier.symbol;
+      if (auto hint = this->lex_state.global_type_hints.find(identifier.symbol);
+          hint != this->lex_state.global_type_hints.end()) {
+         global.result_type = hint->second.primary;
+         global.object_class_id = hint->second.object_class_id;
+         global.struct_def = hint->second.struct_def;
+      }
+      return ParserResult<ExpDesc>::success(global);
+   }
+
+   if (category IS AssignmentTargetResolution::NewLocal) {
+      bool valid_binding = AllocNewLocal and Reference.binding_id and
+         identifier.binding_id IS Reference.binding_id and
+         Reference.binding_id.raw() < this->ctx.descriptors().binding_count();
+      if (valid_binding) {
+         valid_binding = this->ctx.descriptors().binding(Reference.binding_id).name IS identifier.symbol;
+      }
+
+      ExpDesc resolved;
+      this->lex_state.var_lookup_symbol(identifier.symbol, &resolved);
+      if (not valid_binding or resolved.k != ExpKind::Unscoped) {
+         return invariant("new-local assignment target disagrees with emitted storage");
+      }
+      return ParserResult<ExpDesc>::success(resolved);
+   }
+
+   if (category IS AssignmentTargetResolution::Invalid) {
+      std::string name(strdata(identifier.symbol), identifier.symbol->len);
+      return ParserResult<ExpDesc>::failure(this->make_error(ParserErrorCode::UndefinedVariable,
+         std::format("cannot use compound/update operator on undeclared variable '{}'", name), identifier.span));
+   }
+
+   return invariant("assignment target has an unknown semantic category");
+}
+
+ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(
+   const ExprNode &Expr, bool AllocNewLocal, ControlFlowEdge* SafeNavSkip, bool UseAssignmentResolution)
 {
    auto append_safe_nav_skip = [&](BCPos SkipPos) {
       if (not SafeNavSkip) return;
@@ -405,51 +499,12 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
    switch (Expr.kind) {
       case AstNodeKind::IdentifierExpr: {
          const NameRef& name_ref = std::get<NameRef>(Expr.data);
+         if (UseAssignmentResolution) return this->emit_assignment_identifier(name_ref, AllocNewLocal);
 
-         // Blank identifiers (_) are treated specially - they discard values
-         if (name_ref.identifier.is_blank) {
-            ExpDesc blank_expr;
-            blank_expr.init(ExpKind::Global, 0);
-            blank_expr.u.sval = NAME_BLANK;
-            return ParserResult<ExpDesc>::success(blank_expr);
-         }
-
-         // Registered constants are immutable unless this target resolves to an explicit local/upvalue shadow.
-         ExpDesc resolved;
-         this->lex_state.var_lookup_symbol(name_ref.identifier.symbol, &resolved);
-         if (lookup_constant(name_ref.identifier.symbol) and
-             resolved.k != ExpKind::Local and resolved.k != ExpKind::Upval) {
-            std::string var_name(strdata(name_ref.identifier.symbol), name_ref.identifier.symbol->len);
-            std::string msg = "cannot assign to constant '" + var_name + "'";
-            return ParserResult<ExpDesc>::failure(this->make_error(ParserErrorCode::AssignToConstant, msg));
-         }
-
-         auto result = this->emit_identifier_expr(name_ref, true);
+         auto result = this->emit_identifier_expr(name_ref, false);
          if (not result.ok()) return result;
          ExpDesc value = result.value_ref();
-         if (value.k IS ExpKind::Local) { // Local variable already exists
-            value.u.s.aux = this->func_state.varmap[value.u.s.info];
-         }
-         else if (value.k IS ExpKind::Unscoped) { // Undeclared variable used as assignment target
-            GCstr *name = value.u.sval;
-
-            // Check if this was explicitly declared as global (in this or parent scope)
-            if (this->func_state.declared_globals.count(name) > 0) {
-               value.k = ExpKind::Global;
-            }
-            else if (AllocNewLocal) {
-               // Plain assignment: return Unscoped and let prepare_assignment_targets handle
-               // the local creation with proper timing for multi-value assignments.
-               // The ExpKind::Unscoped with name will signal that a new local should be created.
-               // value is already Unscoped with name set, so just return it.
-            }
-            else { // Compound/update assignment on an undeclared variable is an error
-               std::string var_name(strdata(name), name->len);
-               std::string msg = "cannot use compound/update operator on undeclared variable '" + var_name + "'";
-               return ParserResult<ExpDesc>::failure(this->make_error(ParserErrorCode::UndefinedVariable, msg));
-            }
-         }
-         // Allow Unscoped for deferred local creation in prepare_assignment_targets
+         if (value.k IS ExpKind::Local) value.u.s.aux = this->func_state.varmap[value.u.s.info];
          if (not expkind_is_variable_like(value.k)) return this->unsupported_expr(Expr.kind, Expr.span);
          return ParserResult<ExpDesc>::success(value);
       }
@@ -459,7 +514,7 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
          if (not payload.table or not payload.member.symbol) return this->unsupported_expr(Expr.kind, Expr.span);
 
          auto table_result = SafeNavSkip
-            ? this->emit_lvalue_expr(*payload.table, false, SafeNavSkip)
+            ? this->emit_lvalue_expr(*payload.table, false, SafeNavSkip, false)
             : this->emit_expression(*payload.table);
          if (not table_result.ok()) return table_result;
          ExpDesc table = table_result.value_ref();
@@ -508,7 +563,7 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
          if (not payload.table or not payload.index) return this->unsupported_expr(Expr.kind, Expr.span);
 
          auto table_result = SafeNavSkip
-            ? this->emit_lvalue_expr(*payload.table, false, SafeNavSkip)
+            ? this->emit_lvalue_expr(*payload.table, false, SafeNavSkip, false)
             : this->emit_expression(*payload.table);
          if (not table_result.ok()) return table_result;
 
@@ -574,7 +629,7 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
          const auto &payload = std::get<SafeMemberExprPayload>(Expr.data);
          if (not payload.table or not payload.member.symbol) return this->unsupported_expr(Expr.kind, Expr.span);
 
-         auto table_result = this->emit_lvalue_expr(*payload.table, false, SafeNavSkip);
+         auto table_result = this->emit_lvalue_expr(*payload.table, false, SafeNavSkip, false);
          if (not table_result.ok()) return table_result;
          ExpDesc table = table_result.value_ref();
          StaticValueHandle receiver_descriptor = table.static_value;
@@ -627,7 +682,7 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
          const auto &payload = std::get<SafeIndexExprPayload>(Expr.data);
          if (not payload.table or not payload.index) return this->unsupported_expr(Expr.kind, Expr.span);
 
-         auto table_result = this->emit_lvalue_expr(*payload.table, false, SafeNavSkip);
+         auto table_result = this->emit_lvalue_expr(*payload.table, false, SafeNavSkip, false);
          if (not table_result.ok()) return table_result;
          ExpDesc table = table_result.value_ref();
          StaticValueHandle receiver_descriptor = table.static_value;

--- a/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
@@ -183,6 +183,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_try_except_stmt(const TryExceptPayload 
          this->lex_state.var_add(BCReg(1));
 
          exception_reg = saved_nactvar; // The exception register is the slot we just added
+         fs->var_get(exception_reg).binding_id = clause.exception_var->binding_id;
 
          // Update local binding so the variable can be referenced
          this->update_local_binding(clause.exception_var->symbol, BCReg(exception_reg));
@@ -408,6 +409,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_import_entry(const ImportEntryPayload &
       // Mark as const
       VarInfo* info = &fs->var_get(fs->varmap.size() - 1);
       info->info |= VarInfoFlag::Const;
+      info->binding_id = ns_id.binding_id;
 
       // Update binding table
       this->update_local_binding(ns_id.symbol, BCReg(fs->varmap.size() - 1));

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1182,15 +1182,25 @@ std::optional<CompileTimeValue> IrEmitter::resolve_compile_time_value(const Name
 void IrEmitter::apply_inferred_local_type(BCReg Slot, const ExprNode& Value)
 {
    InferredTypeInfo inferred = infer_expression_type_ext(Value);
+   const StaticValueDescriptor *descriptor = Value.static_value ?
+      &this->ctx.descriptors().value(Value.static_value) : nullptr;
+   bool descriptor_is_complete = descriptor and
+      (descriptor->primary != TiriType::Array or descriptor->array_element.known);
+   if (descriptor and (inferred.type IS TiriType::Unknown or inferred.type IS TiriType::Any) and
+       descriptor->primary != TiriType::Unknown and descriptor->primary != TiriType::Any and
+       descriptor_is_complete) {
+      inferred.type = descriptor->primary;
+      inferred.object_class_id = descriptor->object_class_id;
+      inferred.struct_def = descriptor->struct_def;
+   }
    if (inferred.type IS TiriType::Unknown or inferred.type IS TiriType::Any or inferred.type IS TiriType::Nil) return;
+   if (inferred.type IS TiriType::Array and not descriptor_is_complete) return;
 
    VarInfo *info = &this->func_state.var_get(Slot.raw());
    info->fixed_type = inferred.type;
    info->object_class_id = (inferred.type IS TiriType::Object) ? inferred.object_class_id : CLASSID::NIL;
    info->struct_def = inferred.struct_def;
-   if (Value.static_value) {
-      info->array_element = this->ctx.descriptors().value(Value.static_value).array_element;
-   }
+   if (descriptor) info->array_element = descriptor->array_element;
    info->static_value = Value.static_value;
    info->static_results = Value.static_results;
 }
@@ -1204,7 +1214,8 @@ bool IrEmitter::apply_analysed_local_type(BCReg Slot, StaticBindingID Binding)
 
    const auto &value = this->ctx.descriptors().value(binding.analysed_value);
    if (value.primary IS TiriType::Unknown or value.primary IS TiriType::Any or
-       value.primary IS TiriType::Nil) return false;
+       value.primary IS TiriType::Nil or
+       (value.primary IS TiriType::Array and not value.array_element.known)) return false;
 
    VarInfo *info = &this->func_state.var_get(Slot.raw());
    info->fixed_type = value.primary;
@@ -1224,12 +1235,15 @@ void IrEmitter::assert_analysed_local_type(BCReg Slot, StaticBindingID Binding) 
    if (not binding.analysed_value) return;
 
    const auto &value = this->ctx.descriptors().value(binding.analysed_value);
+   if (value.primary IS TiriType::Array and not value.array_element.known) return;
    const VarInfo &info = this->func_state.var_get(Slot.raw());
    lj_assertX(info.fixed_type IS value.primary, "analysed and emitted binding types diverged");
    lj_assertX(info.object_class_id IS value.object_class_id, "analysed and emitted binding object classes diverged");
    lj_assertX(info.struct_def IS value.struct_def, "analysed and emitted binding structures diverged");
-   lj_assertX(info.array_element IS value.array_element,
-      "analysed and emitted binding array member types diverged");
+   if (value.array_element.known) {
+      lj_assertX(info.array_element IS value.array_element,
+         "analysed and emitted binding array member types diverged");
+   }
 #endif
 }
 
@@ -2569,7 +2583,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_numeric_for_stmt(const NumericForStmtPa
       FuncScope visible_scope;
       ScopeGuard guard(fs, &visible_scope, FuncScopeFlag::None);
       this->lex_state.var_add(1);
-      fs->var_get(base.raw() + FORL_EXT).fixed_type = TiriType::Num;
+      VarInfo &control = fs->var_get(base.raw() + FORL_EXT);
+      control.fixed_type = TiriType::Num;
+      control.binding_id = Payload.control.binding_id;
+      control.static_value = Payload.control.static_value;
       RegisterAllocator allocator(fs);
       allocator.reserve(BCReg(1));
       std::array<BlockBinding, 1> loop_bindings{};
@@ -2691,7 +2708,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_range_for_stmt(const RangeForStmtPayloa
       ScopeGuard guard(fs, &visible_scope, FuncScopeFlag::None);
       this->lex_state.var_add(1);
       BCReg value_slot(base.raw() + BCREG(direct_integer ? int(FORL_EXT) : int(RANGE_FOR_VALUE)));
-      fs->var_get(value_slot.raw()).fixed_type = TiriType::Num;
+      VarInfo &control = fs->var_get(value_slot.raw());
+      control.fixed_type = TiriType::Num;
+      control.binding_id = Payload.control.binding_id;
+      control.static_value = Payload.control.static_value;
       RegisterAllocator allocator(fs);
       allocator.reserve(BCReg(1));
       if (not direct_integer) bcemit_AD(fs, BC_RANGEVAL, base, 0);
@@ -4549,6 +4569,15 @@ ParserResult<ExpDesc> IrEmitter::emit_range_expr(const RangeExprPayload &Payload
    fs->freereg = base + 1;
 
    return ParserResult<ExpDesc>::success(result);
+}
+
+//********************************************************************************************************************
+// Release an emitted expression and restore the register floor.
+
+void IrEmitter::release_expression(ExpDesc &Expression, std::string_view Usage)
+{
+   expr_free(&this->func_state, &Expression);
+   this->ensure_register_floor(Usage);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
@@ -12,10 +12,10 @@
 
 #include "../ast/nodes.h"
 #include "../constant_evaluator.h"
+#include "../parse_regalloc.h"
 #include "operator_emitter.h"
 #include "../parser_context.h"
 #include "../parse_control_flow.h"
-#include "../parse_regalloc.h"
 #include "../parse_types.h"
 
 //********************************************************************************************************************
@@ -265,7 +265,9 @@ private:
    ParserResult<IrEmitUnit> emit_annotation_registration(BCReg func_reg, const std::vector<AnnotationEntry>& annotations, GCstr* funcname);
    ParserResult<ExpDesc> emit_expression_list(const ExprNodeList& expressions, BCReg& count);
    ParserResult<ExpDesc> emit_lvalue_expr(
-      const ExprNode& expr, bool allow_new_local = true, ControlFlowEdge* safe_nav_skip = nullptr);
+      const ExprNode& expr, bool allow_new_local = true, ControlFlowEdge* safe_nav_skip = nullptr,
+      bool UseAssignmentResolution = true);
+   ParserResult<ExpDesc> emit_assignment_identifier(const NameRef &, bool AllocNewLocal);
    ParserResult<ControlFlowEdge> emit_condition_jump(const ExprNode& expr);
    ParserResult<ExpDesc> emit_function_lvalue(const FunctionNamePath& path);
    ParserResult<std::vector<PreparedAssignment>> prepare_assignment_targets(
@@ -300,7 +302,7 @@ private:
       GCstr *Symbol, BCReg Slot, std::optional<CompileTimeValue> Value = std::nullopt) {
       this->binding_table.add(Symbol, Slot, std::move(Value));
    }
-   inline void release_expression(ExpDesc &expression, std::string_view usage) { expr_free(&this->func_state, &expression); this->ensure_register_floor(usage); }
+   void release_expression(ExpDesc &Expression, std::string_view Usage);
 
    struct LoopContext {
       ControlFlowEdge break_edge;

--- a/src/tiri/jit/src/parser/parser.cpp
+++ b/src/tiri/jit/src/parser/parser.cpp
@@ -51,6 +51,7 @@ static const struct {
 #include "parse_internal.h"
 #include "parser_symbols.h"
 #include "parser_profiler.h"
+#include "assignment_target_resolution.h"
 #include "static_type_descriptor.h"
 #include "static_descriptor_analysis.h"
 #include "value_categories.h"
@@ -64,6 +65,7 @@ static const struct {
 #include "static_descriptor_analysis.cpp"
 #include "table_ownership.cpp"
 #include "ast/nodes.cpp"
+#include "assignment_target_resolution.cpp"
 #include "ast/builder.cpp"
 #include "parser_symbols.cpp"
 #include "parse_control_flow.cpp"
@@ -196,6 +198,7 @@ static void run_ast_pipeline(ParserContext &Context, ParserProfiler &Profiler)
    }
 
    trace_ast_boundary(Context, *chunk, "parse");
+   resolve_assignment_targets(Context, *chunk);
    discover_static_bindings(Context, *chunk);
    // Publish the first descriptor pass before semantic type analysis so dynamic-ingress policy can distinguish
    // genuinely unknown values from concrete native and callable results.  A second pass below refreshes descriptors

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -270,7 +270,11 @@ static bool test_assignment_target_semantic_resolution(kt::Log &Log)
       "   Parameter = 3\n"
       "   print = 2\n"
       "end\n"
-      "glHostThing = 4\n";
+      "glHostThing = 4\n"
+      "global declared = 0\n"
+      "declared = 1\n"
+      "if_empty ?= 5\n"
+      "if_nil ?" "?= 6\n";
 
    auto result = build_resolved_ast_from_source(source, true);
    if (not result.chunk.ok() or not result.diagnostics.empty()) {
@@ -298,6 +302,9 @@ static bool test_assignment_target_semantic_resolution(kt::Log &Log)
    NameRef *missing = target(assignment(chunk, 6), 0);
    NameRef *blank = target(assignment(chunk, 7), 0);
    NameRef *named_external_policy = target(assignment(chunk, 9), 0);
+   NameRef *declared_global = target(assignment(chunk, 11), 0);
+   NameRef *if_empty = target(assignment(chunk, 12), 0);
+   NameRef *if_nil = target(assignment(chunk, 13), 0);
    const auto *local_declaration = std::get_if<LocalDeclStmtPayload>(&chunk.statements[2]->data);
    const auto *sibling_rhs = siblings and not siblings->values.empty() ?
       std::get_if<NameRef>(&siblings->values.front()->data) : nullptr;
@@ -318,7 +325,11 @@ static bool test_assignment_target_semantic_resolution(kt::Log &Log)
        not missing or missing->assignment_resolution != AssignmentTargetResolution::Invalid or
        not blank or blank->assignment_resolution != AssignmentTargetResolution::Blank or
        not named_external_policy or
-       named_external_policy->assignment_resolution != AssignmentTargetResolution::NewLocal) {
+       named_external_policy->assignment_resolution != AssignmentTargetResolution::NewLocal or
+       not declared_global or
+       declared_global->assignment_resolution != AssignmentTargetResolution::ExistingGlobal or
+       not if_empty or if_empty->assignment_resolution != AssignmentTargetResolution::NewLocal or
+       not if_nil or if_nil->assignment_resolution != AssignmentTargetResolution::NewLocal) {
       Log.error("assignment target categories or statement-order binding publication were incorrect");
       return false;
    }
@@ -343,6 +354,15 @@ static bool test_assignment_target_semantic_resolution(kt::Log &Log)
    if (not environment_target or
        environment_target->assignment_resolution != AssignmentTargetResolution::ExistingGlobal) {
       Log.error("a non-nil environment global did not resolve as existing global storage");
+      return false;
+   }
+
+   auto protected_global = build_resolved_ast_from_source("print = 2", true);
+   NameRef *protected_target = protected_global.chunk.ok() ?
+      target(assignment(*protected_global.chunk.value_ref(), 0), 0) : nullptr;
+   if (not protected_target or
+       protected_target->assignment_resolution != AssignmentTargetResolution::ExistingGlobal) {
+      Log.error("an unshadowed protected global did not resolve as existing global storage");
       return false;
    }
 
@@ -380,6 +400,43 @@ static bool test_assignment_target_semantic_resolution(kt::Log &Log)
       return false;
    }
 
+   auto compound = build_resolved_ast_from_source("compound_missing -= 1");
+   NameRef *compound_target = compound.chunk.ok() ?
+      target(assignment(*compound.chunk.value_ref(), 0), 0) : nullptr;
+   if (not compound_target or compound_target->assignment_resolution != AssignmentTargetResolution::Invalid) {
+      Log.error("an undefined compound target was not classified as invalid");
+      return false;
+   }
+
+   constexpr std::string_view lvalue_source =
+      "local object = {}\n"
+      "local key = 'field'\n"
+      "object.field = 1\n"
+      "object[key] = 2\n"
+      "object?.field = 3\n"
+      "object?[key] = 4\n";
+   auto lvalues = build_resolved_ast_from_source(lvalue_source);
+   if (not lvalues.chunk.ok() or not lvalues.diagnostics.empty()) {
+      Log.error("member, index or safe-navigation assignment controls did not parse cleanly");
+      log_diagnostics(lvalues.diagnostics, Log);
+      return false;
+   }
+
+   constexpr std::array<AstNodeKind, 4> lvalue_kinds = { {
+      AstNodeKind::MemberExpr,
+      AstNodeKind::IndexExpr,
+      AstNodeKind::SafeMemberExpr,
+      AstNodeKind::SafeIndexExpr
+   } };
+   for (size_t i = 0; i < lvalue_kinds.size(); ++i) {
+      AssignmentStmtPayload *payload = assignment(*lvalues.chunk.value_ref(), i + 2);
+      if (not payload or payload->targets.size() IS 0 or
+          payload->targets.front()->kind != lvalue_kinds[i]) {
+         Log.error("non-identifier assignment control %zu changed AST shape", i);
+         return false;
+      }
+   }
+
    return true;
 }
 
@@ -400,7 +457,9 @@ static bool test_assignment_target_descriptor_discovery(kt::Log &Log)
       "external = 3\n"
       "contracted_nil = 4\n"
       "_ = 5\n"
-      "missing += 1\n";
+      "missing += 1\n"
+      "function pair():<num, num> return 6, 7 end\n"
+      "left, right = pair()\n";
 
    LuaStateHolder state;
    lua_State *lua = state.get();
@@ -452,20 +511,27 @@ static bool test_assignment_target_descriptor_discovery(kt::Log &Log)
    const NameRef *capture = capture_assignment and not capture_assignment->targets.empty() and
       capture_assignment->targets.front() ?
          std::get_if<NameRef>(&capture_assignment->targets.front()->data) : nullptr;
+   const auto *pair_assignment = std::get_if<AssignmentStmtPayload>(&chunk.value_ref()->statements[10]->data);
+   const NameRef *left = pair_assignment and pair_assignment->targets.size() IS 2 ?
+      std::get_if<NameRef>(&pair_assignment->targets[0]->data) : nullptr;
+   const NameRef *right = pair_assignment and pair_assignment->targets.size() IS 2 ?
+      std::get_if<NameRef>(&pair_assignment->targets[1]->data) : nullptr;
 
    if (not fresh or fresh->assignment_resolution != AssignmentTargetResolution::NewLocal or not fresh->binding_id or
        not existing or existing->assignment_resolution != AssignmentTargetResolution::ExistingLocal or
        existing->binding_id != fresh->binding_id or not capture or
        capture->assignment_resolution != AssignmentTargetResolution::ExistingUpvalue or
        capture->binding_id != fresh->binding_id or not external or external->binding_id or not contracted or
-       contracted->binding_id or not blank or blank->binding_id or not invalid or invalid->binding_id) {
+       contracted->binding_id or not blank or blank->binding_id or not invalid or invalid->binding_id or
+       not left or left->assignment_resolution != AssignmentTargetResolution::NewLocal or not left->binding_id or
+       not right or right->assignment_resolution != AssignmentTargetResolution::NewLocal or not right->binding_id) {
       Log.error("descriptor discovery changed an assignment category or published binding");
       return false;
    }
 
-   // The unreachable local, fresh local, local function and parameter are the only lexical declarations.
-   if (context.descriptors().binding_count() != 5) {
-      Log.error("assignment discovery allocated %zu descriptors instead of four",
+   // The unreachable local, fresh local, two local functions, parameter and result pair are the lexical declarations.
+   if (context.descriptors().binding_count() != 8) {
+      Log.error("assignment discovery allocated %zu descriptors instead of seven",
          context.descriptors().binding_count() - 1);
       return false;
    }
@@ -473,6 +539,13 @@ static bool test_assignment_target_descriptor_discovery(kt::Log &Log)
    if (fresh_descriptor.name != fresh->identifier.symbol or fresh_descriptor.immutable or
        not fresh_descriptor.captured) {
       Log.error("existing local/upvalue writes did not update the original descriptor");
+      return false;
+   }
+   const StaticBindingDescriptor &left_descriptor = context.descriptors().binding(left->binding_id);
+   const StaticBindingDescriptor &right_descriptor = context.descriptors().binding(right->binding_id);
+   if (left_descriptor.result_position != 0 or right_descriptor.result_position != 1 or
+       left_descriptor.initialiser != right_descriptor.initialiser) {
+      Log.error("multi-result assignment descriptors lost their source expression or result positions");
       return false;
    }
 
@@ -1589,7 +1662,7 @@ static bool test_colon_method_syntax_rejected(kt::Log &Log)
 
    auto implicit = build_ast_from_source("entry, count:num = 5, 6", true);
    if (not implicit.chunk.ok() or not implicit.diagnostics.empty()) {
-      Log.error("bare type-annotated assignment did not parse as an implicit local declaration");
+      Log.error("bare type-annotated assignment did not parse successfully");
       log_diagnostics(implicit.diagnostics, Log);
       return false;
    }
@@ -1784,7 +1857,7 @@ static bool test_annotated_local_validation_parity(kt::Log &Log)
       std::string_view expected_error;
    };
 
-   constexpr std::array<ValidationCase, 11> cases = { {
+   constexpr std::array<ValidationCase, 13> cases = { {
       { "primary match", {}, "local value:num = 1", "value:num = 1", {} },
       { "primary mismatch", {}, "local value:num = 'wrong'", "value:num = 'wrong'", "cannot assign 'str'" },
       { "dynamic ingress", "function dynamic(Value:any):any return Value end\n",
@@ -1802,6 +1875,10 @@ static bool test_annotated_local_validation_parity(kt::Log &Log)
          "value:array<int> = array<str> { 'wrong' }", "array member mismatch" },
       { "broad object", {}, "local value:obj = obj.new('time')\nvalue = obj.new('file')",
          "value:obj = obj.new('time')\nvalue = obj.new('file')", {} },
+      { "inferred object match", {}, "local value = obj.new('time')\nvalue = obj.new('time')",
+         "value = obj.new('time')\nvalue = obj.new('time')", {} },
+      { "inferred object mismatch", {}, "local value = obj.new('time')\nvalue = obj.new('file')",
+         "value = obj.new('time')\nvalue = obj.new('file')", "object class mismatch" },
       { "multi-result mismatch", "local function pair():<num, str> return 1, 'wrong' end\n",
          "local first:num, second:bool = pair()", "first:num, second:bool = pair()", "cannot assign 'str'" },
       { "missing result", "local function one():num return 1 end\n",
@@ -1944,6 +2021,140 @@ static BindingDiscoveryResult discover_bindings_from_source(std::string_view Sou
    auto diagnostics = context.diagnostics().entries();
    result.diagnostics.assign(diagnostics.begin(), diagnostics.end());
    return result;
+}
+
+//********************************************************************************************************************
+
+static bool test_assignment_target_regressions(kt::Log &Log)
+{
+   auto first_target = [](BindingDiscoveryResult &Result, size_t Statement = 0) -> NameRef * {
+      if (not Result.chunk.ok() or Statement >= Result.chunk.value_ref()->statements.size()) return nullptr;
+      auto *assignment = std::get_if<AssignmentStmtPayload>(
+         &Result.chunk.value_ref()->statements[Statement]->data);
+      if (not assignment or assignment->targets.empty() or not assignment->targets.front()) return nullptr;
+      return std::get_if<NameRef>(&assignment->targets.front()->data);
+   };
+   auto has_diagnostic = [](const std::vector<ParserDiagnostic> &Diagnostics, std::string_view Text) {
+      return std::ranges::any_of(Diagnostics, [Text](const ParserDiagnostic &Diagnostic) {
+         return Diagnostic.message.find(Text) != std::string::npos;
+      });
+   };
+   auto count_root_opcode = [](lua_State *Lua, BCOp Opcode) {
+      GCproto *prototype = funcproto(funcV(Lua->top - 1));
+      size_t count = 0;
+      for (MSize i = 1; i < prototype->sizebc; ++i) {
+         if (bc_op(proto_bc(prototype)[i]) IS Opcode) ++count;
+      }
+      return count;
+   };
+
+   auto typed_extern = discover_bindings_from_source("extern counter\ncounter:num = 2");
+   NameRef *typed_extern_target = first_target(typed_extern, 1);
+   if (not typed_extern_target or
+       typed_extern_target->assignment_resolution != AssignmentTargetResolution::ExistingGlobal or
+       not has_diagnostic(typed_extern.diagnostics,
+          "cannot redeclare existing global 'counter' with a type annotation")) {
+      Log.error("a typed named-extern assignment lost its category or redeclaration diagnostic");
+      log_diagnostics(typed_extern.diagnostics, Log);
+      return false;
+   }
+
+   auto fresh_typed = discover_bindings_from_source("fresh:num = 2");
+   NameRef *fresh_target = first_target(fresh_typed);
+   if (not fresh_target or fresh_target->assignment_resolution != AssignmentTargetResolution::NewLocal or
+       not fresh_target->binding_id or fresh_target->identifier.type != TiriType::Num or
+       not fresh_typed.diagnostics.empty()) {
+      Log.error("a fresh typed assignment did not publish a typed NewLocal binding");
+      log_diagnostics(fresh_typed.diagnostics, Log);
+      return false;
+   }
+
+   LuaStateHolder fixed_holder;
+   lua_State *fixed = fixed_holder.get();
+   if (lua_load(fixed, "fresh:num = 2\nfresh = 'wrong'", "=assignment-fixed-new-local") IS 0) {
+      Log.error("a typed NewLocal assignment did not establish a fixed local contract");
+      return false;
+   }
+   if (std::string_view(lua_tostring(fixed, -1)).find("cannot assign 'str'") IS std::string_view::npos) {
+      Log.error("a typed NewLocal reassignment produced the wrong diagnostic: %s", lua_tostring(fixed, -1));
+      return false;
+   }
+
+   LuaStateHolder extern_holder;
+   lua_State *external = extern_holder.get();
+   constexpr std::string_view extern_source =
+      "extern task_eight_external\n"
+      "task_eight_external = 2\n";
+   if (lua_load(external, extern_source, "=assignment-named-extern")) {
+      Log.error("an untyped named-extern assignment did not compile: %s", lua_tostring(external, -1));
+      return false;
+   }
+   if (count_root_opcode(external, BC_GSET) != 1) {
+      Log.error("an untyped named-extern assignment did not emit exactly one global store");
+      return false;
+   }
+   if (lua_pcall(external, 0, 0, 0)) {
+      Log.error("an untyped named-extern assignment did not execute: %s", lua_tostring(external, -1));
+      return false;
+   }
+   lua_getglobal(external, "task_eight_external");
+   bool extern_stored = lua_tointeger(external, -1) IS 2;
+   lua_pop(external, 1);
+   if (not extern_stored) {
+      Log.error("an untyped named-extern assignment did not update the environment");
+      return false;
+   }
+
+   LuaStateHolder contract_holder;
+   lua_State *contract = contract_holder.get();
+   if (lua_load(contract, "global glTaskEightContract:num = 1", "=assignment-contract-declaration") or
+       lua_pcall(contract, 0, 0, 0)) {
+      Log.error("failed to establish the task-eight persisted contract: %s", lua_tostring(contract, -1));
+      return false;
+   }
+   lua_pushnil(contract);
+   lua_setglobal(contract, "glTaskEightContract");
+
+   if (lua_load(contract, "glTaskEightContract:num = 2", "=assignment-contract-redeclaration") IS 0) {
+      Log.error("a typed assignment redeclared a nil-valued persisted global");
+      return false;
+   }
+   if (std::string_view(lua_tostring(contract, -1)).find(
+         "cannot redeclare existing global 'glTaskEightContract'") IS std::string_view::npos) {
+      Log.error("a nil-valued persisted-global annotation produced the wrong diagnostic: %s",
+         lua_tostring(contract, -1));
+      return false;
+   }
+   lua_pop(contract, 1);
+
+   if (lua_load(contract, "glTaskEightContract = 2", "=assignment-contracted-global")) {
+      Log.error("an untyped persisted-global assignment did not compile: %s", lua_tostring(contract, -1));
+      return false;
+   }
+   if (count_root_opcode(contract, BC_GSET) != 1) {
+      Log.error("an untyped persisted-global assignment did not emit exactly one global store");
+      return false;
+   }
+   if (lua_pcall(contract, 0, 0, 0)) {
+      Log.error("an untyped persisted-global assignment did not execute: %s", lua_tostring(contract, -1));
+      return false;
+   }
+   lua_getglobal(contract, "glTaskEightContract");
+   bool contract_stored = lua_tointeger(contract, -1) IS 2;
+   lua_pop(contract, 1);
+   if (not contract_stored) {
+      Log.error("an untyped persisted-global assignment did not update the environment");
+      return false;
+   }
+
+   auto wildcard = build_ast_from_source("extern *", true);
+   if (not has_diagnostic(wildcard.diagnostics, "Extern wildcard '*' is not supported")) {
+      Log.error("removed extern wildcard syntax produced the wrong parser diagnostic");
+      log_diagnostics(wildcard.diagnostics, Log);
+      return false;
+   }
+
+   return true;
 }
 
 //********************************************************************************************************************
@@ -10539,7 +10750,7 @@ static bool test_defer_runtime_registration_state(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 97> tests = { {
+   constexpr std::array<TestCase, 98> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "assignment_target_resolution_ast", test_assignment_target_resolution_ast },
@@ -10569,6 +10780,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "colon_method_syntax_rejected", test_colon_method_syntax_rejected },
       { "typed_assignment_name_resolution", test_typed_assignment_name_resolution },
       { "annotated_local_validation_parity", test_annotated_local_validation_parity },
+      { "assignment_target_regressions", test_assignment_target_regressions },
       { "implicit_later_name_attributes", test_implicit_later_name_attributes },
       { "implicit_attribute_shadowing", test_implicit_attribute_shadowing },
       { "ternary_colon_separators", test_ternary_colon_separators },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -47,6 +47,7 @@
 #include "parser.h"
 #include "static_descriptor_analysis.h"
 #include "table_ownership.h"
+#include "ir_emitter/ir_emitter.h"
 #include "../runtime/lj_array.h"
 #include "../../../defs.h"
 
@@ -569,6 +570,86 @@ static bool test_assignment_target_environment_types(kt::Log &Log)
        struct_hint->second.primary != TiriType::Struct or struct_hint->second.struct_def != definition or
        struct_hint->second.contract_policy != GlobalContractPolicy::Advisory) {
       Log.error("persisted array or structure identity was not seeded as advisory environment metadata");
+      return false;
+   }
+
+   return true;
+}
+
+//********************************************************************************************************************
+
+static bool test_assignment_target_emitter_invariant(kt::Log &Log)
+{
+   constexpr std::string_view source =
+      "local value = 1\n"
+      "value = 2\n";
+   LuaStateHolder state;
+   lua_State *lua = state.get();
+   StringReaderCtx reader{ source.data(), source.size() };
+   LexState lex(lua, unit_reader, &reader, "assignment-emitter-invariant", std::nullopt);
+   FuncState &fs = lex.fs_init();
+   ParserContext context = ParserContext::from(lex, fs, ParserAllocator::from(lua));
+   ParserConfig config;
+   config.abort_on_error = false;
+   config.max_diagnostics = 32;
+   ParserSession session(context, config);
+   lex.next();
+   AstBuilder builder(context);
+   auto chunk = builder.parse_chunk();
+   if (not chunk.ok()) return false;
+
+   resolve_assignment_targets(context, *chunk.value_ref());
+   discover_static_bindings(context, *chunk.value_ref());
+   propagate_static_descriptors(context, *chunk.value_ref());
+   run_type_analysis(context, *chunk.value_ref());
+   propagate_static_descriptors(context, *chunk.value_ref());
+
+   StatementListView statements = chunk.value_ref()->view();
+   auto *assignment = statements.size() IS 2 ?
+      std::get_if<AssignmentStmtPayload>(&statements[1].data) : nullptr;
+   auto *reference = assignment and assignment->targets.size() IS 1 ?
+      std::get_if<NameRef>(&assignment->targets[0]->data) : nullptr;
+   if (not reference or reference->assignment_resolution != AssignmentTargetResolution::ExistingLocal or
+       not reference->binding_id) {
+      Log.error("emitter invariant fixture did not resolve to an existing local");
+      return false;
+   }
+
+   ++reference->binding_id;
+   reference->identifier.binding_id = reference->binding_id;
+   IrEmitter emitter(context);
+   auto emitted = emitter.emit_chunk(*chunk.value_ref());
+   if (emitted.ok() or emitted.error_ref().code != ParserErrorCode::InternalInvariant) {
+      Log.error("emitter accepted a lexical target whose binding disagreed with semantic resolution");
+      return false;
+   }
+
+   return true;
+}
+
+//********************************************************************************************************************
+
+static bool test_assignment_new_local_emission(kt::Log &Log)
+{
+   constexpr std::string_view source =
+      "function values():<num, num> return 17, 23 end\n"
+      "first, second = values()\n"
+      "return first, second\n";
+   LuaStateHolder state;
+   lua_State *lua = state.get();
+   if (lua_load(lua, source, "assignment-new-local-emission")) {
+      Log.error("compiling deferred new-local assignment failed: %s", lua_tostring(lua, -1));
+      return false;
+   }
+   if (lua_pcall(lua, 0, 2, 0)) {
+      Log.error("executing deferred new-local assignment failed: %s", lua_tostring(lua, -1));
+      return false;
+   }
+
+   bool ordered = lua_tointeger(lua, -2) IS 17 and lua_tointeger(lua, -1) IS 23;
+   lua_pop(lua, 2);
+   if (not ordered) {
+      Log.error("deferred new-local assignment changed multi-result register ordering");
       return false;
    }
 
@@ -1686,6 +1767,80 @@ static bool test_typed_assignment_name_resolution(kt::Log &Log)
    if (lua_tonumber(mixed, -2) != 2 or lua_tonumber(mixed, -1) != 3) {
       Log.error("a type annotation changed name resolution for another assignment target");
       return false;
+   }
+
+   return true;
+}
+
+//********************************************************************************************************************
+
+static bool test_annotated_local_validation_parity(kt::Log &Log)
+{
+   struct ValidationCase {
+      std::string_view label;
+      std::string_view prefix;
+      std::string_view explicit_local;
+      std::string_view new_local;
+      std::string_view expected_error;
+   };
+
+   constexpr std::array<ValidationCase, 11> cases = { {
+      { "primary match", {}, "local value:num = 1", "value:num = 1", {} },
+      { "primary mismatch", {}, "local value:num = 'wrong'", "value:num = 'wrong'", "cannot assign 'str'" },
+      { "dynamic ingress", "function dynamic(Value:any):any return Value end\n",
+         "local value:num = dynamic(1)", "value:num = dynamic(1)", {} },
+      { "explicit any", {}, "local value:any = 1\nvalue = 'text'", "value:any = 1\nvalue = 'text'", {} },
+      { "structure match", "struct ParityRecord Value: int end\n",
+         "local value:struct<ParityRecord> = struct<ParityRecord> { Value = 1 }",
+         "value:struct<ParityRecord> = struct<ParityRecord> { Value = 1 }", {} },
+      { "structure mismatch", "struct ParityExpected Value: int end\nstruct ParityActual Value: double end\n",
+         "local value:struct<ParityExpected> = struct<ParityActual> { Value = 1 }",
+         "value:struct<ParityExpected> = struct<ParityActual> { Value = 1 }", "struct layout mismatch" },
+      { "array match", {}, "local value:array<int> = array<int> { 1 }",
+         "value:array<int> = array<int> { 1 }", {} },
+      { "array mismatch", {}, "local value:array<int> = array<str> { 'wrong' }",
+         "value:array<int> = array<str> { 'wrong' }", "array member mismatch" },
+      { "broad object", {}, "local value:obj = obj.new('time')\nvalue = obj.new('file')",
+         "value:obj = obj.new('time')\nvalue = obj.new('file')", {} },
+      { "multi-result mismatch", "local function pair():<num, str> return 1, 'wrong' end\n",
+         "local first:num, second:bool = pair()", "first:num, second:bool = pair()", "cannot assign 'str'" },
+      { "missing result", "local function one():num return 1 end\n",
+         "local first:num, second:str = one()", "first:num, second:str = one()", {} }
+   } };
+
+   auto compile = [](const ValidationCase &Case, std::string_view Declaration, std::string &Error) {
+      LuaStateHolder holder;
+      lua_State *lua = holder.get();
+      luaL_openlibs(lua);
+      std::string source(Case.prefix);
+      source.append(Declaration);
+      if (lua_load(lua, source, Case.label.data())) {
+         Error.assign(lua_tostring(lua, -1));
+         return false;
+      }
+      lua_pop(lua, 1);
+      Error.clear();
+      return true;
+   };
+
+   for (const ValidationCase &test_case : cases) {
+      std::string explicit_error;
+      std::string assignment_error;
+      bool explicit_ok = compile(test_case, test_case.explicit_local, explicit_error);
+      bool assignment_ok = compile(test_case, test_case.new_local, assignment_error);
+      bool expected_ok = test_case.expected_error.empty();
+      if (explicit_ok != expected_ok or assignment_ok != expected_ok) {
+         Log.error("annotated %.*s parity failed: explicit='%s', assignment='%s'",
+            int(test_case.label.size()), test_case.label.data(), explicit_error.c_str(), assignment_error.c_str());
+         return false;
+      }
+      if (not expected_ok and
+          (explicit_error.find(test_case.expected_error) IS std::string::npos or
+           assignment_error.find(test_case.expected_error) IS std::string::npos)) {
+         Log.error("annotated %.*s parity produced different diagnostics: explicit='%s', assignment='%s'",
+            int(test_case.label.size()), test_case.label.data(), explicit_error.c_str(), assignment_error.c_str());
+         return false;
+      }
    }
 
    return true;
@@ -6076,9 +6231,8 @@ static bool test_environment_store_boundary(kt::Log &Log)
    }
 
    // A separately compiled direct assignment must rely on BC_GSET instead of copying the persisted descriptor into a
-   // preceding BC_CONTRACT.
+   // preceding BC_CONTRACT.  No source extern is needed: semantic resolution recognises the nil-valued contract.
    constexpr std::string_view assignment_source =
-      "extern glUnitEnvBoundary\n"
       "glUnitEnvBoundary = 'compiled'\n";
    if (lua_load(L, assignment_source, "=envboundary-assignment")) {
       Log.error("compiling the persisted-policy assignment failed: %s", lua_tostring(L, -1));
@@ -10385,13 +10539,15 @@ static bool test_defer_runtime_registration_state(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 94> tests = { {
+   constexpr std::array<TestCase, 97> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "assignment_target_resolution_ast", test_assignment_target_resolution_ast },
       { "assignment_target_semantic_resolution", test_assignment_target_semantic_resolution },
       { "assignment_target_descriptor_discovery", test_assignment_target_descriptor_discovery },
       { "assignment_target_environment_types", test_assignment_target_environment_types },
+      { "assignment_target_emitter_invariant", test_assignment_target_emitter_invariant },
+      { "assignment_new_local_emission", test_assignment_new_local_emission },
       { "literal_binary_expr", test_literal_binary_expr },
       { "type_test_ast", test_type_test_ast },
       { "choose_type_pattern_ast", test_choose_type_pattern_ast },
@@ -10412,6 +10568,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "deprecated_numeric_for_rejected", test_deprecated_numeric_for_rejected },
       { "colon_method_syntax_rejected", test_colon_method_syntax_rejected },
       { "typed_assignment_name_resolution", test_typed_assignment_name_resolution },
+      { "annotated_local_validation_parity", test_annotated_local_validation_parity },
       { "implicit_later_name_attributes", test_implicit_later_name_attributes },
       { "implicit_attribute_shadowing", test_implicit_attribute_shadowing },
       { "ternary_colon_separators", test_ternary_colon_separators },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -2069,6 +2069,19 @@ static bool test_assignment_target_regressions(kt::Log &Log)
       return false;
    }
 
+   LuaStateHolder import_holder;
+   lua_State *import_state = import_holder.get();
+   if (lua_load(import_state, "import 'options'\noptions = {}", "=assignment-import-namespace") IS 0) {
+      Log.error("an imported namespace assignment unexpectedly compiled");
+      return false;
+   }
+   std::string_view import_error(lua_tostring(import_state, -1));
+   if (import_error.find("cannot assign to const local 'options'") IS std::string_view::npos or
+       import_error.find("Internal invariant") != std::string_view::npos) {
+      Log.error("an imported namespace assignment produced the wrong diagnostic: %s", lua_tostring(import_state, -1));
+      return false;
+   }
+
    LuaStateHolder fixed_holder;
    lua_State *fixed = fixed_holder.get();
    if (lua_load(fixed, "fresh:num = 2\nfresh = 'wrong'", "=assignment-fixed-new-local") IS 0) {

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -37,6 +37,7 @@
 
 #include "ast/builder.h"
 #include "ast/nodes.h"
+#include "assignment_target_resolution.h"
 #include "parser_context.h"
 #include "parser_diagnostics.h"
 #include "parse_types.h"
@@ -83,6 +84,57 @@ static std::string describe_instruction(BCIns instruction)
    std::snprintf(buffer, sizeof(buffer), "%s op=%d a=%d b=%d c=%d d=%d", name, (int)op,
       (int)bc_a(instruction), (int)bc_b(instruction), (int)bc_c(instruction), (int)bc_d(instruction));
    return std::string(buffer);
+}
+
+//********************************************************************************************************************
+
+static bool test_assignment_target_resolution_ast(kt::Log &Log)
+{
+   NameRef reference;
+   if (reference.resolution != NameResolution::Unresolved or
+       reference.assignment_resolution != AssignmentTargetResolution::Unresolved) {
+      Log.error("a default name reference did not retain independent unresolved read and assignment categories");
+      return false;
+   }
+
+   constexpr std::array<AssignmentTargetResolution, 7> categories = { {
+      AssignmentTargetResolution::Unresolved,
+      AssignmentTargetResolution::Blank,
+      AssignmentTargetResolution::ExistingLocal,
+      AssignmentTargetResolution::ExistingUpvalue,
+      AssignmentTargetResolution::ExistingGlobal,
+      AssignmentTargetResolution::NewLocal,
+      AssignmentTargetResolution::Invalid
+   } };
+
+   for (AssignmentTargetResolution category : categories) {
+      reference.resolution = NameResolution::BuiltinCallable;
+      reference.assignment_resolution = category;
+
+      ExprNodePtr expression = make_identifier_expr({}, reference);
+      ExprNode moved = std::move(*expression);
+      const auto *stored = std::get_if<NameRef>(&moved.data);
+      if (not stored or stored->resolution != NameResolution::BuiltinCallable or
+          stored->assignment_resolution != category) {
+         Log.error("an identifier AST copy or move lost assignment target category %d", int(category));
+         return false;
+      }
+   }
+
+   if (not assignment_target_is_existing_lexical(AssignmentTargetResolution::ExistingLocal) or
+       not assignment_target_is_existing_lexical(AssignmentTargetResolution::ExistingUpvalue) or
+       assignment_target_is_existing_lexical(AssignmentTargetResolution::ExistingGlobal) or
+       not assignment_target_is_existing_storage(AssignmentTargetResolution::ExistingLocal) or
+       not assignment_target_is_existing_storage(AssignmentTargetResolution::ExistingUpvalue) or
+       not assignment_target_is_existing_storage(AssignmentTargetResolution::ExistingGlobal) or
+       assignment_target_is_existing_storage(AssignmentTargetResolution::NewLocal) or
+       not assignment_target_creates_local(AssignmentTargetResolution::NewLocal) or
+       assignment_target_creates_local(AssignmentTargetResolution::ExistingLocal)) {
+      Log.error("assignment target category predicates produced inconsistent semantic classifications");
+      return false;
+   }
+
+   return true;
 }
 
 //********************************************************************************************************************
@@ -160,6 +212,174 @@ static AstHarnessResult build_ast_from_source(std::string_view source, bool Diag
    auto diag_entries = context.diagnostics().entries();
    result.diagnostics.assign(diag_entries.begin(), diag_entries.end());
    return result;
+}
+
+//********************************************************************************************************************
+
+static AstHarnessResult build_resolved_ast_from_source(std::string_view Source,
+   bool OpenLibraries = false, bool AddEnvironmentGlobal = false, bool AddNilContract = false)
+{
+   AstHarnessResult result;
+   result.state = std::make_unique<LuaStateHolder>();
+   lua_State *L = result.state->get();
+   if (OpenLibraries) luaL_openlibs(L);
+   if (AddEnvironmentGlobal) {
+      lua_pushnumber(L, 1);
+      lua_setglobal(L, "host_existing");
+   }
+   if (AddNilContract) {
+      GCstr *name = lj_str_newlit(L, "contracted_nil");
+      GCstr *descriptor = lj_str_newlit(L, "persisted-contract");
+      lj_tab_set_global_contract(L, tabref(L->env), name, descriptor);
+   }
+
+   StringReaderCtx reader{ Source.data(), Source.size() };
+   LexState lex(L, unit_reader, &reader, "assignment-target-resolution", std::nullopt);
+   FuncState &fs = lex.fs_init();
+   ParserContext context = ParserContext::from(lex, fs, ParserAllocator::from(L));
+   ParserConfig config;
+   config.abort_on_error = false;
+   config.max_diagnostics = 32;
+   ParserSession session(context, config);
+
+   lex.next();
+   AstBuilder builder(context);
+   result.chunk = builder.parse_chunk();
+   if (result.chunk.ok()) resolve_assignment_targets(context, *result.chunk.value_ref());
+
+   auto diagnostics = context.diagnostics().entries();
+   result.diagnostics.assign(diagnostics.begin(), diagnostics.end());
+   return result;
+}
+
+//********************************************************************************************************************
+
+static bool test_assignment_target_semantic_resolution(kt::Log &Log)
+{
+   constexpr std::string_view source =
+      "extern counter\n"
+      "counter:num = 2\n"
+      "local print = 0\n"
+      "print = 1\n"
+      "fresh, sibling = sibling, 2\n"
+      "after = sibling\n"
+      "missing += 1\n"
+      "_ = 5\n"
+      "function nested(Parameter)\n"
+      "   Parameter = 3\n"
+      "   print = 2\n"
+      "end\n"
+      "glHostThing = 4\n";
+
+   auto result = build_resolved_ast_from_source(source, true);
+   if (not result.chunk.ok() or not result.diagnostics.empty()) {
+      Log.error("assignment target semantic resolution fixture did not parse cleanly");
+      log_diagnostics(result.diagnostics, Log);
+      return false;
+   }
+
+   auto assignment = [](BlockStmt &Block, size_t Index) -> AssignmentStmtPayload * {
+      if (Index >= Block.statements.size() or not Block.statements[Index] or
+          Block.statements[Index]->kind != AstNodeKind::AssignmentStmt) return nullptr;
+      return std::get_if<AssignmentStmtPayload>(&Block.statements[Index]->data);
+   };
+   auto target = [](AssignmentStmtPayload *Assignment, size_t Index) -> NameRef * {
+      if (not Assignment or Index >= Assignment->targets.size() or not Assignment->targets[Index]) return nullptr;
+      return std::get_if<NameRef>(&Assignment->targets[Index]->data);
+   };
+
+   BlockStmt &chunk = *result.chunk.value_ref();
+   NameRef *external = target(assignment(chunk, 1), 0);
+   NameRef *local = target(assignment(chunk, 3), 0);
+   AssignmentStmtPayload *siblings = assignment(chunk, 4);
+   NameRef *fresh = target(siblings, 0);
+   NameRef *sibling = target(siblings, 1);
+   NameRef *missing = target(assignment(chunk, 6), 0);
+   NameRef *blank = target(assignment(chunk, 7), 0);
+   NameRef *named_external_policy = target(assignment(chunk, 9), 0);
+   const auto *local_declaration = std::get_if<LocalDeclStmtPayload>(&chunk.statements[2]->data);
+   const auto *sibling_rhs = siblings and not siblings->values.empty() ?
+      std::get_if<NameRef>(&siblings->values.front()->data) : nullptr;
+   AssignmentStmtPayload *after = assignment(chunk, 5);
+   const auto *published_sibling = after and not after->values.empty() ?
+      std::get_if<NameRef>(&after->values.front()->data) : nullptr;
+
+   if (not external or external->assignment_resolution != AssignmentTargetResolution::ExistingGlobal or
+       external->resolution != NameResolution::Unresolved or not local or
+       local->assignment_resolution != AssignmentTargetResolution::ExistingLocal or
+       not local_declaration or local_declaration->names.empty() or
+       local->binding_id != local_declaration->names.front().binding_id or
+       not fresh or fresh->assignment_resolution != AssignmentTargetResolution::NewLocal or not fresh->binding_id or
+       not sibling or sibling->assignment_resolution != AssignmentTargetResolution::NewLocal or
+       not sibling->binding_id or sibling->binding_id IS fresh->binding_id or
+       not sibling_rhs or sibling_rhs->binding_id or not published_sibling or
+       published_sibling->binding_id != sibling->binding_id or
+       not missing or missing->assignment_resolution != AssignmentTargetResolution::Invalid or
+       not blank or blank->assignment_resolution != AssignmentTargetResolution::Blank or
+       not named_external_policy or
+       named_external_policy->assignment_resolution != AssignmentTargetResolution::NewLocal) {
+      Log.error("assignment target categories or statement-order binding publication were incorrect");
+      return false;
+   }
+
+   const auto *function = std::get_if<FunctionStmtPayload>(&chunk.statements[8]->data);
+   BlockStmt *body = function and function->function ? function->function->body.get() : nullptr;
+   NameRef *parameter = body ? target(assignment(*body, 0), 0) : nullptr;
+   NameRef *upvalue = body ? target(assignment(*body, 1), 0) : nullptr;
+   if (not function or function->name.segments.empty() or not function->function or
+       function->function->parameters.empty() or not parameter or
+       parameter->assignment_resolution != AssignmentTargetResolution::ExistingLocal or
+       parameter->binding_id != function->function->parameters.front().name.binding_id or not upvalue or
+       upvalue->assignment_resolution != AssignmentTargetResolution::ExistingUpvalue or
+       upvalue->binding_id != local_declaration->names.front().binding_id) {
+      Log.error("function parameters or captured assignment targets received the wrong lexical category");
+      return false;
+   }
+
+   auto environment = build_resolved_ast_from_source("host_existing = 2", false, true);
+   NameRef *environment_target = environment.chunk.ok() ?
+      target(assignment(*environment.chunk.value_ref(), 0), 0) : nullptr;
+   if (not environment_target or
+       environment_target->assignment_resolution != AssignmentTargetResolution::ExistingGlobal) {
+      Log.error("a non-nil environment global did not resolve as existing global storage");
+      return false;
+   }
+
+   auto contracted = build_resolved_ast_from_source("contracted_nil = 2", false, false, true);
+   NameRef *contracted_target = contracted.chunk.ok() ?
+      target(assignment(*contracted.chunk.value_ref(), 0), 0) : nullptr;
+   cTValue *contracted_value = lj_tab_getstr(
+      tabref(contracted.state->get()->env), lj_str_newlit(contracted.state->get(), "contracted_nil"));
+   if ((contracted_value and not tvisnil(contracted_value)) or not contracted_target or
+       contracted_target->assignment_resolution != AssignmentTargetResolution::ExistingGlobal) {
+      Log.error("a persisted contract did not keep its nil-valued name in global storage");
+      return false;
+   }
+
+   auto constant = build_resolved_ast_from_source("enum FLAGS { VALUE }\nFLAGS_VALUE = 2");
+   AssignmentStmtPayload *constant_assignment =
+      constant.chunk.ok() and not constant.chunk.value_ref()->statements.empty() ?
+         assignment(*constant.chunk.value_ref(), constant.chunk.value_ref()->statements.size() - 1) : nullptr;
+   NameRef *constant_target = target(constant_assignment, 0);
+   if (not constant_target or
+       constant_target->assignment_resolution != AssignmentTargetResolution::ExistingGlobal) {
+      Log.error("a registered constant assignment target was incorrectly classified as a new local");
+      return false;
+   }
+
+   auto update = build_resolved_ast_from_source("update_missing++");
+   const auto *expression_statement = update.chunk.ok() and not update.chunk.value_ref()->statements.empty() ?
+      std::get_if<ExpressionStmtPayload>(&update.chunk.value_ref()->statements.front()->data) : nullptr;
+   const auto *update_expression = expression_statement and expression_statement->expression ?
+      std::get_if<UpdateExprPayload>(&expression_statement->expression->data) : nullptr;
+   const NameRef *update_target = update_expression and update_expression->target ?
+      std::get_if<NameRef>(&update_expression->target->data) : nullptr;
+   if (not update_target or update_target->assignment_resolution != AssignmentTargetResolution::Invalid) {
+      Log.error("an undefined update target was not classified as invalid");
+      return false;
+   }
+
+   return true;
 }
 
 struct ExpressionParseHarness {
@@ -9896,9 +10116,11 @@ static bool test_defer_runtime_registration_state(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 90> tests = { {
+   constexpr std::array<TestCase, 92> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
+      { "assignment_target_resolution_ast", test_assignment_target_resolution_ast },
+      { "assignment_target_semantic_resolution", test_assignment_target_semantic_resolution },
       { "literal_binary_expr", test_literal_binary_expr },
       { "type_test_ast", test_type_test_ast },
       { "choose_type_pattern_ast", test_choose_type_pattern_ast },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -382,6 +382,133 @@ static bool test_assignment_target_semantic_resolution(kt::Log &Log)
    return true;
 }
 
+//********************************************************************************************************************
+
+static bool test_assignment_target_descriptor_discovery(kt::Log &Log)
+{
+   constexpr std::string_view source =
+      "if false then\n"
+      "   local unreachable = 0\n"
+      "end\n"
+      "fresh = 1\n"
+      "fresh = 2\n"
+      "function touch(parameter)\n"
+      "   fresh = parameter\n"
+      "end\n"
+      "extern external\n"
+      "external = 3\n"
+      "contracted_nil = 4\n"
+      "_ = 5\n"
+      "missing += 1\n";
+
+   LuaStateHolder state;
+   lua_State *lua = state.get();
+   GCstr *contracted_name = lj_str_newlit(lua, "contracted_nil");
+   lj_tab_set_global_contract(lua, tabref(lua->env), contracted_name, lj_str_newlit(lua, "persisted-contract"));
+   StringReaderCtx reader{ source.data(), source.size() };
+   LexState lex(lua, unit_reader, &reader, "assignment-target-descriptors", std::nullopt);
+   FuncState &fs = lex.fs_init();
+   ParserContext context = ParserContext::from(lex, fs, ParserAllocator::from(lua));
+   ParserConfig config;
+   config.abort_on_error = false;
+   config.max_diagnostics = 32;
+   ParserSession session(context, config);
+
+   lex.next();
+   AstBuilder builder(context);
+   auto chunk = builder.parse_chunk();
+   if (not chunk.ok()) {
+      Log.error("assignment descriptor fixture did not parse");
+      return false;
+   }
+   resolve_assignment_targets(context, *chunk.value_ref());
+   discover_static_bindings(context, *chunk.value_ref());
+   propagate_static_descriptors(context, *chunk.value_ref());
+   propagate_static_descriptors(context, *chunk.value_ref());
+   if (context.diagnostics().has_errors()) {
+      Log.error("assignment descriptor discovery reported an unexpected invariant");
+      log_diagnostics(context.diagnostics().entries(), Log);
+      return false;
+   }
+
+   auto target = [&chunk](size_t Statement) -> NameRef * {
+      if (Statement >= chunk.value_ref()->statements.size()) return nullptr;
+      auto *assignment = std::get_if<AssignmentStmtPayload>(&chunk.value_ref()->statements[Statement]->data);
+      if (not assignment or assignment->targets.empty() or not assignment->targets.front()) return nullptr;
+      return std::get_if<NameRef>(&assignment->targets.front()->data);
+   };
+
+   NameRef *fresh = target(1);
+   NameRef *existing = target(2);
+   NameRef *external = target(5);
+   NameRef *contracted = target(6);
+   NameRef *blank = target(7);
+   NameRef *invalid = target(8);
+   const auto *function = std::get_if<FunctionStmtPayload>(&chunk.value_ref()->statements[3]->data);
+   const auto *capture_assignment = function and function->function and function->function->body and
+      not function->function->body->statements.empty() ?
+         std::get_if<AssignmentStmtPayload>(&function->function->body->statements.front()->data) : nullptr;
+   const NameRef *capture = capture_assignment and not capture_assignment->targets.empty() and
+      capture_assignment->targets.front() ?
+         std::get_if<NameRef>(&capture_assignment->targets.front()->data) : nullptr;
+
+   if (not fresh or fresh->assignment_resolution != AssignmentTargetResolution::NewLocal or not fresh->binding_id or
+       not existing or existing->assignment_resolution != AssignmentTargetResolution::ExistingLocal or
+       existing->binding_id != fresh->binding_id or not capture or
+       capture->assignment_resolution != AssignmentTargetResolution::ExistingUpvalue or
+       capture->binding_id != fresh->binding_id or not external or external->binding_id or not contracted or
+       contracted->binding_id or not blank or blank->binding_id or not invalid or invalid->binding_id) {
+      Log.error("descriptor discovery changed an assignment category or published binding");
+      return false;
+   }
+
+   // The unreachable local, fresh local, local function and parameter are the only lexical declarations.
+   if (context.descriptors().binding_count() != 5) {
+      Log.error("assignment discovery allocated %zu descriptors instead of four",
+         context.descriptors().binding_count() - 1);
+      return false;
+   }
+   const StaticBindingDescriptor &fresh_descriptor = context.descriptors().binding(fresh->binding_id);
+   if (fresh_descriptor.name != fresh->identifier.symbol or fresh_descriptor.immutable or
+       not fresh_descriptor.captured) {
+      Log.error("existing local/upvalue writes did not update the original descriptor");
+      return false;
+   }
+
+   constexpr std::string_view invalid_source = "broken = 1";
+   LuaStateHolder invalid_state;
+   lua_State *invalid_lua = invalid_state.get();
+   StringReaderCtx invalid_reader{ invalid_source.data(), invalid_source.size() };
+   LexState invalid_lex(invalid_lua, unit_reader, &invalid_reader, "assignment-target-invariant", std::nullopt);
+   invalid_lex.diagnose_mode = true;
+   FuncState &invalid_fs = invalid_lex.fs_init();
+   ParserContext invalid_context = ParserContext::from(
+      invalid_lex, invalid_fs, ParserAllocator::from(invalid_lua));
+   ParserSession invalid_session(invalid_context, config);
+   invalid_lex.next();
+   AstBuilder invalid_builder(invalid_context);
+   auto invalid_chunk = invalid_builder.parse_chunk();
+   if (not invalid_chunk.ok()) return false;
+   resolve_assignment_targets(invalid_context, *invalid_chunk.value_ref());
+   auto &broken_assignment = std::get<AssignmentStmtPayload>(invalid_chunk.value_ref()->statements.front()->data);
+   auto &broken = std::get<NameRef>(broken_assignment.targets.front()->data);
+   broken.assignment_resolution = AssignmentTargetResolution::ExistingLocal;
+   broken.binding_id = {};
+   broken.identifier.binding_id = {};
+   discover_static_bindings(invalid_context, *invalid_chunk.value_ref());
+
+   bool found_invariant = false;
+   for (const ParserDiagnostic &diagnostic : invalid_context.diagnostics().entries()) {
+      if (diagnostic.code IS ParserErrorCode::InternalInvariant) found_invariant = true;
+   }
+   if (not found_invariant or invalid_context.descriptors().binding_count() != 1) {
+      Log.error("diagnose mode manufactured a binding instead of reporting the resolver mismatch");
+      return false;
+   }
+
+   return true;
+}
+
 struct ExpressionParseHarness {
    std::unique_ptr<LuaStateHolder> holder;
    std::unique_ptr<StringReaderCtx> reader;
@@ -1588,6 +1715,7 @@ static BindingDiscoveryResult discover_bindings_from_source(std::string_view Sou
    AstBuilder builder(context);
    result.chunk = builder.parse_chunk();
    if (result.chunk.ok()) {
+      resolve_assignment_targets(context, *result.chunk.value_ref());
       discover_static_bindings(context, *result.chunk.value_ref());
       if (EnableTypeAnalysis) run_type_analysis(context, *result.chunk.value_ref());
    }
@@ -6412,6 +6540,7 @@ static bool test_builtin_method_static_classification(kt::Log &Log)
       log_diagnostics(context.diagnostics().entries(), Log);
       return false;
    }
+   resolve_assignment_targets(context, *chunk.value_ref());
    discover_static_bindings(context, *chunk.value_ref());
    propagate_static_descriptors(context, *chunk.value_ref());
    run_type_analysis(context, *chunk.value_ref());
@@ -6552,6 +6681,7 @@ static bool test_stage_b_collection_api_contracts(kt::Log &Log)
       log_diagnostics(context.diagnostics().entries(), Log);
       return false;
    }
+   resolve_assignment_targets(context, *chunk.value_ref());
    discover_static_bindings(context, *chunk.value_ref());
    propagate_static_descriptors(context, *chunk.value_ref());
    run_type_analysis(context, *chunk.value_ref());
@@ -6677,6 +6807,7 @@ static bool test_unresolved_method_receiver_diagnostic(kt::Log &Log)
       AstBuilder builder(context);
       result.chunk = builder.parse_chunk();
       if (result.chunk.ok()) {
+         resolve_assignment_targets(context, *result.chunk.value_ref());
          discover_static_bindings(context, *result.chunk.value_ref());
          propagate_static_descriptors(context, *result.chunk.value_ref());
          run_type_analysis(context, *result.chunk.value_ref());
@@ -9697,6 +9828,7 @@ static bool test_contextual_designation_ownership(kt::Log &Log)
       log_diagnostics(context.diagnostics().entries(), Log);
       return false;
    }
+   resolve_assignment_targets(context, *chunk.value_ref());
    discover_static_bindings(context, *chunk.value_ref());
    propagate_static_descriptors(context, *chunk.value_ref());
 
@@ -10116,11 +10248,12 @@ static bool test_defer_runtime_registration_state(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 92> tests = { {
+   constexpr std::array<TestCase, 93> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "assignment_target_resolution_ast", test_assignment_target_resolution_ast },
       { "assignment_target_semantic_resolution", test_assignment_target_semantic_resolution },
+      { "assignment_target_descriptor_discovery", test_assignment_target_descriptor_discovery },
       { "literal_binary_expr", test_literal_binary_expr },
       { "type_test_ast", test_type_test_ast },
       { "choose_type_pattern_ast", test_choose_type_pattern_ast },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -509,6 +509,72 @@ static bool test_assignment_target_descriptor_discovery(kt::Log &Log)
    return true;
 }
 
+//********************************************************************************************************************
+
+static bool test_assignment_target_environment_types(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *lua = state.get();
+   luaL_openlibs(lua);
+   constexpr std::string_view declarations =
+      "struct AssignmentPersistedRecord Value: int end\n"
+      "global glAssignmentPersistedArray:array<int> = array<int> { 1 }\n"
+      "global glAssignmentPersistedStruct:struct<AssignmentPersistedRecord> = "
+         "struct<AssignmentPersistedRecord> { Value = 1 }\n";
+   if (lua_load(lua, declarations, "=assignment-environment-types") or lua_pcall(lua, 0, 0, 0)) {
+      Log.error("failed to establish persisted assignment types: %s", lua_tostring(lua, -1));
+      return false;
+   }
+   lua_pushnil(lua);
+   lua_setglobal(lua, "glAssignmentPersistedArray");
+   lua_pushnil(lua);
+   lua_setglobal(lua, "glAssignmentPersistedStruct");
+
+   constexpr std::string_view source =
+      "extern glAssignmentPersistedArray, glAssignmentPersistedStruct\n"
+      "glAssignmentPersistedArray = array<int> { 2 }\n"
+      "glAssignmentPersistedStruct = struct<AssignmentPersistedRecord> { Value = 2 }\n";
+   StringReaderCtx reader{ source.data(), source.size() };
+   LexState lex(lua, unit_reader, &reader, "assignment-environment-types", std::nullopt);
+   FuncState &fs = lex.fs_init();
+   ParserContext context = ParserContext::from(lex, fs, ParserAllocator::from(lua));
+   ParserConfig config;
+   config.abort_on_error = false;
+   config.max_diagnostics = 32;
+   ParserSession session(context, config);
+   lex.next();
+   AstBuilder builder(context);
+   auto chunk = builder.parse_chunk();
+   if (not chunk.ok()) return false;
+
+   resolve_assignment_targets(context, *chunk.value_ref());
+   discover_static_bindings(context, *chunk.value_ref());
+   propagate_static_descriptors(context, *chunk.value_ref());
+   run_type_analysis(context, *chunk.value_ref());
+   if (context.diagnostics().has_errors()) {
+      Log.error("persisted assignment types produced unexpected diagnostics");
+      log_diagnostics(context.diagnostics().entries(), Log);
+      return false;
+   }
+
+   GCstr *array_name = lj_str_newlit(lua, "glAssignmentPersistedArray");
+   GCstr *struct_name = lj_str_newlit(lua, "glAssignmentPersistedStruct");
+   auto array_hint = lex.global_type_hints.find(array_name);
+   auto struct_hint = lex.global_type_hints.find(struct_name);
+   struct_record *definition = find_struct(lua, "AssignmentPersistedRecord");
+   if (array_hint IS lex.global_type_hints.end() or struct_hint IS lex.global_type_hints.end() or
+       array_hint->second.primary != TiriType::Array or
+       array_hint->second.array_element.storage != AET::INT32 or
+       array_hint->second.contract_policy != GlobalContractPolicy::Advisory or
+       struct_hint->second.primary != TiriType::Struct or struct_hint->second.struct_def != definition or
+       struct_hint->second.contract_policy != GlobalContractPolicy::Advisory) {
+      Log.error("persisted array or structure identity was not seeded as advisory environment metadata");
+      return false;
+   }
+
+   return true;
+}
+
 struct ExpressionParseHarness {
    std::unique_ptr<LuaStateHolder> holder;
    std::unique_ptr<StringReaderCtx> reader;
@@ -6042,6 +6108,77 @@ static bool test_environment_store_boundary(kt::Log &Log)
       return false;
    }
 
+   if (lua_load(L, std::string_view("glUnitEnvBoundary:str = 'annotated'"),
+         "=envboundary-annotated-assignment") IS 0) {
+      Log.error("a typed assignment redeclared a nil-valued persisted global");
+      lua_pop(L, 1);
+      return false;
+   }
+   std::string_view annotated_error = lua_tostring(L, -1);
+   if (annotated_error.find("cannot redeclare existing global 'glUnitEnvBoundary'") IS std::string_view::npos) {
+      Log.error("a persisted-global annotation produced the wrong diagnostic: %s", lua_tostring(L, -1));
+      lua_pop(L, 1);
+      return false;
+   }
+   lua_pop(L, 1);
+
+   if (lua_load(L, std::string_view("extern glUnitNamedExtern\nglUnitNamedExtern:num = 2"),
+         "=named-extern-annotated-assignment") IS 0) {
+      Log.error("a typed assignment redeclared a named extern");
+      lua_pop(L, 1);
+      return false;
+   }
+   std::string_view extern_error = lua_tostring(L, -1);
+   if (extern_error.find("cannot redeclare existing global 'glUnitNamedExtern'") IS std::string_view::npos) {
+      Log.error("a named-extern annotation produced the wrong diagnostic: %s", lua_tostring(L, -1));
+      lua_pop(L, 1);
+      return false;
+   }
+   lua_pop(L, 1);
+
+   constexpr std::string_view exact_contract_source =
+      "struct UnitPersistedRecord\n"
+      "   Value: int\n"
+      "end\n"
+      "global glUnitPersistedArray:array<int> = array<int> { 1 }\n"
+      "global glUnitPersistedStruct:struct<UnitPersistedRecord> = "
+         "struct<UnitPersistedRecord> { Value = 1 }\n";
+   if (lua_load(L, exact_contract_source, "=environment-exact-contracts") or lua_pcall(L, 0, 0, 0)) {
+      Log.error("establishing exact persisted contracts failed: %s", lua_tostring(L, -1));
+      return false;
+   }
+   lua_pushnil(L);
+   lua_setglobal(L, "glUnitPersistedArray");
+   lua_pushnil(L);
+   lua_setglobal(L, "glUnitPersistedStruct");
+
+   constexpr std::string_view exact_assignment_source =
+      "extern glUnitPersistedArray, glUnitPersistedStruct\n"
+      "glUnitPersistedArray = array<int> { 2 }\n"
+      "glUnitPersistedStruct = struct<UnitPersistedRecord> { Value = 2 }\n"
+      "return glUnitPersistedArray[0], glUnitPersistedStruct.Value\n";
+   if (lua_load(L, exact_assignment_source, "=environment-exact-assignments")) {
+      Log.error("compiling exact persisted assignments failed: %s", lua_tostring(L, -1));
+      return false;
+   }
+   BytecodeSnapshot exact_assignment = snapshot_proto(funcproto(funcV(L->top - 1)));
+   if (count_opcode_tree(exact_assignment, BC_CONTRACT) != 0 or
+       count_opcode_tree(exact_assignment, BC_GSET) != 2) {
+      Log.error("persisted metadata emitted contracts=%zu and global stores=%zu",
+         count_opcode_tree(exact_assignment, BC_CONTRACT), count_opcode_tree(exact_assignment, BC_GSET));
+      return false;
+   }
+   if (lua_pcall(L, 0, 2, 0)) {
+      Log.error("executing exact persisted assignments failed: %s", lua_tostring(L, -1));
+      return false;
+   }
+   bool exact_values = lua_tointeger(L, -2) IS 2 and lua_tointeger(L, -1) IS 2;
+   lua_pop(L, 2);
+   if (not exact_values) {
+      Log.error("exact persisted assignments returned the wrong values");
+      return false;
+   }
+
    // Non-raw C API stores must validate policy without bypassing the environment's __newindex handler.
    lua_pushvalue(L, LUA_GLOBALSINDEX);
    lua_newtable(L);
@@ -10248,12 +10385,13 @@ static bool test_defer_runtime_registration_state(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 93> tests = { {
+   constexpr std::array<TestCase, 94> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "assignment_target_resolution_ast", test_assignment_target_resolution_ast },
       { "assignment_target_semantic_resolution", test_assignment_target_semantic_resolution },
       { "assignment_target_descriptor_discovery", test_assignment_target_descriptor_discovery },
+      { "assignment_target_environment_types", test_assignment_target_environment_types },
       { "literal_binary_expr", test_literal_binary_expr },
       { "type_test_ast", test_type_test_ast },
       { "choose_type_pattern_ast", test_choose_type_pattern_ast },

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -78,11 +78,6 @@ private:
       return {};
    }
 
-   [[nodiscard]] bool is_declared_global(GCstr *Name) const
-   {
-      return std::find(this->global_names_.begin(), this->global_names_.end(), Name) != this->global_names_.end();
-   }
-
    [[nodiscard]] bool is_registered_constant(GCstr *Name) const
    {
       if (not Name) return false;
@@ -94,7 +89,9 @@ private:
    [[nodiscard]] bool implicit_declaration_conflicts(GCstr *Name) const
    {
       if (not Name) return false;
-      if (this->resolve(Name) or this->is_declared_global(Name) or this->is_registered_constant(Name)) return true;
+      if (this->resolve(Name) or
+          std::find(this->global_names_.begin(), this->global_names_.end(), Name) != this->global_names_.end() or
+          this->is_registered_constant(Name)) return true;
       if ((Name->flags & STRFLAG_PROTECTED_GLOBAL) != 0) return true;
 
       cTValue *global = lj_tab_getstr(tabref(this->context_.lua().env), Name);
@@ -125,15 +122,36 @@ private:
       }
    }
 
+   void report_binding_invariant(const Identifier &Name, std::string Message)
+   {
+      ParserDiagnostic diagnostic;
+      diagnostic.severity = ParserDiagnosticSeverity::Error;
+      diagnostic.code = ParserErrorCode::InternalInvariant;
+      diagnostic.message = std::move(Message);
+      diagnostic.token = Token::from_span(Name.span, TokenKind::Identifier);
+      this->context_.diagnostics().report(diagnostic);
+   }
+
+   [[nodiscard]] bool binding_is_catalogued(StaticBindingID Binding) const
+   {
+      return Binding and Binding.raw() < this->catalogue_.binding_count();
+   }
+
    StaticBindingID declare(Identifier &Name, const ExprNode *Initialiser, uint8_t ResultPosition,
       const FunctionExprPayload *Function = nullptr, bool IsParameter = false)
    {
-      if (this->validation_only_) {
-         StaticBindingID placeholder(1);
-         if (Name.symbol and not Name.is_blank) {
-            this->scopes_.back().entries.emplace_back(Name.symbol, placeholder);
-         }
-         return placeholder;
+      if (not Name.symbol or Name.is_blank) {
+         if (Name.binding_id) this->report_binding_invariant(Name,
+            "blank or unnamed declaration unexpectedly has a published binding");
+         return {};
+      }
+
+      StaticBindingID expected(this->catalogue_.binding_count());
+      if (Name.binding_id != expected) {
+         this->report_binding_invariant(Name, std::format(
+            "published binding {} for '{}' disagrees with descriptor position {}",
+            Name.binding_id.raw(), std::string_view(strdata(Name.symbol), Name.symbol->len), expected.raw()));
+         return {};
       }
 
       StaticBindingDescriptor binding;
@@ -146,13 +164,55 @@ private:
       binding.is_parameter = IsParameter;
       binding.is_variant = Name.type IS TiriType::Any;
       StaticBindingID id = this->catalogue_.add_binding(binding);
-      Name.binding_id = id;
-      if (Name.symbol and not Name.is_blank) this->scopes_.back().entries.emplace_back(Name.symbol, id);
+      this->scopes_.back().entries.emplace_back(Name.symbol, id);
       return id;
+   }
+
+   void attach_assignment_write(NameRef &Reference)
+   {
+      AssignmentTargetResolution category = Reference.assignment_resolution;
+      if (category IS AssignmentTargetResolution::Unresolved or
+          category IS AssignmentTargetResolution::NewLocal) {
+         this->report_binding_invariant(Reference.identifier,
+            "assignment target reached descriptor discovery without a usable storage category");
+         return;
+      }
+      bool lexical = assignment_target_is_existing_lexical(category);
+      bool has_binding = bool(Reference.binding_id);
+      if (not lexical) {
+         if (has_binding) {
+            this->report_binding_invariant(Reference.identifier,
+               "non-lexical assignment target unexpectedly has a published binding");
+         }
+         return;
+      }
+
+      StaticBindingID resolved = this->resolve(Reference.identifier.symbol);
+      if (not has_binding or Reference.identifier.binding_id != Reference.binding_id or
+          resolved != Reference.binding_id or not this->binding_is_catalogued(Reference.binding_id)) {
+         this->report_binding_invariant(Reference.identifier,
+            "lexical assignment target does not agree with its published binding");
+         return;
+      }
+
+      auto &binding = this->catalogue_.binding(Reference.binding_id);
+      bool expected_upvalue = binding.function_depth < this->function_depth_;
+      if ((category IS AssignmentTargetResolution::ExistingUpvalue) != expected_upvalue) {
+         this->report_binding_invariant(Reference.identifier,
+            "assignment target local/upvalue category disagrees with its binding depth");
+         return;
+      }
+      if (this->validation_only_) return;
+      if (expected_upvalue) binding.captured = true;
+      binding.immutable = false;
    }
 
    void reference(NameRef &Reference, bool Write = false)
    {
+      if (Write) {
+         this->attach_assignment_write(Reference);
+         return;
+      }
       if (this->validation_only_) return;
 
       StaticBindingID id = this->resolve(Reference.identifier.symbol);
@@ -162,7 +222,6 @@ private:
 
       auto &binding = this->catalogue_.binding(id);
       if (binding.function_depth < this->function_depth_) binding.captured = true;
-      if (Write) binding.immutable = false;
    }
 
    void discover_function(FunctionExprPayload &Function)
@@ -318,6 +377,7 @@ private:
       StaticDescriptorAnalyser validator(this->context_, this->native_calls_only_, true);
       validator.scopes_ = this->scopes_;
       validator.global_names_ = this->global_names_;
+      validator.function_depth_ = this->function_depth_;
       validator.discover_expression(Expression);
    }
 
@@ -326,6 +386,7 @@ private:
       StaticDescriptorAnalyser validator(this->context_, this->native_calls_only_, true);
       validator.scopes_ = this->scopes_;
       validator.global_names_ = this->global_names_;
+      validator.function_depth_ = this->function_depth_;
       validator.discover_block(Block);
    }
 
@@ -356,19 +417,16 @@ private:
 
                if (target->kind IS AstNodeKind::IdentifierExpr) {
                   auto &reference = std::get<NameRef>(target->data);
-                  GCstr *name = reference.identifier.symbol;
-                  bool protected_global = name and ((name->flags & STRFLAG_PROTECTED_GLOBAL) != 0);
-                  bool creates_local = payload.op IS AssignmentOperator::Plain or
-                     payload.op IS AssignmentOperator::IfEmpty or payload.op IS AssignmentOperator::IfNil;
-                  if (creates_local and
-                      name and not reference.identifier.is_blank and not protected_global and
-                      not this->is_declared_global(name) and not this->resolve(name)) {
+                  if (reference.assignment_resolution IS AssignmentTargetResolution::NewLocal) {
                      const ExprNode *initialiser = i < payload.values.size() ? payload.values[i].get() :
                         (payload.values.empty() ? nullptr : payload.values.back().get());
                      uint8_t position = i < payload.values.size() ? 0 :
                         uint8_t(i - payload.values.size() + 1);
                      StaticBindingID binding = this->declare(reference.identifier, initialiser, position);
-                     if (not this->validation_only_) reference.binding_id = binding;
+                     if (reference.binding_id != binding or reference.identifier.binding_id != reference.binding_id) {
+                        this->report_binding_invariant(reference.identifier,
+                           "new-local assignment target does not agree with its descriptor binding");
+                     }
                      continue;
                   }
                }
@@ -436,11 +494,18 @@ private:
             }
             break;
          }
-         case AstNodeKind::WhileStmt:
-         case AstNodeKind::RepeatStmt: {
+         case AstNodeKind::WhileStmt: {
             auto &payload = std::get<LoopStmtPayload>(Statement.data);
             if (payload.condition) this->discover_expression(*payload.condition);
             if (payload.body) this->discover_block(*payload.body);
+            break;
+         }
+         case AstNodeKind::RepeatStmt: {
+            auto &payload = std::get<LoopStmtPayload>(Statement.data);
+            this->scopes_.push_back(BindingScope{});
+            if (payload.body) this->discover_block(*payload.body, false);
+            if (payload.condition) this->discover_expression(*payload.condition);
+            this->scopes_.pop_back();
             break;
          }
          case AstNodeKind::NumericForStmt: {
@@ -535,6 +600,7 @@ private:
          case AstNodeKind::ImportStmt: {
             for (auto &entry : std::get<ImportStmtPayload>(Statement.data).entries) {
                if (entry.inlined_body) this->discover_block(*entry.inlined_body);
+               if (entry.namespace_name) this->declare(*entry.namespace_name, nullptr, 0);
             }
             break;
          }

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -21,6 +21,8 @@
 #include <ankerl/unordered_dense.h>
 #include <kotuku/main.h>
 #include "parser/parser_context.h"
+#include "../runtime/lj_array.h"
+#include "../runtime/lj_tab.h"
 #include "../../../defs.h"
 
 #ifdef INCLUDE_TIPS
@@ -401,16 +403,27 @@ private:
       const FunctionExprPayload* forward_declaration = nullptr; // Original empty declaration used as the contract
       bool is_const = false;  // True if declared with <const> attribute
       bool implicit = false;  // True if inferred from a plain assignment rather than a 'global' declaration
+      bool environment_contract = false; // Persisted policy already enforced by the environment store boundary.
+      GlobalContractPolicy contract_policy = GlobalContractPolicy::Advisory;
+   };
+
+   struct EnvironmentGlobalFacts {
+      bool exists = false;
+      bool is_const = false;
+      std::optional<InferredType> exact_type;
       GlobalContractPolicy contract_policy = GlobalContractPolicy::Advisory;
    };
 
    void declare_global(GCstr *Name, const InferredType &Type, SourceSpan Location, bool IsConst = false,
       GlobalContractPolicy ContractPolicy = GlobalContractPolicy::Advisory);
    void declare_global_function(GCstr *Name, const FunctionExprPayload *Function, SourceSpan Location);
-   [[nodiscard]] bool declare_implicit_global(GCstr *Name, InferredType Type, SourceSpan Location);
+   void record_implicit_global(GCstr *Name, InferredType Type, SourceSpan Location);
+   [[nodiscard]] EnvironmentGlobalFacts environment_global_facts(GCstr *Name) const;
+   void seed_environment_global(GCstr *Name, SourceSpan Location);
    [[nodiscard]] std::optional<InferredType> lookup_global_type(GCstr *Name) const;
    [[nodiscard]] bool is_global_const(GCstr *Name) const;
    [[nodiscard]] bool is_implicit_global(GCstr *Name) const;
+   [[nodiscard]] bool has_environment_contract(GCstr *Name) const;
    void fix_global_type(GCstr *Name, TiriType Type, CLASSID ObjectClassId = CLASSID::NIL,
       struct_record *StructDef = nullptr, ArrayElementDescriptor ArrayElement = {});
    void mark_dynamic_ingress(GCstr *Name, bool IsGlobal, bool RequiresDestination = true);
@@ -1522,51 +1535,97 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
          if (not name_ref) continue;
 
          GCstr *name = name_ref->identifier.symbol;
+         AssignmentTargetResolution category = name_ref->assignment_resolution;
+         if (category IS AssignmentTargetResolution::Unresolved) {
+            TypeDiagnostic diag;
+            diag.location = target.span;
+            diag.code = ParserErrorCode::InternalInvariant;
+            diag.message = "assignment target reached type analysis without semantic resolution";
+            this->record_diagnostic(std::move(diag));
+            continue;
+         }
+         if (category IS AssignmentTargetResolution::Blank or
+             category IS AssignmentTargetResolution::Invalid) continue;
+
+         bool is_global = category IS AssignmentTargetResolution::ExistingGlobal;
+         bool is_lexical = assignment_target_is_existing_lexical(category);
 
          // A plain identifier target naming a host pre-registered global is an override unless an
          // explicit local shadow or parameter is in scope.
 
-         if (name and not name_ref->identifier.is_blank and
-             ((name->flags & STRFLAG_PROTECTED_GLOBAL) != 0) and
-             not this->resolve_identifier(name)) {
+         if (is_global and name and ((name->flags & STRFLAG_PROTECTED_GLOBAL) != 0)) {
             this->report_protected_global_override(name, target.span);
             continue;
          }
 
-         // First check local variables
-
-         auto existing = this->resolve_identifier(name);
-         bool is_global = false;
-         bool is_const = false;
-         bool environment_global = false;
-
-         // If not found as local, check global variables
-
-         if (not existing) {
-            existing = this->lookup_global_type(name);
-            is_global = existing.has_value();
-            if (is_global) is_const = this->is_global_const(name);
-            else {
-               cTValue *global = lj_tab_getstr(tabref(this->ctx_.lua().env), name);
-               environment_global = global and not tvisnil(global);
-            }
+         if (is_global and type_is_registered_constant(name)) {
+            TypeDiagnostic diag;
+            diag.location = target.span;
+            diag.code = ParserErrorCode::AssignToConstant;
+            diag.message = std::format("cannot assign to constant '{}'", std::string_view(strdata(name), name->len));
+            this->record_diagnostic(std::move(diag));
+            continue;
          }
-         else is_const = this->is_local_const(name);
 
          const Identifier &identifier = name_ref->identifier;
-         if ((existing or environment_global) and identifier.type != TiriType::Unknown) {
+         std::optional<InferredType> existing;
+         bool is_const = false;
+         if (is_lexical) {
+            existing = this->resolve_identifier(name);
+            is_const = this->is_local_const(name);
+            bool valid_binding = name_ref->binding_id and identifier.binding_id IS name_ref->binding_id and
+               name_ref->binding_id.raw() < this->ctx_.descriptors().binding_count();
+            if (valid_binding) {
+               valid_binding = this->ctx_.descriptors().binding(name_ref->binding_id).name IS name;
+            }
+            if (not existing or not valid_binding) {
+               TypeDiagnostic diag;
+               diag.location = target.span;
+               diag.code = ParserErrorCode::InternalInvariant;
+               diag.message = "lexical assignment target does not match an analysed binding";
+               this->record_diagnostic(std::move(diag));
+               continue;
+            }
+         }
+
+         if (assignment_target_is_existing_storage(category) and identifier.type != TiriType::Unknown) {
             std::string_view name_view(strdata(name), name->len);
             TypeDiagnostic diag;
             diag.location = identifier.span;
             diag.code = ParserErrorCode::InvalidAssignment;
             diag.message = std::format(
                "cannot redeclare existing {} '{}' with a type annotation",
-               (is_global or environment_global) ? "global" : "local", name_view);
+               is_global ? "global" : "local", name_view);
             this->record_diagnostic(std::move(diag));
             continue;
          }
 
+         if (is_global) {
+            this->seed_environment_global(name, target.span);
+            existing = this->lookup_global_type(name);
+            if (existing) is_const = this->is_global_const(name);
+            else {
+               InferredType inferred(TiriType::Any, false, true, true);
+               if (Payload.op IS AssignmentOperator::Plain and not Payload.values.empty()) {
+                  size_t source = std::min(i, Payload.values.size() - 1);
+                  size_t result_position = i - source;
+                  if (result_position IS 0) inferred = this->infer_expression_type(*Payload.values[source]);
+                  else inferred = this->infer_call_return_type(*Payload.values[source], result_position);
+               }
+               this->record_implicit_global(name, inferred, target.span);
+               existing = this->lookup_global_type(name);
+            }
+         }
+
          if (not existing) {
+            if (category != AssignmentTargetResolution::NewLocal) {
+               TypeDiagnostic diag;
+               diag.location = target.span;
+               diag.code = ParserErrorCode::InternalInvariant;
+               diag.message = "existing assignment target has no type-analysis record";
+               this->record_diagnostic(std::move(diag));
+               continue;
+            }
             if (name_ref->binding_id and identifier.type != TiriType::Unknown) {
                InferredType inferred;
                inferred.primary = TiriType::Nil;
@@ -1657,35 +1716,20 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
                if (result_position IS 0 and is_table_read_expression(*Payload.values[source])) {
                   this->explicit_variant_bindings_.insert(name_ref->binding_id);
                }
-               if (Payload.op != AssignmentOperator::Plain and not inferred.requires_destination_type) {
-                  this->current_scope().declare_local(name, inferred, target.span);
-                  this->implicit_local_bindings_.insert(name_ref->binding_id);
-                  this->publish_binding_type(name_ref->binding_id, inferred);
-                  continue;
+               if (inferred.requires_destination_type) {
+                  inferred = InferredType(TiriType::Any);
+                  this->explicit_variant_bindings_.insert(name_ref->binding_id);
                }
-
-               if (Payload.op IS AssignmentOperator::Plain) {
-                  if (not this->declare_implicit_global(name, inferred, target.span)) {
-                     if (inferred.requires_destination_type) {
-                        inferred = InferredType(TiriType::Any);
-                        this->explicit_variant_bindings_.insert(name_ref->binding_id);
-                     }
-                     this->current_scope().declare_local(name, inferred, target.span);
-                     this->implicit_local_bindings_.insert(name_ref->binding_id);
-                     this->publish_binding_type(name_ref->binding_id, inferred);
-                  }
-                  continue;
-               }
+               this->current_scope().declare_local(name, inferred, target.span);
+               this->implicit_local_bindings_.insert(name_ref->binding_id);
+               this->publish_binding_type(name_ref->binding_id, inferred);
+               continue;
             }
 
-            // The name is neither a local nor a known global.  A plain assignment to a name that already exists in
-            // the environment table updates that global at runtime, so record an implicit global type for it.  Only
-            // simple '=' assignments are used for inference; compound operators require an existing value and never
-            // create a global.
-            if (Payload.op IS AssignmentOperator::Plain and i < Payload.values.size()) {
-               InferredType inferred = this->infer_expression_type(*Payload.values[i]);
-               (void)this->declare_implicit_global(name, inferred, target.span);
-            }
+            InferredType inferred(TiriType::Nil, false, true, false);
+            this->current_scope().declare_local(name, inferred, target.span);
+            this->implicit_local_bindings_.insert(name_ref->binding_id);
+            this->publish_binding_type(name_ref->binding_id, inferred);
             continue;
          }
 
@@ -1729,6 +1773,10 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
             }
             continue;
          }
+
+         // Persisted contracts remain authoritative at the environment boundary.  Static metadata supports reads
+         // and redeclaration checks, but ordinary stores must still compile so runtime validation remains catchable.
+         if (is_global and this->has_environment_contract(name)) continue;
 
          if (existing->is_fixed) {
             // Fixed type: check compatibility
@@ -3500,18 +3548,12 @@ void TypeAnalyser::declare_global_function(GCstr *Name, const FunctionExprPayloa
    this->trace_decl(this->ctx_.lex().linenumber, Name, TiriType::Func, true);
 }
 
-// Records a pre-existing environment global updated through plain assignment.  The inferred type is advisory only:
-// conflicting later assignments degrade it to 'any' instead of diagnosing, since the assignment carries no
-// user-declared type contract.
+// Records an ExistingGlobal assignment that has no exact persisted contract.  Storage identity is supplied by the
+// assignment resolver; this advisory type never decides whether the target is local or global.
 
-bool TypeAnalyser::declare_implicit_global(GCstr *Name, InferredType Type, SourceSpan Location)
+void TypeAnalyser::record_implicit_global(GCstr *Name, InferredType Type, SourceSpan Location)
 {
-   if (not Name) return false;
-   if ((Name->flags & STRFLAG_PROTECTED_GLOBAL) != 0) return false;
-
-   cTValue *global = lj_tab_getstr(tabref(this->ctx_.lua().env), Name);
-   bool is_global_store = (global != nullptr) and not tvisnil(global);
-   if (not is_global_store) return false;  // Plain assignment to this name creates a local, not a global
+   if (not Name or (Name->flags & STRFLAG_PROTECTED_GLOBAL) != 0) return;
 
    Type.requires_destination_type = false;
    if (Type.primary != TiriType::Nil and Type.primary != TiriType::Any and Type.primary != TiriType::Unknown) {
@@ -3525,7 +3567,73 @@ bool TypeAnalyser::declare_implicit_global(GCstr *Name, InferredType Type, Sourc
    info.implicit = true;
    this->global_types_[Name] = info;
    this->trace_decl(this->ctx_.lex().linenumber, Name, Type.primary, Type.is_fixed);
-   return true;
+}
+
+TypeAnalyser::EnvironmentGlobalFacts TypeAnalyser::environment_global_facts(GCstr *Name) const
+{
+   EnvironmentGlobalFacts facts;
+   if (not Name) return facts;
+
+   GCtab *environment = tabref(this->ctx_.lua().env);
+   if (not environment) return facts;
+
+   cTValue *value = lj_tab_getstr(environment, Name);
+   facts.exists = value and not tvisnil(value);
+
+   GCstr *persisted = lj_tab_get_global_contract(environment, Name);
+   if (not persisted) return facts;
+   facts.exists = true;
+
+   RuntimeContractDescriptor descriptor;
+   if (not decode_runtime_contract(persisted, descriptor) or
+       descriptor.boundary != ContractBoundary::Global or descriptor.contract_count IS 0) return facts;
+
+   const RuntimeContractEntry &entry = descriptor.entries[0];
+   InferredType type;
+   type.primary = entry.type;
+   type.object_class_id = entry.type IS TiriType::Object ? entry.object_class_id : CLASSID::NIL;
+   type.is_nullable = (entry.flags & contract_flag(ContractEntryFlag::Nullable)) != 0;
+   type.is_fixed = entry.type != TiriType::Any and entry.type != TiriType::Unknown;
+
+   if (entry.type IS TiriType::Struct and not entry.constraint_name.empty()) {
+      type.struct_def = find_struct(&this->ctx_.lua(), entry.constraint_name);
+   }
+   else if (entry.type IS TiriType::Array and entry.array_element_type != AET::MAX) {
+      std::string element_name;
+      if (entry.array_element_type IS AET::STRUCT and not entry.constraint_name.empty()) {
+         element_name = std::format("struct<{}>", entry.constraint_name);
+      }
+      else if (entry.array_element_type IS AET::ARRAY and not entry.constraint_name.empty()) {
+         element_name.assign(entry.constraint_name);
+      }
+      else element_name = lj_array_elemtype_name(entry.array_element_type);
+
+      if (auto element = parse_array_element_type(element_name, &this->ctx_.lua())) {
+         type.array_element = *element;
+      }
+   }
+
+   facts.is_const = contract_entry_is_const(entry);
+   facts.exact_type = type;
+   facts.contract_policy = entry.type IS TiriType::Any ?
+      GlobalContractPolicy::Variant : GlobalContractPolicy::Enforced;
+   return facts;
+}
+
+void TypeAnalyser::seed_environment_global(GCstr *Name, SourceSpan Location)
+{
+   if (not Name or this->global_types_.contains(Name)) return;
+   EnvironmentGlobalFacts facts = this->environment_global_facts(Name);
+   if (not facts.exists or not facts.exact_type) return;
+
+   GlobalTypeInfo info;
+   info.type = *facts.exact_type;
+   info.location = Location;
+   info.is_const = facts.is_const;
+   info.environment_contract = true;
+   info.contract_policy = facts.contract_policy;
+   this->global_types_[Name] = info;
+   this->trace_decl(this->ctx_.lex().linenumber, Name, info.type.primary, info.type.is_fixed);
 }
 
 std::optional<InferredType> TypeAnalyser::lookup_global_type(GCstr *Name) const
@@ -3539,6 +3647,15 @@ bool TypeAnalyser::is_implicit_global(GCstr *Name) const
 {
    if (not Name) return false;
    if (auto it = this->global_types_.find(Name); it != this->global_types_.end()) return it->second.implicit;
+   return false;
+}
+
+bool TypeAnalyser::has_environment_contract(GCstr *Name) const
+{
+   if (not Name) return false;
+   if (auto it = this->global_types_.find(Name); it != this->global_types_.end()) {
+      return it->second.environment_contract;
+   }
    return false;
 }
 
@@ -4094,6 +4211,17 @@ static void publish_type_diagnostics(ParserContext& Context, const std::vector<T
 void TypeAnalyser::publish_global_type_hints(LexState &Lex) const
 {
    for (const auto &[name, info] : this->global_types_) {
+      if (info.environment_contract) {
+         if (info.type.is_fixed and
+             (info.type.primary IS TiriType::Struct or info.type.primary IS TiriType::Object or
+              info.type.primary IS TiriType::Array)) {
+            Lex.global_type_hints[name] = {
+               info.type.primary, info.type.object_class_id, info.type.struct_def, info.type.array_element,
+               GlobalContractPolicy::Advisory
+            };
+         }
+         continue;
+      }
       if (info.contract_policy IS GlobalContractPolicy::Variant) {
          Lex.global_type_hints[name] = {
             TiriType::Any, CLASSID::NIL, nullptr, {}, GlobalContractPolicy::Variant

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -298,6 +298,13 @@ private:
    [[nodiscard]] bool is_variant_expression(const ExprNode &, size_t Position = 0) const;
    [[nodiscard]] bool is_table_read_expression(const ExprNode &);
    [[nodiscard]] InferredType infer_call_return_type(const ExprNode &, size_t Position) const;
+   struct LocalInitialiser {
+      InferredType type;
+      const ExprNode *expression = nullptr;
+   };
+   [[nodiscard]] std::optional<LocalInitialiser> infer_local_initialiser(const ExprNodeList &, size_t Position);
+   [[nodiscard]] InferredType analyse_annotated_local_binding(
+      const Identifier &, const ExprNodeList &, size_t Position);
 
    // Symbol resolution - looks up variables and functions in scope stack
    [[nodiscard]] std::optional<InferredType> resolve_identifier(GCstr *) const;
@@ -1627,63 +1634,8 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
                continue;
             }
             if (name_ref->binding_id and identifier.type != TiriType::Unknown) {
-               InferredType inferred;
-               inferred.primary = TiriType::Nil;
-
-               if (not Payload.values.empty()) {
-                  size_t source = std::min(i, Payload.values.size() - 1);
-                  size_t result_position = i - source;
-                  if (result_position IS 0) inferred = this->infer_expression_type(*Payload.values[source]);
-                  else inferred = this->infer_call_return_type(*Payload.values[source], result_position);
-
-                  if (identifier.type != TiriType::Any and inferred.primary != TiriType::Nil and
-                      inferred.primary != TiriType::Any and inferred.primary != TiriType::Unknown and
-                      inferred.primary != identifier.type) {
-                     TypeDiagnostic diag;
-                     diag.location = Payload.values[source]->span;
-                     diag.expected = identifier.type;
-                     diag.actual = inferred.primary;
-                     diag.code = ParserErrorCode::TypeMismatchAssignment;
-                     diag.message = std::format("cannot assign '{}' to variable of type '{}'",
-                        type_name(inferred.primary), type_name(identifier.type));
-                     this->record_diagnostic(std::move(diag));
-                  }
-                  else if (identifier.type IS TiriType::Struct and inferred.primary IS TiriType::Struct and
-                      identifier.struct_def and inferred.struct_def and
-                      identifier.struct_def != inferred.struct_def) {
-                     TypeDiagnostic diag;
-                     diag.location = Payload.values[source]->span;
-                     diag.expected = TiriType::Struct;
-                     diag.actual = TiriType::Struct;
-                     diag.code = ParserErrorCode::TypeMismatchAssignment;
-                     diag.message = std::format("struct layout mismatch: cannot assign '{}' to '{}'",
-                        inferred.struct_def->Name, identifier.struct_def->Name);
-                     this->record_diagnostic(std::move(diag));
-                  }
-                  else if (identifier.type IS TiriType::Array and inferred.primary IS TiriType::Array and
-                      inferred.array_element.known and
-                      not array_element_matches(identifier.array_element, inferred.array_element)) {
-                     TypeDiagnostic diag;
-                     diag.location = Payload.values[source]->span;
-                     diag.expected = TiriType::Array;
-                     diag.actual = TiriType::Array;
-                     diag.code = ParserErrorCode::TypeMismatchAssignment;
-                     diag.message = std::format("array member mismatch: expected array<{}>, got array<{}>",
-                        array_element_name(identifier.array_element), array_element_name(inferred.array_element));
-                     this->record_diagnostic(std::move(diag));
-                  }
-               }
-
-               inferred.primary = identifier.type;
-               inferred.struct_def = identifier.struct_def;
-               inferred.array_element = identifier.array_element;
-               inferred.requires_destination_type = false;
-               inferred.is_fixed = identifier.type != TiriType::Any;
+               InferredType inferred = this->analyse_annotated_local_binding(identifier, Payload.values, i);
                this->current_scope().declare_local(name, inferred, target.span);
-               if (identifier.type IS TiriType::Any) {
-                  this->explicit_variant_bindings_.insert(name_ref->binding_id);
-               }
-               this->publish_binding_type(name_ref->binding_id, inferred);
                continue;
             }
 
@@ -1691,7 +1643,10 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
                size_t source = std::min(i, Payload.values.size() - 1);
                size_t result_position = i - source;
                InferredType inferred;
-               if (result_position IS 0) inferred = this->infer_expression_type(*Payload.values[source]);
+               if (result_position IS 0) {
+                  inferred = this->infer_expression_type(*Payload.values[source]);
+                  inferred = this->refine_static_expression_type(*Payload.values[source], inferred);
+               }
                else {
                   const ExprNode &value_expr = *Payload.values[source];
                   bool provides_multiple_results = value_expr.kind IS AstNodeKind::CallExpr or
@@ -1907,119 +1862,37 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
 
 void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
 {
-   // Track which position we're at for multi-value returns from function calls
-   // When a function call is the last (or only) value, it may provide multiple return values
-   size_t value_index = 0;
-   size_t call_return_index = 0;  // Position within a multi-return call
-   const ExprNode* multi_return_call = nullptr;  // The function call providing multi-returns
-
    for (size_t name_index = 0; name_index < Payload.names.size(); ++name_index) {
       const auto& name = Payload.names[name_index];
       InferredType inferred;
-      InferredType value_type;
-      bool have_value_type = false;
-      const ExprNode *initialiser = nullptr;  // Direct initialiser, excluding trailing multi-return positions
-
-      // Determine the value type for this variable
-      if (value_index < Payload.values.size()) {
-         // We have an explicit value at this position
-         const ExprNode& value_expr = *Payload.values[value_index];
-         value_type = this->infer_expression_type(value_expr);
-         value_type = this->refine_static_expression_type(value_expr, value_type);
-         have_value_type = true;
-         initialiser = &value_expr;
-
-         // If this is the last value and it can provide multiple results, retain it for later declaration positions.
-         if (value_index IS Payload.values.size() - 1 and
-             (value_expr.kind IS AstNodeKind::CallExpr or value_expr.kind IS AstNodeKind::SafeCallExpr or
-              (value_expr.static_results and
-               (this->ctx_.descriptors().results(value_expr.static_results).declared_count > 1 or
-                this->ctx_.descriptors().results(value_expr.static_results).variadic)))) {
-            multi_return_call = &value_expr;
-            call_return_index = 0;
-         }
-
-         value_index += 1;
-      }
-      else if (multi_return_call) {
-         // No more explicit values, but we have a trailing function call
-         // Use the next return value position from the multi-return call
-         call_return_index += 1;
-         value_type = this->infer_call_return_type(*multi_return_call, call_return_index);
-         have_value_type = true;
-      }
+      std::optional<LocalInitialiser> initialiser;
 
       // Explicit type annotation takes precedence (Unknown = no annotation)
       if (name.type != TiriType::Unknown) {
-         inferred.primary = name.type;
-         inferred.struct_def = name.struct_def;
-         inferred.array_element = name.array_element;
-         // 'any' type is not fixed - it accepts any value
-         inferred.is_fixed = (name.type != TiriType::Any);
-
-         // Check that initial value matches declared type (if present and not 'any')
-         if (name.type != TiriType::Any and have_value_type) {
-            // Nil is always allowed as initial value for typed variables
-            if (value_type.primary != TiriType::Nil and
-                value_type.primary != TiriType::Any and
-                value_type.primary != name.type) {
-               TypeDiagnostic diag;
-               if (value_index > 0 and value_index - 1 < Payload.values.size()) {
-                  diag.location = Payload.values[value_index - 1]->span;
-               }
-               diag.expected = name.type;
-               diag.actual = value_type.primary;
-               diag.code = ParserErrorCode::TypeMismatchAssignment;
-               diag.message = std::format("cannot assign '{}' to variable of type '{}'",
-                  type_name(value_type.primary), type_name(name.type));
-               this->record_diagnostic(std::move(diag));
-            }
-            else if (name.type IS TiriType::Struct and value_type.primary IS TiriType::Struct and
-                name.struct_def and value_type.struct_def and name.struct_def != value_type.struct_def) {
-               TypeDiagnostic diag;
-               if (value_index > 0 and value_index - 1 < Payload.values.size()) {
-                  diag.location = Payload.values[value_index - 1]->span;
-               }
-               diag.expected = TiriType::Struct;
-               diag.actual = TiriType::Struct;
-               diag.code = ParserErrorCode::TypeMismatchAssignment;
-               diag.message = std::format("struct layout mismatch: cannot assign '{}' to '{}'",
-                  value_type.struct_def->Name, name.struct_def->Name);
-               this->record_diagnostic(std::move(diag));
-            }
-            else if (name.type IS TiriType::Array and value_type.primary IS TiriType::Array and
-                value_type.array_element.known and
-                not array_element_matches(name.array_element, value_type.array_element)) {
-               TypeDiagnostic diag;
-               diag.location = initialiser ? initialiser->span : name.span;
-               diag.expected = TiriType::Array;
-               diag.actual = TiriType::Array;
-               diag.code = ParserErrorCode::TypeMismatchAssignment;
-               diag.message = std::format("array member mismatch: expected array<{}>, got array<{}>",
-                  array_element_name(name.array_element), array_element_name(value_type.array_element));
-               this->record_diagnostic(std::move(diag));
-            }
-         }
-      }
-      else if (have_value_type) {
-         // No annotation: infer type from initial value
-         inferred = value_type;
-
-         inferred.requires_destination_type = not name.is_blank and
-            (inferred.primary IS TiriType::Any or inferred.primary IS TiriType::Unknown) and
-            not (initialiser and is_table_read_expression(*initialiser));
-
-         // Non-nil, non-any initial values fix the type
-         if (inferred.primary != TiriType::Nil and inferred.primary != TiriType::Any and
-             inferred.primary != TiriType::Unknown) {
-            inferred.is_fixed = true;
-         }
+         inferred = this->analyse_annotated_local_binding(name, Payload.values, name_index);
       }
       else {
-         // No annotation and no initialiser: starts as nil, type not yet determined
-         // Use Nil (not Any) so the first non-nil assignment will fix the type
-         inferred.primary = TiriType::Nil;
-         inferred.is_fixed = false;
+         initialiser = this->infer_local_initialiser(Payload.values, name_index);
+         if (initialiser) {
+            // No annotation: infer type from initial value
+            inferred = initialiser->type;
+
+            inferred.requires_destination_type = not name.is_blank and
+               (inferred.primary IS TiriType::Any or inferred.primary IS TiriType::Unknown) and
+               not is_table_read_expression(*initialiser->expression);
+
+            // Non-nil, non-any initial values fix the type
+            if (inferred.primary != TiriType::Nil and inferred.primary != TiriType::Any and
+                inferred.primary != TiriType::Unknown) {
+               inferred.is_fixed = true;
+            }
+         }
+         else {
+            // No annotation and no initialiser: starts as nil, type not yet determined
+            // Use Nil (not Any) so the first non-nil assignment will fix the type
+            inferred.primary = TiriType::Nil;
+            inferred.is_fixed = false;
+         }
       }
 
       #ifdef INCLUDE_TIPS
@@ -2027,17 +1900,89 @@ void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
       #endif
 
       this->current_scope().declare_local(name.symbol, inferred, name.span, name.has_const);
-      if ((name.type IS TiriType::Any or (initialiser and is_table_read_expression(*initialiser))) and
-          name.binding_id) {
+      if (name.type IS TiriType::Unknown and initialiser and
+          is_table_read_expression(*initialiser->expression) and name.binding_id) {
          this->explicit_variant_bindings_.insert(name.binding_id);
       }
-      this->publish_binding_type(name.binding_id, inferred);
+      if (name.type IS TiriType::Unknown) this->publish_binding_type(name.binding_id, inferred);
       this->trace_decl(this->ctx_.lex().linenumber, name.symbol, inferred.primary, inferred.is_fixed);
    }
 
    for (const auto &value : Payload.values) {
       this->analyse_expression(*value);
    }
+}
+
+std::optional<TypeAnalyser::LocalInitialiser> TypeAnalyser::infer_local_initialiser(
+   const ExprNodeList &Values, size_t Position)
+{
+   if (Values.empty()) return std::nullopt;
+
+   size_t source = std::min(Position, Values.size() - 1);
+   size_t result_position = Position - source;
+   const ExprNode &expression = *Values[source];
+   InferredType type;
+   if (result_position IS 0) {
+      type = this->infer_expression_type(expression);
+      type = this->refine_static_expression_type(expression, type);
+   }
+   else {
+      bool provides_multiple_results = expression.kind IS AstNodeKind::CallExpr or
+         expression.kind IS AstNodeKind::SafeCallExpr or
+         (expression.static_results and
+          (this->ctx_.descriptors().results(expression.static_results).declared_count > 1 or
+           this->ctx_.descriptors().results(expression.static_results).variadic));
+      if (not provides_multiple_results) return std::nullopt;
+      type = this->infer_call_return_type(expression, result_position);
+   }
+   return LocalInitialiser { type, &expression };
+}
+
+InferredType TypeAnalyser::analyse_annotated_local_binding(
+   const Identifier &Name, const ExprNodeList &Values, size_t Position)
+{
+   InferredType inferred;
+   inferred.primary = Name.type;
+   inferred.struct_def = Name.struct_def;
+   inferred.array_element = Name.array_element;
+   inferred.requires_destination_type = false;
+   inferred.is_fixed = Name.type != TiriType::Any;
+
+   auto initialiser = this->infer_local_initialiser(Values, Position);
+   if (Name.type != TiriType::Any and initialiser) {
+      const InferredType &value_type = initialiser->type;
+      TypeDiagnostic diag;
+      diag.location = initialiser->expression->span;
+      diag.expected = Name.type;
+      diag.actual = value_type.primary;
+      diag.code = ParserErrorCode::TypeMismatchAssignment;
+
+      if (value_type.primary != TiriType::Nil and value_type.primary != TiriType::Any and
+          value_type.primary != TiriType::Unknown and value_type.primary != Name.type) {
+         diag.message = std::format("cannot assign '{}' to variable of type '{}'",
+            type_name(value_type.primary), type_name(Name.type));
+         this->record_diagnostic(std::move(diag));
+      }
+      else if (Name.type IS TiriType::Struct and value_type.primary IS TiriType::Struct and
+          Name.struct_def and value_type.struct_def and Name.struct_def != value_type.struct_def) {
+         diag.message = std::format("struct layout mismatch: cannot assign '{}' to '{}'",
+            value_type.struct_def->Name, Name.struct_def->Name);
+         this->record_diagnostic(std::move(diag));
+      }
+      else if (Name.type IS TiriType::Array and value_type.primary IS TiriType::Array and
+          value_type.array_element.known and
+          not array_element_matches(Name.array_element, value_type.array_element)) {
+         diag.message = std::format("array member mismatch: expected array<{}>, got array<{}>",
+            array_element_name(Name.array_element), array_element_name(value_type.array_element));
+         this->record_diagnostic(std::move(diag));
+      }
+   }
+
+   if (Name.type IS TiriType::Any and Name.binding_id) {
+      this->explicit_variant_bindings_.insert(Name.binding_id);
+   }
+   this->publish_binding_type(Name.binding_id, inferred);
+   return inferred;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -1482,11 +1482,21 @@ void TypeAnalyser::analyse_statement(StmtNode &Statement)
          auto *payload = std::get_if<ImportStmtPayload>(&Statement.data);
          if (payload) {
             for (const auto &entry : payload->entries) {
-               if (not entry.inlined_body) continue;
-               ImportGuard guard(*this, entry.file_source_idx);
-               this->push_scope();
-               this->analyse_block(*entry.inlined_body);
-               this->pop_scope();
+               if (entry.inlined_body) {
+                  ImportGuard guard(*this, entry.file_source_idx);
+                  this->push_scope();
+                  this->analyse_block(*entry.inlined_body);
+                  this->pop_scope();
+               }
+
+               // Import emission publishes the namespace as a const local after the isolated library body.  Type
+               // analysis must mirror that declaration so later assignments receive a user-facing const diagnostic
+               // instead of appearing to reference an unknown lexical binding.
+               if (entry.namespace_name) {
+                  const Identifier &name = *entry.namespace_name;
+                  this->current_scope().declare_local(
+                     name.symbol, InferredType(TiriType::Any), name.span, name.has_const);
+               }
             }
          }
          break;

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -1082,11 +1082,13 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
    if (not Entry.label.empty()) {
       CSTRING message = lj_strfmt_pushf(L, "type contract failed for %s %u ('%.*s'): expected %s, got %s",
          boundary, Position, int(Entry.label.size()), Entry.label.data(), expected, actual);
+      if (Boundary IS ContractBoundary::Local) lj_err_currentmsg(L, message);
       lj_err_callermsg(L, message);
    }
    else {
       CSTRING message = lj_strfmt_pushf(L, "type contract failed for %s %u: expected %s, got %s",
          boundary, Position, expected, actual);
+      if (Boundary IS ContractBoundary::Local) lj_err_currentmsg(L, message);
       lj_err_callermsg(L, message);
    }
 }

--- a/src/tiri/tests/test_global_types.tiri
+++ b/src/tiri/tests/test_global_types.tiri
@@ -567,6 +567,152 @@ end
 -- Environment mutation boundary: separately compiled chunks writing through _G aliases must honour the persisted
 -- contract, and a declaration composes with a value seeded earlier through rawset().
 
+struct GTNilIntervalRecord
+   Value: int
+end
+
+struct GTNilIntervalOther
+   Value: int
+end
+
+local function expect_cross_chunk_failure(Source:str, Expected:str):str
+   local message = nil
+   try
+      exec(Source)
+   except e
+      message = tostring(e.message)
+   end
+
+   assert(message != nil, 'Expected separately compiled source to fail')
+   assert(message.find(Expected) != nil,
+      'Expected cross-chunk diagnostic to contain "' .. Expected .. '", got: ' .. message)
+   return message
+end
+
+@Test function NilValuedContractRetainsGlobalIdentity()
+   global glGTNilIdentityCounter:num = 1
+   defer
+      rawset(_G, 'glGTNilIdentityCounter', nil)
+   end
+
+   glGTNilIdentityCounter = nil
+   assert(rawget(_G, 'glGTNilIdentityCounter') is nil,
+      'The fixture must clear the global value before compiling the assignment')
+
+   exec([[glGTNilIdentityCounter = 2]])
+   assert(glGTNilIdentityCounter is 2,
+      'A separately compiled assignment must update a nil-valued contracted global')
+end
+
+@Test function NilValuedContractRejectsIncompatibleStore()
+   global glGTNilRejectedCounter:num = 1
+   defer
+      rawset(_G, 'glGTNilRejectedCounter', nil)
+   end
+
+   glGTNilRejectedCounter = nil
+   local message = expect_cross_chunk_failure(
+      [[glGTNilRejectedCounter = 'wrong']], 'type contract failed for global')
+   assert(message.find('expected num') != nil and message.find('got string') != nil,
+      'The incompatible store diagnostic must identify both scalar types: ' .. message)
+   assert(rawget(_G, 'glGTNilRejectedCounter') is nil,
+      'A rejected separately compiled store must preserve the nil value')
+end
+
+@Test function NilValuedContractRejectsAnnotationRedeclaration()
+   global glGTNilAnnotatedCounter:num = 1
+   defer
+      rawset(_G, 'glGTNilAnnotatedCounter', nil)
+   end
+
+   glGTNilAnnotatedCounter = nil
+   local message = expect_cross_chunk_failure(
+      [[glGTNilAnnotatedCounter:num = 2]],
+      "cannot redeclare existing global 'glGTNilAnnotatedCounter' with a type annotation")
+   assert(message.find('glGTNilAnnotatedCounter') != nil,
+      'The annotation diagnostic must identify the persisted global: ' .. message)
+   assert(rawget(_G, 'glGTNilAnnotatedCounter') is nil,
+      'A rejected annotation redeclaration must preserve the nil value')
+end
+
+@Test function NilValuedExactContractsRetainIdentity()
+   global glGTNilIdentityArray:array<int> = array<int> { 1 }
+   global glGTNilIdentityStruct:struct<GTNilIntervalRecord> =
+      struct<GTNilIntervalRecord> { Value = 1 }
+   defer
+      rawset(_G, 'glGTNilIdentityArray', nil)
+      rawset(_G, 'glGTNilIdentityStruct', nil)
+   end
+
+   glGTNilIdentityArray = nil
+   glGTNilIdentityStruct = nil
+   exec([[
+glGTNilIdentityArray = array<int> { 2 }
+glGTNilIdentityStruct = struct<GTNilIntervalRecord> { Value = 3 }
+]])
+   assert(glGTNilIdentityArray[0] is 2,
+      'A matching array member identity must survive a nil interval')
+   assert(glGTNilIdentityStruct.Value is 3,
+      'A matching structure identity must survive a nil interval')
+
+   glGTNilIdentityArray = nil
+   glGTNilIdentityStruct = nil
+   local array_message = expect_cross_chunk_failure(
+      [[glGTNilIdentityArray = array<str> { 'wrong' }]], 'expected array<int>')
+   assert(array_message.find('got array<str>') != nil,
+      'The array mismatch must identify the actual member identity: ' .. array_message)
+   assert(rawget(_G, 'glGTNilIdentityArray') is nil,
+      'A rejected array identity must preserve the nil value')
+
+   local struct_message = expect_cross_chunk_failure(
+      [[glGTNilIdentityStruct = struct<GTNilIntervalOther> { Value = 4 }]],
+      'expected struct<GTNilIntervalRecord>')
+   assert(struct_message.find('got struct<GTNilIntervalOther>') != nil,
+      'The structure mismatch must identify the actual layout: ' .. struct_message)
+   assert(rawget(_G, 'glGTNilIdentityStruct') is nil,
+      'A rejected structure identity must preserve the nil value')
+end
+
+@Test function ExplicitLocalShadowsNilValuedContract()
+   global glGTNilShadowCounter:num = 1
+   defer
+      rawset(_G, 'glGTNilShadowCounter', nil)
+   end
+
+   glGTNilShadowCounter = nil
+   local result = exec([[
+local glGTNilShadowCounter = 'local value'
+return glGTNilShadowCounter
+]])
+   assert(result is 'local value',
+      'The separately compiled explicit local must retain its own value')
+   assert(rawget(_G, 'glGTNilShadowCounter') is nil,
+      'The separately compiled explicit local must not mutate the contracted global')
+end
+
+@Test function NamedExternAssignmentsUseGlobalStorage()
+   defer
+      rawset(_G, 'glGTNamedExternStore', nil)
+      rawset(_G, 'glGTNamedExternAnnotated', nil)
+   end
+
+   exec([[
+extern glGTNamedExternStore
+glGTNamedExternStore = 9
+]])
+   assert(glGTNamedExternStore is 9,
+      'An untyped named-extern assignment must update the environment')
+
+   local message = expect_cross_chunk_failure([[
+extern glGTNamedExternAnnotated
+glGTNamedExternAnnotated:num = 9
+]], "cannot redeclare existing global 'glGTNamedExternAnnotated' with a type annotation")
+   assert(message.find('glGTNamedExternAnnotated') != nil,
+      'The named-extern annotation diagnostic must identify the symbol: ' .. message)
+   assert(rawget(_G, 'glGTNamedExternAnnotated') is nil,
+      'A rejected named-extern annotation must not publish a value')
+end
+
 @Test function CrossChunkAliasStoreIsChecked()
    global glGTCrossAlias = 'text'
 

--- a/src/tiri/tests/test_if_empty.tiri
+++ b/src/tiri/tests/test_if_empty.tiri
@@ -4,15 +4,15 @@
 function enforce_hotpath() end
 
 @Test function Nil()
-   v = nil ?? "A"
+   local v = nil ?? "A"
    assert(v is "A", "Failed nil case: expected 'A', got '" .. tostring(v) .. "'")
 
    Options = { quit = nil }
-   v = (Options.quit ?? nil)
+   local v = (Options.quit ?? nil)
    assert(v is nil, "Expected nil, got " .. tostring(v))
 
    Options.quit = true
-   v = (Options.quit ?? nil)
+   local v = (Options.quit ?? nil)
    assert(v is true, "Expected true, got " .. tostring(v))
 end
 

--- a/src/tiri/tests/test_locality.tiri
+++ b/src/tiri/tests/test_locality.tiri
@@ -72,6 +72,26 @@ end
 end
 
 -----------------------------------------------------------------------------------------------------------------------
+-- A global declared in one function must not affect assignment resolution in a sibling function.
+
+@Test function NestedGlobalDeclarationDoesNotLeakToSibling()
+   defer rawset(_G, 'nested_declaration_only', nil) end
+
+   local function declare_global()
+      global nested_declaration_only = 'global value'
+   end
+
+   local function assign_local()
+      nested_declaration_only = 'local value'
+      return true
+   end
+
+   assert(assign_local(), 'The sibling assignment function should run')
+   assert(rawget(_G, 'nested_declaration_only') is nil,
+      'A nested global declaration must not redirect a sibling assignment to the environment')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
 -- Test that local shadows global
 
 @Test(hotpath=true) function LocalShadowsGlobal()

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -2,6 +2,7 @@
 
 import './type_contract_fixture'
 import './typ08_reduced_import_fixture'
+import './type_contract_local_store_fixture'
 
 struct ContractAlpha
    Value: int
@@ -238,6 +239,20 @@ target.acRefresh()
    assert(script.errorMessage.startsWith("[script:2:0] type contract failed for parameter 1 ('Window')"),
       'A native callback contract failure should report its Tiri source and line with an unavailable column: ' ..
       script.errorMessage)
+end
+
+@Test function LocalStoreContractLocation()
+   local failed = false
+   try
+      imported_local_store_contract_failure(true)
+   except e
+      failed = true
+      assert(tostring(e.source).endsWith('type_contract_local_store_fixture.tiri'),
+         'A local-store contract failure should retain the defining source file: ' .. tostring(e.source))
+      assert(e.line is 3,
+         'A local-store contract failure should report the failing assignment line: ' .. tostring(e.line))
+   end
+   assert(failed, 'The incompatible local store should fail its runtime contract')
 end
 
 @Test function ImportedNativeCallbackContractLocation()

--- a/src/tiri/tests/type_contract_local_store_fixture.tiri
+++ b/src/tiri/tests/type_contract_local_store_fixture.tiri
@@ -1,0 +1,4 @@
+global function imported_local_store_contract_failure(Value:any)
+   local result = 'text'
+   result = Value
+end


### PR DESCRIPTION
## Summary

- Resolve identifier assignment targets and binding identities before descriptor analysis, type analysis, and emission.
- Preserve persisted global contracts across nil values and enforce their exact type identities.
- Improve assignment-contract diagnostics and add parser and Flute regressions.

## Validation

- `cmake --build build/agents --config Debug --target tiri --parallel`
- `build/agents-install/origo tools/flute.tiri file=src/tiri/tests/test_global_types.tiri --log-warning`
- `build/agents-install/origo tools/flute.tiri file=src/tiri/tests/test_type_contracts.tiri --log-warning`