### PR TITLE
[Tiri] Improved defer runtime performance with a flat active stack

### DIFF
--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -10710,13 +10710,13 @@ static bool test_defer_runtime_registration_state(kt::Log &Log)
    ptrdiff_t owner_offset = savestack(lua, lua->base);
    lj_defer_arm(lua, lua->base, 3, 2, 1);
    lj_defer_arm(lua, lua->base, 7, 1, 1);
-   if (lua->defer_frames.size() != 1 or lua->defer_frames[0].owner_base != owner_offset or
-       lua->defer_frames[0].registrations.size() != 2) {
-      Log.error("defer registrations were not appended to their owning frame");
+   if (lua->defer_stack.size() != 2 or lua->defer_stack[0].owner_base != owner_offset or
+       lua->defer_stack[1].owner_base != owner_offset) {
+      Log.error("defer registrations were not appended to the active stack");
       return false;
    }
 
-   const DeferRegistration &first = lua->defer_frames[0].registrations[0];
+   const DeferRegistration &first = lua->defer_stack[0];
    if (first.callable_slot != 3 or first.argument_count != 2 or first.scope_base != 1) {
       Log.error("defer registration metadata was not retained");
       return false;
@@ -10724,36 +10724,65 @@ static bool test_defer_runtime_registration_state(kt::Log &Log)
 
    lj_state_growstack(lua, 64);
    TValue *owner = restorestack(lua, owner_offset);
-   if (lua->defer_frames[0].owner_base != savestack(lua, owner) or
-       not lj_defer_consume(lua, owner, 7) or lua->defer_frames[0].registrations.size() != 1) {
+   if (lua->defer_stack[0].owner_base != savestack(lua, owner) or
+       not lj_defer_consume(lua, owner, 7) or lua->defer_stack.size() != 1) {
       Log.error("defer ownership did not survive stack relocation or consume in LIFO order");
       return false;
    }
-   if (not lj_defer_consume(lua, owner, 3) or not lua->defer_frames.empty()) {
-      Log.error("consuming the last defer did not remove its empty frame state");
+   if (not lj_defer_consume(lua, owner, 3) or not lua->defer_stack.empty()) {
+      Log.error("consuming the last defer did not empty the active stack");
       return false;
    }
 
    TValue *inner_owner = owner + 8;
    lj_defer_arm(lua, owner, 2, 0, 1);
+   lj_defer_arm(lua, inner_owner, 2, 0, 1);
+   if (lua->defer_stack.size() != 2 or lua->defer_stack[0].owner_base IS lua->defer_stack[1].owner_base or
+       not lj_defer_consume(lua, inner_owner, 2) or not lj_defer_consume(lua, owner, 2)) {
+      Log.error("identical defer slots in nested activations did not retain independent LIFO ownership");
+      return false;
+   }
+
+   lj_defer_arm(lua, owner, 2, 0, 1);
    lj_defer_arm(lua, owner, 5, 1, 4);
    lj_defer_arm(lua, inner_owner, 1, 0, 0);
    lj_defer_unwind(lua, owner);
-   if (lua->defer_frames.size() != 1 or lua->defer_frames[0].owner_base != owner_offset or
-       lua->defer_frames[0].registrations.size() != 2) {
-      Log.error("unwinding did not discard only frame states above the surviving owner");
+   if (lua->defer_stack.size() != 2 or lua->defer_stack[0].owner_base != owner_offset or
+       lua->defer_stack[1].owner_base != owner_offset) {
+      Log.error("unwinding did not discard only registrations above the surviving owner");
       return false;
    }
 
    lj_defer_discard(lua, owner, 4);
-   if (lua->defer_frames.size() != 1 or lua->defer_frames[0].registrations.size() != 1 or
-       lua->defer_frames[0].registrations[0].callable_slot != 2) {
+   if (lua->defer_stack.size() != 1 or lua->defer_stack[0].callable_slot != 2) {
       Log.error("lexical defer discard removed registrations outside the abandoned slot range");
       return false;
    }
-   if (not lj_defer_consume(lua, owner, 2) or not lua->defer_frames.empty()) {
+   if (not lj_defer_consume(lua, owner, 2) or not lua->defer_stack.empty()) {
       Log.error("surviving defer registration could not be consumed after a partial unwind");
       return false;
+   }
+
+   for (uint32_t slot = 0; slot < 3; ++slot) lj_defer_arm(lua, owner, slot, 0, 0);
+   for (uint32_t slot = 3; slot > 0; --slot) {
+      if (not lj_defer_consume(lua, owner, slot - 1)) {
+         Log.error("failed to consume a defer while establishing the active-stack high-water mark");
+         return false;
+      }
+   }
+   const size_t retained_capacity = lua->defer_stack.capacity();
+   for (uint32_t iteration = 0; iteration < 32; ++iteration) {
+      for (uint32_t slot = 0; slot < 3; ++slot) lj_defer_arm(lua, owner, slot, 0, 0);
+      for (uint32_t slot = 3; slot > 0; --slot) {
+         if (not lj_defer_consume(lua, owner, slot - 1)) {
+            Log.error("failed to consume a repeated defer registration");
+            return false;
+         }
+      }
+      if (not lua->defer_stack.empty() or lua->defer_stack.capacity() != retained_capacity) {
+         Log.error("repeated defer scopes did not retain stable empty-stack capacity");
+         return false;
+      }
    }
 
    return true;

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -1720,14 +1720,10 @@ inline void hook_restore(global_State *g, uint8_t h) noexcept { g->hookmask = (g
 // Per-thread state object.  See lua_newstate() in lj_state.cpp for initialisation.
 
 struct DeferRegistration {
+   ptrdiff_t owner_base = 0;
    uint8_t callable_slot = 0;
    uint8_t argument_count = 0;
    uint8_t scope_base = 0;
-};
-
-struct DeferFrameState {
-   ptrdiff_t owner_base = 0;
-   std::vector<DeferRegistration> registrations;
 };
 
 struct lua_State {
@@ -1793,7 +1789,7 @@ struct lua_State {
       uint64_t armed_slots = 0;
    };
    std::vector<CloseFrameState> close_frames;
-   std::vector<DeferFrameState> defer_frames;
+   std::vector<DeferRegistration> defer_stack;
 
    struct SavedMultresFrame {
       ptrdiff_t frame_base = 0;

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -478,21 +478,16 @@ extern "C" void lj_defer_arm(lua_State *L, TValue *OwnerBase, uint32_t CallableS
    }
 
    ptrdiff_t owner_base = savestack(L, OwnerBase);
-   auto frame = std::find_if(L->defer_frames.rbegin(), L->defer_frames.rend(),
-      [owner_base](const DeferFrameState &Frame) { return Frame.owner_base IS owner_base; });
-   if (frame IS L->defer_frames.rend()) {
-      L->defer_frames.push_back(DeferFrameState{ .owner_base = owner_base });
-      frame = L->defer_frames.rbegin();
-   }
-
-   auto duplicate = std::find_if(frame->registrations.rbegin(), frame->registrations.rend(),
-      [CallableSlot](const DeferRegistration &Registration) {
-         return Registration.callable_slot IS CallableSlot;
+#ifdef LUA_USE_ASSERT
+   auto duplicate = std::find_if(L->defer_stack.rbegin(), L->defer_stack.rend(),
+      [owner_base, CallableSlot](const DeferRegistration &Registration) {
+         return Registration.owner_base IS owner_base and Registration.callable_slot IS CallableSlot;
       });
-   lj_assertL(duplicate IS frame->registrations.rend(), "defer callable slot armed more than once");
-   if (duplicate != frame->registrations.rend()) return;
+   lj_assertL(duplicate IS L->defer_stack.rend(), "defer callable slot armed more than once");
+#endif
 
-   frame->registrations.push_back(DeferRegistration{
+   L->defer_stack.push_back(DeferRegistration{
+      .owner_base = owner_base,
       .callable_slot = uint8_t(CallableSlot),
       .argument_count = uint8_t(ArgumentCount),
       .scope_base = uint8_t(ScopeBase)
@@ -515,21 +510,15 @@ extern "C" bool lj_defer_consume(lua_State *L, TValue *OwnerBase, uint32_t Calla
    if (OwnerBase < stack or OwnerBase > stack_end or CallableSlot >= LJ_MAX_SLOTS) return false;
 
    ptrdiff_t owner_base = savestack(L, OwnerBase);
-   auto frame = std::find_if(L->defer_frames.rbegin(), L->defer_frames.rend(),
-      [owner_base](const DeferFrameState &Frame) { return Frame.owner_base IS owner_base; });
-   lj_assertL(frame != L->defer_frames.rend(), "defer consumption has no owning frame state");
-   if (frame IS L->defer_frames.rend()) return false;
+   lj_assertL(not L->defer_stack.empty(), "defer consumption has no active registration");
+   if (L->defer_stack.empty()) return false;
 
-   auto registration = std::find_if(frame->registrations.rbegin(), frame->registrations.rend(),
-      [CallableSlot](const DeferRegistration &Registration) {
-         return Registration.callable_slot IS CallableSlot;
-      });
-   lj_assertL(registration != frame->registrations.rend(), "defer callable slot is not armed");
-   if (registration IS frame->registrations.rend()) return false;
+   const DeferRegistration &registration = L->defer_stack.back();
+   lj_assertL(registration.owner_base IS owner_base, "defer registrations consumed out of activation order");
+   lj_assertL(registration.callable_slot IS CallableSlot, "defer registrations consumed out of LIFO order");
+   if (registration.owner_base != owner_base or registration.callable_slot != CallableSlot) return false;
 
-   lj_assertL(registration IS frame->registrations.rbegin(), "defer registrations consumed out of LIFO order");
-   frame->registrations.erase(std::next(registration).base());
-   if (frame->registrations.empty()) L->defer_frames.erase(std::next(frame).base());
+   L->defer_stack.pop_back();
    return true;
 }
 
@@ -548,21 +537,15 @@ bool lj_defer_find_scope(lua_State *State, const TValue *OwnerBase, uint32_t Low
    if (not State or not OwnerBase or not ScopeBase or LowerCallableSlot > UpperCallableSlot) return false;
 
    ptrdiff_t owner_base = savestack(State, OwnerBase);
-   auto frame = std::find_if(State->defer_frames.rbegin(), State->defer_frames.rend(),
-      [owner_base](const DeferFrameState &Frame) { return Frame.owner_base IS owner_base; });
-   if (frame IS State->defer_frames.rend()) return false;
-
-   bool found = false;
-   uint32_t scope_base = 0;
-   for (const DeferRegistration &registration : frame->registrations) {
-      if (registration.callable_slot < LowerCallableSlot or registration.callable_slot >= UpperCallableSlot) continue;
-      if (not found or registration.scope_base > scope_base) {
-         found = true;
-         scope_base = registration.scope_base;
-      }
+   // Registrations are appended in dynamic execution order.  The newest matching entry therefore belongs to the
+   // innermost active lexical scope, irrespective of the bytecode slots used by conditional control flow.
+   for (auto registration = State->defer_stack.rbegin(); registration != State->defer_stack.rend(); ++registration) {
+      if (registration->owner_base != owner_base or registration->callable_slot < LowerCallableSlot or
+          registration->callable_slot >= UpperCallableSlot) continue;
+      *ScopeBase = registration->scope_base;
+      return true;
    }
-   if (found) *ScopeBase = scope_base;
-   return found;
+   return false;
 }
 
 //********************************************************************************************************************
@@ -574,16 +557,12 @@ bool lj_defer_peek_scope(lua_State *State, const TValue *OwnerBase, uint32_t Low
    if (not State or not OwnerBase or not Registration or LowerCallableSlot > UpperCallableSlot) return false;
 
    ptrdiff_t owner_base = savestack(State, OwnerBase);
-   auto frame = std::find_if(State->defer_frames.rbegin(), State->defer_frames.rend(),
-      [owner_base](const DeferFrameState &Frame) { return Frame.owner_base IS owner_base; });
-   if (frame IS State->defer_frames.rend()) return false;
-
-   auto registration = std::find_if(frame->registrations.rbegin(), frame->registrations.rend(),
-      [LowerCallableSlot, UpperCallableSlot, ScopeBase](const DeferRegistration &Candidate) {
-         return Candidate.callable_slot >= LowerCallableSlot and Candidate.callable_slot < UpperCallableSlot and
-            Candidate.scope_base IS ScopeBase;
+   auto registration = std::find_if(State->defer_stack.rbegin(), State->defer_stack.rend(),
+      [owner_base, LowerCallableSlot, UpperCallableSlot, ScopeBase](const DeferRegistration &Candidate) {
+         return Candidate.owner_base IS owner_base and Candidate.callable_slot >= LowerCallableSlot and
+            Candidate.callable_slot < UpperCallableSlot and Candidate.scope_base IS ScopeBase;
       });
-   if (registration IS frame->registrations.rend()) return false;
+   if (registration IS State->defer_stack.rend()) return false;
    *Registration = *registration;
    return true;
 }
@@ -595,8 +574,10 @@ bool lj_defer_has_owner_above(lua_State *State, const TValue *SurvivingBase) noe
 {
    if (not State or not SurvivingBase) return false;
    ptrdiff_t surviving_base = savestack(State, SurvivingBase);
-   return std::any_of(State->defer_frames.begin(), State->defer_frames.end(),
-      [surviving_base](const DeferFrameState &Frame) { return Frame.owner_base > surviving_base; });
+   return std::any_of(State->defer_stack.begin(), State->defer_stack.end(),
+      [surviving_base](const DeferRegistration &Registration) {
+         return Registration.owner_base > surviving_base;
+      });
 }
 
 //********************************************************************************************************************
@@ -615,15 +596,12 @@ void lj_defer_discard(lua_State *State, const TValue *OwnerBase, uint32_t Minimu
    if (OwnerBase < stack or OwnerBase > stack_end or MinimumCallableSlot > LJ_MAX_SLOTS) return;
 
    ptrdiff_t owner_base = savestack(State, OwnerBase);
-   auto frame = std::find_if(State->defer_frames.begin(), State->defer_frames.end(),
-      [owner_base](const DeferFrameState &Frame) { return Frame.owner_base IS owner_base; });
-   if (frame IS State->defer_frames.end()) return;
-
-   frame->registrations.erase(std::remove_if(frame->registrations.begin(), frame->registrations.end(),
-      [MinimumCallableSlot](const DeferRegistration &Registration) {
-         return Registration.callable_slot >= MinimumCallableSlot;
-      }), frame->registrations.end());
-   if (frame->registrations.empty()) State->defer_frames.erase(frame);
+   // Protected transfers can abandon a lexical range while retaining earlier entries for the same activation.
+   // Keep the exceptional path general so registrations outside that range retain their dynamic order.
+   State->defer_stack.erase(std::remove_if(State->defer_stack.begin(), State->defer_stack.end(),
+      [owner_base, MinimumCallableSlot](const DeferRegistration &Registration) {
+         return Registration.owner_base IS owner_base and Registration.callable_slot >= MinimumCallableSlot;
+      }), State->defer_stack.end());
 }
 
 void lj_defer_unwind(lua_State *State, const TValue *SurvivingBase) noexcept
@@ -636,9 +614,19 @@ void lj_defer_unwind(lua_State *State, const TValue *SurvivingBase) noexcept
    if (SurvivingBase < stack or SurvivingBase > stack_end) return;
 
    ptrdiff_t surviving_base = savestack(State, SurvivingBase);
-   State->defer_frames.erase(std::remove_if(State->defer_frames.begin(), State->defer_frames.end(),
-      [surviving_base](const DeferFrameState &Frame) { return Frame.owner_base > surviving_base; }),
-      State->defer_frames.end());
+   // Nested activations register after their callers and finish before control returns, so abandoned owners form a
+   // suffix.  Truncating that suffix retains vector capacity for later calls.
+   while (not State->defer_stack.empty() and State->defer_stack.back().owner_base > surviving_base) {
+      State->defer_stack.pop_back();
+   }
+#ifdef LUA_USE_ASSERT
+   auto abandoned = std::find_if(State->defer_stack.begin(), State->defer_stack.end(),
+      [surviving_base](const DeferRegistration &Registration) {
+         return Registration.owner_base > surviving_base;
+      });
+   lj_assertG_(G(State), abandoned IS State->defer_stack.end(),
+      "abandoned defer registrations did not form a stack suffix");
+#endif
 }
 
 extern "C" void lj_array_view_mode(lua_State *L, uint32_t Enabled)
@@ -948,7 +936,7 @@ static void close_state(lua_State *L)
 {
    global_State *g = G(L);
    // Teardown also covers states terminated while an activation or asynchronous root boundary is still live.
-   L->defer_frames.clear();
+   L->defer_stack.clear();
    L->context_stack.clear();
    L->context_active = 0;
    L->context_root_floors.clear();
@@ -1108,7 +1096,7 @@ void lj_state_free(global_State* g, lua_State *L)
    if (obj2gco(L) IS gcref(g->cur_L)) setgcrefnull(g->cur_L);
    lj_assertG(L->context_stack.empty(), "state freed with active contextual activations");
    lj_assertG(L->context_root_floors.empty(), "state freed with active asynchronous root boundaries");
-   L->defer_frames.clear();
+   L->defer_stack.clear();
 
    if (L->parser_diagnostics) { delete (ParserDiagnostics*)L->parser_diagnostics; L->parser_diagnostics = nullptr; }
    if (L->parser_tips) { delete L->parser_tips; L->parser_tips = nullptr; }

--- a/src/tiri/tests/test_defer.tiri
+++ b/src/tiri/tests/test_defer.tiri
@@ -550,6 +550,48 @@ end
    assert(join(order) is 'enter-3,enter-2,enter-1,leave-1,defer-1,leave-2,defer-2,leave-3,defer-3', "Unexpected recursive defer order: '" .. join(order) .. "'")
 end
 
+function flat_stack_recurse(Depth:num, Events:table)
+   defer(Captured)
+      Events.insert('defer-' .. tostring(Captured))
+   end(Depth)
+   Events.insert('body-' .. tostring(Depth))
+   if Depth > 0 then flat_stack_recurse(Depth - 1, Events) end
+end
+
+@Test function RecursiveActivationsShareCallableSlot()
+   local events = {}
+   flat_stack_recurse(3, events)
+   assert(join(events) is 'body-3,body-2,body-1,body-0,defer-0,defer-1,defer-2,defer-3',
+      "Recursive activations of one compiled defer must retain independent registrations: '" .. join(events) .. "'")
+end
+
+function conditional_flat_stack(First:bool, Second:bool, Events:table)
+   defer Events.insert('outer') end
+   if First then
+      defer Events.insert('first-a') end
+      if Second then defer Events.insert('second') end end
+      defer Events.insert('first-b') end
+      Events.insert('body')
+   end
+end
+
+@Test function ConditionalRegistrationUsesDynamicOrder()
+   local events = {}
+   conditional_flat_stack(true, true, events)
+   assert(join(events) is 'second,body,first-b,first-a,outer',
+      "Reached conditional defers should retain dynamic LIFO order: '" .. join(events) .. "'")
+
+   events.clear()
+   conditional_flat_stack(true, false, events)
+   assert(join(events) is 'body,first-b,first-a,outer',
+      "An unreached conditional defer must not leave an active registration: '" .. join(events) .. "'")
+
+   events.clear()
+   conditional_flat_stack(false, true, events)
+   assert(join(events) is 'outer',
+      "A skipped conditional scope must leave only its active outer defer: '" .. join(events) .. "'")
+end
+
 @Test function RepeatedLoopAndRecursiveUnwind()
    local events = {}
    local caught_message = nil
@@ -711,6 +753,56 @@ end
    assert(join(events) is 'abandoned,survivor-body,survivor',
       "An abandoned frame should not leak registrations into a later call: '" .. join(events) .. "'")
    assert(caught_message.find('abandon frame') != nil, 'Abandoning a frame should preserve the body error')
+end
+
+function repeated_flat_stack_iteration(Index:num, ShouldThrow:bool, Events:table)
+   defer(Captured) Events.insert('cleanup-' .. tostring(Captured)) end(Index)
+   Events.insert('body-' .. tostring(Index))
+   if ShouldThrow then error('iteration failure ' .. tostring(Index)) end
+end
+
+@Test function RepeatedNormalAndThrowingIterationsLeaveNoRegistrations()
+   local events = {}
+   for iteration in {0 to 12} do
+      try
+         repeated_flat_stack_iteration(iteration, iteration % 2 is 1, events)
+      except e
+         assert(e.message.find('iteration failure') != nil, 'The expected iteration error should propagate')
+      end
+   end
+   repeated_flat_stack_iteration(99, false, events)
+
+   local event_log = ',' .. join(events) .. ','
+   for iteration in {0 to 12} do
+      assert(event_log.count(',cleanup-' .. tostring(iteration) .. ',') is 1,
+         f'Iteration {iteration} should execute its defer exactly once')
+   end
+   assert(event_log.count(',cleanup-99,') is 1, 'A later normal call should execute only its own defer once')
+   assert(event_log.endsWith('body-99,cleanup-99,'),
+      'No stale registration should execute after the final normal cleanup')
+end
+
+function nested_defer_from_cleanup(Events:table)
+   defer Events.insert('nested-defer') end
+   Events.insert('nested-body')
+end
+
+@Test function CleanupHandlerPreservesOuterRegistrationStack()
+   local events = {}
+   function subject()
+      defer events.insert('outer-first') end
+      defer
+         events.insert('handler-enter')
+         nested_defer_from_cleanup(events)
+         events.insert('handler-leave')
+      end
+      defer events.insert('outer-last') end
+   end
+
+   subject()
+   assert(join(events) is
+      'outer-last,handler-enter,nested-body,nested-defer,handler-leave,outer-first',
+      "Nested Tiri cleanup must preserve the remaining outer registration order: '" .. join(events) .. "'")
 end
 
 @Test function ClosureReturn()

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -3564,11 +3564,47 @@ function run_defer_trace(Workload, Count):<str, str, num, num, num>
 end
 
 @Test function JITDeferNormalCleanupAndOrdering()
+   local function flat_stack_workload(Count:num):str
+      local events = {}
+      function recursive(Depth:num, Value:num):nil
+         defer(CapturedDepth, CapturedValue)
+            events.insert('recursive-' .. tostring(CapturedValue) .. '-' .. tostring(CapturedDepth))
+         end(Depth, Value)
+         if Depth > 0 then recursive(Depth - 1, Value) end
+      end
+      function nested(Value:num)
+         defer(Captured) events.insert('nested-defer-' .. tostring(Captured)) end(Value)
+         events.insert('nested-body-' .. tostring(Value))
+      end
+
+      for iteration in {0 to Count} do
+         defer(Value) events.insert('outer-' .. tostring(Value)) end(iteration)
+         defer(Value)
+            events.insert('handler-enter-' .. tostring(Value))
+            nested(Value)
+            events.insert('handler-leave-' .. tostring(Value))
+         end(iteration)
+         if iteration % 2 is 0 then
+            defer(Value) events.insert('conditional-' .. tostring(Value)) end(iteration)
+         end
+         recursive(1, iteration)
+         events.insert('body-' .. tostring(iteration))
+      end
+      return events.concat(',')
+   end
+
    local expected, result, compiled, aborted, defer_aborts = run_defer_trace(defer_ordering_workload, 80)
    assert(result is expected, 'Recorded defer cleanup should match complete interpreter event ordering')
    assert(compiled > 0, 'A hot loop containing defer registration and consumption should compile')
    assert(defer_aborts is 0,
       f'DEFERARM and DEFERCONSUME should not abort trace recording (total aborts={aborted}, defer aborts={defer_aborts})')
+
+   expected, result, compiled, aborted, defer_aborts = run_defer_trace(flat_stack_workload, 80)
+   assert(result is expected,
+      'Recorded recursive, conditional and nested-handler defers should match interpreter ordering')
+   assert(compiled > 0, 'The flat defer-stack ordering workload should compile')
+   assert(defer_aborts is 0,
+      f'DEFERARM and DEFERCONSUME should not abort the ordering workload (aborts={aborted}, defer={defer_aborts})')
 end
 
 @Test function JITDeferRegistrationSurvivesSideExit()


### PR DESCRIPTION
* Replaced nested frame registration vectors with retained LIFO defer state and constant-time normal consumption
* Adapted exceptional cleanup for recursive activations, protected transfers and stack relocation
* Expanded runtime, interpreter and JIT coverage for ordering, stale registrations and capacity reuse