### PR TITLE
[Tiri] Optimised array metadata and slice copying

### DIFF
--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -34,6 +34,7 @@
 #include "lib_range.h"
 #include "../parser/static_type_descriptor.h"
 
+#include <cctype>
 #include <cstdio>
 #include <cstring>
 #include <algorithm>
@@ -110,12 +111,27 @@ static ArrayAllocationDescriptor parse_elemtype(lua_State *L, int NArg)
 {
    GCstr *type_str = lj_lib_checkstr(L, NArg);
    std::string_view type_name(strdata(type_str), type_str->len);
-   if (auto element = parse_array_element_type(type_name, L)) {
+   while (not type_name.empty() and std::isspace(uint8_t(type_name.front()))) type_name.remove_prefix(1);
+   while (not type_name.empty() and std::isspace(uint8_t(type_name.back()))) type_name.remove_suffix(1);
+
+   if (auto element = describe_array_element(type_name, L)) {
       ArrayAllocationDescriptor descriptor;
       descriptor.storage = element->storage;
       descriptor.struct_def = element->struct_def;
-      descriptor.canonical_identity = std::format("array<{}>", array_element_name(*element));
       return descriptor;
+   }
+
+   if (type_name.starts_with("array")) {
+      if (auto member_identity = canonical_array_type_name(type_name, L)) {
+         std::string complete_identity = std::format("array<{}>", *member_identity);
+         return {
+            .storage = AET::ARRAY,
+            .nested_identity = lj_str_new(L, complete_identity.data(), complete_identity.size())
+         };
+      }
+   }
+   else if (auto element = parse_array_element_type(type_name, L)) {
+      return { .storage = element->storage, .struct_def = element->struct_def };
    }
 
    lj_err_argv(L, NArg, ErrMsg::BADTYPE, "valid array type", strdata(type_str));
@@ -2102,7 +2118,7 @@ static void array_push_element(lua_State *L, GCarray *Arr, MSize Idx)
          break;
       }
       case AET::STRUCT: {
-         auto value = lj_struct_new(L, *Arr->structdef);
+         auto value = lj_struct_new(L, *Arr->struct_definition());
          memcpy(value->data, elem, Arr->elemsize);
          setstructV(L, L->top++, value);
          break;

--- a/src/tiri/jit/src/lib/lib_range.cpp
+++ b/src/tiri/jit/src/lib/lib_range.cpp
@@ -997,18 +997,25 @@ static int range_slice_impl(lua_State *L)
       // Create result array
       GCarray *new_arr = lj_array_new_like(L, arr, MSize(result_size));
 
-      // Copy elements
-      int32_t dst_idx = 0;
-      if (forward) {
-         for (int32_t i = start; i <= effective_stop; i += step) {
-            lj_array_copy(L, new_arr, MSize(dst_idx), arr, MSize(i), 1);
-            dst_idx++;
-         }
+      // A unit forward step is contiguous and can use one fully checked bulk copy.  Other ranges have already been
+      // clipped and the result was created from the source metadata, so validate that contract once before copying.
+      if (forward and step IS 1) {
+         lj_array_copy(L, new_arr, 0, arr, MSize(start), MSize(result_size));
       }
       else {
-         for (int32_t i = start; i >= effective_stop; i += step) {
-            lj_array_copy(L, new_arr, MSize(dst_idx), arr, MSize(i), 1);
-            dst_idx++;
+         lj_array_copy(L, new_arr, 0, arr, MSize(start), 0);
+         int32_t dst_idx = 0;
+         if (forward) {
+            for (int32_t i = start; i <= effective_stop; i += step) {
+               lj_array_copy_unchecked(L, new_arr, MSize(dst_idx), arr, MSize(i), 1);
+               dst_idx++;
+            }
+         }
+         else {
+            for (int32_t i = start; i >= effective_stop; i += step) {
+               lj_array_copy_unchecked(L, new_arr, MSize(dst_idx), arr, MSize(i), 1);
+               dst_idx++;
+            }
          }
       }
 

--- a/src/tiri/jit/src/lib/lib_struct.cpp
+++ b/src/tiri/jit/src/lib/lib_struct.cpp
@@ -189,7 +189,7 @@ static void write_array_field(lua_State *L, APTR Address, const struct_field &Fi
             "Array field '%s' has an unresolved struct element type.", FieldName);
       }
       if (source->elemtype IS AET::STRUCT) {
-         if ((source->structdef != field_def) or (source->elemsize != Field.ElementStride)) {
+         if ((source->struct_definition() != field_def) or (source->elemsize != Field.ElementStride)) {
             struct_field_error(L, CurrentFrame, ERR::InvalidType,
                "Array field '%s' requires '%s' struct elements.", FieldName,
                field_def->Name.c_str());

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -351,14 +351,13 @@ static void recff_rawtype(jit_State* J, RecordFFData* Data)
       IRBuilder ir(J);
       TRef element_type_ref = ir.fload(value_ref, IRFL_ARRAY_ELEMTYPE, IRT_U8);
       ir.guard_eq_int(element_type_ref, ir.kint(int32_t(array->elemtype)));
-      if (gcref(array->type_identity)) {
-         GCstr *identity = strref(array->type_identity);
+      if (GCstr *identity = array->nested_identity()) {
          TRef identity_ref = ir.fload(value_ref, IRFL_ARRAY_IDENTITY, IRT_STR);
          ir.guard_eq(identity_ref, ir.kstr(identity), IRT_STR);
       }
       else if (array->elemtype IS AET::STRUCT) {
          TRef definition_ref = ir.fload(value_ref, IRFL_ARRAY_STRUCTDEF, IRT_PTR);
-         TRef definition = array->structdef ? ir.kkptr(array->structdef) : ir.knull(IRT_PTR);
+         TRef definition = array->struct_definition() ? ir.kkptr(array->struct_definition()) : ir.knull(IRT_PTR);
          ir.guard_eq(definition_ref, definition, IRT_PTR);
       }
    }

--- a/src/tiri/jit/src/lj_ir.h
+++ b/src/tiri/jit/src/lj_ir.h
@@ -221,8 +221,8 @@ typedef enum {
   _(STRUCT_DEF, offsetof(GCstruct, def)) \
   _(TAB_GCONTRACTS, offsetof(GCtab, global_type_contracts)) \
   _(OBJ_CLASSPTR, offsetof(GCobject, classptr)) \
-  _(ARRAY_STRUCTDEF, offsetof(GCarray, structdef)) \
-  _(ARRAY_IDENTITY, offsetof(GCarray, type_identity)) \
+  _(ARRAY_STRUCTDEF, offsetof(GCarray, type_metadata)) \
+  _(ARRAY_IDENTITY, offsetof(GCarray, type_metadata)) \
   _(TAB_FLAGS, offsetof(GCtab, flags))
 
 typedef enum {

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -525,7 +525,7 @@ static RecordedContract rec_contract_guard_array(
 
    if (Entry.array_element_type IS AET::STRUCT) {
       struct_record *definition = find_struct(J->L, Entry.constraint_name);
-      if (not definition or array->structdef != definition) return RecordedContract::Mismatch;
+      if (not definition or array->struct_definition() != definition) return RecordedContract::Mismatch;
       TRef definition_ref = ir.fload(ValueRef, IRFL_ARRAY_STRUCTDEF, IRT_PTR);
       ir.guard_eq(definition_ref, ir.kkptr(definition), IRT_PTR);
    }
@@ -533,9 +533,10 @@ static RecordedContract rec_contract_guard_array(
       if (not lj_array_member_identity_matches(array, Entry.constraint_name)) return RecordedContract::Mismatch;
       std::string expected_identity = std::format("array<{}>", Entry.constraint_name);
       if (not lj_array_identity_matches(array, expected_identity)) return RecordedContract::Complex;
-      GCstr *identity = strref(array->type_identity);
-      TRef identity_ref = ir.fload(ValueRef, IRFL_ARRAY_IDENTITY, IRT_STR);
-      ir.guard_eq(identity_ref, ir.kstr(identity), IRT_STR);
+      if (GCstr *identity = array->nested_identity()) {
+         TRef identity_ref = ir.fload(ValueRef, IRFL_ARRAY_IDENTITY, IRT_STR);
+         ir.guard_eq(identity_ref, ir.kstr(identity), IRT_STR);
+      }
    }
 
    return RecordedContract::Basic;
@@ -678,11 +679,10 @@ static TRef rec_type_test(jit_State *J, BCREG Slot, GCstr *Encoded)
          RuntimeContractEntry observed;
          observed.type = TiriType::Array;
          observed.array_element_type = arrayV(value)->elemtype;
-         if (arrayV(value)->elemtype IS AET::STRUCT and arrayV(value)->structdef) {
-            observed.constraint_name = arrayV(value)->structdef->Name;
+         if (struct_record *definition = arrayV(value)->struct_definition()) {
+            observed.constraint_name = definition->Name;
          }
-         else if (arrayV(value)->elemtype IS AET::ARRAY and gcref(arrayV(value)->type_identity)) {
-            GCstr *identity = strref(arrayV(value)->type_identity);
+         else if (GCstr *identity = arrayV(value)->nested_identity()) {
             std::string_view outer(strdata(identity), identity->len);
             if (outer.starts_with("array<") and outer.ends_with('>')) {
                observed.constraint_name = outer.substr(6, outer.size() - 7);

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -6126,11 +6126,11 @@ static bool test_static_descriptor_model(kt::Log &Log)
    }
    ArrayAllocationDescriptor matching_array {
       .storage = AET::ARRAY,
-      .canonical_identity = "array<array<int>>"
+      .nested_identity = lj_str_new(recursive_lua, "array<array<int>>", sizeof("array<array<int>>") - 1)
    };
    ArrayAllocationDescriptor mismatched_array {
       .storage = AET::ARRAY,
-      .canonical_identity = "array<array<str>>"
+      .nested_identity = lj_str_new(recursive_lua, "array<array<str>>", sizeof("array<array<str>>") - 1)
    };
    if (not array_element_matches(*exact, lj_array_new(recursive_lua, 0, matching_array)) or
        array_element_matches(*exact, lj_array_new(recursive_lua, 0, mismatched_array))) {

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -79,7 +79,8 @@ ArrayElementDescriptor describe_array_element(const GCarray *Array)
    ArrayElementDescriptor result;
    result.storage = public_array_storage(Array->elemtype);
    result.logical_type = TiriType::Any;
-   result.struct_def = Array->elemtype IS AET::STRUCT ? Array->structdef : nullptr;
+   result.struct_def = Array->struct_definition();
+   result.nested_array_identity = Array->nested_identity();
    result.known = true;
    switch (result.storage) {
       case AET::BYTE:
@@ -110,11 +111,9 @@ ArrayElementDescriptor describe_array_element(const GCarray *Array)
 bool array_element_matches(const ArrayElementDescriptor &Expected, const GCarray *Actual)
 {
    if (Expected.storage IS AET::ARRAY and Expected.nested_array_identity) {
-      if (not Actual or Actual->elemtype != AET::ARRAY or not gcref(Actual->type_identity)) return false;
-      GCstr *actual_identity = strref(Actual->type_identity);
+      if (not Actual or Actual->elemtype != AET::ARRAY) return false;
       std::string_view expected_name(strdata(Expected.nested_array_identity), Expected.nested_array_identity->len);
-      std::string_view actual_name(strdata(actual_identity), actual_identity->len);
-      return recursive_array_identity_matches(expected_name, actual_name);
+      return lj_array_identity_matches(Actual, expected_name);
    }
    return array_element_matches(Expected, describe_array_element(Actual));
 }
@@ -147,6 +146,7 @@ public:
 
    std::optional<std::string> canonical_name()
    {
+      this->retain_nested_identity_ = false;
       std::string canonical;
       auto result = this->parse_member(0, &canonical);
       this->skip_space();
@@ -206,8 +206,10 @@ private:
             return std::nullopt;
          }
          std::string identity = std::format("array<{}>", member_name);
-         if (this->lexer_) result.nested_array_identity = this->lexer_->keepstr(identity);
-         else if (this->state_) {
+         if (this->retain_nested_identity_ and this->lexer_) {
+            result.nested_array_identity = this->lexer_->keepstr(identity);
+         }
+         else if (this->retain_nested_identity_ and this->state_) {
             result.nested_array_identity = lj_str_new(this->state_, identity.data(), identity.size());
          }
          if (Canonical) *Canonical = identity;
@@ -237,6 +239,7 @@ private:
    lua_State *state_ = nullptr;
    LexState *lexer_ = nullptr;
    size_t position_ = 0;
+   bool retain_nested_identity_ = true;
 };
 
 } // namespace

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -10,6 +10,7 @@
 #include "lj_array.h"
 #include "lj_bulk.h"
 #include "lj_object.h"
+#include "lj_state.h"
 #include "lj_str.h"
 #include "lj_tab.h"
 #include "stack_helpers.h"
@@ -18,7 +19,6 @@
 #include <cfloat>
 #include <climits>
 #include <cmath>
-#include <format>
 #include <limits>
 #include <string_view>
 #include <kotuku/main.h>
@@ -204,7 +204,7 @@ static LJ_AINLINE ArrayElementResult array_validate_element(GCarray *Array, cTVa
       case AET::STRUCT:
          if (tvisstruct(Value)) {
             auto source = structV(Value);
-            if (source->def IS Array->structdef and source->structsize IS Array->elemsize) {
+            if (source->def IS Array->struct_definition() and source->structsize IS Array->elemsize) {
                return ArrayElementResult::OK;
             }
          }
@@ -537,12 +537,6 @@ static void array_attach_basemt(lua_State *L, GCarray *Arr)
 // - String content is copied into a vector<char> owned by the array
 // - The storage area stores CSTRING pointers into the vector
 
-std::string lj_array_default_identity(AET Type, const struct_record *StructDef)
-{
-   if (Type IS AET::STRUCT and StructDef) return std::format("array<struct<{}>>", StructDef->Name);
-   return std::format("array<{}>", lj_array_elemtype_name(Type));
-}
-
 static bool array_identity_text_matches(std::string_view Expected, std::string_view Actual)
 {
    if (Expected IS Actual) return true;
@@ -565,53 +559,61 @@ static bool array_identity_text_matches(std::string_view Expected, std::string_v
 bool lj_array_identity_accepts(const GCarray *Destination, const GCarray *Value)
 {
    if (not Destination or not Value or Destination->elemtype != AET::ARRAY) return false;
-   if (not gcref(Destination->type_identity)) return true;
+   GCstr *destination_identity = Destination->nested_identity();
+   if (not destination_identity) return true;
 
-   GCstr *destination_identity = strref(Destination->type_identity);
    std::string_view destination_name(strdata(destination_identity), destination_identity->len);
    if (destination_name IS "array<array>") return true;
-   if (not destination_name.starts_with("array<") or not destination_name.ends_with('>') or
-       not gcref(Value->type_identity)) return false;
+   if (not destination_name.starts_with("array<") or not destination_name.ends_with('>')) return false;
 
    std::string_view expected_member = destination_name.substr(6, destination_name.size() - 7);
-   GCstr *value_identity = strref(Value->type_identity);
-   std::string_view actual_name(strdata(value_identity), value_identity->len);
-   return array_identity_text_matches(expected_member, actual_name);
+   return lj_array_identity_matches(Value, expected_member);
 }
 
 bool lj_array_identity_matches(const GCarray *Array, std::string_view Expected)
 {
-   if (not Array or not gcref(Array->type_identity)) return false;
-   GCstr *identity = strref(Array->type_identity);
-   return array_identity_text_matches(Expected, std::string_view(strdata(identity), identity->len));
+   if (not Array) return false;
+   if (GCstr *identity = Array->nested_identity()) {
+      return array_identity_text_matches(Expected, std::string_view(strdata(identity), identity->len));
+   }
+   if (Expected IS "array" or Expected IS "array<any>") return true;
+   if (not Expected.starts_with("array<") or not Expected.ends_with('>')) return false;
+   return lj_array_member_identity_matches(Array, Expected.substr(6, Expected.size() - 7));
 }
 
 bool lj_array_member_identity_matches(const GCarray *Array, std::string_view ExpectedMember)
 {
-   if (not Array or not gcref(Array->type_identity)) return false;
-   GCstr *identity = strref(Array->type_identity);
-   std::string_view actual(strdata(identity), identity->len);
-   if (not actual.starts_with("array<") or not actual.ends_with('>')) return false;
-   return array_identity_text_matches(ExpectedMember, actual.substr(6, actual.size() - 7));
+   if (not Array) return false;
+   if (GCstr *identity = Array->nested_identity()) {
+      std::string_view actual(strdata(identity), identity->len);
+      if (not actual.starts_with("array<") or not actual.ends_with('>')) return false;
+      return array_identity_text_matches(ExpectedMember, actual.substr(6, actual.size() - 7));
+   }
+   if (ExpectedMember IS "any") return true;
+   if (Array->elemtype IS AET::ARRAY) return array_identity_text_matches(ExpectedMember, "array");
+   if (Array->elemtype IS AET::STRUCT) {
+      struct_record *definition = Array->struct_definition();
+      if (not definition or not ExpectedMember.starts_with("struct<") or not ExpectedMember.ends_with('>')) {
+         return false;
+      }
+      return ExpectedMember.substr(7, ExpectedMember.size() - 8) IS definition->Name;
+   }
+   return ExpectedMember IS lj_array_elemtype_name(Array->elemtype);
 }
 
 static bool array_copy_identity_compatible(const GCarray *Destination, const GCarray *Source)
 {
    if (Destination->elemtype != AET::ARRAY) return true;
-   if (not gcref(Destination->type_identity)) return true;
+   GCstr *destination_identity = Destination->nested_identity();
+   if (not destination_identity) return true;
 
-   GCstr *destination_identity = strref(Destination->type_identity);
    std::string_view destination_name(strdata(destination_identity), destination_identity->len);
    if (destination_name IS "array<array>") return true;
-   if (not gcref(Source->type_identity)) return false;
-
-   GCstr *source_identity = strref(Source->type_identity);
-   std::string_view source_name(strdata(source_identity), source_identity->len);
-   return array_identity_text_matches(destination_name, source_name);
+   return lj_array_identity_matches(Source, destination_name);
 }
 
 extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Data, uint8_t Flags,
-   std::string_view StructName, struct_record *StructDef)
+   std::string_view StructName, struct_record *StructDef, GCstr *NestedIdentity)
 {
    MSize elem_size;
    struct_record *sdef = nullptr;
@@ -629,9 +631,6 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
    }
    else elem_size = lj_array_elemsize(Type);
 
-   std::string identity = lj_array_default_identity(Type, sdef);
-   GCstr *type_identity = lj_str_new(L, identity.data(), identity.size());
-
    lj_assertL(elem_size > 0, "invalid element size for array creation");
 
    if (Data or (Flags & ARRAY_EXTERNAL)) {
@@ -639,7 +638,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
          // External data - caller manages lifetime (no storage allocation needed)
          // External arrays have capacity = length and cannot grow
          auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-         arr->init(Data, Type, elem_size, Length, Length, Flags, sdef, type_identity);
+         arr->init(Data, Type, elem_size, Length, Length, Flags, sdef, NestedIdentity);
          array_attach_basemt(L, arr);
          return arr;
       }
@@ -650,7 +649,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
             size_t byte_size = Length * sizeof(CSTRING);
             void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
             auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-            arr->init(storage, AET::CSTR, sizeof(CSTRING), Length, Length, 0, sdef, type_identity);
+            arr->init(storage, AET::CSTR, sizeof(CSTRING), Length, Length, 0, sdef);
             array_attach_basemt(L, arr);
 
             // Calculate total string content size
@@ -710,7 +709,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
             size_t byte_size = Length * elem_size;
             void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
             auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-            arr->init(storage, Type, elem_size, Length, Length, Flags, sdef, type_identity);
+            arr->init(storage, Type, elem_size, Length, Length, Flags, sdef, NestedIdentity);
             array_attach_basemt(L, arr);
 
             auto refs = arr->get<GCRef>();
@@ -732,7 +731,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
             size_t byte_size = Length * elem_size;
             void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
             auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-            arr->init(storage, Type, elem_size, Length, Length, Flags, sdef, type_identity);
+            arr->init(storage, Type, elem_size, Length, Length, Flags, sdef, NestedIdentity);
             array_attach_basemt(L, arr);
             if (byte_size > 0) {
                if (Type IS AET::ANY) lj_bulk_copy_tvalue((TValue *)storage, (const TValue *)Data, Length);
@@ -748,7 +747,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
       size_t byte_size = Length * elem_size;
       void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
       auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-      arr->init(storage, Type, elem_size, Length, Length, Flags & ~(ARRAY_EXTERNAL|ARRAY_CACHED), sdef, type_identity);
+      arr->init(storage, Type, elem_size, Length, Length, Flags & ~(ARRAY_EXTERNAL|ARRAY_CACHED), sdef, NestedIdentity);
       array_attach_basemt(L, arr);
       if (storage) {
          if (Type IS AET::ANY) {
@@ -764,15 +763,17 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
 GCarray * lj_array_new(lua_State *L, uint32_t Length, const ArrayAllocationDescriptor &Descriptor, void *Data,
    uint8_t Flags)
 {
+   ptrdiff_t saved_top = savestack(L, L->top);
+   if (Descriptor.nested_identity) {
+      setstrV(L, L->top, Descriptor.nested_identity);
+      incr_top(L);
+   }
    std::string_view struct_name = Descriptor.storage IS AET::STRUCT and Descriptor.struct_def ?
       std::string_view(Descriptor.struct_def->Name) : std::string_view{};
-   GCarray *array = lj_array_new(
-      L, Length, Descriptor.storage, Data, Flags, struct_name, Descriptor.struct_def);
-   if (not Descriptor.canonical_identity.empty()) {
-      GCstr *identity = lj_str_new(L, Descriptor.canonical_identity.data(), Descriptor.canonical_identity.size());
-      setgcref(array->type_identity, obj2gco(identity));
-      lj_gc_objbarrier(L, array, identity);
-   }
+   GCarray *array = lj_array_new(L, Length, Descriptor.storage, Data, Flags, struct_name, Descriptor.struct_def,
+      Descriptor.nested_identity);
+   if (Descriptor.nested_identity) lj_gc_objbarrier(L, array, Descriptor.nested_identity);
+   L->top = restorestack(L, saved_top);
    return array;
 }
 
@@ -780,11 +781,8 @@ GCarray * lj_array_new_like(lua_State *L, const GCarray *Source, uint32_t Length
 {
    ArrayAllocationDescriptor descriptor;
    descriptor.storage = Source->elemtype;
-   descriptor.struct_def = Source->structdef;
-   if (gcref(Source->type_identity)) {
-      GCstr *identity = strref(Source->type_identity);
-      descriptor.canonical_identity.assign(strdata(identity), identity->len);
-   }
+   descriptor.struct_def = Source->struct_definition();
+   descriptor.nested_identity = Source->nested_identity();
    return lj_array_new(L, Length, descriptor);
 }
 
@@ -868,19 +866,13 @@ void lj_array_clear_range(GCarray *Array, MSize Start, MSize Count)
 
 //********************************************************************************************************************
 
-void lj_array_copy(lua_State *L, GCarray *Dest, uint32_t DstIdx, GCarray *Src, uint32_t SrcIdx, uint32_t Count)
+void lj_array_copy_unchecked(
+   lua_State *L, GCarray *Dest, uint32_t DstIdx, const GCarray *Src, uint32_t SrcIdx, uint32_t Count)
 {
-   if (SrcIdx > Src->len or Count > Src->len - SrcIdx or DstIdx > Dest->len or Count > Dest->len - DstIdx) {
-      lj_err_caller(L, ErrMsg::IDXRNG);
-   }
-   if (Dest->is_readonly()) lj_err_caller(L, ErrMsg::ARRRO);
-   if (not (Dest->elemtype IS Src->elemtype) or not array_copy_identity_compatible(Dest, Src)) {
-      lj_err_caller(L, ErrMsg::ARRTYPE);
-   }
    if (Count IS 0) return;
 
    void *dst_ptr = lj_array_index(Dest, DstIdx);
-   void *src_ptr = lj_array_index(Src, SrcIdx);
+   const void *src_ptr = lj_array_index(Src, SrcIdx);
    if (Dest->elemtype IS AET::ANY) {
       lj_bulk_move_tvalue((TValue *)dst_ptr, (const TValue *)src_ptr, Count);
       auto dst_slots = (TValue *)dst_ptr;
@@ -901,6 +893,18 @@ void lj_array_copy(lua_State *L, GCarray *Dest, uint32_t DstIdx, GCarray *Src, u
       size_t byte_count = Count * Dest->elemsize;
       memmove(dst_ptr, src_ptr, byte_count); // Use memmove to handle overlapping regions
    }
+}
+
+void lj_array_copy(lua_State *L, GCarray *Dest, uint32_t DstIdx, GCarray *Src, uint32_t SrcIdx, uint32_t Count)
+{
+   if (SrcIdx > Src->len or Count > Src->len - SrcIdx or DstIdx > Dest->len or Count > Dest->len - DstIdx) {
+      lj_err_caller(L, ErrMsg::IDXRNG);
+   }
+   if (Dest->is_readonly()) lj_err_caller(L, ErrMsg::ARRRO);
+   if (not (Dest->elemtype IS Src->elemtype) or not array_copy_identity_compatible(Dest, Src)) {
+      lj_err_caller(L, ErrMsg::ARRTYPE);
+   }
+   lj_array_copy_unchecked(L, Dest, DstIdx, Src, SrcIdx, Count);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_array.h
+++ b/src/tiri/jit/src/runtime/lj_array.h
@@ -8,14 +8,13 @@
 struct ArrayAllocationDescriptor {
    AET storage = AET::ANY;
    struct_record *struct_def = nullptr;
-   std::string canonical_identity;
+   GCstr *nested_identity = nullptr;
 };
 
 extern GCarray * lj_array_new(lua_State *, uint32_t, AET, void *Data = nullptr, uint8_t Flags = 0,
-   std::string_view StructName = {}, struct_record *StructDef = nullptr);
+   std::string_view StructName = {}, struct_record *StructDef = nullptr, GCstr *NestedIdentity = nullptr);
 extern GCarray * lj_array_new(lua_State *, uint32_t, const ArrayAllocationDescriptor &, void *Data = nullptr,
    uint8_t Flags = 0);
-[[nodiscard]] extern std::string lj_array_default_identity(AET, const struct_record * = nullptr);
 [[nodiscard]] extern bool lj_array_identity_accepts(const GCarray *, const GCarray *);
 [[nodiscard]] extern bool lj_array_identity_matches(const GCarray *, std::string_view);
 [[nodiscard]] extern bool lj_array_member_identity_matches(const GCarray *, std::string_view);
@@ -25,7 +24,9 @@ extern void lj_array_free(global_State *, GCarray *);
 [[nodiscard]] extern CSTRING lj_array_elemtype_name(AET) noexcept;
 [[nodiscard]] extern bool lj_array_struct_is_trivial(const struct_record &Def);
 extern void lj_array_clear_range(GCarray *, MSize Start, MSize Count);
-extern void lj_array_copy(lua_State *, GCarray *, uint32_t dstidx, GCarray *, uint32_t srcidx, uint32_t count);
+extern void lj_array_copy(lua_State *, GCarray *, uint32_t DstIdx, GCarray *, uint32_t SrcIdx, uint32_t Count);
+extern void lj_array_copy_unchecked(lua_State *, GCarray *, uint32_t DstIdx, const GCarray *, uint32_t SrcIdx,
+   uint32_t Count);
 extern GCtab* lj_array_to_table(lua_State *, GCarray *);
 extern bool lj_array_grow(lua_State *, GCarray *, MSize MinCapacity);
 
@@ -47,4 +48,8 @@ extern void lj_array_store_new_values(lua_State *, GCarray *, cTValue *Values, M
 
 inline void * lj_array_index(GCarray *Array, uint32_t Idx) {
    return (int8_t*)Array->arraydata() + (Idx * Array->elemsize);
+}
+
+inline const void * lj_array_index(const GCarray *Array, uint32_t Idx) {
+   return (const int8_t*)Array->arraydata() + (Idx * Array->elemsize);
 }

--- a/src/tiri/jit/src/runtime/lj_gc.cpp
+++ b/src/tiri/jit/src/runtime/lj_gc.cpp
@@ -495,7 +495,7 @@ static void gc_traverse_array(global_State *g, GCarray *Arr)
 {
    GCtab *mt = tabref(Arr->metatable);
    if (mt) gc_markobj(g, mt);
-   if (gcref(Arr->type_identity)) gc_markobj(g, gcref(Arr->type_identity));
+   if (GCstr *identity = Arr->nested_identity()) gc_markobj(g, obj2gco(identity));
 
    if (Arr->elemtype IS AET::STR_GC or Arr->elemtype IS AET::TABLE or Arr->elemtype IS AET::ARRAY or Arr->elemtype IS AET::OBJECT) {
       GCRef *refs = Arr->get<GCRef>();

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -200,12 +200,11 @@ void lj_meta_raw_type_text(lua_State *L, cTValue *Value, char *Buffer, size_t Si
 
    if (tvisarray(Value)) {
       GCarray *array = arrayV(Value);
-      if (gcref(array->type_identity)) {
-         GCstr *identity = strref(array->type_identity);
+      if (GCstr *identity = array->nested_identity()) {
          std::snprintf(Buffer, Size, "%.*s", int(identity->len), strdata(identity));
       }
-      else if (array->elemtype IS AET::STRUCT and array->structdef) {
-         std::snprintf(Buffer, Size, "array<struct<%s>>", array->structdef->Name.c_str());
+      else if (struct_record *definition = array->struct_definition()) {
+         std::snprintf(Buffer, Size, "array<struct<%s>>", definition->Name.c_str());
       }
       else std::snprintf(Buffer, Size, "array<%s>", lj_array_elemtype_name(array->elemtype));
       return;
@@ -944,7 +943,7 @@ namespace {
    if (not string_match and actual != expected) return false;
    if (expected IS AET::STRUCT) {
       struct_record *definition = find_struct(L, Entry.constraint_name);
-      return definition and Array->structdef IS definition;
+      return definition and Array->struct_definition() IS definition;
    }
    if (expected IS AET::ARRAY and not Entry.constraint_name.empty()) {
       return lj_array_member_identity_matches(Array, Entry.constraint_name);

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -1381,10 +1381,14 @@ struct GCarray {
    MSize   len;         // Number of elements currently in use
    MSize   capacity;    // Number of elements that can be stored (allocated capacity)
    MSize   elemsize;    // Size of each element in bytes
-   struct struct_record *structdef;  // Optional: struct definition for struct arrays
+   // Structure definitions and specialised nested-array identities are mutually exclusive and share the historic
+   // structure-definition offset.  Access this storage only through the tagged helpers below.
+   union {
+      struct struct_record *structure_definition;
+      GCRef nested_array_identity;
+   } type_metadata;
    std::vector<char> *strcache; // Optional: cached string content for CSTRING/STRING_CPP arrays
    RESOURCEID resource_id; // Optional Core resource pin owned by an external view
-   GCRef type_identity; // Interned complete public type name, appended to preserve fixed field offsets
 
 public:
    // Initialise the array structure. Storage must be pre-allocated by the caller using lj_mem_new()
@@ -1406,10 +1410,21 @@ public:
       len       = Length;
       capacity  = Capacity;
       elemsize  = ElemSize;
-      structdef = StructDef;
+      type_metadata.nested_array_identity.gcptr64 = 0;
+      if (Type IS AET::STRUCT) type_metadata.structure_definition = StructDef;
+      else if (Type IS AET::ARRAY) type_metadata.nested_array_identity.gcptr64 = uint64_t(TypeIdentity);
       strcache  = nullptr;
       resource_id = 0;
-      type_identity.gcptr64 = uint64_t(TypeIdentity);
+   }
+
+   [[nodiscard]] inline struct struct_record * struct_definition() const noexcept
+   {
+      return elemtype IS AET::STRUCT ? type_metadata.structure_definition : nullptr;
+   }
+
+   [[nodiscard]] inline GCstr * nested_identity() const noexcept
+   {
+      return elemtype IS AET::ARRAY ? (GCstr *)(void *)type_metadata.nested_array_identity.gcptr64 : nullptr;
    }
 
    // Destructor only handles strcache. Storage is freed by lj_array_free() for proper GC tracking.
@@ -1448,6 +1463,8 @@ public:
 // Ensure metatable field is at the same offset in GCtab, GCarray, GCudata
 static_assert(offsetof(GCarray, metatable) IS offsetof(GCtab, metatable));
 static_assert(offsetof(GCarray, gclist) IS offsetof(GCtab, gclist));
+static_assert(offsetof(GCarray, type_metadata) IS 56);
+static_assert(sizeof(GCarray) IS 80);
 
 // Forward declaration - defined after GCobj is complete
 inline GCarray* arrayref(GCRef r) noexcept;

--- a/src/tiri/jit/src/runtime/lj_vmarray.cpp
+++ b/src/tiri/jit/src/runtime/lj_vmarray.cpp
@@ -118,7 +118,7 @@ static void arr_load_elem(lua_State *L, GCarray *Array, uint32_t Idx, TValue *Re
       }
 
       case AET::STRUCT: {
-         auto value = lj_struct_new(L, *Array->structdef);
+         auto value = lj_struct_new(L, *Array->struct_definition());
          memcpy(value->data, elem, Array->elemsize);
          setstructV(L, Result, value);
          break;

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -170,24 +170,41 @@ static bool test_array_recursive_identity(kt::Log &Log)
    lua_State *lua = holder.get();
    if (not lua) return false;
 
-   GCarray *ordinary = lj_array_new(lua, 0, AET::ARRAY);
-   if (not gcref(ordinary->type_identity) or
-       std::string_view(strdata(strref(ordinary->type_identity)), strref(ordinary->type_identity)->len) !=
-          "array<array>") {
-      Log.error("the C++ convenience allocator did not derive an unconstrained canonical identity");
+   std::array<AET, 4> implicit_types { AET::INT32, AET::STR_GC, AET::ANY, AET::ARRAY };
+   for (AET type : implicit_types) {
+      GCarray *ordinary = lj_array_new(lua, 0, type);
+      if (ordinary->nested_identity()) {
+         Log.error("ordinary array type %d stored a redundant identity", int(type));
+         return false;
+      }
+   }
+
+   struct_record structure("ArrayIdentityStructure");
+   structure.Size = sizeof(int32_t);
+   GCarray *structures = lj_array_new(lua, 0, AET::STRUCT, nullptr, 0, structure.Name, &structure);
+   if (structures->struct_definition() != &structure or structures->nested_identity()) {
+      Log.error("a structure array did not use the tagged structure-definition slot");
       return false;
    }
 
+   GCstr *matrix_identity = lj_str_new(lua, "array<array<double>>", sizeof("array<array<double>>") - 1);
+
    ArrayAllocationDescriptor descriptor {
       .storage = AET::ARRAY,
-      .canonical_identity = "array<array<double>>"
+      .nested_identity = matrix_identity
    };
-   GCarray *matrix = lj_array_new(lua, 0, descriptor);
+   GCarray *matrix = lj_array_new(lua, 3, descriptor);
    setarrayV(lua, lua->top++, matrix);
    lua_gc(lua, LUA_GCCOLLECT);
-   GCstr *identity = strref(matrix->type_identity);
-   if (not identity or std::string_view(strdata(identity), identity->len) != "array<array<double>>") {
+   GCstr *identity = matrix->nested_identity();
+   if (identity != matrix_identity or std::string_view(strdata(identity), identity->len) != "array<array<double>>") {
       Log.error("a descriptor-aware array allocation lost its identity during GC traversal");
+      return false;
+   }
+
+   GCarray *derived = lj_array_new_like(lua, matrix, 0);
+   if (derived->nested_identity() != matrix_identity) {
+      Log.error("a derived recursive array did not share its source identity");
       return false;
    }
 
@@ -207,7 +224,7 @@ static bool test_array_recursive_identity(kt::Log &Log)
 
    ArrayAllocationDescriptor wildcard_descriptor {
       .storage = AET::ARRAY,
-      .canonical_identity = "array<array<any>>"
+      .nested_identity = lj_str_new(lua, "array<array<any>>", sizeof("array<array<any>>") - 1)
    };
    GCarray *wildcard = lj_array_new(lua, 0, wildcard_descriptor);
    if (lj_array_validate_element(wildcard, &value) != ArrayElementResult::OK) {
@@ -217,11 +234,11 @@ static bool test_array_recursive_identity(kt::Log &Log)
 
    ArrayAllocationDescriptor deep_wildcard_descriptor {
       .storage = AET::ARRAY,
-      .canonical_identity = "array<array<array>>"
+      .nested_identity = lj_str_new(lua, "array<array<array>>", sizeof("array<array<array>>") - 1)
    };
    ArrayAllocationDescriptor specialised_matrix_descriptor {
       .storage = AET::ARRAY,
-      .canonical_identity = "array<array<int>>"
+      .nested_identity = lj_str_new(lua, "array<array<int>>", sizeof("array<array<int>>") - 1)
    };
    GCarray *deep_wildcard = lj_array_new(lua, 0, deep_wildcard_descriptor);
    GCarray *specialised_matrix = lj_array_new(lua, 0, specialised_matrix_descriptor);
@@ -235,6 +252,28 @@ static bool test_array_recursive_identity(kt::Log &Log)
    if (not lj_array_member_identity_matches(bare_matrix, "array<any>") or
        not lj_array_identity_matches(bare_matrix, "array<array<any>>")) {
       Log.error("an array<any> wildcard rejected a bare array identity");
+      return false;
+   }
+
+   GCarray *source = lj_array_new(lua, 5, AET::INT32);
+   GCarray *copy = lj_array_new_like(lua, source, 5);
+   for (MSize i = 0; i < source->len; i++) source->get<int32_t>()[i] = int32_t(i + 1);
+   lj_array_copy(lua, copy, 0, source, 0, source->len);
+   if (copy->get<int32_t>()[4] != 5) {
+      Log.error("a contiguous internal array copy lost values");
+      return false;
+   }
+   lj_array_copy_unchecked(lua, copy, 0, source, 4, 1);
+   lj_array_copy_unchecked(lua, copy, 1, source, 2, 1);
+   lj_array_copy_unchecked(lua, copy, 2, source, 0, 1);
+   if (copy->get<int32_t>()[0] != 5 or copy->get<int32_t>()[1] != 3 or copy->get<int32_t>()[2] != 1) {
+      Log.error("stepped or descending internal copies lost values");
+      return false;
+   }
+
+   GCarray *empty = lj_array_new_like(lua, matrix, 0);
+   if (empty->len != 0 or empty->nested_identity() != matrix_identity) {
+      Log.error("an empty derived array lost its recursive identity");
       return false;
    }
    return true;

--- a/src/tiri/tests/test_array_manip.tiri
+++ b/src/tiri/tests/test_array_manip.tiri
@@ -1529,3 +1529,33 @@ end
       error("Positional fill should reject a negative Stop")
    end
 end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Slice copying paths
+
+@Test function ArraySlicesPreserveOrdinaryValues()
+   local integers = array<int> { 0, 1, 2, 3, 4 }
+   local strings = array<str> { 'zero', 'one', 'two', 'three', 'four' }
+   local mixed = array<any> { 0, 'one', true, 3, 'four' }
+
+   local empty = integers.slice({0 to 0})
+   local contiguous = integers.slice({1 into 3})
+   local stepped = integers.slice({0 into 4 by 2})
+   local descending = integers.slice({4 into 0 by -2})
+   assert(#empty is 0 and rawtype(empty) is 'array<int>', 'an empty primitive slice lost its type')
+   assert(contiguous[0] is 1 and contiguous[2] is 3, 'a contiguous primitive slice lost values')
+   assert(stepped[0] is 0 and stepped[2] is 4, 'a stepped primitive slice lost values')
+   assert(descending[0] is 4 and descending[2] is 0, 'a descending primitive slice lost values')
+
+   local string_slice = strings.slice({4 into 0 by -2})
+   local mixed_slice = mixed.slice({0 into 4 by 2})
+   strings = nil
+   mixed = nil
+   processing.collect('full')
+   assert(string_slice[0] is 'four' and string_slice[1] is 'two' and string_slice[2] is 'zero',
+      'a string slice lost references after collection')
+   assert(mixed_slice[0] is 0 and mixed_slice[1] is true and mixed_slice[2] is 'four',
+      'an any slice lost values after collection')
+   assert(rawtype(string_slice) is 'array<str>' and rawtype(mixed_slice) is 'array<any>',
+      'an ordinary reference slice lost its implicit identity')
+end

--- a/src/tiri/tests/test_recursive_array_types.tiri
+++ b/src/tiri/tests/test_recursive_array_types.tiri
@@ -99,6 +99,31 @@ end
    end
 end
 
+@Test function OrdinaryArrayIdentitiesRemainCanonicalOnTraces()
+   local values = {
+      array<char>,
+      array<str>,
+      array<any>,
+      array<array>,
+      array<obj>,
+      array<struct<RecursiveArrayPoint>>
+   }
+   local expected = {
+      'array<byte>',
+      'array<str>',
+      'array<any>',
+      'array<array>',
+      'array<obj>',
+      'array<struct<RecursiveArrayPoint>>'
+   }
+
+   for _ in {0 to 200} do
+      for index in {0 to #values} do
+         assert(rawtype(values[index]) is expected[index], 'an implicit ordinary identity changed on a trace')
+      end
+   end
+end
+
 @Test function RecursiveRuntimeTypeTests()
    local matrix:any = array<array<int>> { array<int> { 1 } }
    local cube:any = array<array<array<int>>> { array<array<int>> { array<int> { 2 } } }
@@ -305,6 +330,43 @@ end
    local wildcard = array<array<any>> { row }
    wildcard[0] = mismatch
    assert(wildcard[0] is mismatch, 'array<array<any>> did not retain wildcard runtime semantics')
+end
+
+@Test function RecursiveSlicesPreserveIdentityValuesAndReferences()
+   local source = array<array<int>> {
+      array<int> { 1 },
+      array<int> { 2 },
+      array<int> { 3 },
+      array<int> { 4 },
+      array<int> { 5 }
+   }
+   local slices = {
+      source.slice({0 to 0}),
+      source.slice({1 into 3}),
+      source.slice({0 into 4 by 2}),
+      source.slice({4 into 0 by -2})
+   }
+
+   assert(#slices[0] is 0, 'an empty recursive slice should remain empty')
+   assert(slices[1][0][0] is 2 and slices[1][2][0] is 4, 'a contiguous recursive slice lost values')
+   assert(slices[2][0][0] is 1 and slices[2][2][0] is 5, 'a stepped recursive slice lost values')
+   assert(slices[3][0][0] is 5 and slices[3][2][0] is 1, 'a descending recursive slice lost values')
+
+   source = nil
+   processing.collect('full')
+   for _, value in slices do
+      assert(rawtype(value) is 'array<array<int>>', 'a recursive slice lost its identity after collection')
+   end
+   assert(slices[1][1][0] is 3 and slices[3][1][0] is 3,
+      'a recursive slice did not retain copied array references after collection')
+
+   local mismatch:any = array<str> { 'wrong' }
+   for _, value in slices do
+      if #value > 0 then
+         expect_recursive_store_failure(() => do value[0] = mismatch end,
+            'a recursive slice accepted an incompatible member')
+      end
+   end
 end
 
 @Test function MalformedRecursiveTypesAreRejected()

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -1412,7 +1412,7 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
                ErrorMsg = std::format("Arg #{} ({}) array element type does not match the span.", i, args[i].Name);
                return ERR::InvalidType;
             }
-            if ((element_type IS AET::STRUCT) and (array->structdef != struct_def)) {
+            if ((element_type IS AET::STRUCT) and (array->struct_definition() != struct_def)) {
                ErrorMsg = std::format("Arg #{} ({}) structure array type does not match the span.", i, args[i].Name);
                return ERR::InvalidType;
             }

--- a/src/tiri/tiri_objects_calls.cpp
+++ b/src/tiri/tiri_objects_calls.cpp
@@ -494,7 +494,7 @@ static ERR build_span_arg(lua_State *Lua, int StackIndex, const FunctionField &F
          *ErrorMsg = "Array element type does not match the span element type.";
          return ERR::InvalidType;
       }
-      if ((element_type IS AET::STRUCT) and (array->structdef != struct_def)) {
+      if ((element_type IS AET::STRUCT) and (array->struct_definition() != struct_def)) {
          *ErrorMsg = "Structure array type does not match the span structure type.";
          return ERR::InvalidType;
       }

--- a/src/tiri/tiri_regex.cpp
+++ b/src/tiri/tiri_regex.cpp
@@ -408,7 +408,7 @@ static int regex_search(lua_State *Lua)
 
    ArrayAllocationDescriptor descriptor {
       .storage = AET::ARRAY,
-      .canonical_identity = "array<array<str>>"
+      .nested_identity = lj_str_new(Lua, "array<array<str>>", sizeof("array<array<str>>") - 1)
    };
    GCarray *results = lj_array_new(Lua, 0, descriptor);
    setarrayV(Lua, Lua->top++, results); // Root results to prevent GC during callbacks


### PR DESCRIPTION
* Stored nested array identities only where specialised runtime type checks require them
* Added checked bulk and unchecked internal array copying for slice operations
* Extended recursive and ordinary array coverage for type identity and collection safety