### PR TITLE
[Tiri] Optimised fresh array cloning and slicing

### DIFF
--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -2635,11 +2635,8 @@ LJLIB_CF(array_clone)
 
    // Create new array with same type and length
    GCarray *result = lj_array_new_like(L, arr, arr->len);
+   lj_array_copy_to_fresh(L, result, 0, arr, 0, 1, arr->len);
    setarrayV(L, L->top++, result);
-
-   if (arr->len IS 0) return 1;
-
-   lj_array_copy(L, result, 0, arr, 0, arr->len);
    return 1;
 }
 

--- a/src/tiri/jit/src/lib/lib_range.cpp
+++ b/src/tiri/jit/src/lib/lib_range.cpp
@@ -997,15 +997,9 @@ static int range_slice_impl(lua_State *L)
       // Create result array
       GCarray *new_arr = lj_array_new_like(L, arr, MSize(result_size));
 
-      // A unit forward step is contiguous and can use one fully checked bulk copy.  Other ranges have already been
-      // clipped and the result was created from the source metadata, so validate that contract once before copying.
-      if (forward and step IS 1) {
-         lj_array_copy(L, new_arr, 0, arr, MSize(start), MSize(result_size));
-      }
-      else {
-         lj_array_copy(L, new_arr, 0, arr, MSize(start), 0);
-         lj_array_copy_strided_unchecked(L, new_arr, 0, arr, MSize(start), step, MSize(result_size));
-      }
+      // The result is current-white and remains unobservable until it reaches the stack.  The dedicated fresh-copy
+      // path validates the complete contract once and then copies without per-reference barriers.
+      lj_array_copy_to_fresh(L, new_arr, 0, arr, MSize(start), step, MSize(result_size));
 
       setarrayV(L, L->top++, new_arr); // Push array onto the stack
       return 1;

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -930,6 +930,69 @@ void lj_array_copy_strided_unchecked(lua_State *L, GCarray *Dest, uint32_t DstId
    }
 }
 
+// Copy into a newly allocated, unexposed array.  All checks occur before the first store so that the copy itself cannot
+// allocate, call script code, raise an error or advance the collector.  A current-white destination will be traversed
+// normally when marked, so copied references do not require forward barriers.
+void lj_array_copy_to_fresh(lua_State *L, GCarray *Dest, uint32_t DstIdx, const GCarray *Src, uint32_t SrcIdx,
+   int32_t SrcStride, uint32_t Count)
+{
+   if (DstIdx > Dest->len or Count > Dest->len - DstIdx or SrcIdx > Src->len) luaL_error(L, ErrMsg::IDXRNG);
+   if (Count > 0) {
+      int64_t last_source = int64_t(SrcIdx) + (int64_t(Count) - 1) * int64_t(SrcStride);
+      if (SrcIdx >= Src->len or SrcStride IS 0 or last_source < 0 or last_source >= int64_t(Src->len)) {
+         luaL_error(L, ErrMsg::IDXRNG);
+      }
+   }
+   if (Dest->is_readonly()) luaL_error(L, ErrMsg::ARRRO);
+   if (not (Dest->elemtype IS Src->elemtype) or not array_copy_identity_compatible(Dest, Src)) {
+      luaL_error(L, ErrMsg::ARRTYPE);
+   }
+
+   lj_assertL(Dest != Src, "fresh array copy source and destination must differ");
+   lj_assertL(not Dest->is_external(), "fresh array copy destination must own its storage");
+   lj_assertL((Dest->marked & LJ_GC_WHITES) IS curwhite(G(L)),
+      "fresh array copy destination must be current-white");
+
+   if (Count IS 0) return;
+
+   if (SrcStride IS 1) {
+      void *dst_ptr = lj_array_index(Dest, DstIdx);
+      const void *src_ptr = lj_array_index(Src, SrcIdx);
+      if (Dest->elemtype IS AET::ANY) {
+         lj_bulk_move_tvalue((TValue *)dst_ptr, (const TValue *)src_ptr, Count);
+      }
+      else {
+         std::memmove(dst_ptr, src_ptr, size_t(Count) * Dest->elemsize);
+      }
+   }
+   else if (Dest->elemtype IS AET::ANY) {
+      auto dst_slots = &Dest->get<TValue>()[DstIdx];
+      auto src_slot = &Src->get<TValue>()[SrcIdx];
+      for (MSize i = 0; i < Count; i++) {
+         copyTV(L, &dst_slots[i], src_slot);
+         if (i + 1 < Count) src_slot += SrcStride;
+      }
+   }
+   else if (array_is_gc_ref_type(Dest->elemtype)) {
+      auto dst_refs = &Dest->get<GCRef>()[DstIdx];
+      auto src_ref = &Src->get<GCRef>()[SrcIdx];
+      for (MSize i = 0; i < Count; i++) {
+         setgcrefr(dst_refs[i], *src_ref);
+         if (i + 1 < Count) src_ref += SrcStride;
+      }
+   }
+   else {
+      auto dst_ptr = (uint8_t *)lj_array_index(Dest, DstIdx);
+      auto src_ptr = (const uint8_t *)lj_array_index(Src, SrcIdx);
+      ptrdiff_t src_byte_stride = ptrdiff_t(SrcStride) * Src->elemsize;
+      for (MSize i = 0; i < Count; i++) {
+         std::memcpy(dst_ptr, src_ptr, Dest->elemsize);
+         dst_ptr += Dest->elemsize;
+         if (i + 1 < Count) src_ptr += src_byte_stride;
+      }
+   }
+}
+
 void lj_array_copy(lua_State *L, GCarray *Dest, uint32_t DstIdx, GCarray *Src, uint32_t SrcIdx, uint32_t Count)
 {
    if (SrcIdx > Src->len or Count > Src->len - SrcIdx or DstIdx > Dest->len or Count > Dest->len - DstIdx) {

--- a/src/tiri/jit/src/runtime/lj_array.h
+++ b/src/tiri/jit/src/runtime/lj_array.h
@@ -30,6 +30,10 @@ extern void lj_array_copy_unchecked(lua_State *, GCarray *, uint32_t DstIdx, con
 // Copies a non-overlapping source sequence after the caller has validated bounds, mutability, storage and identity.
 extern void lj_array_copy_strided_unchecked(lua_State *, GCarray *, uint32_t DstIdx, const GCarray *,
    uint32_t SrcIdx, int32_t SrcStride, uint32_t Count);
+// Copies into an owned array that was just allocated and has not escaped.  The destination must remain current-white
+// and no allocation, callback, error transition or GC step may occur after validation and before this function returns.
+extern void lj_array_copy_to_fresh(lua_State *, GCarray *, uint32_t DstIdx, const GCarray *, uint32_t SrcIdx,
+   int32_t SrcStride, uint32_t Count);
 extern GCtab* lj_array_to_table(lua_State *, GCarray *);
 extern bool lj_array_grow(lua_State *, GCarray *, MSize MinCapacity);
 

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -357,6 +357,52 @@ static bool test_array_strided_copy(kt::Log &Log)
 
 //********************************************************************************************************************
 
+static bool test_array_fresh_copy(kt::Log &Log)
+{
+   LuaStateHolder holder;
+   lua_State *lua = holder.get();
+   if (not lua) return false;
+
+   GCarray *strings = lj_array_new(lua, 6, AET::STR_GC);
+   setarrayV(lua, lua->top++, strings);
+   for (MSize i = 0; i < strings->len; i++) {
+      std::string value = std::to_string(i);
+      GCstr *string = lj_str_new(lua, value.data(), value.size());
+      setgcref(strings->get<GCRef>()[i], obj2gco(string));
+      lj_gc_objbarrier(lua, strings, string);
+   }
+
+   GCarray *contiguous = lj_array_new_like(lua, strings, 3);
+   lj_array_copy_to_fresh(lua, contiguous, 0, strings, 1, 1, 3);
+   setarrayV(lua, lua->top++, contiguous);
+   GCarray *descending = lj_array_new_like(lua, strings, 3);
+   lj_array_copy_to_fresh(lua, descending, 0, strings, 5, -2, 3);
+   setarrayV(lua, lua->top++, descending);
+   GCarray *empty = lj_array_new_like(lua, strings, 0);
+   lj_array_copy_to_fresh(lua, empty, 0, strings, strings->len, 1, 0);
+   setarrayV(lua, lua->top++, empty);
+
+   lj_gc_fullgc(lua);
+   const char contiguous_expected[] = { '1', '2', '3' };
+   const char descending_expected[] = { '5', '3', '1' };
+   for (MSize i = 0; i < 3; i++) {
+      GCstr *contiguous_string = strref(contiguous->get<GCRef>()[i]);
+      GCstr *descending_string = strref(descending->get<GCRef>()[i]);
+      if (contiguous_string->len != 1 or strdata(contiguous_string)[0] != contiguous_expected[i] or
+          descending_string->len != 1 or strdata(descending_string)[0] != descending_expected[i]) {
+         Log.error("a barrier-free fresh array copy lost a string reference at slot %d", int(i));
+         return false;
+      }
+   }
+   if (empty->len != 0) {
+      Log.error("an empty fresh array copy changed the destination length");
+      return false;
+   }
+   return true;
+}
+
+//********************************************************************************************************************
+
 static bool test_unsigned_array_types(kt::Log &Log)
 {
    LuaStateHolder holder;
@@ -1957,12 +2003,13 @@ static bool test_lib_array_double_type(kt::Log &Log)
 
 void array_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 42> Tests = { {
+   constexpr std::array<TestCase, 43> Tests = { {
       // Core Data Structures
       { "array_creation_byte", test_array_creation_byte },
       { "array_creation_int32", test_array_creation_int32 },
       { "array_recursive_identity", test_array_recursive_identity },
       { "array_strided_copy", test_array_strided_copy },
+      { "array_fresh_copy", test_array_fresh_copy },
       { "unsigned_array_types", test_unsigned_array_types },
       { "struct_pointer_array_sentinel", test_struct_pointer_array_sentinel },
       { "struct_to_table_string_vector", test_struct_to_table_string_vector },

--- a/src/tiri/tests/test_array_manip.tiri
+++ b/src/tiri/tests/test_array_manip.tiri
@@ -1568,14 +1568,33 @@ end
    local nested_value = array<int> { 23 }
    local table_value = { answer=42 }
    local references = array<any> { 'text', 0, object_value, 0, table_value, 0, nested_value }
+   local contiguous_reference_slice = references.slice({0 into 6})
    local reference_slice = references.slice({0 into 6 by 2})
    object_value = nil
    nested_value = nil
    table_value = nil
    references = nil
+   processing.collect('step', { stepSize=100 })
    processing.collect('full')
+   assert(contiguous_reference_slice[0] is 'text' and rawtype(contiguous_reference_slice[2]) is 'obj<Time>' and
+      contiguous_reference_slice[4].answer is 42 and contiguous_reference_slice[6][0] is 23,
+      'a contiguous any slice lost references after collection')
    assert(reference_slice[0] is 'text', 'a strided any slice lost a string after collection')
    assert(rawtype(reference_slice[1]) is 'obj<Time>', 'a strided any slice lost an object after collection')
    assert(reference_slice[2].answer is 42, 'a strided any slice lost a table after collection')
    assert(reference_slice[3][0] is 23, 'a strided any slice lost a nested array after collection')
+
+   local large_source = array<table, 1024>
+   for i in {0 to 1024} do large_source[i] = { index=i, label=f'entry-{i}' } end
+   local large_contiguous = large_source.slice({128 to 896})
+   local large_reverse = large_source.slice({1023 into 1 by -2})
+   large_source = nil
+   processing.collect('step', { stepSize=100 })
+   assert(large_contiguous[0].index is 128 and large_contiguous[767].label is 'entry-895',
+      'a large contiguous table slice lost references after incremental collection')
+   assert(large_reverse[0].index is 1023 and large_reverse[511].label is 'entry-1',
+      'a large reverse table slice lost references after incremental collection')
+   processing.collect('full')
+   assert(large_contiguous[384].index is 512 and large_reverse[256].index is 511,
+      'large fresh array copies lost references after full collection')
 end


### PR DESCRIPTION
* Added a validated barrier-free copy path for newly allocated arrays
* Protected contiguous and strided reference slices across collection
* Added runtime and Tiri coverage for fresh array copies