### PR TITLE
[Tiri] Added structure-array type-test descriptors

### DIFF
--- a/src/network/tests/test_ipv6.tiri
+++ b/src/network/tests/test_ipv6.tiri
@@ -132,7 +132,7 @@ end
       callback = function(Lookup, Error)
          addresses = Lookup.addresses
          if (Error is ERR_Okay) and addresses then
-            assert(addresses is <array IPAddress>, 'NetLookup.addresses should be an IPAddress struct array')
+            assert(addresses is <array struct<IPAddress>>, 'NetLookup.addresses should be an IPAddress struct array')
             logOutput('[DNS] Resolved ' .. tostring(Lookup.hostName) .. ' to ' .. #addresses .. ' addresses:')
             for i, addr in ipairs(addresses) do
                assert(type(addr) is 'struct', 'NetLookup.addresses should contain native structs')

--- a/src/tiri/jit/src/parser/ast/choose.cpp
+++ b/src/tiri/jit/src/parser/ast/choose.cpp
@@ -27,7 +27,7 @@ bool AstBuilder::choose_case_has_type_test_descriptor() const
       close_offset = 2;
    }
    else if (close_or_constraint.kind() IS TokenKind::Identifier or
-      close_or_constraint.kind() IS TokenKind::ArrayTyped) {
+      close_or_constraint.kind() IS TokenKind::ArrayTyped or close_or_constraint.kind() IS TokenKind::StructTyped) {
       if (this->ctx.tokens().peek(3).kind() != TokenKind::Greater) return false;
       close_offset = 3;
    }

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -304,7 +304,7 @@ ParserResult<Token> AstBuilder::parse_type_annotation(
 
 //********************************************************************************************************************
 // Parses the contextual descriptor following `is` or `is not`.  Aggregate type tests permit an optional,
-// whitespace-separated inner name, unlike declaration annotations.
+// whitespace-separated inner constraint, unlike declaration annotations.
 
 ParserResult<TypeTestDescriptor> AstBuilder::parse_type_test_descriptor()
 {
@@ -356,9 +356,14 @@ ParserResult<TypeTestDescriptor> AstBuilder::parse_type_test_descriptor()
          constraint_name = std::format("array<{}>",
             std::string_view(strdata(constraint_symbol), constraint_symbol->len));
       }
+      else if (descriptor.type IS TiriType::Array and constraint_token.kind() IS TokenKind::StructTyped) {
+         GCstr *constraint_symbol = constraint_token.payload().as_string();
+         constraint_name = std::format("struct<{}>",
+            std::string_view(strdata(constraint_symbol), constraint_symbol->len));
+      }
       else {
          return this->fail<TypeTestDescriptor>(ParserErrorCode::ExpectedIdentifier, constraint_token,
-            "Expected one inner name in type-test descriptor");
+            "Expected one inner constraint in type-test descriptor");
       }
 
       this->ctx.tokens().advance();
@@ -369,7 +374,9 @@ ParserResult<TypeTestDescriptor> AstBuilder::parse_type_test_descriptor()
          if (element and element->storage != AET::PTR and
              (element->storage != AET::STRUCT or element->struct_def)) descriptor.array_element = *element;
          else if (struct_record *definition = find_struct(&this->ctx.lua(), constraint_name)) {
-            descriptor.array_element = { AET::STRUCT, TiriType::Struct, CLASSID::NIL, definition, true };
+            return this->fail<TypeTestDescriptor>(ParserErrorCode::UnknownTypeName, constraint_token,
+               std::format("Structure array type tests require 'struct<{}>'; use '<array struct<{}>>'",
+                  definition->Name, definition->Name));
          }
          else {
             return this->fail<TypeTestDescriptor>(ParserErrorCode::UnknownTypeName, constraint_token,
@@ -393,7 +400,7 @@ ParserResult<TypeTestDescriptor> AstBuilder::parse_type_test_descriptor()
 
       if (not this->ctx.check(TokenKind::Greater)) {
          return this->fail<TypeTestDescriptor>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-            "Type-test descriptors accept at most one inner name");
+            "Type-test descriptors accept at most one inner constraint");
       }
    }
 

--- a/src/tiri/tests/test_type_tests.tiri
+++ b/src/tiri/tests/test_type_tests.tiri
@@ -60,7 +60,14 @@ end
    assert(alpha is <struct>, 'unconstrained struct should match')
    assert(alpha is <struct TypeTestAlpha>, 'named structure identity should match')
    assert(bravo is not <struct TypeTestAlpha>, 'different structure definitions should not match')
-   assert(alpha_array is <array TypeTestAlpha>, 'structure-array identity should match')
+   assert(alpha_array is <array struct<TypeTestAlpha>>, 'structure-array identity should match')
+   assert(alpha_array is not <array struct<TypeTestBravo>>, 'structure-array identity should reject a mismatch')
+
+   local array_kind = choose alpha_array from
+      <array struct<TypeTestAlpha>> -> 'alpha'
+      else -> 'other'
+   end
+   assert(array_kind is 'alpha', 'choose should recognise a structure-array type pattern')
 end
 
 @Test function ObjectDescriptorsAndInheritance()
@@ -139,7 +146,15 @@ end
    try
       exec([[return 1 is <array int str>]])
    except error_value
-      failed = error_value.message.find('at most one inner name') != nil
+      failed = error_value.message.find('at most one inner constraint') != nil
    end
    assert(failed, 'surplus descriptor names should have a focused diagnostic')
+
+   failed = false
+   try
+      exec([[return array<struct<TypeTestAlpha>> {} is <array TypeTestAlpha>]])
+   except error_value
+      failed = error_value.message.find("use '<array struct<TypeTestAlpha>>'") != nil
+   end
+   assert(failed, 'bare structure-array descriptors should report the canonical spelling')
 end

--- a/tools/tiri_lsp/include/lsp_parsing.tiri
+++ b/tools/tiri_lsp/include/lsp_parsing.tiri
@@ -209,8 +209,9 @@ global function tokenizeTiri(Source:str, ModulePrefixes:table):array<table>
       return Pos
    end
 
-   -- A type-test primary word may carry an inner constraint name: `<array int>`, `<obj Vector>` and
-   -- `<struct Point>`.  The remaining primaries (`num`, `str`, `nil`, `range`, ...) are unconstrained.
+   -- A type-test primary word may carry an inner constraint: `<array int>`, `<array struct<Point>>`,
+   -- `<obj Vector>` and `<struct Point>`.  The remaining primaries (`num`, `str`, `nil`, `range`, ...) are
+   -- unconstrained.
    type_test_types = {
       ['any'] = true, ['nil'] = true, ['bool'] = true, ['num'] = true, ['str'] = true, ['table'] = true,
       ['array'] = true, ['func'] = true, ['struct'] = true, ['obj'] = true, ['object'] = true, ['range'] = true,
@@ -288,6 +289,10 @@ global function tokenizeTiri(Source:str, ModulePrefixes:table):array<table>
 
       inner_col = nil
       inner_len = 0
+      nested_type_col = nil
+      nested_type_len = 0
+      nested_open_col = nil
+      nested_close_col = nil
       if type_test_constrainable[primary] then
          mark_pos = pos
          mark_col = col
@@ -296,12 +301,61 @@ global function tokenizeTiri(Source:str, ModulePrefixes:table):array<table>
             col++
          end
          if pos < len and isIdentStart(Source.sub(pos, pos + 1)) then
+            inner_pos = pos
             inner_col = col
             while pos < len and isIdentChar(Source.sub(pos, pos + 1)) do
                pos++
                col++
             end
             inner_len = col - inner_col
+            inner_name = Source.sub(inner_pos, pos)
+
+            if primary is 'array' and inner_name is 'struct' then
+               nested_type_col = inner_col
+               nested_type_len = inner_len
+
+               while pos < len and (Source.sub(pos, pos + 1) is ' ' or Source.sub(pos, pos + 1) is '\t') do
+                  pos++
+                  col++
+               end
+               if pos >= len or Source.sub(pos, pos + 1) != '<' then
+                  pos = save_pos
+                  col = save_col
+                  return false
+               end
+               nested_open_col = col
+               pos++
+               col++
+
+               while pos < len and (Source.sub(pos, pos + 1) is ' ' or Source.sub(pos, pos + 1) is '\t') do
+                  pos++
+                  col++
+               end
+               if pos >= len or not isIdentStart(Source.sub(pos, pos + 1)) then
+                  pos = save_pos
+                  col = save_col
+                  return false
+               end
+               inner_col = col
+               while pos < len and isIdentChar(Source.sub(pos, pos + 1)) do
+                  pos++
+                  col++
+               end
+               inner_len = col - inner_col
+
+               while pos < len and (Source.sub(pos, pos + 1) is ' ' or Source.sub(pos, pos + 1) is '\t') do
+                  pos++
+                  col++
+               end
+               if pos >= len or Source.sub(pos, pos + 1) != '>' then
+                  pos = save_pos
+                  col = save_col
+                  return false
+               end
+               nested_close_col = col
+               pos++
+               col++
+            end
          else
             pos = mark_pos
             col = mark_col
@@ -332,9 +386,14 @@ global function tokenizeTiri(Source:str, ModulePrefixes:table):array<table>
       if NotCol then addToken(NotLine, NotCol, 3, 1, 0) end  -- 'not' operator
       addToken(line, open_col, 1, 1, 0)                    -- '<' operator
       addToken(line, primary_col, primary_len, 7, 0)       -- descriptor primary: type
+      if nested_type_col then
+         addToken(line, nested_type_col, nested_type_len, 7, 0) -- nested element descriptor: type
+         addToken(line, nested_open_col, 1, 1, 0)           -- nested '<' operator
+      end
       if inner_col then
          addToken(line, inner_col, inner_len, 11, 0)       -- inner constraint name: class
       end
+      if nested_close_col then addToken(line, nested_close_col, 1, 1, 0) end -- nested '>' operator
       addToken(line, close_col, 1, 1, 0)                   -- '>' operator
       return true
    end

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -571,6 +571,20 @@ end
    assert(inner and inner.type is 11, 'A constrained array element name should be a class token.')
 end
 
+@Test function StructArrayTypeTestReceivesNestedTypeTokens()
+   source = 'ok = points is <array struct<Point>>\n'
+
+   tokens = tokenizeTiri(source)
+
+   array_type = findToken(tokens, 0, 16, 'array')
+   struct_type = findToken(tokens, 0, 22, 'struct')
+   struct_name = findToken(tokens, 0, 29, 'Point')
+
+   assert(array_type and array_type.type is 7, 'The array descriptor primary should be a type token.')
+   assert(struct_type and struct_type.type is 7, 'The nested struct descriptor should be a type token.')
+   assert(struct_name and struct_name.type is 11, 'The nested structure name should be a class token.')
+end
+
 @Test function StructTypeTestIsNotAStructDeclaration()
    -- A mid-line `<struct Name>` type test must not trip the struct-declaration branch, which would emit the name
    -- with a declaration modifier and mislead go-to-definition and document symbols.

--- a/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
+++ b/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
@@ -33,6 +33,22 @@
          "patterns": [
             {
                "name": "meta.type-test.tiri",
+               "comment": "Contextual structure-array `is [not] <array struct<Name>>` boolean type test.",
+               "match": "\\b(is)\\b(?:\\s+(not))?\\s*(<)\\s*(array)\\s+(struct)\\s*(<)\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*(>)\\s*(>)",
+               "captures": {
+                  "1": { "name": "keyword.operator.logical.tiri" },
+                  "2": { "name": "keyword.operator.logical.tiri" },
+                  "3": { "name": "punctuation.definition.type-test.begin.tiri" },
+                  "4": { "name": "support.type.primitive.tiri" },
+                  "5": { "name": "support.type.primitive.tiri" },
+                  "6": { "name": "punctuation.definition.type-test.begin.tiri" },
+                  "7": { "name": "entity.name.type.tiri" },
+                  "8": { "name": "punctuation.definition.type-test.end.tiri" },
+                  "9": { "name": "punctuation.definition.type-test.end.tiri" }
+               }
+            },
+            {
+               "name": "meta.type-test.tiri",
                "comment": "Contextual constrained `is [not] <aggregate Name>` boolean type test.",
                "match": "\\b(is)\\b(?:\\s+(not))?\\s*(<)\\s*(array|struct|obj|object)\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*(>)",
                "captures": {
@@ -42,6 +58,21 @@
                   "4": { "name": "support.type.primitive.tiri" },
                   "5": { "name": "entity.name.type.tiri" },
                   "6": { "name": "punctuation.definition.type-test.end.tiri" }
+               }
+            },
+            {
+               "name": "meta.type-test.tiri",
+               "comment": "Structure-array `!= <array struct<Name>>` or `≠ <array struct<Name>>` boolean type test.",
+               "match": "(!=|≠)\\s*(<)\\s*(array)\\s+(struct)\\s*(<)\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*(>)\\s*(>)",
+               "captures": {
+                  "1": { "name": "keyword.operator.comparison.tiri" },
+                  "2": { "name": "punctuation.definition.type-test.begin.tiri" },
+                  "3": { "name": "support.type.primitive.tiri" },
+                  "4": { "name": "support.type.primitive.tiri" },
+                  "5": { "name": "punctuation.definition.type-test.begin.tiri" },
+                  "6": { "name": "entity.name.type.tiri" },
+                  "7": { "name": "punctuation.definition.type-test.end.tiri" },
+                  "8": { "name": "punctuation.definition.type-test.end.tiri" }
                }
             },
             {
@@ -83,6 +114,20 @@
       },
       "choose-type-patterns": {
          "patterns": [
+            {
+               "name": "meta.choose.type-pattern.tiri",
+               "comment": "Structure-array `<array struct<Name>>` choose type pattern before when or ->.",
+               "match": "(<)\\s*(array)\\s+(struct)\\s*(<)\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*(>)\\s*(>)(?=\\s*(?:when\\b|->))",
+               "captures": {
+                  "1": { "name": "punctuation.definition.type-test.begin.tiri" },
+                  "2": { "name": "support.type.primitive.tiri" },
+                  "3": { "name": "support.type.primitive.tiri" },
+                  "4": { "name": "punctuation.definition.type-test.begin.tiri" },
+                  "5": { "name": "entity.name.type.tiri" },
+                  "6": { "name": "punctuation.definition.type-test.end.tiri" },
+                  "7": { "name": "punctuation.definition.type-test.end.tiri" }
+               }
+            },
             {
                "name": "meta.choose.type-pattern.tiri",
                "comment": "Constrained `<aggregate Name>` choose type pattern before when or ->.",


### PR DESCRIPTION
* Accepted canonical '<array struct<Name>>' descriptors in type tests and choose patterns
* [LSP] Highlighted nested structure-array descriptors in semantic tokens and VS Code