### PR TITLE
[Tiri] Replaced Tiri termination checks with raises

### DIFF
--- a/scripts/gui/fileview.tiri
+++ b/scripts/gui/fileview.tiri
@@ -1612,7 +1612,7 @@ gui.fileview = function(Options)
             -- Complete refresh required due to edge-case of the user changing the folder again.
             mSys.SubscribeTimer(0.1, function()
                self.refresh()
-               check ERR_Terminate
+               raise ERR_Terminate
             end)
          else
             self.view.sortView()

--- a/scripts/gui/menu.tiri
+++ b/scripts/gui/menu.tiri
@@ -375,7 +375,7 @@ gui.menu = function(Options)
          gui.tooltip({ text=&hItem.tip })
       end
       &tipTimer = nil
-      check ERR_Terminate
+      raise ERR_Terminate
    end
 
    -- Main entry point --
@@ -426,7 +426,7 @@ gui.menu = function(Options)
             if &client.mtSubscribeKeyboard(function(Viewport:obj!, Qualifiers:num!, Value:num!, Unicode:num!)
                if not &visible then
                   &_subscribedKb = false
-                  check ERR_Terminate
+                  raise ERR_Terminate
                end
 
                if not (Qualifiers has KQ_PRESSED) then return end

--- a/src/core/lib_functions.cpp
+++ b/src/core/lib_functions.cpp
@@ -893,7 +893,7 @@ A callback function must be provided that follows this prototype: `ERR Function(
 The `Elapsed` parameter is the total number of microseconds that have elapsed since the last call.  The `CurrentTime`
 parameter is set to the ~PreciseTime() value just prior to the `Callback` being called.  The callback function
 can return `ERR::Terminate` at any time to cancel the subscription.  All other error codes are ignored.  Tiri callbacks
-should call `check(ERR::Terminate)` to perform the equivalent of this behaviour.
+should use `raise ERR_Terminate` to perform the equivalent of this behaviour.
 
 To change the interval, call ~UpdateTimer() with the new value.  To release a timer subscription, call
 ~UpdateTimer() with the resulting `Subscription` handle and an `Interval` of zero.

--- a/src/core/lib_messages.cpp
+++ b/src/core/lib_messages.cpp
@@ -181,7 +181,7 @@ be passed to the handler.  The `Routine` parameter must point to the function ha
 The handler must return `ERR::Okay` if the message was handled.  This means that the message will not be passed to message
 handlers that are yet to receive the message.  Throw `ERR::NothingDone` if the message has been ignored or `ERR::Continue`
 if the message was processed but may be analysed by other handlers.  Throw `ERR::Terminate` to break the current
-~ProcessMessages() loop.  When using Tiri, this is best achieved by writing `check(errorcode)` in the handler.
+~ProcessMessages() loop.  When using Tiri, this is best achieved with `raise ERR_Terminate` in the handler.
 
 The handler will be identified by a unique pointer returned in the Handle parameter.  This handle will be garbage
 collected or can be passed to ~FreeResource() once it is no longer required.

--- a/src/http/tests/test_content_types.tiri
+++ b/src/http/tests/test_content_types.tiri
@@ -293,7 +293,7 @@ end
          assert(binarySent != true, 'Binary upload body requested more than once.')
          HTTP.acWrite(binaryData)
          binarySent = true
-         check ERR_Terminate
+         raise ERR_Terminate
       end,
       stateChanged = function(HTTP, State)
          if (State is HGS_COMPLETED) or (State is HGS_TERMINATED) then
@@ -373,7 +373,7 @@ end
          assert(textSent != true, 'Text upload body requested more than once.')
          HTTP.acWrite(textData)
          textSent = true
-         check ERR_Terminate
+         raise ERR_Terminate
       end,
       stateChanged = function(HTTP, State)
          if (State is HGS_COMPLETED) or (State is HGS_TERMINATED) then

--- a/src/http/tests/test_edge_cases.tiri
+++ b/src/http/tests/test_edge_cases.tiri
@@ -180,7 +180,7 @@ end
          -- The server will send malformed chunked data in response
          HTTP.acWrite('test data for malformed chunks')
          testCompleted = true
-         check ERR_Terminate
+         raise ERR_Terminate
       end,
       stateChanged = function(HTTP, State)
          if (State is HGS_COMPLETED) or (State is HGS_TERMINATED) then
@@ -314,7 +314,7 @@ end
          content ..= Buffer.getString()
       end,
       outgoing = function(HTTP)
-         check ERR_Terminate
+         raise ERR_Terminate
       end,
       stateChanged = function(HTTP, State)
          if (State is HGS_COMPLETED) or (State is HGS_TERMINATED) then

--- a/src/http/tests/test_http.tiri
+++ b/src/http/tests/test_http.tiri
@@ -109,7 +109,7 @@ end
          msg('Request for data received.')
          HTTP.acWrite(outgoing_body)
          testPostStringCompleted = true
-         check ERR_Terminate
+         raise ERR_Terminate
       end,
       stateChanged = function(HTTP, State)
          if (State is HGS_COMPLETED) or (State is HGS_TERMINATED) then
@@ -151,7 +151,7 @@ end
          msg('Request for data received.')
          HTTP.acWrite('fname=smith&lname=jones')
          testPostStringCompleted = true
-         check ERR_Terminate
+         raise ERR_Terminate
       end,
       stateChanged = function(HTTP, State)
          if (State is HGS_COMPLETED) or (State is HGS_TERMINATED) then

--- a/src/http/tests/test_large_requests.tiri
+++ b/src/http/tests/test_large_requests.tiri
@@ -113,7 +113,7 @@ end
          print('Sending large chunked body (' .. largeBody.len() .. ' bytes)')
          HTTP.acWrite(largeBody)
          testPostCompleted = true
-         check ERR_Terminate
+         raise ERR_Terminate
       end,
       stateChanged = function(HTTP, State)
          if (State is HGS_COMPLETED) or (State is HGS_TERMINATED) then
@@ -244,7 +244,7 @@ end
          print('Sending very large body (' .. veryLargeBody.len() .. ' bytes)')
          HTTP.acWrite(veryLargeBody)
          testPostCompleted = true
-         check ERR_Terminate
+         raise ERR_Terminate
       end,
       stateChanged = function(HTTP, State)
          if (State is HGS_COMPLETED) or (State is HGS_TERMINATED) then


### PR DESCRIPTION
* Updated GUI callbacks and HTTP tests to raise termination errors explicitly
* [Doc] Corrected Tiri termination guidance in timer and message APIs