### PR TITLE
[Tiri] Added declarative library namespaces

### DIFF
--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -704,7 +704,7 @@ end
    })
 
    assert(head_result.returnCode is 0, 'HEAD should return 0: ' .. head_result.errors)
-   assert(head_result.text.trim() is '200', 'HEAD status should be 200, got ' .. head_result.text)
+   assert(head_result.output.trim() is '200', 'HEAD status should be 200, got ' .. head_result.output)
 
    options_result = runTuku(array<str> {
       f'url=http://127.0.0.1:{SERVER_PORT}/options',
@@ -714,8 +714,8 @@ end
    })
 
    assert(options_result.returnCode is 0, 'OPTIONS should return 0: ' .. options_result.errors)
-   assert(options_result.text.trim() is '200' or options_result.text.trim() is '204',
-      'OPTIONS status should be successful, got ' .. options_result.text)
+   assert(options_result.output.trim() is '200' or options_result.output.trim() is '204',
+      'OPTIONS status should be successful, got ' .. options_result.output)
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/scripts/benchmark.tiri
+++ b/scripts/benchmark.tiri
@@ -2,13 +2,7 @@
 
    import 'json'
 
-   namespace 'bmark'
-
-   _LIB[_NS] = {
-      ['null'] = {}
-   }
-
-   bmark = _LIB[_NS]
+   namespace bmark { }
 
 bmark.save = function(Results:table!, Path:str!)
    local file = io.open(Path, 'w')

--- a/scripts/config.tiri
+++ b/scripts/config.tiri
@@ -9,10 +9,7 @@
 --
 -- Decoded values are always strings.  Comments, source ordering and formatting are not preserved.
 
-   namespace 'config'
-
-   _LIB[_NS] = { }
-   config = _LIB[_NS]
+   namespace config { }
 
 local rx_non_space = regex.new('[^ \\t]')
 

--- a/scripts/git.tiri
+++ b/scripts/git.tiri
@@ -1,12 +1,6 @@
 -- Common interface for querying git repositories
 
-   namespace 'git'
-
-   _LIB[_NS] = {
-      ['null'] = {}
-   }
-
-   git = _LIB[_NS]
+   namespace git { }
 
 local rx_head = <{ regex.new('ref: refs/heads/(.+)') }>
 

--- a/scripts/gui.tiri
+++ b/scripts/gui.tiri
@@ -1,11 +1,10 @@
 -- Graphical User Interface functions
 
-   namespace 'gui'
    include 'vector'
 
    module vector as mVec
 
-_LIB[_NS] = {
+namespace gui {
    theme = nil,
    _counter = 0,
    configureScene = function(Window, Scene)
@@ -13,8 +12,6 @@ _LIB[_NS] = {
       -- and patterns for fills.
    end
 }
-
-gui = _LIB[_NS]
 
 rxPixel    <const> = <{ regex.new([[^(\d+)([a-zA-Z]*)$]]) }>
 rxFontSize <const> = <{ regex.new([[^(-?\d+)%$]]) }>

--- a/scripts/gui.tiri
+++ b/scripts/gui.tiri
@@ -4,14 +4,14 @@
 
    module vector as mVec
 
-namespace gui {
-   theme = nil,
-   _counter = 0,
-   configureScene = function(Window, Scene)
-      -- Themes can set a custom configuration function that adds definitions to all window scenes, e.g. images
-      -- and patterns for fills.
-   end
-}
+   namespace gui {
+      theme = nil,
+      _counter = 0,
+      configureScene = function(Window, Scene)
+         -- Themes can set a custom configuration function that adds definitions to all window scenes, e.g. images
+         -- and patterns for fills.
+      end
+   }
 
 rxPixel    <const> = <{ regex.new([[^(\d+)([a-zA-Z]*)$]]) }>
 rxFontSize <const> = <{ regex.new([[^(-?\d+)%$]]) }>

--- a/scripts/gui/button.tiri
+++ b/scripts/gui/button.tiri
@@ -4,7 +4,7 @@ Documentation is available in the Kotuku Wiki.
 
    import 'gui'
 
-   namespace 'gui'
+   namespace gui
 
 LINE_SPACING, FONT_HEIGHT = gui.getFontHeight(gui.fonts.button)
 HEIGHT    <const> = math.floor(LINE_SPACING * 1.75) + 1

--- a/scripts/gui/checkbox.tiri
+++ b/scripts/gui/checkbox.tiri
@@ -6,7 +6,7 @@ Documentation is available in the Kotuku Wiki.
 
    import 'gui'
 
-   namespace 'gui'
+   namespace gui
 
 FONT_MAX_HEIGHT, FONT_HEIGHT = gui.getFontHeight(gui.fonts.widget)
 HEIGHT    <const> = math.floor(FONT_MAX_HEIGHT * 1.25) + 1

--- a/scripts/gui/colourdialog.tiri
+++ b/scripts/gui/colourdialog.tiri
@@ -9,7 +9,7 @@ Documentation is available in the Kotuku Wiki.
    import 'gui/button'
    import 'gui/input'
 
-   namespace 'gui'
+   namespace gui
 
    module display as mGfx
 

--- a/scripts/gui/columnview.tiri
+++ b/scripts/gui/columnview.tiri
@@ -7,7 +7,7 @@ Documentation is available in the Kotuku Wiki.
    import 'gui'
    import 'gui/libview'
 
-   namespace 'gui'
+   namespace gui
 
 lDate = nil
 VSPACING <const> = 2

--- a/scripts/gui/combobox.tiri
+++ b/scripts/gui/combobox.tiri
@@ -7,7 +7,7 @@ Documentation is available in the Kotuku Wiki.
    import 'gui'
    import 'gui/dropdown'
 
-   namespace 'gui'
+   namespace gui
 
 FONT_MAX_HEIGHT, FONT_HEIGHT = gui.getFontHeight(gui.fonts.widget)
 BOX_HEIGHT <const> = math.floor(FONT_MAX_HEIGHT * 1.35) + 1

--- a/scripts/gui/dialog.tiri
+++ b/scripts/gui/dialog.tiri
@@ -8,7 +8,7 @@ Documentation is available in the Kotuku Wiki.
    import 'gui/window'
    include 'document', 'xml'
 
-   namespace 'gui'
+   namespace gui
 
 LINE_SPACING, FONT_HEIGHT = gui.getFontHeight(gui.fonts.window)
 MIN_WIDTH <const> = 300

--- a/scripts/gui/divider.tiri
+++ b/scripts/gui/divider.tiri
@@ -5,7 +5,7 @@ Documentation is available in the Kotuku Wiki.
    import 'gui'
    include 'vector'
 
-   namespace 'gui'
+   namespace gui
 
    module display as mGfx
 

--- a/scripts/gui/dropdown.tiri
+++ b/scripts/gui/dropdown.tiri
@@ -5,7 +5,7 @@ Internal script for combobox drop-down menus.
    import 'gui'
    include 'display'
 
-   namespace 'gui'
+   namespace gui
 
    module display as mGfx
 

--- a/scripts/gui/filedialog.tiri
+++ b/scripts/gui/filedialog.tiri
@@ -10,7 +10,7 @@ Documentation is available in the Kotuku Wiki.
    import 'gui/input'
    import 'gui/window'
 
-   namespace 'gui'
+   namespace gui
 
    gui.dialog ?= { }
 

--- a/scripts/gui/fileview.tiri
+++ b/scripts/gui/fileview.tiri
@@ -15,7 +15,7 @@ Documentation is available in the Kotuku Wiki.
    import 'json'
    include 'vector'
 
-   namespace 'gui'
+   namespace gui
 
 glState <const> = mSys.GetSystemState()
 

--- a/scripts/gui/fontdialog.tiri
+++ b/scripts/gui/fontdialog.tiri
@@ -9,7 +9,7 @@ Documentation is available in the Kotuku Wiki.
    import 'config'
    include 'display', 'font'
 
-   namespace 'gui'
+   namespace gui
    module font as mFont
 
    gui.dialog ?= { }

--- a/scripts/gui/icon.tiri
+++ b/scripts/gui/icon.tiri
@@ -4,7 +4,7 @@ Documentation is available in the Kotuku Wiki.
 
    import 'gui'
 
-   namespace 'gui'
+   namespace gui
    module vector as mVec
 
 FONT_MAX_HEIGHT, FONT_HEIGHT = gui.getFontHeight(gui.fonts.icon)

--- a/scripts/gui/input.tiri
+++ b/scripts/gui/input.tiri
@@ -4,7 +4,7 @@ Documentation is available in the Kotuku Wiki.
 
    import 'gui'
 
-   namespace 'gui'
+   namespace gui
 
 function reportActivate(self:table!, State:str!, Force:bool!)
    self.events.activate ?! return

--- a/scripts/gui/libview.tiri
+++ b/scripts/gui/libview.tiri
@@ -3,7 +3,7 @@
    import 'gui'
    import 'gui/scrollbar'
 
-   namespace 'gui'
+   namespace gui
 
    module display as mGfx
 

--- a/scripts/gui/listview.tiri
+++ b/scripts/gui/listview.tiri
@@ -7,7 +7,7 @@ Documentation is available in the Kotuku Wiki.
    import 'gui'
    import 'gui/libview'
 
-   namespace 'gui'
+   namespace gui
 
 ICON_SIZE <const> = 16
 VSPACING  <const> = 1

--- a/scripts/gui/menu.tiri
+++ b/scripts/gui/menu.tiri
@@ -6,7 +6,7 @@ To be used in conjunction with the gui.menubar or as an independent pop-up only.
    import 'gui'
    include 'display'
 
-   namespace 'gui'
+   namespace gui
 
    module display as mGfx
 

--- a/scripts/gui/menubar.tiri
+++ b/scripts/gui/menubar.tiri
@@ -6,7 +6,7 @@ Documentation is available in the Kotuku Wiki.
    import 'gui/menu'
    include 'vector'
 
-   namespace 'gui'
+   namespace gui
 
 VMARGIN   = gui.sizing.widget.margin
 GAP       <const> = 26

--- a/scripts/gui/scrollbar.tiri
+++ b/scripts/gui/scrollbar.tiri
@@ -4,7 +4,7 @@ Documentation is available in the Kotuku Wiki.
 
    import 'gui'
 
-   namespace 'gui'
+   namespace gui
 
    local lStyle
    if mSys.AnalysePath('style:scrollbar.tiri') is ERR_Okay then

--- a/scripts/gui/slider.tiri
+++ b/scripts/gui/slider.tiri
@@ -4,7 +4,7 @@ Documentation is available in the Kotuku Wiki.
 
    import 'gui'
 
-   namespace 'gui'
+   namespace gui
 
 FONT_MAX_HEIGHT, FONT_HEIGHT = gui.getFontHeight(gui.fonts.widget)
 BOX_SIZE <const> = math.floor(FONT_MAX_HEIGHT * 1.35) + 1

--- a/scripts/gui/toolbar.tiri
+++ b/scripts/gui/toolbar.tiri
@@ -6,7 +6,7 @@ Documentation is available in the Kotuku Wiki.
    import 'gui/tooltip'
    include 'vector'
 
-   namespace 'gui'
+   namespace gui
 
 local lClickX, lClickY
 lCounter = 0

--- a/scripts/gui/tooltip.tiri
+++ b/scripts/gui/tooltip.tiri
@@ -2,9 +2,10 @@
 Documentation is available in the Kotuku Wiki.
 --]]
 
+   import 'gui'
    include 'display', 'vector'
 
-   namespace 'gui'
+   namespace gui
 
 gui.tooltip = function(Options)
    local self = { } -- Public variables

--- a/scripts/gui/window.tiri
+++ b/scripts/gui/window.tiri
@@ -5,7 +5,7 @@ Documentation is available in the Kotuku Wiki.
    import 'gui'
    include 'display', 'vector'
 
-   namespace 'gui'
+   namespace gui
 
    module display as mGfx
 

--- a/scripts/json.tiri
+++ b/scripts/json.tiri
@@ -1,18 +1,13 @@
 -- A compact pure-Lua JSON library originally written by @tylerneylon for the public domain.
 
-   namespace 'json'
-
-   _LIB[_NS] = {
+   namespace json {
       ['null'] = {}
    }
 
-   json = _LIB[_NS]
-
-   in_char  = array<str> { '\\', '"', '/', '\b', '\f', '\n', '\r', '\t' }
-   out_char = array<str> { '\\', '"', '/',  'b',  'f',  'n',  'r',  't' }
-
-local num_regex = regex.new([[^-?[0-9]+\.?[0-9]*[eE]?[+\-]?[0-9]*]])
-local rx_whitespace = regex.new("[^ \\t\\n\\r\\f\\v]")
+in_char  = array<str> { '\\', '"', '/', '\b', '\f', '\n', '\r', '\t' }
+out_char = array<str> { '\\', '"', '/',  'b',  'f',  'n',  'r',  't' }
+num_regex = r[[^-?[0-9]+\.?[0-9]*[eE]?[+\-]?[0-9]*]]
+rx_whitespace = r"[^ \t\n\r\f\v]"
 
 function escape_str(String:str!):str
    for i, c in in_char do
@@ -31,7 +26,7 @@ function skip_delim(String:str!, Pos:num, Delimiter:str!, ThrowIfMissing:bool):<
    Pos ?= #String
    if String.sub(Pos, Pos+1) != Delimiter then
       if ThrowIfMissing then
-         error('Expected ' .. Delimiter .. ' near position ' .. Pos)
+         raise ERR_Syntax, 'Expected ' .. Delimiter .. ' near position ' .. Pos
       end
       return Pos, false
    end
@@ -69,7 +64,7 @@ function decode_num_val(String:str!, pos:num!):<any, num>
       return val, pos + #num_str
    end
 
-   error(f'Error parsing number at position {pos} for "{substr}"')
+   raise ERR_InvalidValue, f'Error parsing number at position {pos} for "{substr}"'
 end
 
 -- Public values and functions.
@@ -162,7 +157,7 @@ num: position after the final parsed character
 ]])
 json.decode = function(String:str!, Pos:num, EndToken:str):<any, num>
    Pos ?= 0
-   if Pos >= #String then error('Reached unexpected end of input.') end
+   if Pos >= #String then raise ERR_Syntax, 'Reached unexpected end of input.' end
    Pos = rx_whitespace.findFirst(String, Pos)  -- Skip whitespace
    Pos ?= #String
    first = String.sub(Pos, Pos+1)
@@ -172,7 +167,7 @@ json.decode = function(String:str!, Pos:num, EndToken:str):<any, num>
       while true do
          key, Pos = json.decode(String, Pos, '}')
          if not key then return map, Pos end
-         if not delim_found then error('Comma missing between object items.') end
+         if not delim_found then raise ERR_Syntax, 'Comma missing between object items.' end
          Pos = skip_delim(String, Pos, ':', true)  -- true -> error if missing.
          map[key], Pos = json.decode(String, Pos)
          Pos, delim_found = skip_delim(String, Pos, ',')
@@ -183,7 +178,7 @@ json.decode = function(String:str!, Pos:num, EndToken:str):<any, num>
       while true do
          val, Pos = json.decode(String, Pos, ']')
          if val is nil then return arr, Pos end
-         if not delim_found then error('Comma missing between array items.') end
+         if not delim_found then raise ERR_Syntax, 'Comma missing between array items.' end
          arr.push(val)
          Pos, delim_found = skip_delim(String, Pos, ',')
       end
@@ -199,6 +194,6 @@ json.decode = function(String:str!, Pos:num, EndToken:str):<any, num>
          lit_end = Pos + #lit_str
          if String.sub(Pos, lit_end) is lit_str then return lit_val, lit_end end
       end
-      error('Invalid json syntax starting at position ' .. Pos .. ': ' .. String.sub(Pos, Pos + 11))
+      raise ERR_Syntax, 'Invalid json syntax starting at position ' .. Pos .. ': ' .. String.sub(Pos, Pos + 11)
    end
 end

--- a/scripts/net/httpserver.tiri
+++ b/scripts/net/httpserver.tiri
@@ -8,9 +8,7 @@
    import 'tempus'
    import 'json'
 
-   namespace 'hslib'
-   _LIB[_NS] = { }
-   hslib = _LIB[_NS]
+   namespace hslib { }
 
    module network as mNet
 

--- a/scripts/net/proxyserver.tiri
+++ b/scripts/net/proxyserver.tiri
@@ -9,10 +9,7 @@
    import 'tempus'
    import 'json'
 
-   namespace 'proxylib'
-
-   _LIB[_NS] = { }
-   proxylib = _LIB[_NS]
+   namespace proxylib { }
 
    module network as mNet
 

--- a/scripts/net/url.tiri
+++ b/scripts/net/url.tiri
@@ -4,10 +4,7 @@
 --   import 'net/url'
 --   parts = url.parse('https://example.com/path?query=value')
 
-   namespace 'url'
-
-   _LIB[_NS] = { }
-   url = _LIB[_NS]
+   namespace url { }
 
 DEFAULT_PORTS <const> = {
    http = 80,

--- a/scripts/options.tiri
+++ b/scripts/options.tiri
@@ -4,15 +4,12 @@ Declarative command-line option parsing for Tiri scripts.  Refer to the Tiri-Opt
 
    include 'core'
    import 'json'
-   namespace 'options'
 
    local create_parser, get_error_instruction, apply_error_instruction, get_help
 
-   _LIB[_NS] = function(Config:table!):table
+   namespace options function(Config:table!):table
       return create_parser(Config)
    end
-   options = _LIB[_NS]
-
 
 help_result_marker = {}
 rx_env_camel <const> = <{ regex.new('([a-z0-9])([A-Z])') }>

--- a/scripts/tempus.tiri
+++ b/scripts/tempus.tiri
@@ -1,9 +1,6 @@
 -- Tempus value library.
 
-   namespace 'tempus'
-
-   _LIB[_NS] = {}
-   tempus = _LIB[_NS]
+   namespace tempus { }
 
 value_storage = setmetatable({}, { __mode = 'k' })
 metatable_by_type = {}

--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -874,6 +874,7 @@ set (TIRI_TESTS
    type_inference jit jit_try_regex pipe for_each arrow_functions result_filter thunks deferred_expr shadow_assert
    ranges contains bare_iteration compiler_intrinsics
    annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options type_name
+   library_namespaces
    try_except checkall import include_list processing metatables with thunk_table_index debug malformed_syntax numeric_limits return_types url tips tempus
    comparison_chaining reserved_keywords compile_if_import overflow protected_globals constant_shadowing config_library
    module_namespaces module_result_contracts builtin_methods

--- a/src/tiri/jit/src/parser/assignment_target_resolution.cpp
+++ b/src/tiri/jit/src/parser/assignment_target_resolution.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <format>
 #include <shared_mutex>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -21,6 +22,7 @@ struct AssignmentBinding {
    StaticBindingID binding_id{};
    uint16_t function_depth = 0;
    bool is_import_namespace = false;
+   std::string import_registry_namespace;
 };
 
 struct AssignmentScope {
@@ -502,6 +504,7 @@ private:
                if (entry.namespace_name) {
                   AssignmentBinding binding = this->prepare_declaration(*entry.namespace_name);
                   binding.is_import_namespace = true;
+                  binding.import_registry_namespace = entry.default_namespace;
                   this->publish_declaration(std::move(binding));
                }
             }
@@ -509,8 +512,10 @@ private:
          case AstNodeKind::NamespaceStmt: {
             auto &payload = std::get<NamespaceStmtPayload>(Statement.data);
             const AssignmentBinding *existing = this->find_binding(payload.name.symbol);
+            std::string_view namespace_name(strdata(payload.name.symbol), payload.name.symbol->len);
             if (payload.mode IS NamespaceDeclarationMode::Join and existing and existing->is_import_namespace and
-                existing->function_depth IS this->function_depth_) {
+                existing->function_depth IS this->function_depth_ and
+                existing->import_registry_namespace.compare(namespace_name) IS 0) {
                payload.name.binding_id = existing->binding_id;
                payload.reuses_import_binding = true;
             }

--- a/src/tiri/jit/src/parser/assignment_target_resolution.cpp
+++ b/src/tiri/jit/src/parser/assignment_target_resolution.cpp
@@ -508,8 +508,6 @@ private:
             break;
          case AstNodeKind::NamespaceStmt: {
             auto &payload = std::get<NamespaceStmtPayload>(Statement.data);
-            if (payload.initialiser) this->resolve_expression(*payload.initialiser);
-
             const AssignmentBinding *existing = this->find_binding(payload.name.symbol);
             if (payload.mode IS NamespaceDeclarationMode::Join and existing and existing->is_import_namespace and
                 existing->function_depth IS this->function_depth_) {
@@ -521,6 +519,8 @@ private:
                payload.reuses_import_binding = true;  // Suppress invalid downstream redeclaration after the error.
             }
             else this->declare(payload.name);
+
+            if (payload.initialiser) this->resolve_expression(*payload.initialiser);
             break;
          }
          case AstNodeKind::WithStmt: {

--- a/src/tiri/jit/src/parser/assignment_target_resolution.cpp
+++ b/src/tiri/jit/src/parser/assignment_target_resolution.cpp
@@ -3,7 +3,9 @@
 #include "assignment_target_resolution.h"
 
 #include <algorithm>
+#include <format>
 #include <shared_mutex>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -18,6 +20,7 @@ struct AssignmentBinding {
    GCstr *name = nullptr;
    StaticBindingID binding_id{};
    uint16_t function_depth = 0;
+   bool is_import_namespace = false;
 };
 
 struct AssignmentScope {
@@ -109,6 +112,17 @@ private:
    void declare(Identifier &Name)
    {
       this->publish_declaration(this->prepare_declaration(Name));
+   }
+
+   void report_namespace_conflict(const Identifier &Name)
+   {
+      ParserDiagnostic diagnostic;
+      diagnostic.severity = ParserDiagnosticSeverity::Error;
+      diagnostic.code = ParserErrorCode::InvalidAssignment;
+      diagnostic.message = std::format("Namespace '{}' conflicts with an existing lexical binding",
+         std::string_view(strdata(Name.symbol), Name.symbol->len));
+      diagnostic.token = Token::from_span(Name.span, TokenKind::Identifier);
+      this->context_.diagnostics().report(diagnostic);
    }
 
    void resolve_reference(NameRef &Reference)
@@ -485,9 +499,30 @@ private:
          case AstNodeKind::ImportStmt:
             for (ImportEntryPayload &entry : std::get<ImportStmtPayload>(Statement.data).entries) {
                if (entry.inlined_body) this->resolve_block(*entry.inlined_body);
-               if (entry.namespace_name) this->declare(*entry.namespace_name);
+               if (entry.namespace_name) {
+                  AssignmentBinding binding = this->prepare_declaration(*entry.namespace_name);
+                  binding.is_import_namespace = true;
+                  this->publish_declaration(std::move(binding));
+               }
             }
             break;
+         case AstNodeKind::NamespaceStmt: {
+            auto &payload = std::get<NamespaceStmtPayload>(Statement.data);
+            if (payload.initialiser) this->resolve_expression(*payload.initialiser);
+
+            const AssignmentBinding *existing = this->find_binding(payload.name.symbol);
+            if (payload.mode IS NamespaceDeclarationMode::Join and existing and existing->is_import_namespace and
+                existing->function_depth IS this->function_depth_) {
+               payload.name.binding_id = existing->binding_id;
+               payload.reuses_import_binding = true;
+            }
+            else if (existing) {
+               this->report_namespace_conflict(payload.name);
+               payload.reuses_import_binding = true;  // Suppress invalid downstream redeclaration after the error.
+            }
+            else this->declare(payload.name);
+            break;
+         }
          case AstNodeKind::WithStmt: {
             auto &payload = std::get<WithStmtPayload>(Statement.data);
             for (auto &object : payload.objects) if (object) this->resolve_expression(*object);

--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -46,6 +46,7 @@ private:
    int function_depth = 0;           // Tracks nesting depth inside function bodies
    int block_depth = 0;              // Tracks nested statement blocks below chunk scope
    bool enum_constants_committed = false;
+   bool source_namespace_declared = false;
    AstBuilder *parent_builder = nullptr;
    std::vector<GCstr *> function_name_stack;
    std::vector<uint32_t> registered_enum_constants;

--- a/src/tiri/jit/src/parser/ast/nodes.cpp
+++ b/src/tiri/jit/src/parser/ast/nodes.cpp
@@ -556,6 +556,11 @@ struct StatementChildCounter {
       return total;
    }
 
+   [[nodiscard]] inline size_t operator()(const NamespaceStmtPayload &Payload) const
+   {
+      return Payload.initialiser ? 1 : 0;
+   }
+
    [[nodiscard]] inline size_t operator()(const WithStmtPayload &Payload) const
    {
       return Payload.objects.size() + block_child_count(Payload.block);
@@ -616,6 +621,7 @@ RaiseStmtPayload::~RaiseStmtPayload() = default;
 CheckStmtPayload::~CheckStmtPayload() = default;
 ImportEntryPayload::~ImportEntryPayload() = default;
 ImportStmtPayload::~ImportStmtPayload() = default;
+NamespaceStmtPayload::~NamespaceStmtPayload() = default;
 WithStmtPayload::~WithStmtPayload() = default;
 BlockStmt::~BlockStmt() = default;
 

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -1060,6 +1060,26 @@ struct ImportStmtPayload {
    ~ImportStmtPayload();
 };
 
+enum class NamespaceDeclarationMode : uint8_t {
+   Create,
+   Join
+};
+
+struct NamespaceStmtPayload {
+   NamespaceStmtPayload() = default;
+   NamespaceStmtPayload(const NamespaceStmtPayload&) = delete;
+   NamespaceStmtPayload& operator=(const NamespaceStmtPayload&) = delete;
+   NamespaceStmtPayload(NamespaceStmtPayload&&) noexcept = default;
+   NamespaceStmtPayload& operator=(NamespaceStmtPayload&&) noexcept = default;
+
+   Identifier name;
+   ExprNodePtr initialiser;
+   NamespaceDeclarationMode mode = NamespaceDeclarationMode::Join;
+   bool reuses_import_binding = false;
+
+   ~NamespaceStmtPayload();
+};
+
 // With statement payload: with obj1, obj2 do ... end - auto-lock/unlock objects
 struct WithStmtPayload {
    WithStmtPayload(ExprNodeList objects, std::unique_ptr<BlockStmt> block)
@@ -1094,7 +1114,7 @@ struct StmtNode {
       LoopStmtPayload, NumericForStmtPayload, RangeForStmtPayload, GenericForStmtPayload,
       ReturnStmtPayload, BreakStmtPayload, ContinueStmtPayload, DeferStmtPayload,
       DoStmtPayload, ContextStmtPayload, ConditionalShorthandStmtPayload, TryExceptPayload,
-      CheckallStmtPayload, RaiseStmtPayload, CheckStmtPayload, ImportStmtPayload, WithStmtPayload,
+      CheckallStmtPayload, RaiseStmtPayload, CheckStmtPayload, ImportStmtPayload, NamespaceStmtPayload, WithStmtPayload,
       ExpressionStmtPayload>
       data;
 

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -1789,13 +1789,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_import()
 }
 
 //********************************************************************************************************************
-// Parses namespace statements: namespace 'name'
-//
-// The namespace statement declares a default namespace for a library. When this library is imported, the
-// importing file can reference the library exports via `_LIB['name']`. This statement generates:
-//   local _NS <const> = 'name'
-//
-// The namespace is stored in the current file's FileSource entry for lookup by the importing statement.
+// Parses namespace statements: namespace name [{ ... } | function ... end | thunk ... end]
 
 ParserResult<StmtNodePtr> AstBuilder::parse_namespace()
 {
@@ -1810,21 +1804,30 @@ ParserResult<StmtNodePtr> AstBuilder::parse_namespace()
 
    this->ctx.tokens().advance();  // consume 'namespace'
 
-   // Require string literal for namespace name
    Token name_token = this->ctx.tokens().current();
-   if (not name_token.is(TokenKind::String)) {
-      return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken, name_token,
-         "Namespace name must be a string literal");
+   if (name_token.is(TokenKind::String)) {
+      return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedIdentifier, name_token,
+         "Namespace names are identifiers; remove the quotes");
+   }
+   if (name_token.kind() != TokenKind::Identifier or not name_token.identifier()) {
+      return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedIdentifier, name_token,
+         "Namespace name must be an identifier");
    }
 
-   GCstr *name_str = name_token.payload().as_string();
+   GCstr *name_str = name_token.identifier();
    std::string_view ns_name(strdata(name_str), name_str->len);
-   this->ctx.tokens().advance();  // consume string
+   this->ctx.tokens().advance();  // consume identifier
 
    log.detail("Namespace: %.*s", int(ns_name.size()), ns_name.data());
 
    lua_State *L = &this->ctx.lua();
    uint8_t current_file_index = this->ctx.lex().current_file_index;
+
+   if (this->source_namespace_declared) {
+      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, name_token,
+         "A source file can only declare one namespace");
+   }
+   this->source_namespace_declared = true;
 
    // Namespace conflicts are permitted - common namespaces like gui have many interlinking parts.
    auto existing_file = find_file_source_by_namespace(L, std::string(ns_name));
@@ -1835,26 +1838,44 @@ ParserResult<StmtNodePtr> AstBuilder::parse_namespace()
    // Record the namespace in the current file's FileSource entry
    set_file_source_namespace(L, current_file_index, std::string(ns_name));
 
-   // Transform to: local _NS <const> = 'name'
-   Identifier id;
-   id.symbol = lj_str_new(L, "_NS", 3);
-   id.span = ns_token.span();
-   id.has_const = true;
+   NamespaceStmtPayload payload;
+   payload.name = make_identifier(name_token);
+   payload.name.has_const = true;
 
-   std::vector<Identifier> names;
-   names.push_back(std::move(id));
+   Token initialiser_token = this->ctx.tokens().current();
+   if (initialiser_token.span().line IS name_token.span().line) {
+      if (initialiser_token.kind() IS TokenKind::LeftBrace) {
+         auto initialiser = this->parse_table_literal(false);
+         if (not initialiser.ok()) return ParserResult<StmtNodePtr>::failure(initialiser.error_ref());
+         payload.initialiser = std::move(initialiser.value_ref());
+      }
+      else if (initialiser_token.kind() IS TokenKind::Function or
+               initialiser_token.kind() IS TokenKind::ThunkToken) {
+         bool is_thunk = initialiser_token.kind() IS TokenKind::ThunkToken;
+         this->ctx.tokens().advance();
+         auto initialiser = this->parse_function_literal(initialiser_token, is_thunk, name_str);
+         if (not initialiser.ok()) return ParserResult<StmtNodePtr>::failure(initialiser.error_ref());
+         if (is_thunk) {
+            auto *function = std::get_if<FunctionExprPayload>(&initialiser.value_ref()->data);
+            if (function and function->parameters.empty()) {
+               SourceSpan span = initialiser.value_ref()->span;
+               ExprNodeList arguments;
+               initialiser.value_ref() = make_call_expr(
+                  span, std::move(initialiser.value_ref()), std::move(arguments), false);
+            }
+         }
+         payload.initialiser = std::move(initialiser.value_ref());
+      }
+      else if (initialiser_token.kind() != TokenKind::Semicolon and
+               initialiser_token.kind() != TokenKind::EndOfFile) {
+         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, initialiser_token,
+            "Namespace initialisers must be table, function or thunk literals");
+      }
+   }
 
-   ExprNodeList values;
-   auto str_expr = std::make_unique<ExprNode>(AstNodeKind::LiteralExpr, name_token.span());
-   LiteralValue lit;
-   lit.kind = LiteralKind::String;
-   lit.string_value = name_str;
-   str_expr->data = lit;
-   values.push_back(std::move(str_expr));
-
-   auto stmt = std::make_unique<StmtNode>(AstNodeKind::LocalDeclStmt, ns_token.span());
-   stmt->data.emplace<LocalDeclStmtPayload>(AssignmentOperator::Plain,
-      std::move(names), std::move(values));
+   payload.mode = payload.initialiser ? NamespaceDeclarationMode::Create : NamespaceDeclarationMode::Join;
+   auto stmt = std::make_unique<StmtNode>(AstNodeKind::NamespaceStmt, ns_token.span());
+   stmt->data = std::move(payload);
 
    return ParserResult<StmtNodePtr>::success(std::move(stmt));
 }

--- a/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
@@ -456,10 +456,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_import_entry(const ImportEntryPayload &
 }
 
 //********************************************************************************************************************
-// Emit a namespace declaration.  Creation evaluates its literal once, stores that value in the registry and then
-// promotes the same register to a const local.  A join loads the registry value and rejects a missing entry before
-// publishing the local.  Joins following an import already have the correct binding and only validate that its
-// registry value is present.
+// Emit a namespace declaration.  Creation publishes its const local before evaluating the literal so closures can
+// capture their owning namespace, then stores the completed value in the registry.  A join loads the registry value
+// and rejects a missing entry before publishing the local.  Joins following an import already have the correct
+// binding and only validate that its registry value is present.
 
 ParserResult<IrEmitUnit> IrEmitter::emit_namespace_stmt(const NamespaceStmtPayload &Payload)
 {
@@ -484,11 +484,13 @@ ParserResult<IrEmitUnit> IrEmitter::emit_namespace_stmt(const NamespaceStmtPaylo
             ParserErrorCode::InternalInvariant, "Creating namespace has no initialiser"));
       }
 
+      bcreg_reserve(fs, BCReg(1));
+      this->publish_namespace_local(Payload.name, value_reg);
+
       auto emitted = this->emit_expression(*Payload.initialiser);
       if (not emitted.ok()) return ParserResult<IrEmitUnit>::failure(emitted.error_ref());
       ExpDesc value = emitted.value_ref();
       this->materialise_to_reg(value, value_reg, "namespace initialiser");
-      bcreg_reserve(fs, BCReg(1));
 
       BCReg registry_reg = fs->free_reg();
       bcreg_reserve(fs, BCReg(1));
@@ -503,9 +505,9 @@ ParserResult<IrEmitUnit> IrEmitter::emit_namespace_stmt(const NamespaceStmtPaylo
       bcreg_reserve(fs, BCReg(1));
       this->emit_namespace_registry_load(namespace_name, value_reg);
       this->emit_namespace_missing_guard(namespace_name, value_reg);
+      this->publish_namespace_local(Payload.name, value_reg);
    }
 
-   this->publish_namespace_local(Payload.name, value_reg);
    return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
 }
 

--- a/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
@@ -355,10 +355,69 @@ ParserResult<IrEmitUnit> IrEmitter::emit_check_stmt(const CheckStmtPayload &Payl
 // When namespace_name is set (from 'as alias' or module's default namespace), emits:
 //   local <namespace_name> <const> = _LIB['<default_namespace>']
 
-ParserResult<IrEmitUnit> IrEmitter::emit_import_entry(const ImportEntryPayload &Entry)
+void IrEmitter::emit_namespace_registry_load(std::string_view Name, BCReg Destination)
 {
    FuncState *fs = &this->func_state;
    lua_State *L = this->lex_state.L;
+   auto str_const = [fs](GCstr *String) -> BCREG {
+      return const_gc(fs, obj2gco(String), LJ_TSTR);
+   };
+
+   bcemit_AD(fs, BC_GGET, Destination.raw(), str_const(lj_str_newlit(L, "_LIB")));
+   GCstr *namespace_name = lj_str_new(L, Name.data(), Name.size());
+   bcemit_tgets(fs, Destination.raw(), Destination.raw(), str_const(namespace_name));
+}
+
+void IrEmitter::emit_namespace_missing_guard(std::string_view Name, BCReg Value)
+{
+   FuncState *fs = &this->func_state;
+   lua_State *L = this->lex_state.L;
+   ExpDesc nil_value(ExpKind::Nil);
+   bcemit_INS(fs, BCINS_AD(BC_ISEQP, Value.raw(), const_pri(&nil_value)));
+   ControlFlowEdge missing = this->control_flow.make_unconditional(BCPos(bcemit_jmp(fs)));
+   ControlFlowEdge present = this->control_flow.make_unconditional(BCPos(bcemit_jmp(fs)));
+
+   missing.patch_here();
+   BCReg saved_freereg = fs->free_reg();
+   BCReg call_base = saved_freereg;
+   bcreg_reserve(fs, BCReg(2 + LJ_FR2));
+   auto str_const = [fs](GCstr *String) -> BCREG {
+      return const_gc(fs, obj2gco(String), LJ_TSTR);
+   };
+   bcemit_AD(fs, BC_GGET, call_base.raw(), str_const(lj_str_newlit(L, "error")));
+   std::string message = std::format("Cannot join namespace '{}': registry entry does not exist", Name);
+   bcemit_AD(fs, BC_KSTR, call_base.raw() + 1 + LJ_FR2,
+      str_const(lj_str_new(L, message.c_str(), message.size())));
+   bcemit_ABC(fs, BC_CALL, call_base.raw(), 2, 2);
+   fs->freereg = saved_freereg.raw();
+   present.patch_here();
+}
+
+void IrEmitter::publish_namespace_local(const Identifier &Name, BCReg Slot)
+{
+   FuncState *fs = &this->func_state;
+   this->lex_state.var_new(BCReg(0), Name.symbol, Name.span.line, Name.span.column);
+   this->lex_state.var_add(BCReg(1));
+
+   VarInfo *info = &fs->var_get(fs->varmap.size() - 1);
+   info->info |= VarInfoFlag::Const;
+   info->binding_id = Name.binding_id;
+   info->static_value = Name.static_value;
+   if (Name.binding_id) {
+      const auto &binding = this->ctx.descriptors().binding(Name.binding_id);
+      info->static_callable = binding.callable;
+      if (binding.callable) info->static_results = this->ctx.descriptors().callable(binding.callable).results;
+      this->apply_analysed_local_type(Slot, Name.binding_id);
+      this->assert_analysed_local_type(Slot, Name.binding_id);
+   }
+
+   this->update_local_binding(Name.symbol, Slot);
+   fs->reset_freereg();
+}
+
+ParserResult<IrEmitUnit> IrEmitter::emit_import_entry(const ImportEntryPayload &Entry)
+{
+   FuncState *fs = &this->func_state;
 
    // If there's a body, emit the inlined content first
    if (Entry.inlined_body) {
@@ -386,36 +445,67 @@ ParserResult<IrEmitUnit> IrEmitter::emit_import_entry(const ImportEntryPayload &
             "import namespace_name is set but default_namespace is empty"));
       }
 
-      // Helper to get constant string index
-      auto str_const = [fs](GCstr* s) -> BCREG {
-         return const_gc(fs, obj2gco(s), LJ_TSTR);
-      };
-
       // Allocate a register for the namespace local variable
       BCReg dest = BCReg(fs->freereg);
       bcreg_reserve(fs, BCReg(1));
-
-      // GGET _LIB -> dest
-      bcemit_AD(fs, BC_GGET, dest, str_const(lj_str_newlit(L, "_LIB")));
-
-      // TGETS <default_namespace> -> dest (uses helper for constant index overflow protection)
-      GCstr* ns_str = lj_str_new(L, default_ns.c_str(), default_ns.size());
-      bcemit_tgets(fs, dest.raw(), dest.raw(), str_const(ns_str));
-
-      // Create the local variable
-      this->lex_state.var_new(BCReg(0), ns_id.symbol, ns_id.span.line, ns_id.span.column);
-      this->lex_state.var_add(BCReg(1));
-
-      // Mark as const
-      VarInfo* info = &fs->var_get(fs->varmap.size() - 1);
-      info->info |= VarInfoFlag::Const;
-      info->binding_id = ns_id.binding_id;
-
-      // Update binding table
-      this->update_local_binding(ns_id.symbol, BCReg(fs->varmap.size() - 1));
-      fs->reset_freereg();
+      this->emit_namespace_registry_load(default_ns, dest);
+      this->publish_namespace_local(ns_id, dest);
    }
 
+   return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
+}
+
+//********************************************************************************************************************
+// Emit a namespace declaration.  Creation evaluates its literal once, stores that value in the registry and then
+// promotes the same register to a const local.  A join loads the registry value and rejects a missing entry before
+// publishing the local.  Joins following an import already have the correct binding and only validate that its
+// registry value is present.
+
+ParserResult<IrEmitUnit> IrEmitter::emit_namespace_stmt(const NamespaceStmtPayload &Payload)
+{
+   std::string_view namespace_name(strdata(Payload.name.symbol), Payload.name.symbol->len);
+   if (Payload.reuses_import_binding) {
+      std::optional<BCReg> existing = this->resolve_local(Payload.name.symbol);
+      if (not existing) {
+         return ParserResult<IrEmitUnit>::failure(this->make_error(
+            ParserErrorCode::InternalInvariant, "Reused namespace import binding is unavailable"));
+      }
+      this->emit_namespace_missing_guard(namespace_name, *existing);
+      return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
+   }
+
+   FuncState *fs = &this->func_state;
+   lua_State *L = this->lex_state.L;
+   BCReg value_reg = fs->free_reg();
+
+   if (Payload.mode IS NamespaceDeclarationMode::Create) {
+      if (not Payload.initialiser) {
+         return ParserResult<IrEmitUnit>::failure(this->make_error(
+            ParserErrorCode::InternalInvariant, "Creating namespace has no initialiser"));
+      }
+
+      auto emitted = this->emit_expression(*Payload.initialiser);
+      if (not emitted.ok()) return ParserResult<IrEmitUnit>::failure(emitted.error_ref());
+      ExpDesc value = emitted.value_ref();
+      this->materialise_to_reg(value, value_reg, "namespace initialiser");
+      bcreg_reserve(fs, BCReg(1));
+
+      BCReg registry_reg = fs->free_reg();
+      bcreg_reserve(fs, BCReg(1));
+      auto str_const = [fs](GCstr *String) -> BCREG {
+         return const_gc(fs, obj2gco(String), LJ_TSTR);
+      };
+      bcemit_AD(fs, BC_GGET, registry_reg.raw(), str_const(lj_str_newlit(L, "_LIB")));
+      bcemit_tsets(fs, value_reg.raw(), registry_reg.raw(), str_const(Payload.name.symbol));
+      fs->freereg = registry_reg.raw();
+   }
+   else {
+      bcreg_reserve(fs, BCReg(1));
+      this->emit_namespace_registry_load(namespace_name, value_reg);
+      this->emit_namespace_missing_guard(namespace_name, value_reg);
+   }
+
+   this->publish_namespace_local(Payload.name, value_reg);
    return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
 }
 

--- a/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
@@ -491,6 +491,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_namespace_stmt(const NamespaceStmtPaylo
       if (not emitted.ok()) return ParserResult<IrEmitUnit>::failure(emitted.error_ref());
       ExpDesc value = emitted.value_ref();
       this->materialise_to_reg(value, value_reg, "namespace initialiser");
+      fs->reset_freereg();
 
       BCReg registry_reg = fs->free_reg();
       bcreg_reserve(fs, BCReg(1));
@@ -499,7 +500,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_namespace_stmt(const NamespaceStmtPaylo
       };
       bcemit_AD(fs, BC_GGET, registry_reg.raw(), str_const(lj_str_newlit(L, "_LIB")));
       bcemit_tsets(fs, value_reg.raw(), registry_reg.raw(), str_const(Payload.name.symbol));
-      fs->freereg = registry_reg.raw();
+      fs->reset_freereg();
    }
    else {
       bcreg_reserve(fs, BCReg(1));

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -911,6 +911,8 @@ static UnsupportedNodeRecorder glUnsupportedNodes;
       case AstNodeKind::RaiseStmt:     return "RaiseStmt";
       case AstNodeKind::CheckStmt:     return "CheckStmt";
       case AstNodeKind::ExternStmt:    return "ExternStmt";
+      case AstNodeKind::ImportStmt:    return "ImportStmt";
+      case AstNodeKind::NamespaceStmt: return "NamespaceStmt";
       case AstNodeKind::WithStmt:      return "WithStmt";
       case AstNodeKind::ExpressionStmt: return "ExpressionStmt";
       default: return "Unknown";

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -234,6 +234,10 @@ private:
             }
             return false;
          }
+         case AstNodeKind::NamespaceStmt: {
+            const auto &payload = std::get<NamespaceStmtPayload>(Statement.data);
+            return payload.initialiser and this->expression_uses_context_impl(*payload.initialiser);
+         }
          case AstNodeKind::WithStmt: {
             const auto &payload = std::get<WithStmtPayload>(Statement.data);
             return this->expressions_use_context(payload.objects) or this->block_uses_context(payload.block);
@@ -1445,6 +1449,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_statement(const StmtNode& stmt)
    case AstNodeKind::ImportStmt: {
       const auto &payload = std::get<ImportStmtPayload>(stmt.data);
       return this->emit_import_stmt(payload);
+   }
+   case AstNodeKind::NamespaceStmt: {
+      const auto &payload = std::get<NamespaceStmtPayload>(stmt.data);
+      return this->emit_namespace_stmt(payload);
    }
    case AstNodeKind::WithStmt: {
       const auto &payload = std::get<WithStmtPayload>(stmt.data);

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
@@ -221,6 +221,10 @@ private:
    ParserResult<IrEmitUnit> emit_check_stmt(const CheckStmtPayload& payload, const SourceSpan& span);
    ParserResult<IrEmitUnit> emit_import_entry(const ImportEntryPayload& entry);
    ParserResult<IrEmitUnit> emit_import_stmt(const ImportStmtPayload& payload);
+   ParserResult<IrEmitUnit> emit_namespace_stmt(const NamespaceStmtPayload& payload);
+   void emit_namespace_registry_load(std::string_view name, BCReg destination);
+   void emit_namespace_missing_guard(std::string_view name, BCReg value);
+   void publish_namespace_local(const Identifier& name, BCReg slot);
    ParserResult<IrEmitUnit> emit_with_stmt(const WithStmtPayload& payload);
    ParserResult<IrEmitUnit> emit_context_stmt(const ContextStmtPayload& Payload);
    ParserResult<IrEmitUnit> emit_assignment_stmt(const AssignmentStmtPayload& payload);

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -2025,6 +2025,64 @@ static BindingDiscoveryResult discover_bindings_from_source(std::string_view Sou
 
 //********************************************************************************************************************
 
+static bool test_library_namespace_declarations(kt::Log &Log)
+{
+   auto created = discover_bindings_from_source(
+      "namespace sample { value=1 }\n"
+      "local observed = sample.value\n");
+   if (not created.chunk.ok() or not created.diagnostics.empty() or
+       created.chunk.value_ref()->statements.empty() or
+       created.chunk.value_ref()->statements[0]->kind != AstNodeKind::NamespaceStmt) {
+      Log.error("a table namespace declaration did not produce a clean NamespaceStmt AST");
+      log_diagnostics(created.diagnostics, Log);
+      return false;
+   }
+
+   const auto *payload = std::get_if<NamespaceStmtPayload>(&created.chunk.value_ref()->statements[0]->data);
+   if (not payload or payload->mode != NamespaceDeclarationMode::Create or not payload->initialiser or
+       payload->initialiser->kind != AstNodeKind::TableExpr or not payload->name.has_const or
+       not payload->name.binding_id) {
+      Log.error("a table namespace declaration lost its mode, initialiser or const binding metadata");
+      return false;
+   }
+
+   auto callable = discover_bindings_from_source(
+      "namespace callable function(Value:num):num return Value + 1 end\n");
+   const NamespaceStmtPayload *callable_payload = callable.chunk.ok() and
+      not callable.chunk.value_ref()->statements.empty() ?
+      std::get_if<NamespaceStmtPayload>(&callable.chunk.value_ref()->statements[0]->data) : nullptr;
+   if (not callable_payload or not callable_payload->initialiser or
+       callable_payload->initialiser->kind != AstNodeKind::FunctionExpr or not callable.diagnostics.empty()) {
+      Log.error("a function namespace declaration did not retain its function literal");
+      log_diagnostics(callable.diagnostics, Log);
+      return false;
+   }
+
+   constexpr std::array<std::pair<std::string_view, std::string_view>, 5> invalid = { {
+      { "namespace 'legacy' { }", "Namespace names are identifiers; remove the quotes" },
+      { "namespace invalid 42", "Namespace initialisers must be table, function or thunk literals" },
+      { "namespace first { }\nnamespace second { }", "A source file can only declare one namespace" },
+      { "function nested() namespace invalid { } end", "'namespace' must be at library level" },
+      { "local conflict = { }\nnamespace conflict", "conflicts with an existing lexical binding" }
+   } };
+
+   for (const auto &[source, expected] : invalid) {
+      auto result = discover_bindings_from_source(source);
+      bool found = std::ranges::any_of(result.diagnostics, [expected](const ParserDiagnostic &diagnostic) {
+         return diagnostic.message.find(expected) != std::string::npos;
+      });
+      if (not found) {
+         Log.error("namespace diagnostic did not contain '%.*s'", int(expected.size()), expected.data());
+         log_diagnostics(result.diagnostics, Log);
+         return false;
+      }
+   }
+
+   return true;
+}
+
+//********************************************************************************************************************
+
 static bool test_assignment_target_regressions(kt::Log &Log)
 {
    auto first_target = [](BindingDiscoveryResult &Result, size_t Statement = 0) -> NameRef * {
@@ -10792,7 +10850,7 @@ static bool test_defer_runtime_registration_state(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 98> tests = { {
+   constexpr std::array<TestCase, 99> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "assignment_target_resolution_ast", test_assignment_target_resolution_ast },
@@ -10823,6 +10881,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "typed_assignment_name_resolution", test_typed_assignment_name_resolution },
       { "annotated_local_validation_parity", test_annotated_local_validation_parity },
       { "assignment_target_regressions", test_assignment_target_regressions },
+      { "library_namespace_declarations", test_library_namespace_declarations },
       { "implicit_later_name_attributes", test_implicit_later_name_attributes },
       { "implicit_attribute_shadowing", test_implicit_attribute_shadowing },
       { "ternary_colon_separators", test_ternary_colon_separators },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -2047,7 +2047,8 @@ static bool test_library_namespace_declarations(kt::Log &Log)
    }
 
    auto callable = discover_bindings_from_source(
-      "namespace callable function(Value:num):num return Value + 1 end\n");
+      "namespace callable function(Value:num):num "
+      "if Value <= 1 then return 1 end return Value * callable(Value - 1) end\n");
    const NamespaceStmtPayload *callable_payload = callable.chunk.ok() and
       not callable.chunk.value_ref()->statements.empty() ?
       std::get_if<NamespaceStmtPayload>(&callable.chunk.value_ref()->statements[0]->data) : nullptr;
@@ -2055,6 +2056,14 @@ static bool test_library_namespace_declarations(kt::Log &Log)
        callable_payload->initialiser->kind != AstNodeKind::FunctionExpr or not callable.diagnostics.empty()) {
       Log.error("a function namespace declaration did not retain its function literal");
       log_diagnostics(callable.diagnostics, Log);
+      return false;
+   }
+
+   auto self_capturing_table = discover_bindings_from_source(
+      "namespace owner { value=1, read=function():num return owner.value end }\n");
+   if (not self_capturing_table.chunk.ok() or not self_capturing_table.diagnostics.empty()) {
+      Log.error("a table namespace closure could not capture its owning namespace binding");
+      log_diagnostics(self_capturing_table.diagnostics, Log);
       return false;
    }
 

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -600,7 +600,33 @@ private:
          case AstNodeKind::ImportStmt: {
             for (auto &entry : std::get<ImportStmtPayload>(Statement.data).entries) {
                if (entry.inlined_body) this->discover_block(*entry.inlined_body);
-               if (entry.namespace_name) this->declare(*entry.namespace_name, nullptr, 0);
+               if (entry.namespace_name) {
+                  const ExprNode *initialiser = nullptr;
+                  const FunctionExprPayload *function = nullptr;
+                  if (entry.inlined_body) {
+                     for (const auto &statement : entry.inlined_body->statements) {
+                        if (not statement or statement->kind != AstNodeKind::NamespaceStmt) continue;
+                        const auto &namespace_payload = std::get<NamespaceStmtPayload>(statement->data);
+                        StaticBindingID binding_id = namespace_payload.name.binding_id;
+                        if (not binding_id or binding_id.raw() >= this->catalogue_.binding_count()) continue;
+                        const StaticBindingDescriptor &binding = this->catalogue_.binding(binding_id);
+                        initialiser = binding.initialiser;
+                        function = binding.function;
+                     }
+                  }
+                  this->declare(*entry.namespace_name, initialiser, 0, function);
+               }
+            }
+            break;
+         }
+         case AstNodeKind::NamespaceStmt: {
+            auto &payload = std::get<NamespaceStmtPayload>(Statement.data);
+            if (payload.initialiser) this->discover_expression(*payload.initialiser);
+            if (not payload.reuses_import_binding) {
+               const FunctionExprPayload *function = payload.initialiser and
+                  payload.initialiser->kind IS AstNodeKind::FunctionExpr ?
+                  &std::get<FunctionExprPayload>(payload.initialiser->data) : nullptr;
+               this->declare(payload.name, payload.initialiser.get(), 0, function);
             }
             break;
          }
@@ -2563,6 +2589,9 @@ private:
             auto &p = std::get<RaiseStmtPayload>(Statement.data); visit(p.error_code); visit(p.message); break;
          }
          case AstNodeKind::CheckStmt: visit(std::get<CheckStmtPayload>(Statement.data).error_code); break;
+         case AstNodeKind::NamespaceStmt:
+            visit(std::get<NamespaceStmtPayload>(Statement.data).initialiser);
+            break;
          case AstNodeKind::WithStmt:
             for (auto &v : std::get<WithStmtPayload>(Statement.data).objects) visit(v);
             break;

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -621,13 +621,13 @@ private:
          }
          case AstNodeKind::NamespaceStmt: {
             auto &payload = std::get<NamespaceStmtPayload>(Statement.data);
-            if (payload.initialiser) this->discover_expression(*payload.initialiser);
             if (not payload.reuses_import_binding) {
                const FunctionExprPayload *function = payload.initialiser and
                   payload.initialiser->kind IS AstNodeKind::FunctionExpr ?
                   &std::get<FunctionExprPayload>(payload.initialiser->data) : nullptr;
                this->declare(payload.name, payload.initialiser.get(), 0, function);
             }
+            if (payload.initialiser) this->discover_expression(*payload.initialiser);
             break;
          }
          case AstNodeKind::WithStmt: {

--- a/src/tiri/jit/src/parser/table_ownership.cpp
+++ b/src/tiri/jit/src/parser/table_ownership.cpp
@@ -100,6 +100,21 @@ void collect_assignments(
             if (block_writes(entry.inlined_body, InspectAssignments)) return true;
          }
          return false;
+      case AstNodeKind::NamespaceStmt: {
+         const auto &payload = std::get<NamespaceStmtPayload>(Statement.data);
+         if (not payload.initialiser) return false;
+
+         const FunctionExprPayload *function = std::get_if<FunctionExprPayload>(&payload.initialiser->data);
+         if (not function and payload.initialiser->kind IS AstNodeKind::CallExpr) {
+            const auto &call = std::get<CallExprPayload>(payload.initialiser->data);
+            const auto *direct = std::get_if<DirectCallTarget>(&call.target);
+            if (direct and direct->callable and direct->callable->kind IS AstNodeKind::FunctionExpr) {
+               const auto *candidate = std::get_if<FunctionExprPayload>(&direct->callable->data);
+               if (candidate and candidate->is_thunk) function = candidate;
+            }
+         }
+         return function and block_writes(function->body, true);
+      }
       default:
          return false;
    }

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -1516,9 +1516,18 @@ void TypeAnalyser::analyse_statement(StmtNode &Statement)
          auto *payload = std::get_if<NamespaceStmtPayload>(&Statement.data);
          if (not payload) break;
 
+         if (not payload->reuses_import_binding) {
+            this->current_scope().declare_local(
+               payload->name.symbol, InferredType(TiriType::Any), payload->name.span, true);
+         }
+
          InferredType inferred(TiriType::Any);
          if (payload->initialiser) {
-            this->analyse_expression(*payload->initialiser);
+            if (payload->initialiser->kind IS AstNodeKind::FunctionExpr) {
+               this->analyse_function_payload(
+                  std::get<FunctionExprPayload>(payload->initialiser->data), payload->name.symbol);
+            }
+            else this->analyse_expression(*payload->initialiser);
             inferred = this->infer_expression_type(*payload->initialiser);
             inferred = this->refine_static_expression_type(*payload->initialiser, inferred);
             if (inferred.primary != TiriType::Any and inferred.primary != TiriType::Unknown) {
@@ -1527,8 +1536,7 @@ void TypeAnalyser::analyse_statement(StmtNode &Statement)
          }
 
          if (not payload->reuses_import_binding) {
-            this->current_scope().declare_local(
-               payload->name.symbol, inferred, payload->name.span, true);
+            this->current_scope().update_local_type(payload->name.symbol, inferred);
             this->publish_binding_type(payload->name.binding_id, inferred);
          }
          break;

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -1248,6 +1248,11 @@ void TypeAnalyser::lower_unanalysed_statement(StmtNode &Statement)
          }
          break;
       }
+      case AstNodeKind::NamespaceStmt: {
+         auto *payload = std::get_if<NamespaceStmtPayload>(&Statement.data);
+         if (payload and payload->initialiser) this->lower_unanalysed_expression(*payload->initialiser);
+         break;
+      }
       case AstNodeKind::WithStmt: {
          auto *payload = std::get_if<WithStmtPayload>(&Statement.data);
          if (payload) {
@@ -1482,10 +1487,16 @@ void TypeAnalyser::analyse_statement(StmtNode &Statement)
          auto *payload = std::get_if<ImportStmtPayload>(&Statement.data);
          if (payload) {
             for (const auto &entry : payload->entries) {
+               std::optional<InferredType> namespace_type;
                if (entry.inlined_body) {
                   ImportGuard guard(*this, entry.file_source_idx);
                   this->push_scope();
                   this->analyse_block(*entry.inlined_body);
+                  if (not entry.default_namespace.empty()) {
+                     GCstr *namespace_symbol = lj_str_new(
+                        &this->ctx_.lua(), entry.default_namespace.data(), entry.default_namespace.size());
+                     namespace_type = this->resolve_identifier(namespace_symbol);
+                  }
                   this->pop_scope();
                }
 
@@ -1495,9 +1506,30 @@ void TypeAnalyser::analyse_statement(StmtNode &Statement)
                if (entry.namespace_name) {
                   const Identifier &name = *entry.namespace_name;
                   this->current_scope().declare_local(
-                     name.symbol, InferredType(TiriType::Any), name.span, name.has_const);
+                     name.symbol, namespace_type.value_or(InferredType(TiriType::Any)), name.span, name.has_const);
                }
             }
+         }
+         break;
+      }
+      case AstNodeKind::NamespaceStmt: {
+         auto *payload = std::get_if<NamespaceStmtPayload>(&Statement.data);
+         if (not payload) break;
+
+         InferredType inferred(TiriType::Any);
+         if (payload->initialiser) {
+            this->analyse_expression(*payload->initialiser);
+            inferred = this->infer_expression_type(*payload->initialiser);
+            inferred = this->refine_static_expression_type(*payload->initialiser, inferred);
+            if (inferred.primary != TiriType::Any and inferred.primary != TiriType::Unknown) {
+               inferred.is_fixed = true;
+            }
+         }
+
+         if (not payload->reuses_import_binding) {
+            this->current_scope().declare_local(
+               payload->name.symbol, inferred, payload->name.span, true);
+            this->publish_binding_type(payload->name.binding_id, inferred);
          }
          break;
       }

--- a/src/tiri/jit/src/parser/type_checker.cpp
+++ b/src/tiri/jit/src/parser/type_checker.cpp
@@ -41,6 +41,16 @@ void TypeCheckScope::declare_function(GCstr *Name, const FunctionExprPayload *Fu
    this->variables_.push_back(info);
 }
 
+void TypeCheckScope::update_local_type(GCstr *Name, const InferredType &Type)
+{
+   for (auto it = this->variables_.rbegin(); it != this->variables_.rend(); ++it) {
+      if (it->name IS Name and not it->is_parameter) {
+         it->type = Type;
+         return;
+      }
+   }
+}
+
 std::optional<InferredType> TypeCheckScope::lookup_parameter_type(GCstr *Name) const
 {
    for (auto it = this->variables_.rbegin(); it != this->variables_.rend(); ++it) {

--- a/src/tiri/jit/src/parser/type_checker.h
+++ b/src/tiri/jit/src/parser/type_checker.h
@@ -99,6 +99,7 @@ public:
       GCstr *, TiriType Type, struct_record *StructDef, bool Required, SourceSpan Location = {});
    void declare_local(GCstr *, const InferredType &, SourceSpan Location = {}, bool IsConst = false);
    void declare_function(GCstr *, const FunctionExprPayload *, SourceSpan Location = {});
+   void update_local_type(GCstr *, const InferredType &);
    void fix_local_type(GCstr *, TiriType Type, CLASSID ObjectClassId = CLASSID::NIL,
       struct_record *StructDef = nullptr, ArrayElementDescriptor ArrayElement = {});
    void mark_dynamic_ingress(GCstr *, bool RequiresDestination);

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -130,6 +130,7 @@ enum class AstNodeKind : uint16_t {
    RaiseStmt,      // raise error_code [, message] or raise message
    CheckStmt,      // check expression
    ImportStmt,     // import 'module' statement
+   NamespaceStmt,  // namespace name [literal] statement
    ExternStmt,     // extern symbol declarations for cross-file references
    WithStmt,       // with obj1, obj2 do ... end
    ExpressionStmt

--- a/src/tiri/tests/import_type_attr_helper.tiri
+++ b/src/tiri/tests/import_type_attr_helper.tiri
@@ -2,7 +2,7 @@
 -- Each test in that file imports its own helper: import deduplication parses a library body only
 -- once per state and test order is randomised, so helpers cannot be shared between tests.
 
-namespace 'type_probe_attr'
+namespace type_probe_attr { }
 
 global function attr_add(A:num, B:num):num
    return A + B

--- a/src/tiri/tests/import_type_clean_helper.tiri
+++ b/src/tiri/tests/import_type_clean_helper.tiri
@@ -1,7 +1,7 @@
 -- Type-clean helper library for test_import_type_analysis.tiri.  The unused local is deliberate:
 -- it verifies that tips raised inside imported statements are suppressed.
 
-namespace 'type_probe_clean'
+namespace type_probe_clean { }
 
 local unused_helper_var = 5
 

--- a/src/tiri/tests/import_type_diamond_inner.tiri
+++ b/src/tiri/tests/import_type_diamond_inner.tiri
@@ -2,7 +2,7 @@
 -- both import_type_diamond_a.tiri and import_type_diamond_b.tiri to form a diamond import.
 -- Do not import this file from a compiled test; it is only referenced through debug.validate() buffers.
 
-namespace 'type_probe_diamond'
+namespace type_probe_diamond { }
 
 local mismatch:num = 'str'
 

--- a/src/tiri/tests/import_type_error_helper.tiri
+++ b/src/tiri/tests/import_type_error_helper.tiri
@@ -1,7 +1,7 @@
 -- Helper library for test_import_type_analysis.tiri containing a deliberate type error.
 -- Do not import this file from a compiled test; it is only referenced through debug.validate() buffers.
 
-namespace 'type_probe_err'
+namespace type_probe_err { }
 
 local mismatch:num = 'str'
 

--- a/src/tiri/tests/import_type_revalidate_helper.tiri
+++ b/src/tiri/tests/import_type_revalidate_helper.tiri
@@ -1,7 +1,7 @@
 -- Helper library for test_import_type_analysis.tiri containing a deliberate type error.
 -- Do not import this file from a compiled test; it is only referenced through debug.validate() buffers.
 
-namespace 'type_probe_reval'
+namespace type_probe_reval { }
 
 local mismatch:num = 'str'
 

--- a/src/tiri/tests/import_type_tips_helper.tiri
+++ b/src/tiri/tests/import_type_tips_helper.tiri
@@ -3,7 +3,7 @@
 -- be shared with other tests: import deduplication means a library body is only parsed once per
 -- state, so a second validate of the same import cannot resolve its globals.
 
-namespace 'type_probe_tips'
+namespace type_probe_tips { }
 
 local unused_helper_var = 5
 

--- a/src/tiri/tests/library_namespace_callable.tiri
+++ b/src/tiri/tests/library_namespace_callable.tiri
@@ -1,3 +1,4 @@
 namespace library_namespace_callable function(Value:num):num
-   return Value + 1
+   if Value <= 1 then return 1 end
+   return Value * library_namespace_callable(Value - 1)
 end

--- a/src/tiri/tests/library_namespace_callable.tiri
+++ b/src/tiri/tests/library_namespace_callable.tiri
@@ -1,0 +1,3 @@
+namespace library_namespace_callable function(Value:num):num
+   return Value + 1
+end

--- a/src/tiri/tests/library_namespace_component_a.tiri
+++ b/src/tiri/tests/library_namespace_component_a.tiri
@@ -1,0 +1,4 @@
+import './library_namespace_root'
+namespace library_namespace
+
+library_namespace.component_a = true

--- a/src/tiri/tests/library_namespace_component_b.tiri
+++ b/src/tiri/tests/library_namespace_component_b.tiri
@@ -1,0 +1,4 @@
+import './library_namespace_root'
+namespace library_namespace
+
+library_namespace.component_b = true

--- a/src/tiri/tests/library_namespace_root.tiri
+++ b/src/tiri/tests/library_namespace_root.tiri
@@ -2,5 +2,6 @@ global library_namespace_initialisations = (library_namespace_initialisations ??
 
 namespace library_namespace {
    initialisations = library_namespace_initialisations,
-   root = true
+   root = true,
+   owns_root = function():bool return library_namespace.root end
 }

--- a/src/tiri/tests/library_namespace_root.tiri
+++ b/src/tiri/tests/library_namespace_root.tiri
@@ -1,0 +1,6 @@
+global library_namespace_initialisations = (library_namespace_initialisations ?? 0) + 1
+
+namespace library_namespace {
+   initialisations = library_namespace_initialisations,
+   root = true
+}

--- a/src/tiri/tests/library_namespace_thunk.tiri
+++ b/src/tiri/tests/library_namespace_thunk.tiri
@@ -1,0 +1,3 @@
+namespace library_namespace_thunk thunk():num
+   return 7
+end

--- a/src/tiri/tests/test_library_namespaces.tiri
+++ b/src/tiri/tests/test_library_namespaces.tiri
@@ -1,8 +1,14 @@
 import './library_namespace_component_a', './library_namespace_component_b', './library_namespace_callable',
    './library_namespace_thunk'
 
-function assert_invalid(Source:str, ExpectedMessage:str, Context:str)
-   local result = debug.validate(Source)
+global glLibraryNamespaceValidationPath
+
+@BeforeAll function SetupLibraryNamespaceTests(State)
+   glLibraryNamespaceValidationPath = State.folder .. 'namespace_validation.tiri'
+end
+
+function assert_invalid(Source:str, ExpectedMessage:str, Context:str, Options:table)
+   local result = debug.validate(Source, Options)
 
    assert(result.success is false, Context .. ': source should fail validation')
    assert(#result.diagnostics > 0, Context .. ': expected at least one diagnostic')
@@ -62,6 +68,19 @@ end]], "'namespace' must be at library level", 'nested declaration')
 namespace conflict]], 'conflicts with an existing lexical binding', 'conflicting local')
    assert_invalid([[namespace locked { }
 locked = { }]], "cannot assign to const local 'locked'", 'const assignment')
+   assert_invalid([[function foreign_table():table return {} end
+local value = {}
+namespace replace_value function() value = foreign_table() end
+replace_value()
+setmetatable(value, { __context = true })]], 'unknown provenance', 'function namespace closure write')
+   assert_invalid([[function foreign_table():table return {} end
+local value = {}
+namespace replace_value thunk():num value = foreign_table(); return 1 end
+local invoked = replace_value + 0
+setmetatable(value, { __context = true })]], 'unknown provenance', 'thunk namespace closure write')
+   assert_invalid([[import './library_namespace_root' as alternate_root; namespace alternate_root]],
+      'conflicts with an existing lexical binding', 'namespace join through differently named import alias',
+      { path=glLibraryNamespaceValidationPath })
    assert_invalid([[namespace no_legacy_name { }
 local value = _NS]], "Undeclared variable '_NS'", '_NS removal')
 end

--- a/src/tiri/tests/test_library_namespaces.tiri
+++ b/src/tiri/tests/test_library_namespaces.tiri
@@ -16,6 +16,8 @@ end
    assert(_LIB.library_namespace is library_namespace, 'Namespace local and registry entry should be identical')
    assert(library_namespace.root is true, 'Table initialiser fields should be retained')
    assert(library_namespace.initialisations is 1, 'Namespace initialiser should execute exactly once')
+   assert(library_namespace.owns_root() is true,
+      'A table namespace closure should capture its owning namespace binding')
 end
 
 @Test function ComponentsJoinOneNamespace()
@@ -24,7 +26,8 @@ end
 end
 
 @Test function FunctionNamespaceIsCallable()
-   assert(library_namespace_callable(4) is 5, 'Function-valued namespace should be directly callable')
+   assert(library_namespace_callable(5) is 120,
+      'Function-valued namespace should be directly callable and recursive')
    assert(_LIB.library_namespace_callable is library_namespace_callable,
       'Function namespace should retain registry identity')
 end

--- a/src/tiri/tests/test_library_namespaces.tiri
+++ b/src/tiri/tests/test_library_namespaces.tiri
@@ -1,0 +1,76 @@
+import './library_namespace_component_a', './library_namespace_component_b', './library_namespace_callable',
+   './library_namespace_thunk'
+
+function assert_invalid(Source:str, ExpectedMessage:str, Context:str)
+   local result = debug.validate(Source)
+
+   assert(result.success is false, Context .. ': source should fail validation')
+   assert(#result.diagnostics > 0, Context .. ': expected at least one diagnostic')
+   assert(result.diagnostics[0].message.find(ExpectedMessage, 0, true) != nil,
+      Context .. ': expected diagnostic containing "' .. ExpectedMessage .. '", got: ' ..
+      tostring(result.diagnostics[0].message))
+end
+
+@Test function CreatedNamespaceHasRegistryIdentity()
+   assert(type(library_namespace) is 'table', 'Created namespace should expose its table value')
+   assert(_LIB.library_namespace is library_namespace, 'Namespace local and registry entry should be identical')
+   assert(library_namespace.root is true, 'Table initialiser fields should be retained')
+   assert(library_namespace.initialisations is 1, 'Namespace initialiser should execute exactly once')
+end
+
+@Test function ComponentsJoinOneNamespace()
+   assert(library_namespace.component_a is true, 'First component should extend the shared namespace')
+   assert(library_namespace.component_b is true, 'Second component should extend the shared namespace')
+end
+
+@Test function FunctionNamespaceIsCallable()
+   assert(library_namespace_callable(4) is 5, 'Function-valued namespace should be directly callable')
+   assert(_LIB.library_namespace_callable is library_namespace_callable,
+      'Function namespace should retain registry identity')
+end
+
+@Test function ThunkNamespaceRetainsLazyValue()
+   assert(isthunk(library_namespace_thunk), 'Parameterless thunk namespace should expose thunk userdata')
+   assert(library_namespace_thunk + 0 is 7, 'Thunk namespace should resolve through normal thunk semantics')
+end
+
+@Test function NamespaceMetadataIsRecordedPerSource()
+   local sources = debug.fileSources()
+   local namespace_sources = 0
+
+   for _, source in sources do
+      if source.namespace is 'library_namespace' then namespace_sources++ end
+   end
+
+   assert(namespace_sources >= 3, 'Root and both component sources should retain namespace metadata')
+end
+
+@Test function NamespaceDiagnostics()
+   assert_invalid([[namespace 'legacy' { }]], 'Namespace names are identifiers; remove the quotes', 'quoted name')
+   assert_invalid([[namespace]], 'Namespace name must be an identifier', 'missing name')
+   assert_invalid([[namespace invalid 42]], 'Namespace initialisers must be table, function or thunk literals',
+      'unsupported initialiser')
+   assert_invalid([[namespace first { }
+namespace second { }]], 'A source file can only declare one namespace', 'duplicate declaration')
+   assert_invalid([[function nested()
+   namespace invalid { }
+end]], "'namespace' must be at library level", 'nested declaration')
+   assert_invalid([[local conflict = { }
+namespace conflict]], 'conflicts with an existing lexical binding', 'conflicting local')
+   assert_invalid([[namespace locked { }
+locked = { }]], "cannot assign to const local 'locked'", 'const assignment')
+   assert_invalid([[namespace no_legacy_name { }
+local value = _NS]], "Undeclared variable '_NS'", '_NS removal')
+end
+
+@Test function MissingJoinFailsImmediately()
+   try
+      exec('namespace definitely_absent_namespace')
+   except err
+      assert(tostring(err).find("Cannot join namespace 'definitely_absent_namespace'"),
+         'Missing join should report the namespace name')
+      return
+   end
+
+   error('Joining an absent namespace should fail')
+end

--- a/tools/tiri_lsp/include/lsp_definition.tiri
+++ b/tools/tiri_lsp/include/lsp_definition.tiri
@@ -9,6 +9,7 @@ rx_def_assign_func    <const> = <{ regex.new([[\b([A-Za-z_][A-Za-z0-9_]*)\s*=\s*
 rx_def_assign         <const> = <{ regex.new([[^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=]]) }>
 rx_def_param          <const> = <{ regex.new([[([A-Za-z_][A-Za-z0-9_]*)]]) }>
 rx_def_struct         <const> = <{ regex.new([[^\s*struct\s+([A-Za-z_][A-Za-z0-9_]*)\b]]) }>
+rx_def_namespace      <const> = <{ regex.new([[^\s*namespace\s+([A-Za-z_][A-Za-z0-9_]*)\b]]) }>
 rx_def_struct_field   <const> = <{ regex.new([[([A-Za-z_][A-Za-z0-9_]*)\s*:]]) }>
 rx_def_end            <const> = <{ regex.new([[\bend\b]]) }>
 rx_def_struct_new     <const> = <{ regex.new([=[([A-Za-z_]\w*)\s*=\s*struct\.new\s*\(\s*['"]([A-Za-z_]\w*)['"]]=]) }>
@@ -373,6 +374,13 @@ global function extractDefinitionSymbols(Doc:table):array<table>
          if not rx_def_end.test(remainder) then struct_frame = struct_name end
          table_depth = updateTableDepth(line_code, table_depth)
          continue
+      end
+
+      namespace_start, _, namespace_cap = rx_def_namespace.findFirst(line_code)
+      if namespace_start then
+         namespace_name = namespace_cap[0]
+         name_start = line_text.find(namespace_name, namespace_start, true) or namespace_start
+         addSymbol(symbols, namespace_name, 'namespace', line_num, name_start, name_start + #namespace_name)
       end
 
       for start, stop, cap in rx_def_func.findAll(line_code) do

--- a/tools/tiri_lsp/include/lsp_handlers.tiri
+++ b/tools/tiri_lsp/include/lsp_handlers.tiri
@@ -147,7 +147,8 @@ global function resolveModuleRename(Doc:table, Position:table, NewName:str):tabl
 
    local token_info = getTokenAtPosition(Doc, Position.line, Position.character)
    local old_name = token_info?.text
-   if not old_name or not moduleDeclarationsForDocument(Doc)[old_name] then return nil end
+   if not old_name or (not moduleDeclarationsForDocument(Doc)[old_name] and
+         not libraryNamespaceDeclarationsForDocument(Doc)[old_name]) then return nil end
 
    local edits = array<table>
    for token in values(tokenizeTiri(Doc.content, modulePrefixesForDocument(Doc))) do

--- a/tools/tiri_lsp/include/lsp_handlers.tiri
+++ b/tools/tiri_lsp/include/lsp_handlers.tiri
@@ -142,30 +142,35 @@ function renamePositionInRange(Line:num, Character:num, Range:table):bool
    return true
 end
 
-function renameFunctionScopePath(Symbols:array<table>, Line:num, Character:num):array<table>
+-- Return the chain of lexical scopes enclosing a position, outermost first.  Scopes nest without overlapping, so
+-- the first candidate that contains the position is the only one worth descending into.
+
+function renameLexicalScopePath(Scopes:array<table>, Line:num, Character:num):array<table>
    local path = array<table>
 
    function visit(Candidates:array<table>):bool
-      for symbol in values(Candidates or array<table>) do
-         if not renamePositionInRange(Line, Character, symbol.range) then continue end
-
-         local is_function = symbol.kind is SYMBOL_KIND.FUNCTION or symbol.kind is SYMBOL_KIND.METHOD
-         if is_function then path.push(symbol) end
-         if visit(symbol.children) then return true end
-         if is_function then return true end
+      for scope in values(Candidates or array<table>) do
+         if not renamePositionInRange(Line, Character, scope.range) then continue end
+         path.push(scope)
+         visit(scope.children)
+         return true
       end
       return false
    end
 
-   visit(Symbols)
+   visit(Scopes)
    return path
 end
+
+-- A definition is visible from a reference when the definition's scope chain is a prefix of the reference's, i.e.
+-- the reference sits in the declaring block or one nested inside it.  Block scopes matter as much as function
+-- scopes here: a `local` inside `do ... end` dies at the `end`, so it must not shadow anything after it.
 
 function renameScopeIsVisible(DefinitionScope:array<table>, ReferenceScope:array<table>):bool
    if #DefinitionScope > #ReferenceScope then return false end
    for i in {0 to #DefinitionScope} do
-      local definition = DefinitionScope[i].selectionRange.start
-      local reference = ReferenceScope[i].selectionRange.start
+      local definition = DefinitionScope[i].range.start
+      local reference = ReferenceScope[i].range.start
       if definition.line != reference.line or definition.character != reference.character then return false end
    end
    return true
@@ -197,7 +202,7 @@ function renameDefinitionIsBefore(Definition:table, Position:table):bool
 end
 
 function renameTokenResolvesToNamespace(Doc:table, Token:table, Definitions:array<table>,
-      DocumentSymbols:array<table>):bool
+      DocumentScopes:array<table>):bool
    if renameTokenIsMemberOrKey(Doc, Token) then return false end
 
    local line_text = getLine(Doc, Token.line)
@@ -205,7 +210,7 @@ function renameTokenResolvesToNamespace(Doc:table, Token:table, Definitions:arra
    local token_end = utf16ColToByteCol(line_text, Token.char + Token.length)
    local token_text = line_text.sub(token_start, token_end)
    local reference_position = { line=Token.line, character=token_start }
-   local reference_scope = renameFunctionScopePath(DocumentSymbols, Token.line, token_start)
+   local reference_scope = renameLexicalScopePath(DocumentScopes, Token.line, token_start)
    local best
    local best_depth = -1
 
@@ -213,8 +218,8 @@ function renameTokenResolvesToNamespace(Doc:table, Token:table, Definitions:arra
       if definition.name != token_text or
             not renameDefinitionIsBefore(definition, reference_position) then continue end
 
-      local definition_scope = renameFunctionScopePath(
-         DocumentSymbols, definition.line, definition.startChar)
+      local definition_scope = renameLexicalScopePath(
+         DocumentScopes, definition.line, definition.startChar)
       if not renameScopeIsVisible(definition_scope, reference_scope) then continue end
 
       local depth = #definition_scope
@@ -246,7 +251,7 @@ global function resolveModuleRename(Doc:table, Position:table, NewName:str):tabl
    if not is_module_namespace and not is_library_namespace then return nil end
 
    local definitions = is_library_namespace and extractDefinitionSymbols(Doc) or nil
-   local document_symbols = is_library_namespace and extractDocumentSymbols(Doc) or nil
+   local document_scopes = is_library_namespace and extractLexicalScopes(Doc) or nil
    local tokens = tokenizeTiri(Doc.content, modulePrefixesForDocument(Doc))
 
    if is_library_namespace then
@@ -262,7 +267,7 @@ global function resolveModuleRename(Doc:table, Position:table, NewName:str):tabl
          local token_end_byte = utf16ColToByteCol(line_text, token.char + token.length)
          local text = line_text.sub(token_start_byte, token_end_byte)
          if text is old_name then
-            target_is_namespace = renameTokenResolvesToNamespace(Doc, token, definitions, document_symbols)
+            target_is_namespace = renameTokenResolvesToNamespace(Doc, token, definitions, document_scopes)
             break
          end
       end
@@ -276,7 +281,7 @@ global function resolveModuleRename(Doc:table, Position:table, NewName:str):tabl
       local token_end_byte = utf16ColToByteCol(line_text, token.char + token.length)
       local text = line_text.sub(token_start_byte, token_end_byte)
       if token.type is 10 and text is old_name and (token.modifiers & 8) is 0 and
-            (is_module_namespace or renameTokenResolvesToNamespace(Doc, token, definitions, document_symbols)) then
+            (is_module_namespace or renameTokenResolvesToNamespace(Doc, token, definitions, document_scopes)) then
          edits.push({
             range = {
                start = { line=token.line, character=token.char },

--- a/tools/tiri_lsp/include/lsp_handlers.tiri
+++ b/tools/tiri_lsp/include/lsp_handlers.tiri
@@ -135,6 +135,100 @@ global function resolveModuleCompletion(Doc:table, Position:table):array<table>
    return items
 end
 
+function renamePositionInRange(Line:num, Character:num, Range:table):bool
+   if Line < Range.start.line or Line > Range['end'].line then return false end
+   if Line is Range.start.line and Character < Range.start.character then return false end
+   if Line is Range['end'].line and Character > Range['end'].character then return false end
+   return true
+end
+
+function renameFunctionScopePath(Symbols:array<table>, Line:num, Character:num):array<table>
+   local path = array<table>
+
+   function visit(Candidates:array<table>):bool
+      for symbol in values(Candidates or array<table>) do
+         if not renamePositionInRange(Line, Character, symbol.range) then continue end
+
+         local is_function = symbol.kind is SYMBOL_KIND.FUNCTION or symbol.kind is SYMBOL_KIND.METHOD
+         if is_function then path.push(symbol) end
+         if visit(symbol.children) then return true end
+         if is_function then return true end
+      end
+      return false
+   end
+
+   visit(Symbols)
+   return path
+end
+
+function renameScopeIsVisible(DefinitionScope:array<table>, ReferenceScope:array<table>):bool
+   if #DefinitionScope > #ReferenceScope then return false end
+   for i in {0 to #DefinitionScope} do
+      local definition = DefinitionScope[i].selectionRange.start
+      local reference = ReferenceScope[i].selectionRange.start
+      if definition.line != reference.line or definition.character != reference.character then return false end
+   end
+   return true
+end
+
+function renameTokenIsMemberOrKey(Doc:table, Token:table):bool
+   local line_text = getLine(Doc, Token.line)
+   local before = utf16ColToByteCol(line_text, Token.char)
+   while before > 0 and (line_text.sub(before - 1, before) is ' ' or
+         line_text.sub(before - 1, before) is '\t') do
+      before -= 1
+   end
+   if before > 0 then
+      local prefix = line_text.sub(before - 1, before)
+      if prefix is '.' or prefix is ':' then return true end
+   end
+
+   local after = utf16ColToByteCol(line_text, Token.char + Token.length)
+   while after < #line_text and (line_text.sub(after, after + 1) is ' ' or
+         line_text.sub(after, after + 1) is '\t') do
+      after++
+   end
+   return after < #line_text and line_text.sub(after, after + 1) is '='
+end
+
+function renameDefinitionIsBefore(Definition:table, Position:table):bool
+   if Definition.line < Position.line then return true end
+   return Definition.line is Position.line and Definition.startChar <= Position.character
+end
+
+function renameTokenResolvesToNamespace(Doc:table, Token:table, Definitions:array<table>,
+      DocumentSymbols:array<table>):bool
+   if renameTokenIsMemberOrKey(Doc, Token) then return false end
+
+   local line_text = getLine(Doc, Token.line)
+   local token_start = utf16ColToByteCol(line_text, Token.char)
+   local token_end = utf16ColToByteCol(line_text, Token.char + Token.length)
+   local token_text = line_text.sub(token_start, token_end)
+   local reference_position = { line=Token.line, character=token_start }
+   local reference_scope = renameFunctionScopePath(DocumentSymbols, Token.line, token_start)
+   local best
+   local best_depth = -1
+
+   for definition in values(Definitions) do
+      if definition.name != token_text or
+            not renameDefinitionIsBefore(definition, reference_position) then continue end
+
+      local definition_scope = renameFunctionScopePath(
+         DocumentSymbols, definition.line, definition.startChar)
+      if not renameScopeIsVisible(definition_scope, reference_scope) then continue end
+
+      local depth = #definition_scope
+      if not best or depth > best_depth or (depth is best_depth and
+            (definition.line > best.line or
+            (definition.line is best.line and definition.startChar > best.startChar))) then
+         best = definition
+         best_depth = depth
+      end
+   end
+
+   return best?.kind is 'namespace'
+end
+
 global function resolveModuleRename(Doc:table, Position:table, NewName:str):table
    if not NewName or #NewName is 0 then return nil end
    local first = NewName.sub(0, 1)
@@ -147,18 +241,46 @@ global function resolveModuleRename(Doc:table, Position:table, NewName:str):tabl
 
    local token_info = getTokenAtPosition(Doc, Position.line, Position.character)
    local old_name = token_info?.text
-   if not old_name or (not moduleDeclarationsForDocument(Doc)[old_name] and
-         not libraryNamespaceDeclarationsForDocument(Doc)[old_name]) then return nil end
+   local is_module_namespace = old_name and moduleDeclarationsForDocument(Doc)[old_name]
+   local is_library_namespace = old_name and libraryNamespaceDeclarationsForDocument(Doc)[old_name]
+   if not is_module_namespace and not is_library_namespace then return nil end
+
+   local definitions = is_library_namespace and extractDefinitionSymbols(Doc) or nil
+   local document_symbols = is_library_namespace and extractDocumentSymbols(Doc) or nil
+   local tokens = tokenizeTiri(Doc.content, modulePrefixesForDocument(Doc))
+
+   if is_library_namespace then
+      local target_is_namespace = false
+      for token in values(tokens) do
+         if token.line != Position.line then continue end
+         local line_text = getLine(Doc, token.line)
+         local token_start = token.char
+         local token_end = token.char + token.length
+         if Position.character < token_start or Position.character > token_end then continue end
+
+         local token_start_byte = utf16ColToByteCol(line_text, token.char)
+         local token_end_byte = utf16ColToByteCol(line_text, token.char + token.length)
+         local text = line_text.sub(token_start_byte, token_end_byte)
+         if text is old_name then
+            target_is_namespace = renameTokenResolvesToNamespace(Doc, token, definitions, document_symbols)
+            break
+         end
+      end
+      if not target_is_namespace then return nil end
+   end
 
    local edits = array<table>
-   for token in values(tokenizeTiri(Doc.content, modulePrefixesForDocument(Doc))) do
+   for token in values(tokens) do
       local line_text = getLine(Doc, token.line)
-      local text = line_text.sub(token.char, token.char + token.length)
-      if token.type is 10 and text is old_name and (token.modifiers & 8) is 0 then
+      local token_start_byte = utf16ColToByteCol(line_text, token.char)
+      local token_end_byte = utf16ColToByteCol(line_text, token.char + token.length)
+      local text = line_text.sub(token_start_byte, token_end_byte)
+      if token.type is 10 and text is old_name and (token.modifiers & 8) is 0 and
+            (is_module_namespace or renameTokenResolvesToNamespace(Doc, token, definitions, document_symbols)) then
          edits.push({
             range = {
-               start = { line=token.line, character=byteColToUtf16Col(line_text, token.char) },
-               ['end'] = { line=token.line, character=byteColToUtf16Col(line_text, token.char + token.length) }
+               start = { line=token.line, character=token.char },
+               ['end'] = { line=token.line, character=token.char + token.length }
             },
             newText = NewName
          })

--- a/tools/tiri_lsp/include/lsp_lib.tiri
+++ b/tools/tiri_lsp/include/lsp_lib.tiri
@@ -364,6 +364,7 @@ global FLUID_MODULES = {
 
 rx_module_namespace_decl = <{ regex.new(
    [[^\s*module\s+([A-Za-z_][A-Za-z0-9_]*)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)\s*;?\s*$]]) }>
+rx_library_namespace_decl = <{ regex.new([[^\s*namespace\s+([A-Za-z_][A-Za-z0-9_]*)\b]]) }>
 
 extern maskNonCode
 
@@ -385,6 +386,20 @@ global function moduleDeclarationsForDocument(Doc:table):table
       if captures then declarations[captures[1]] = captures[0] end
    end
    Doc.moduleDeclarations = declarations
+   return declarations
+end
+
+global function libraryNamespaceDeclarationsForDocument(Doc:table):table
+   local declarations = {}
+   if not Doc?.content then return declarations end
+
+   local in_block_comment = false
+   for line_no in {0 to getTotalLines(Doc)} do
+      local line_code
+      line_code, in_block_comment = maskNonCode(getLine(Doc, line_no), in_block_comment)
+      local _, _, captures = rx_library_namespace_decl.findFirst(line_code)
+      if captures then declarations[captures[0]] = true end
+   end
    return declarations
 end
 

--- a/tools/tiri_lsp/include/lsp_parsing.tiri
+++ b/tools/tiri_lsp/include/lsp_parsing.tiri
@@ -41,6 +41,7 @@ global function tokenizeTiri(Source:str, ModulePrefixes:table):array<table>
    pos = 0
    len = #Source
    module_prefixes = ModulePrefixes or modulePrefixesForDocument({ content=Source, lineIndex=nil })
+   library_namespaces = { }
 
    -- Helper to add a token (skips zero-length tokens)
    function addToken(TokenLine, TokenCol, TokenLen, TokenType, TokenMod)
@@ -850,6 +851,31 @@ global function tokenizeTiri(Source:str, ModulePrefixes:table):array<table>
                line = sk_line
                addToken(sk_line, ident_start, ident_len, 10, 0)  -- namespace ('struct' library)
             end
+         elseif ident is 'namespace' then
+            after_keyword_pos = pos
+            after_keyword_col = col
+            after_keyword_line = line
+            while pos < len and (Source.sub(pos, pos + 1) is ' ' or Source.sub(pos, pos + 1) is '\t') do
+               pos++
+               col++
+            end
+
+            namespace_line = line
+            namespace_col = col
+            namespace_start = pos
+            if line is after_keyword_line and pos < len and isIdentStart(Source.sub(pos, pos + 1)) then
+               while pos < len and isIdentChar(Source.sub(pos, pos + 1)) do pos++; col++ end
+               namespace_name = Source.sub(namespace_start, pos)
+               library_namespaces[namespace_name] = true
+               addToken(after_keyword_line, ident_start, ident_len, 0, 0)
+               addToken(namespace_line, namespace_col, #namespace_name, 10, 5)
+               continue
+            end
+
+            pos = after_keyword_pos
+            col = after_keyword_col
+            line = after_keyword_line
+            addToken(line, ident_start, ident_len, 0, 0)
          elseif ident is 'module' then
             -- 'module' remains contextual so existing module(...) functions keep function highlighting.
             after_keyword_pos = pos
@@ -939,7 +965,7 @@ global function tokenizeTiri(Source:str, ModulePrefixes:table):array<table>
             addToken(line, ident_start, ident_len, 12, 4)  -- macro + readonly
          elseif FLUID_BUILTINS[ident] then
             addToken(line, ident_start, ident_len, 3, 128)  -- function + defaultLibrary
-         elseif FLUID_MODULES[ident] or module_prefixes[ident] then
+         elseif FLUID_MODULES[ident] or module_prefixes[ident] or library_namespaces[ident] then
             addToken(line, ident_start, ident_len, 10, 0)  -- namespace
          elseif ident.startsWith('ERR_') then
             addToken(line, ident_start, ident_len, 12, 4)  -- macro + readonly (error constants)

--- a/tools/tiri_lsp/include/lsp_symbols.tiri
+++ b/tools/tiri_lsp/include/lsp_symbols.tiri
@@ -13,6 +13,7 @@ rx_symbol_struct_field    = <{ regex.new([[([A-Za-z_][A-Za-z0-9_]*)\s*:]]) }>
 rx_symbol_struct_end      = <{ regex.new([[\s+end\s*$]]) }>
 rx_symbol_module_decl = <{ regex.new(
    [[^\s*module\s+([A-Za-z_][A-Za-z0-9_]*)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)\s*$]]) }>
+rx_symbol_namespace_decl = <{ regex.new([[^\s*namespace\s+([A-Za-z_][A-Za-z0-9_]*)\b]]) }>
 
 ----------------------------------------------------------------------------------------------------------------------
 
@@ -270,6 +271,16 @@ function symbolDetectFunction(LineCode:str, LineText:str, LineNo:num, Annotation
 end
 
 function symbolDetectModuleValue(LineCode:str, LineText:str, LineNo:num):table
+   local namespace_start, namespace_stop, namespace_cap = rx_symbol_namespace_decl.findFirst(LineCode)
+   if namespace_start then
+      local namespace_name = namespace_cap[0]
+      local name_start = LineText.find(namespace_name, namespace_start, true) or namespace_start
+      local remainder = LineCode.sub(namespace_stop).trim()
+      local detail = remainder is '' and 'readonly namespace join' or 'readonly namespace'
+      return symbolMakeDocumentSymbol(namespace_name, SYMBOL_KIND.NAMESPACE, LineNo, LineText, name_start,
+         detail, nil)
+   end
+
    local decl_start, _, decl_cap = rx_symbol_module_decl.findFirst(LineCode)
    if decl_start then
       local module_name = decl_cap[0]
@@ -502,7 +513,8 @@ global function extractDocumentSymbols(Doc:table):array<table>
                symbolAddChild(symbols, stack, module_symbol)
                open_count = symbolCountChar(symbol_code, '{')
                close_count = symbolCountChar(symbol_code, '}')
-               if module_symbol.kind is SYMBOL_KIND.OBJECT and open_count > close_count then
+               if (module_symbol.kind is SYMBOL_KIND.OBJECT or module_symbol.kind is SYMBOL_KIND.NAMESPACE) and
+                     open_count > close_count then
                   stack.push({ kind = 'table', symbol = module_symbol, brace_depth = 0 })
                end
             end

--- a/tools/tiri_lsp/include/lsp_symbols.tiri
+++ b/tools/tiri_lsp/include/lsp_symbols.tiri
@@ -365,6 +365,14 @@ function symbolAddStructFields(Symbol:table, LineCode:str, LineText:str, LineNo:
    end
 end
 
+-- Keywords that open an anonymous frame terminated by `end`.  A `do` opens exactly one frame whether it stands
+-- alone or closes a `for`, `while` or `with` header, so counting `do` is both simpler and more reliable than
+-- pairing it with the loop keyword that introduced it.  Every entry here must be balanced by an `end` or `until`,
+-- otherwise symbolCloseBlockFrames() will pop an enclosing function frame and truncate its range.
+-- `struct` is deliberately absent because extractDocumentSymbols() pushes that frame itself.
+
+symbol_block_openers = array<str> { 'do', 'defer', 'try', 'choose', 'checkall', 'checkup' }
+
 function symbolPushBlockFrames(Stack:array<table>, LineCode:str, FunctionFrame:table)
    function_count = symbolCountBlockKeyword(LineCode, 'function') + symbolCountBlockKeyword(LineCode, 'thunk')
    if FunctionFrame and function_count > 0 then function_count -= 1 end
@@ -373,6 +381,8 @@ function symbolPushBlockFrames(Stack:array<table>, LineCode:str, FunctionFrame:t
       Stack.push({ kind = 'function' })
    end
 
+   -- `elseif` continues the frame opened by its `if`, so only leading `if` keywords open a new one.
+
    if symbolCountBlockKeyword(LineCode, 'then') > 0 then
       if_count = symbolCountBlockKeyword(LineCode, 'if')
       for i in {1 to if_count+1} do
@@ -380,13 +390,9 @@ function symbolPushBlockFrames(Stack:array<table>, LineCode:str, FunctionFrame:t
       end
    end
 
-   if symbolCountBlockKeyword(LineCode, 'do') > 0 then
-      for_count = symbolCountBlockKeyword(LineCode, 'for')
-      while_count = symbolCountBlockKeyword(LineCode, 'while')
-      for i in {1 to for_count+1} do
-         Stack.push({ kind = 'block' })
-      end
-      for i in {1 to while_count+1} do
+   for keyword in values(symbol_block_openers) do
+      open_count = symbolCountBlockKeyword(LineCode, keyword)
+      for i in {1 to open_count+1} do
          Stack.push({ kind = 'block' })
       end
    end
@@ -394,11 +400,6 @@ function symbolPushBlockFrames(Stack:array<table>, LineCode:str, FunctionFrame:t
    repeat_count = symbolCountBlockKeyword(LineCode, 'repeat')
    for i in {1 to repeat_count+1} do
       Stack.push({ kind = 'repeat' })
-   end
-
-   defer_count = symbolCountBlockKeyword(LineCode, 'defer')
-   for i in {1 to defer_count+1} do
-      Stack.push({ kind = 'block' })
    end
 end
 
@@ -540,4 +541,121 @@ global function extractDocumentSymbols(Doc:table):array<table>
    end
 
    return symbols
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Lexical Scope Extraction
+--
+-- Document symbols describe named declarations only, so they cannot decide whether a local binding is still live at
+-- a later position.  Rename resolution needs the complete lexical picture, including the anonymous do, conditional,
+-- loop and exception blocks that carry no symbol of their own.  The scanner below records every block terminated by
+-- `end` or `until`, nested to mirror the source.
+
+-- Keywords that open a block.  `then` and `do` stand in for `if`, `for`, `while` and `with` because the body always
+-- begins at those keywords, which keeps loop and condition expressions in the enclosing scope where they belong.
+
+scope_openers = {
+   ['function'] = true, ['thunk'] = true, ['do'] = true, ['then'] = true, ['repeat'] = true,
+   ['defer'] = true, ['try'] = true, ['choose'] = true, ['checkall'] = true, ['checkup'] = true
+}
+
+-- Keywords that terminate the enclosing block and immediately open a sibling.
+
+scope_dividers = { ['else'] = true, ['except'] = true, ['success'] = true }
+
+-- Keywords that terminate the enclosing block.  `elseif` belongs here rather than with the dividers because its own
+-- `then` re-opens the scope.
+
+scope_closers = { ['end'] = true, ['until'] = true, ['elseif'] = true }
+
+-- Split a masked code line into its identifier-like words.  Each entry records the word, its byte column and the
+-- character that follows it, which is enough to distinguish a `struct Name` declaration from a `struct.new()` call.
+
+function scopeLineWords(LineCode:str):array<table>
+   words = array<table>
+   pos = 0
+   len = #LineCode
+
+   while pos < len do
+      if symbolIsBlockTokenChar(LineCode.sub(pos, pos + 1)) then
+         word_start = pos
+         pos++
+         while pos < len and symbolIsBlockTokenChar(LineCode.sub(pos, pos + 1)) do pos++ end
+         words.push({ text = LineCode.sub(word_start, pos), column = word_start,
+            following = LineCode.sub(pos, pos + 1) })
+      else
+         pos++
+      end
+   end
+
+   return words
+end
+
+function scopeOpen(Roots:array<table>, Stack:array<table>, LineNo:num, Column:num)
+   scope = {
+      range = {
+         start = { line = LineNo, character = Column },
+         ['end'] = { line = LineNo, character = Column }
+      },
+      children = array<table>
+   }
+
+   if #Stack > 0 then
+      Stack[#Stack - 1].children.push(scope)
+   else
+      Roots.push(scope)
+   end
+   Stack.push(scope)
+end
+
+function scopeClose(Stack:array<table>, LineNo:num, Column:num)
+   if #Stack is 0 then return end
+   scope = Stack.pop()
+   scope.range['end'].line = LineNo
+   scope.range['end'].character = Column
+end
+
+-- `struct` doubles as the declaration keyword and as a library namespace, so only accept it as a block opener when
+-- it leads the line and is followed by whitespace, matching symbolDetectStruct().
+
+function scopeOpensStruct(Word:table, Index:num):bool
+   if Word.text != 'struct' or Index != 0 then return false end
+   return Word.following is ' ' or Word.following is '\t'
+end
+
+@Doc(text="Extract the nested lexical block scopes of a document as { range, children } nodes.")
+
+global function extractLexicalScopes(Doc:table):array<table>
+   roots = array<table>
+   stack = array<table>
+   in_block_comment = false
+   total_lines = getTotalLines(Doc)
+
+   for line_num in {0 to total_lines} do
+      line_code, in_block_comment = maskNonCode(getLine(Doc, line_num), in_block_comment)
+      words = scopeLineWords(line_code)
+
+      for i in {0 to #words} do
+         word = words[i]
+         if scope_closers[word.text] then
+            scopeClose(stack, line_num, word.column + #word.text)
+         elseif scope_dividers[word.text] then
+            scopeClose(stack, line_num, word.column)
+            scopeOpen(roots, stack, line_num, word.column)
+         elseif scope_openers[word.text] or scopeOpensStruct(word, i) then
+            scopeOpen(roots, stack, line_num, word.column)
+         end
+      end
+   end
+
+   -- Unterminated blocks (an incomplete edit, or source that the masker mis-read) extend to the last content line
+   -- so that trailing references still resolve against them.
+
+   last_line = symbolLastContentLine(Doc, total_lines)
+   last_char = #getLine(Doc, last_line)
+   while #stack > 0 do
+      scopeClose(stack, last_line, last_char)
+   end
+
+   return roots
 end

--- a/tools/tiri_lsp/tests/test_definition.tiri
+++ b/tools/tiri_lsp/tests/test_definition.tiri
@@ -46,6 +46,12 @@ end
    assertLocationLine(locations, 0, 'Variable use should resolve to local declaration')
 end
 
+@Test function CurrentDocumentLibraryNamespace()
+   doc = makeDoc('namespace toolkit { version = "1.0" }\nprint(toolkit.version)\n')
+   locations = resolveDefinition(doc, { line = 1, character = 8 })
+   assertLocationLine(locations, 0, 'Library namespace use should resolve to its declaration')
+end
+
 @Test function CurrentDocumentImplicitVariable()
    doc = makeDoc('win = gui.window({ title = "Test" })\nprint(win)\n')
    locations = resolveDefinition(doc, { line = 1, character = 7 })

--- a/tools/tiri_lsp/tests/test_document_symbols.tiri
+++ b/tools/tiri_lsp/tests/test_document_symbols.tiri
@@ -92,6 +92,22 @@ end
    assert(namespace_symbol.detail is 'module core', 'Namespace symbol detail should retain the module name.')
 end
 
+@Test function LibraryNamespaceDeclarationSymbols()
+   doc = makeDoc('namespace toolkit { version = "1.0" }\n')
+   symbols = extractDocumentSymbols(doc)
+   namespace_symbol = findSymbol(symbols, 'toolkit')
+
+   assert(namespace_symbol and namespace_symbol.kind is SYMBOL_KIND.NAMESPACE,
+      'A library namespace declaration should create a namespace document symbol.')
+   assert(namespace_symbol.detail is 'readonly namespace',
+      'A created library namespace should be identified as readonly.')
+
+   doc = makeDoc('namespace toolkit\n')
+   namespace_symbol = findSymbol(extractDocumentSymbols(doc), 'toolkit')
+   assert(namespace_symbol and namespace_symbol.detail is 'readonly namespace join',
+      'A joined library namespace should retain readonly namespace detail.')
+end
+
 @Test function ModuleScopeVariablesAndTables()
    doc = makeDoc([[
 local glFolderFill

--- a/tools/tiri_lsp/tests/test_document_symbols.tiri
+++ b/tools/tiri_lsp/tests/test_document_symbols.tiri
@@ -343,3 +343,39 @@ end
    assert(not findSymbol(symbols, 'x'), 'Comparison identifiers must not become module variable symbols.')
    assert(not findSymbol(symbols, 'i'), 'Loop variables must not become module variable symbols.')
 end
+
+@Test function AnonymousBlocksDoNotTruncateFunctionRanges()
+   doc = makeDoc([==[
+function alpha()
+   do
+      local scratch = 1
+   end
+   try
+      risky()
+   except e
+   end
+   checkup
+      guarded()
+   end
+   local result = choose scratch from
+      1 -> 'one'
+      else -> 'other'
+   end
+   return result
+end
+
+function beta()
+end
+]==])
+   symbols = extractDocumentSymbols(doc)
+   alpha = findSymbol(symbols, 'alpha')
+   beta = findSymbol(symbols, 'beta')
+
+   assert(alpha, 'Function containing anonymous blocks should be listed.')
+   assert(alpha.range['end'].line is 16,
+      'A do, try, checkup or choose block must not close the enclosing function frame.')
+   assert(beta and beta.range.start.line is 18 and beta.range['end'].line is 19,
+      'Later declarations should keep their own ranges once block frames balance.')
+   assert(not findSymbol(symbols, 'scratch') and not findSymbol(symbols, 'result'),
+      'Locals inside a function body must not be promoted to module scope.')
+end

--- a/tools/tiri_lsp/tests/test_module_namespaces.tiri
+++ b/tools/tiri_lsp/tests/test_module_namespaces.tiri
@@ -89,6 +89,61 @@ local text = 'toolkit'
       'Starting a rename on a shadowing local should not rename the library namespace.')
 end
 
+@Test function RenamesAcrossBlockScopeBoundaries()
+   local doc = makeDoc([==[
+namespace toolkit { version = '1.0' }
+do
+   local toolkit = { version = 'block' }
+   print(toolkit.version)
+end
+for i in {0 to 3} do
+   local toolkit = { version = 'loop' }
+   print(toolkit.version)
+end
+function scan()
+   do
+      local depth = 0
+   end
+   local toolkit = { version = 'inner' }
+   print(toolkit.version)
+end
+print(toolkit.version)
+]==])
+   local edit = resolveModuleRename(doc, { line=0, character=12 }, 'renamedToolkit')
+   local edits = edit?.changes?[doc.uri]
+
+   assert(edits and #edits is 2,
+      'Bindings local to a do or loop block should shadow the namespace only inside that block.')
+   assert(edits[0].range.start.line is 0 and edits[1].range.start.line is 16,
+      'A reference following a closed block should still resolve to the library namespace.')
+end
+
+@Test function RenamesSiblingBranchesIndependently()
+   local doc = makeDoc([==[
+namespace toolkit { version = '1.0' }
+if condition then
+   local toolkit = { version = 'branch' }
+   print(toolkit.version)
+else
+   print(toolkit.version)
+end
+try
+   local toolkit = { version = 'guarded' }
+   print(toolkit.version)
+except e
+   print(toolkit.version)
+end
+print(toolkit.version)
+]==])
+   local edit = resolveModuleRename(doc, { line=0, character=12 }, 'renamedToolkit')
+   local edits = edit?.changes?[doc.uri]
+
+   assert(edits and #edits is 4, 'Sibling branches should not inherit each other\'s local bindings.')
+   assert(edits[0].range.start.line is 0 and edits[1].range.start.line is 5 and
+         edits[2].range.start.line is 11 and edits[3].range.start.line is 13,
+      'Only the else, except and trailing references should resolve to the library namespace.')
+end
+
 @Test function RenameRejectsLegacyAndInvalidNames()
    local legacy_doc = makeDoc('mSys.PreciseTime()')
    assert(not resolveModuleRename(legacy_doc, { line=0, character=1 }, 'mClock'),

--- a/tools/tiri_lsp/tests/test_module_namespaces.tiri
+++ b/tools/tiri_lsp/tests/test_module_namespaces.tiri
@@ -62,13 +62,31 @@ end
    local doc = makeDoc([[
 namespace toolkit { version = '1.0' }
 print(toolkit.version)
+function inspect_shadow()
+   local toolkit = { version = 'shadow' }
+   print(toolkit.version)
+end
+print(toolkit.version)
+print('é', toolkit.version)
+local other = { toolkit = toolkit }
+print(other.toolkit.version)
 local text = 'toolkit'
 -- toolkit
 ]])
    local edit = resolveModuleRename(doc, { line=0, character=12 }, 'renamedToolkit')
    local edits = edit?.changes?[doc.uri]
 
-   assert(edits and #edits is 2, 'Library namespace rename should edit only declaration and code references.')
+   assert(edits and #edits is 5,
+      'Library namespace rename should exclude shadowed bindings, member names, strings and comments.')
+   assert(edits[0].range.start.line is 0 and edits[1].range.start.line is 1 and
+         edits[2].range.start.line is 6 and edits[3].range.start.line is 7 and
+         edits[4].range.start.line is 8,
+      'Library namespace rename should retain only references to the declared lexical binding.')
+   local unicode_edit = resolveModuleRename(doc, { line=7, character=12 }, 'renamedToolkit')
+   assert(#unicode_edit?.changes?[doc.uri] is 5,
+      'Starting a rename after multibyte text should preserve UTF-16 token coordinates.')
+   assert(not resolveModuleRename(doc, { line=3, character=10 }, 'renamedShadow'),
+      'Starting a rename on a shadowing local should not rename the library namespace.')
 end
 
 @Test function RenameRejectsLegacyAndInvalidNames()

--- a/tools/tiri_lsp/tests/test_module_namespaces.tiri
+++ b/tools/tiri_lsp/tests/test_module_namespaces.tiri
@@ -58,6 +58,19 @@ local text = 'runtimeCore'
       'Every namespace edit should use the requested name.')
 end
 
+@Test function RenamesLibraryNamespaceReferences()
+   local doc = makeDoc([[
+namespace toolkit { version = '1.0' }
+print(toolkit.version)
+local text = 'toolkit'
+-- toolkit
+]])
+   local edit = resolveModuleRename(doc, { line=0, character=12 }, 'renamedToolkit')
+   local edits = edit?.changes?[doc.uri]
+
+   assert(edits and #edits is 2, 'Library namespace rename should edit only declaration and code references.')
+end
+
 @Test function RenameRejectsLegacyAndInvalidNames()
    local legacy_doc = makeDoc('mSys.PreciseTime()')
    assert(not resolveModuleRename(legacy_doc, { line=0, character=1 }, 'mClock'),

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -129,6 +129,22 @@ end
       'Existing module(...) identifiers should retain function highlighting.')
 end
 
+@Test function LibraryNamespacesReceiveSemanticTokens()
+   source = 'namespace toolkit { version = "1.0" }\n' ..
+      'toolkit.version = "2.0"\n' ..
+      'namespaceOnly(toolkit)\n'
+   tokens = tokenizeTiri(source)
+
+   keyword = findToken(tokens, 0, 0, 'namespace')
+   declaration = findToken(tokens, 0, 10, 'toolkit')
+   reference = findToken(tokens, 1, 0, 'toolkit')
+
+   assert(keyword and keyword.type is 0, 'Library namespace keyword should receive keyword highlighting.')
+   assert(declaration and declaration.type is 10 and (declaration.modifiers & 5) is 5,
+      'Library namespace declarations should be readonly declaration namespace tokens.')
+   assert(reference and reference.type is 10, 'Library namespace references should retain namespace highlighting.')
+end
+
 @Test function ImportListPathsReceiveSemanticTokens()
    source = "import 'json',\n   'options'\n"
 


### PR DESCRIPTION
* Added readonly namespace declarations with parser, type-analysis and runtime integration
* Migrated bundled Tiri libraries and GUI scripts to declarative namespaces
* Extended the Tiri LSP with namespace navigation, renaming, symbols and semantic-token coverage