### PR TITLE
[Tiri] Fixed JIT array literal-index fallback errors

### DIFF
--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -815,6 +815,8 @@ static void build_subroutines(BuildCtx *ctx)
   |->vmeta_agetb:			// RB = array, RC = literal index
   |  // BC_AGETB carries the index as an operand literal rather than a register, so the key must be boxed into the
   |  // scratch TValue.  Reloading it as a register index would pass an unrelated stack slot as the key.
+  |  decode_RB RB, INS
+  |   decode_RC RC, INS
   |  add RC, RC, TISNUM
   |   add CARG2, BASE, RB, lsl #3
   |   add CARG3, sp, TMPDofs
@@ -847,6 +849,8 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |->vmeta_asetb:			// RB = array, RC = literal index
   |  // BC_ASETB carries the index as an operand literal rather than a register.  See ->vmeta_agetb.
+  |  decode_RB RB, INS
+  |   decode_RC RC, INS
   |  add RC, RC, TISNUM
   |   add CARG2, BASE, RB, lsl #3
   |   add CARG3, sp, TMPDofs

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -812,9 +812,19 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |//-- Array metamethod fallbacks -----------------------------------------
   |
+  |->vmeta_agetb:			// RB = array, RC = literal index
+  |  // BC_AGETB carries the index as an operand literal rather than a register, so the key must be boxed into the
+  |  // scratch TValue.  Reloading it as a register index would pass an unrelated stack slot as the key.
+  |  add RC, RC, TISNUM
+  |   add CARG2, BASE, RB, lsl #3
+  |   add CARG3, sp, TMPDofs
+  |  str RC, TMPD
+  |  b >1
+  |
   |->vmeta_agetv:
   |  add CARG2, BASE, RB, lsl #3
   |   add CARG3, BASE, RC, lsl #3
+  |1:
   |   str BASE, L->base
   |  mov CARG1, L
   |   str PC, SAVE_PC
@@ -835,9 +845,18 @@ static void build_subroutines(BuildCtx *ctx)
   |  and LFUNC:CARG3, CARG3, #LJ_GCVMASK
   |  b ->vm_call_dispatch_f
   |
+  |->vmeta_asetb:			// RB = array, RC = literal index
+  |  // BC_ASETB carries the index as an operand literal rather than a register.  See ->vmeta_agetb.
+  |  add RC, RC, TISNUM
+  |   add CARG2, BASE, RB, lsl #3
+  |   add CARG3, sp, TMPDofs
+  |  str RC, TMPD
+  |  b >1
+  |
   |->vmeta_asetv:
   |  add CARG2, BASE, RB, lsl #3
   |   add CARG3, BASE, RC, lsl #3
+  |1:
   |   str BASE, L->base
   |  mov CARG1, L
   |   str PC, SAVE_PC
@@ -3752,11 +3771,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
   case BC_AGETB:
     |  // RA = dst, RB = array, RC = literal index (0-255, 0-based)
     |  ldr TMP2, [BASE, RB, lsl #3]	// Load array
-    |  checkarray TMP2, ->vmeta_agetv
+    |  checkarray TMP2, ->vmeta_agetb
     |  // Bounds check
     |   ldr TMP3w, ARRAY:TMP2->len
     |  cmp RCw, TMP3w
-    |  bhs ->vmeta_agetv
+    |  bhs ->vmeta_agetb
     |  // Call helper to get element
     |  mov CARG1, L
     |  mov CARG2, ARRAY:TMP2
@@ -3793,14 +3812,14 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
   case BC_ASETB:
     |  // RA = src, RB = array, RC = literal index (0-255, 0-based)
     |  ldr TMP2, [BASE, RB, lsl #3]	// Load array
-    |  checkarray TMP2, ->vmeta_asetv
+    |  checkarray TMP2, ->vmeta_asetb
     |  // Check read-only flag
     |  ldrb TMP3w, ARRAY:TMP2->flags
-    |  tbnz TMP3w, #0, ->vmeta_asetv	// ARRAY_READONLY = 0x01
+    |  tbnz TMP3w, #0, ->vmeta_asetb	// ARRAY_READONLY = 0x01
     |  // Bounds check
     |   ldr TMP3w, ARRAY:TMP2->len
     |  cmp RCw, TMP3w
-    |  bhs ->vmeta_asetv
+    |  bhs ->vmeta_asetb
     |  // Call helper to set element
     |  mov CARG1, L
     |  mov CARG2, ARRAY:TMP2

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -1003,6 +1003,20 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |//-- Array metamethod fallbacks -----------------------------------------
   |
+  |->vmeta_agetb:
+  |  // BC_AGETB carries the index as an operand literal rather than a register, so the key must be boxed into the
+  |  // scratch TValue.  Reloading it as a register index would pass an unrelated stack slot as the key.
+  |  movzx RCd, PC_RC
+  |.if DUALNUM
+  |  setint RC
+  |  mov TMP1, RC
+  |.else
+  |  cvtsi2sd xmm0, RCd
+  |  movsd TMP1, xmm0
+  |.endif
+  |  lea RC, TMP1
+  |  jmp ->vmeta_agetv1
+  |
   |->vmeta_agetv:
   |  movzx RCd, PC_RC         // Reload TValue *k from RC.
   |  lea RC, [BASE+RC*8]
@@ -1033,6 +1047,19 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov LFUNC:RB, [RA-16]    // Guaranteed to be a function here.
   |  cleartp LFUNC:RB
   |  jmp ->vm_call_dispatch_f
+  |
+  |->vmeta_asetb:
+  |  // BC_ASETB carries the index as an operand literal rather than a register.  See ->vmeta_agetb.
+  |  movzx RCd, PC_RC
+  |.if DUALNUM
+  |  setint RC
+  |  mov TMP1, RC
+  |.else
+  |  cvtsi2sd xmm0, RCd
+  |  movsd TMP1, xmm0
+  |.endif
+  |  lea RC, TMP1
+  |  jmp ->vmeta_asetv1
   |
   |->vmeta_asetv:
   |  movzx RCd, PC_RC         // Reload TValue *k from RC.
@@ -4558,9 +4585,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
   case BC_AGETB:
     |  ins_ABC // RA = dst, RB = array, RC = literal index (0-255, 0-based)
     |  mov ARRAY:RB, [BASE+RB*8]
-    |  checkarray ARRAY:RB, ->vmeta_agetv
+    |  checkarray ARRAY:RB, ->vmeta_agetb
     |  cmp RCd, ARRAY:RB->len    // Bounds check.
-    |  jae ->vmeta_agetv      // Out of bounds? Use fallback.
+    |  jae ->vmeta_agetb      // Out of bounds? Use fallback.
     |
     |  // Sync L->base and SAVE_PC before C call (lj_arr_getidx may throw via longjmp on error).
     |  mov TMPR, SAVE_L
@@ -4640,14 +4667,14 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
   case BC_ASETB:
     |  ins_ABC // RA = src, RB = array, RC = literal index (0-255, 0-based)
     |  mov ARRAY:RB, [BASE+RB*8]
-    |  checkarray ARRAY:RB, ->vmeta_asetv
+    |  checkarray ARRAY:RB, ->vmeta_asetb
     |
     |  // Check read-only flag
     |  test byte ARRAY:RB->flags, ARRAY_READONLY
-    |  jnz ->vmeta_asetv      // Read-only? Use fallback (will error).
+    |  jnz ->vmeta_asetb      // Read-only? Use fallback (will error).
     |
     |  cmp RCd, ARRAY:RB->len    // Bounds check.
-    |  jae ->vmeta_asetv      // Out of bounds? Use fallback.
+    |  jae ->vmeta_asetb      // Out of bounds? Use fallback.
     |
     |  // Sync L->base and SAVE_PC before C call (lj_arr_setidx may throw via longjmp on type mismatch).
     |  mov TMPR, SAVE_L

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -439,6 +439,63 @@ end
 end
 
 -----------------------------------------------------------------------------------------------------------------------
+-- A literal index and a variable index compile to different bytecode: BC_AGETB/BC_ASETB carry the index as an operand
+-- literal, BC_AGETV/BC_ASETV read it from a register.  Both forms must report the same fault.  The literal forms
+-- previously entered the fallback with an unrelated stack slot as the key, so a read reported ERR_TypeMismatch and a
+-- write reported the wrong index.
+
+@Test function ArrayBoundsFaultReporting()
+   arr = array<int> { 10, 20, 30 }
+   idx = #arr + 6   -- 9, computed so that the index cannot be folded into an operand literal
+
+   raised = false
+   try
+      t = arr[9]
+   except e
+      raised = true
+      assert(e.code is ERR_OutOfBounds, 'Literal-index read reported ' .. tostring(e.code))
+      assert(e.message.find('index 9'), 'Literal-index read reported: ' .. e.message)
+   end
+   assert(raised, 'Literal-index read beyond bounds must raise')
+
+   raised = false
+   try
+      t = arr[idx]
+   except e
+      raised = true
+      assert(e.code is ERR_OutOfBounds, 'Variable-index read reported ' .. tostring(e.code))
+      assert(e.message.find('index 9'), 'Variable-index read reported: ' .. e.message)
+   end
+   assert(raised, 'Variable-index read beyond bounds must raise')
+
+   raised = false
+   try
+      arr[9] = 1
+   except e
+      raised = true
+      assert(e.code is ERR_OutOfBounds, 'Literal-index write reported ' .. tostring(e.code))
+      assert(e.message.find('index 9'), 'Literal-index write reported: ' .. e.message)
+   end
+   assert(raised, 'Literal-index write beyond bounds must raise')
+
+   raised = false
+   try
+      arr[idx] = 1
+   except e
+      raised = true
+      assert(e.code is ERR_OutOfBounds, 'Variable-index write reported ' .. tostring(e.code))
+      assert(e.message.find('index 9'), 'Variable-index write reported: ' .. e.message)
+   end
+   assert(raised, 'Variable-index write beyond bounds must raise')
+
+   -- In-bounds access through both forms remains unaffected.
+
+   assert(arr[1] is 20, 'Literal-index read of a valid element failed')
+   arr[1] = 99
+   assert(arr[1] is 99, 'Literal-index write of a valid element failed')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
 -- Test table to array copying functionality
 
 @Test function TableToIntegerArrayCopy()

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -445,6 +445,7 @@ end
 -- write reported the wrong index.
 
 @Test function ArrayBoundsFaultReporting()
+   register_sentinel = 'keep array out of register zero'
    arr = array<int> { 10, 20, 30 }
    idx = #arr + 6   -- 9, computed so that the index cannot be folded into an operand literal
 
@@ -493,6 +494,7 @@ end
    assert(arr[1] is 20, 'Literal-index read of a valid element failed')
    arr[1] = 99
    assert(arr[1] is 99, 'Literal-index write of a valid element failed')
+   assert(register_sentinel is 'keep array out of register zero', 'Register sentinel was unexpectedly modified')
 end
 
 -----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
* Corrected x64 and ARM64 fallbacks to box literal array indices before metamethod calls
* Added array bounds-fault coverage for literal and variable index bytecode paths