### PR TITLE
[Tiri] Add strided array slice copy support

### DIFF
--- a/src/core/defs/errors.tdl
+++ b/src/core/defs/errors.tdl
@@ -10,9 +10,9 @@ function declareErrors()
     "False",            -- Non-fatal
     "LimitedSuccess",   -- Limited success
     "Cancelled",        -- Operation cancelled
-    "NothingDone",      -- Operation did not perform any activity (non-fatal)
+    "NothingDone",      -- Nothing to do for the requested operation
     "Continue",         -- Please continue processing
-    "Skip",             -- Skip this operation (do not raise an error)
+    "Skip",             -- Skipped the requested operation
     "Retry",            -- Retry the operation (could not succeed at this time)
     "EndOfSequence",    -- End of sequence reached
     -- Anything above this point is considered non-fatal for exception reporting purposes

--- a/src/tiri/jit/src/lib/lib_range.cpp
+++ b/src/tiri/jit/src/lib/lib_range.cpp
@@ -1004,19 +1004,7 @@ static int range_slice_impl(lua_State *L)
       }
       else {
          lj_array_copy(L, new_arr, 0, arr, MSize(start), 0);
-         int32_t dst_idx = 0;
-         if (forward) {
-            for (int32_t i = start; i <= effective_stop; i += step) {
-               lj_array_copy_unchecked(L, new_arr, MSize(dst_idx), arr, MSize(i), 1);
-               dst_idx++;
-            }
-         }
-         else {
-            for (int32_t i = start; i >= effective_stop; i += step) {
-               lj_array_copy_unchecked(L, new_arr, MSize(dst_idx), arr, MSize(i), 1);
-               dst_idx++;
-            }
-         }
+         lj_array_copy_strided_unchecked(L, new_arr, 0, arr, MSize(start), step, MSize(result_size));
       }
 
       setarrayV(L, L->top++, new_arr); // Push array onto the stack

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -895,6 +895,41 @@ void lj_array_copy_unchecked(
    }
 }
 
+void lj_array_copy_strided_unchecked(lua_State *L, GCarray *Dest, uint32_t DstIdx, const GCarray *Src,
+   uint32_t SrcIdx, int32_t SrcStride, uint32_t Count)
+{
+   if (Count IS 0) return;
+
+   if (Dest->elemtype IS AET::ANY) {
+      auto dst_slots = &Dest->get<TValue>()[DstIdx];
+      auto src_slot = &Src->get<TValue>()[SrcIdx];
+      for (MSize i = 0; i < Count; i++) {
+         copyTV(L, &dst_slots[i], src_slot);
+         if (tvisgcv(&dst_slots[i])) lj_gc_objbarrier(L, Dest, gcV(&dst_slots[i]));
+         if (i + 1 < Count) src_slot += SrcStride;
+      }
+   }
+   else if (array_is_gc_ref_type(Dest->elemtype)) {
+      auto dst_refs = &Dest->get<GCRef>()[DstIdx];
+      auto src_ref = &Src->get<GCRef>()[SrcIdx];
+      for (MSize i = 0; i < Count; i++) {
+         setgcrefr(dst_refs[i], *src_ref);
+         if (gcref(dst_refs[i])) lj_gc_objbarrier(L, Dest, gcref(dst_refs[i]));
+         if (i + 1 < Count) src_ref += SrcStride;
+      }
+   }
+   else {
+      auto dst_ptr = (uint8_t *)lj_array_index(Dest, DstIdx);
+      auto src_ptr = (const uint8_t *)lj_array_index(Src, SrcIdx);
+      ptrdiff_t src_byte_stride = ptrdiff_t(SrcStride) * Src->elemsize;
+      for (MSize i = 0; i < Count; i++) {
+         std::memcpy(dst_ptr, src_ptr, Dest->elemsize);
+         dst_ptr += Dest->elemsize;
+         if (i + 1 < Count) src_ptr += src_byte_stride;
+      }
+   }
+}
+
 void lj_array_copy(lua_State *L, GCarray *Dest, uint32_t DstIdx, GCarray *Src, uint32_t SrcIdx, uint32_t Count)
 {
    if (SrcIdx > Src->len or Count > Src->len - SrcIdx or DstIdx > Dest->len or Count > Dest->len - DstIdx) {

--- a/src/tiri/jit/src/runtime/lj_array.h
+++ b/src/tiri/jit/src/runtime/lj_array.h
@@ -27,6 +27,9 @@ extern void lj_array_clear_range(GCarray *, MSize Start, MSize Count);
 extern void lj_array_copy(lua_State *, GCarray *, uint32_t DstIdx, GCarray *, uint32_t SrcIdx, uint32_t Count);
 extern void lj_array_copy_unchecked(lua_State *, GCarray *, uint32_t DstIdx, const GCarray *, uint32_t SrcIdx,
    uint32_t Count);
+// Copies a non-overlapping source sequence after the caller has validated bounds, mutability, storage and identity.
+extern void lj_array_copy_strided_unchecked(lua_State *, GCarray *, uint32_t DstIdx, const GCarray *,
+   uint32_t SrcIdx, int32_t SrcStride, uint32_t Count);
 extern GCtab* lj_array_to_table(lua_State *, GCarray *);
 extern bool lj_array_grow(lua_State *, GCarray *, MSize MinCapacity);
 

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -280,6 +280,81 @@ static bool test_array_recursive_identity(kt::Log &Log)
    return true;
 }
 
+static bool test_array_strided_copy(kt::Log &Log)
+{
+   LuaStateHolder holder;
+   lua_State *lua = holder.get();
+   if (not lua) return false;
+
+   GCarray *source = lj_array_new(lua, 9, AET::INT32);
+   setarrayV(lua, lua->top++, source);
+   GCarray *destination = lj_array_new_like(lua, source, 6);
+   setarrayV(lua, lua->top++, destination);
+   for (MSize i = 0; i < source->len; i++) source->get<int32_t>()[i] = int32_t(i);
+
+   lj_array_copy_strided_unchecked(lua, destination, 1, source, 8, -2, 4);
+   const int32_t expected[] = { 8, 6, 4, 2 };
+   for (MSize i = 0; i < std::size(expected); i++) {
+      if (destination->get<int32_t>()[i + 1] != expected[i]) {
+         Log.error("a descending strided copy lost a primitive value at slot %d", int(i));
+         return false;
+      }
+   }
+
+   GCarray *strings = lj_array_new(lua, 5, AET::STR_GC);
+   setarrayV(lua, lua->top++, strings);
+   GCarray *string_copy = lj_array_new_like(lua, strings, 3);
+   setarrayV(lua, lua->top++, string_copy);
+   for (MSize i = 0; i < strings->len; i++) {
+      std::string value = std::to_string(i);
+      GCstr *string = lj_str_new(lua, value.data(), value.size());
+      setgcref(strings->get<GCRef>()[i], obj2gco(string));
+      lj_gc_objbarrier(lua, strings, string);
+   }
+   lj_array_copy_strided_unchecked(lua, string_copy, 0, strings, 0, 2, 3);
+   for (MSize i = 0; i < string_copy->len; i++) {
+      GCstr *string = strref(string_copy->get<GCRef>()[i]);
+      if (string->len != 1 or strdata(string)[0] != char('0' + (i * 2))) {
+         Log.error("a forward strided copy lost a string reference at slot %d", int(i));
+         return false;
+      }
+   }
+
+   struct_record structure("StridedCopyStructure");
+   structure.Size = sizeof(uint64_t);
+   GCarray *structures = lj_array_new(lua, 5, AET::STRUCT, nullptr, 0, structure.Name, &structure);
+   setarrayV(lua, lua->top++, structures);
+   GCarray *structure_copy = lj_array_new_like(lua, structures, 3);
+   setarrayV(lua, lua->top++, structure_copy);
+   for (MSize i = 0; i < structures->len; i++) structures->get<uint64_t>()[i] = uint64_t(i + 100);
+   lj_array_copy_strided_unchecked(lua, structure_copy, 0, structures, 4, -2, 3);
+   if (structure_copy->get<uint64_t>()[0] != 104 or structure_copy->get<uint64_t>()[1] != 102 or
+       structure_copy->get<uint64_t>()[2] != 100) {
+      Log.error("a descending strided copy lost structure storage");
+      return false;
+   }
+
+   GCarray *any = lj_array_new(lua, 5, AET::ANY);
+   setarrayV(lua, lua->top++, any);
+   GCarray *any_copy = lj_array_new_like(lua, any, 3);
+   setarrayV(lua, lua->top++, any_copy);
+   for (MSize i = 0; i < any->len; i++) setintV(&any->get<TValue>()[i], int32_t(i * 10));
+   lj_array_copy_strided_unchecked(lua, any_copy, 0, any, 4, -2, 3);
+   for (MSize i = 0; i < any_copy->len; i++) {
+      cTValue *value = &any_copy->get<TValue>()[i];
+      int32_t expected_value = int32_t(40 - int32_t(i * 20));
+      bool matches = (tvisint(value) and intV(value) IS expected_value) or
+         (tvisnum(value) and numberVint(value) IS expected_value);
+      if (not matches) {
+         Log.error("a descending strided copy lost an any value at slot %d", int(i));
+         return false;
+      }
+   }
+
+   lj_array_copy_strided_unchecked(lua, destination, destination->len, source, source->len, -1, 0);
+   return true;
+}
+
 //********************************************************************************************************************
 
 static bool test_unsigned_array_types(kt::Log &Log)
@@ -1882,11 +1957,12 @@ static bool test_lib_array_double_type(kt::Log &Log)
 
 void array_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 41> Tests = { {
+   constexpr std::array<TestCase, 42> Tests = { {
       // Core Data Structures
       { "array_creation_byte", test_array_creation_byte },
       { "array_creation_int32", test_array_creation_int32 },
       { "array_recursive_identity", test_array_recursive_identity },
+      { "array_strided_copy", test_array_strided_copy },
       { "unsigned_array_types", test_unsigned_array_types },
       { "struct_pointer_array_sentinel", test_struct_pointer_array_sentinel },
       { "struct_to_table_string_vector", test_struct_to_table_string_vector },

--- a/src/tiri/tests/test_array_manip.tiri
+++ b/src/tiri/tests/test_array_manip.tiri
@@ -1542,10 +1542,15 @@ end
    local contiguous = integers.slice({1 into 3})
    local stepped = integers.slice({0 into 4 by 2})
    local descending = integers.slice({4 into 0 by -2})
+   local clipped = integers.slice({-100 into 100 by 2})
    assert(#empty is 0 and rawtype(empty) is 'array<int>', 'an empty primitive slice lost its type')
    assert(contiguous[0] is 1 and contiguous[2] is 3, 'a contiguous primitive slice lost values')
    assert(stepped[0] is 0 and stepped[2] is 4, 'a stepped primitive slice lost values')
    assert(descending[0] is 4 and descending[2] is 0, 'a descending primitive slice lost values')
+   assert(clipped[0] is 0 and clipped[2] is 4, 'a clipped stepped primitive slice lost values')
+   assert(rawtype(contiguous) is 'array<int>' and rawtype(stepped) is 'array<int>' and
+      rawtype(descending) is 'array<int>' and rawtype(clipped) is 'array<int>',
+      'a primitive slice lost its exact type')
 
    local string_slice = strings.slice({4 into 0 by -2})
    local mixed_slice = mixed.slice({0 into 4 by 2})
@@ -1558,4 +1563,19 @@ end
       'an any slice lost values after collection')
    assert(rawtype(string_slice) is 'array<str>' and rawtype(mixed_slice) is 'array<any>',
       'an ordinary reference slice lost its implicit identity')
+
+   local object_value = obj.new('time')
+   local nested_value = array<int> { 23 }
+   local table_value = { answer=42 }
+   local references = array<any> { 'text', 0, object_value, 0, table_value, 0, nested_value }
+   local reference_slice = references.slice({0 into 6 by 2})
+   object_value = nil
+   nested_value = nil
+   table_value = nil
+   references = nil
+   processing.collect('full')
+   assert(reference_slice[0] is 'text', 'a strided any slice lost a string after collection')
+   assert(rawtype(reference_slice[1]) is 'obj<Time>', 'a strided any slice lost an object after collection')
+   assert(reference_slice[2].answer is 42, 'a strided any slice lost a table after collection')
+   assert(reference_slice[3][0] is 23, 'a strided any slice lost a nested array after collection')
 end

--- a/tools/benchmark/benchmark_array.tiri
+++ b/tools/benchmark/benchmark_array.tiri
@@ -319,6 +319,91 @@ end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Focused strided-slice cases.  Keep each storage, stride and result-size combination separate so that dispatch
+-- overhead, reference barriers and memory throughput remain distinguishable in benchmark reports.
+
+local glSliceIntegers = array<int, 8192>
+local glSliceStrings = array<str, 8192>
+local glSliceAny = array<any, 8192>
+local glSliceRecursive = array<array<int>, 8192>
+local glSliceRecursiveValue = array<int> { 17 }
+
+for i in {0 to 8192} do
+   glSliceIntegers[i] = i
+   glSliceStrings[i] = f'value_{i}'
+   glSliceAny[i] = (i % 2 is 0) ? i : glSliceStrings[i]
+   glSliceRecursive[i] = glSliceRecursiveValue
+end
+
+@Test function ArraySliceStridedInt()
+   for {0 to 1000} do
+      glSliceIntegers.slice({0 to 16 by 2})
+      glSliceIntegers.slice({0 to 256 by 2})
+      glSliceIntegers.slice({0 to 4096 by 2})
+      glSliceIntegers.slice({0 to 32 by 4})
+      glSliceIntegers.slice({0 to 512 by 4})
+      glSliceIntegers.slice({0 to 8192 by 4})
+      glSliceIntegers.slice({7 into 0 by -1})
+      glSliceIntegers.slice({127 into 0 by -1})
+      glSliceIntegers.slice({2047 into 0 by -1})
+      glSliceIntegers.slice({15 into 0 by -2})
+      glSliceIntegers.slice({255 into 0 by -2})
+      glSliceIntegers.slice({4095 into 0 by -2})
+   end
+end
+
+@Test function ArraySliceStridedStr()
+   for {0 to 1000} do
+      glSliceStrings.slice({0 to 16 by 2})
+      glSliceStrings.slice({0 to 256 by 2})
+      glSliceStrings.slice({0 to 4096 by 2})
+      glSliceStrings.slice({0 to 32 by 4})
+      glSliceStrings.slice({0 to 512 by 4})
+      glSliceStrings.slice({0 to 8192 by 4})
+      glSliceStrings.slice({7 into 0 by -1})
+      glSliceStrings.slice({127 into 0 by -1})
+      glSliceStrings.slice({2047 into 0 by -1})
+      glSliceStrings.slice({15 into 0 by -2})
+      glSliceStrings.slice({255 into 0 by -2})
+      glSliceStrings.slice({4095 into 0 by -2})
+   end
+end
+
+@Test function ArraySliceStridedAny()
+   for {0 to 1000} do
+      glSliceAny.slice({0 to 16 by 2})
+      glSliceAny.slice({0 to 256 by 2})
+      glSliceAny.slice({0 to 4096 by 2})
+      glSliceAny.slice({0 to 32 by 4})
+      glSliceAny.slice({0 to 512 by 4})
+      glSliceAny.slice({0 to 8192 by 4})
+      glSliceAny.slice({7 into 0 by -1})
+      glSliceAny.slice({127 into 0 by -1})
+      glSliceAny.slice({2047 into 0 by -1})
+      glSliceAny.slice({15 into 0 by -2})
+      glSliceAny.slice({255 into 0 by -2})
+      glSliceAny.slice({4095 into 0 by -2})
+   end
+end
+
+@Test function ArraySliceStridedRecursive()
+   for {0 to 1000} do
+      glSliceRecursive.slice({0 to 16 by 2})
+      glSliceRecursive.slice({0 to 256 by 2})
+      glSliceRecursive.slice({0 to 4096 by 2})
+      glSliceRecursive.slice({0 to 32 by 4})
+      glSliceRecursive.slice({0 to 512 by 4})
+      glSliceRecursive.slice({0 to 8192 by 4})
+      glSliceRecursive.slice({7 into 0 by -1})
+      glSliceRecursive.slice({127 into 0 by -1})
+      glSliceRecursive.slice({2047 into 0 by -1})
+      glSliceRecursive.slice({15 into 0 by -2})
+      glSliceRecursive.slice({255 into 0 by -2})
+      glSliceRecursive.slice({4095 into 0 by -2})
+   end
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Goal: Fill an array with a specific value
 
 @Test function ArrayFillWithValue()


### PR DESCRIPTION
## Summary
- optimise non-unit-stride native array slices with a dedicated internal copy routine
- preserve garbage-collector barriers for reference and `any` array elements
- add runtime, Flute, and benchmark coverage for forward and descending strided slices

## Validation
- `cmake --build build/agents --config Debug --target tiri --parallel`
- `cmake --install build/agents --config Debug`
- `build/agents-install/origo tools/flute.tiri file=src/tiri/tests/test_array_manip.tiri --log-warning` (122/122)
- `build/agents-install/origo tools/flute.tiri file=src/tiri/tests/test_unit_tests.tiri --log-warning` (256/256 embedded unit tests)