### PR TITLE
[Tiri] Switched modulo to truncating remainder semantics

### DIFF
--- a/examples/gamepad.tiri
+++ b/examples/gamepad.tiri
@@ -235,7 +235,7 @@ end
       end
 
       ball_spin = ball_vx * ROTATION_SPEED_SCALE
-      ball_angle = math.fmod(ball_angle + (ball_spin * dt), 360)
+      ball_angle = (ball_angle + (ball_spin * dt)) % 360
 
       pivot_x = ballVP.width * squash_pivot_x
       pivot_y = ballVP.height * squash_pivot_y

--- a/scripts/tempus.tiri
+++ b/scripts/tempus.tiri
@@ -1770,7 +1770,9 @@ end
 ]])
 function tempus.mtLocalDate.dayOfWeek(Self):num
    fields = tempus._fields(Self, 'LocalDate')
-   return ((days_from_civil(fields.year, fields.month, fields.day) + 3) % 7) + 1
+   day_index = (days_from_civil(fields.year, fields.month, fields.day) + 3) % 7
+   if day_index < 0 then day_index += 7 end
+   return day_index + 1
 end
 
 @Doc(text=[[

--- a/scripts/vfx.tiri
+++ b/scripts/vfx.tiri
@@ -375,7 +375,7 @@ vfx.shake = function(Viewport:obj!, Options:table)
          end
 
          cycle = (state.seconds / SHAKES) * 1000000
-         angle = (math.fmod(CurrentTime - state.time, cycle) / cycle) * MAX_ANGLE
+         angle = ((CurrentTime - state.time) % cycle / cycle) * MAX_ANGLE
 
          if angle < QRT_ANGLE then -- (45)
             angle = angle

--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -52,9 +52,10 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // Version 0x96 adds BC_ISIN and BC_ISNIN. Version 0x97 adds rawtype and shifts the generated fast-function ordering.
 // Version 0x98 adds forEach and shifts the generated fast-function ordering.  Version 0x99 adds the Stage A array
 // and range collection compatibility callables. Version 0x9a adds BC_CHECKALLENTER and BC_CHECKALLLEAVE. Version 0x9b
-// adds BC_DEFERARM and BC_DEFERCONSUME. Older chunks are rejected rather than retaining compatibility shims.
+// adds BC_DEFERARM and BC_DEFERCONSUME. Version 0x9c removes math.fmod from the generated fast-function ordering.
+// Older chunks are rejected rather than retaining compatibility shims.
 
-constexpr uint8_t BCDUMP_VERSION = 0x9b;
+constexpr uint8_t BCDUMP_VERSION = 0x9c;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/debug/lj_ff.h
+++ b/src/tiri/jit/src/debug/lj_ff.h
@@ -66,7 +66,7 @@ static_assert(FF__MAX <= BUILTIN_CALLABLE_CAPACITY);
 static_assert(FF__MAX - 1 <= (std::numeric_limits<uint16_t>::max)());
 static_assert(builtin_callable_index(BuiltinCallableID::Invalid) >= FF__MAX);
 #ifdef FFDEF_BFUNC_ABI
-static_assert(builtin_callable_abi_fingerprint() IS 0x2a847e2d708bf847ull,
+static_assert(builtin_callable_abi_fingerprint() IS 0x221cb86f8362f2e6ull,
    "fast-function ordering changed: bump BCDUMP_VERSION and update the BC_BFUNC ABI fingerprint");
 #endif
 

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -1576,7 +1576,6 @@ static void build_subroutines(BuildCtx *ctx)
   |  math_extern tanh
   |  math_extern2 pow, lj_vm_pow
   |  math_extern2 atan2
-  |  math_extern2 fmod
   |
   |.ffunc_2 math_ldexp
   |  ldr FARG1, [BASE]
@@ -2223,20 +2222,8 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |  // int lj_vm_modi(int dividend, int divisor);
   |->vm_modi:
-  |    eor CARG4w, CARG1w, CARG2w
-  |    cmp CARG4w, #0
-  |  eor CARG3w, CARG1w, CARG1w, asr #31
-  |   eor CARG4w, CARG2w, CARG2w, asr #31
-  |  sub CARG3w, CARG3w, CARG1w, asr #31
-  |   sub CARG4w, CARG4w, CARG2w, asr #31
-  |  udiv CARG1w, CARG3w, CARG4w
-  |  msub CARG1w, CARG1w, CARG4w, CARG3w
-  |    ccmp CARG1w, #0, #4, mi
-  |    sub CARG3w, CARG1w, CARG4w
-  |    csel CARG1w, CARG1w, CARG3w, eq
-  |  eor CARG3w, CARG1w, CARG2w
-  |  cmp CARG3w, #0
-  |  cneg CARG1w, CARG1w, mi
+  |  sdiv CARG3w, CARG1w, CARG2w
+  |  msub CARG1w, CARG3w, CARG2w, CARG1w
   |  ret
   |
   |//-----------------------------------------------------------------------
@@ -2956,9 +2943,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |.endmacro
     |
     |.macro ins_arithmod, res, reg1, reg2
-    |  fdiv d2, reg1, reg2
-    |  frintm d2, d2
-    |  fmsub res, d2, reg2, reg1
+    |  bl extern fmod
     |.endmacro
     |
     |.macro ins_arithdn, intins, fpins

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -2262,7 +2262,6 @@ static void build_subroutines(BuildCtx *ctx)
   |  math_extern tanh
   |  math_extern2 pow, lj_vm_pow
   |  math_extern2 atan2
-  |  math_extern2 fmod
   |
   |.if DUALNUM
   |.ffunc math_ldexp
@@ -3250,17 +3249,8 @@ static void build_subroutines(BuildCtx *ctx)
   |->vm_modi:
   |  divwo. TMP0, CARG1, CARG2
   |  bso >1
-  |.if GPR64
-  |   xor CARG3, CARG1, CARG2
-  |   cmpwi CARG3, 0
-  |.else
-  |   xor. CARG3, CARG1, CARG2
-  |.endif
   |  mullw TMP0, TMP0, CARG2
   |  sub CARG1, CARG1, TMP0
-  |   bgelr
-  |  cmpwi CARG1, 0; beqlr
-  |  add CARG1, CARG1, CARG2
   |  blr
   |1:
   |  cmpwi CARG2, 0
@@ -4255,29 +4245,15 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |
     |.macro fpmod, a, b, c
     |->BC_MODVN_Z:
-    |  fdiv FARG1, b, c
-    |  // NYI: Use internal implementation of floor.
-    |  blex floor			// floor(b/c)
-    |  fmul a, FARG1, c
-    |  fsub a, b, a			// b - floor(b/c)*c
+    |  fmr FARG1, b
+    |  fmr FARG2, c
+    |  blex fmod
+    |  fmr a, FARG1
     |.endmacro
     |
     |.macro sfpmod
     |->BC_MODVN_Z:
-    |  stw CARG1, SFSAVE_1
-    |  stw CARG2, SFSAVE_2
-    |  mr SAVE0, CARG3
-    |  mr SAVE1, CARG4
-    |  blex __divdf3
-    |  blex floor
-    |  mr CARG3, SAVE0
-    |  mr CARG4, SAVE1
-    |  blex __muldf3
-    |  mr CARG3, CRET1
-    |  mr CARG4, CRET2
-    |  lwz CARG1, SFSAVE_1
-    |  lwz CARG2, SFSAVE_2
-    |  blex __subdf3
+    |  blex fmod
     |.endmacro
     |
     |.macro ins_arithfp, fpins

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -1950,7 +1950,6 @@ static void build_subroutines(BuildCtx *ctx)
   |  math_extern tanh
   |  math_extern2 pow, lj_vm_pow
   |  math_extern2 atan2
-  |  math_extern2 fmod
   |
   |.ffunc_2 math_ldexp
   |  checknumtp [BASE], ->fff_fallback
@@ -2741,36 +2740,6 @@ static void build_subroutines(BuildCtx *ctx)
   |  vm_round vm_floor, 0, 1
   |  vm_round vm_ceil,  1, JIT
   |  vm_round vm_trunc, 2, JIT
-  |
-  |// FP modulo x%y. Called by BC_MOD* and vm_arith.
-  |->vm_mod:
-  |// Args in xmm0/xmm1, return value in xmm0.
-  |// Caveat: xmm0-xmm5 and RC (eax) modified!
-  |  movaps xmm5, xmm0
-  |  divsd xmm0, xmm1
-  |  sseconst_abs xmm2, RD
-  |  sseconst_2p52 xmm3, RD
-  |  movaps xmm4, xmm0
-  |  andpd xmm4, xmm2         // |x/y|
-  |  ucomisd xmm3, xmm4       // No truncation if 2^52 <= |x/y|.
-  |  jbe >1
-  |  andnpd xmm2, xmm0        // Isolate sign bit.
-  |  addsd xmm4, xmm3         // (|x/y| + 2^52) - 2^52
-  |  subsd xmm4, xmm3
-  |  orpd xmm4, xmm2       // Merge sign bit back in.
-  |  sseconst_1 xmm2, RD
-  |  cmpsd xmm0, xmm4, 1      // x/y < result?
-  |  andpd xmm0, xmm2
-  |  subsd xmm4, xmm0         // If yes, subtract 1.0.
-  |  movaps xmm0, xmm5
-  |  mulsd xmm1, xmm4
-  |  subsd xmm0, xmm1
-  |  ret
-  |1:
-  |  mulsd xmm1, xmm0
-  |  movaps xmm0, xmm5
-  |  subsd xmm0, xmm1
-  |  ret
   |
   |//-----------------------------------------------------------------------
   |//-- Miscellaneous functions --------------------------------------------
@@ -3690,7 +3659,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
   case BC_MODVN:
     |  ins_arithpre movsd, xmm1
     |->BC_MODVN_Z:
-    |  call ->vm_mod
+    |  mov RB, BASE
+    |  call extern fmod
+    |  mov BASE, RB
+    |  movzx RAd, PC_RA
     |  ins_arithpost
     |  ins_next
     break;

--- a/src/tiri/jit/src/lib/lib_math.cpp
+++ b/src/tiri/jit/src/lib/lib_math.cpp
@@ -71,7 +71,6 @@ LJLIB_ASM(math_atan2)      LJLIB_REC(.)
    return FFH_RETRY;
 }
 LJLIB_ASM_(math_pow)      LJLIB_REC(.)
-LJLIB_ASM_(math_fmod)
 
 LJLIB_ASM(math_ldexp)      LJLIB_REC(.)
 {
@@ -272,7 +271,6 @@ extern int luaopen_math(lua_State* L)
    reg_iface_prototype("math", "log", { TiriType::Num }, { TiriType::Num, TiriType::Num });
    reg_iface_prototype("math", "atan2", { TiriType::Num }, { TiriType::Num, TiriType::Num });
    reg_iface_prototype("math", "pow", { TiriType::Num }, { TiriType::Num, TiriType::Num });
-   reg_iface_prototype("math", "fmod", { TiriType::Num }, { TiriType::Num, TiriType::Num });
    reg_iface_prototype("math", "ldexp", { TiriType::Num }, { TiriType::Num, TiriType::Num });
    reg_iface_prototype("math", "min", { TiriType::Num }, { TiriType::Num }, FProtoFlags::Variadic);
    reg_iface_prototype("math", "max", { TiriType::Num }, { TiriType::Num }, FProtoFlags::Variadic);

--- a/src/tiri/jit/src/lj_dispatch.h
+++ b/src/tiri/jit/src/lj_dispatch.h
@@ -20,7 +20,7 @@ constexpr int HOTCOUNT_LOOP = 2;
 constexpr int HOTCOUNT_CALL = 1;
 
 // This solves a circular dependency problem -- bump as needed. Sigh.
-constexpr int GG_NUM_ASMFF = 56;
+constexpr int GG_NUM_ASMFF = 55;
 
 constexpr int GG_LEN_DDISP = (BC__MAX + GG_NUM_ASMFF);
 constexpr int GG_LEN_SDISP = BC__MAX;

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -175,6 +175,7 @@ typedef struct CCallInfo {
   _(ANY,    cmath_sinh,            1,   N, NUM, XA_FP) \
   _(ANY,    cmath_cosh,            1,   N, NUM, XA_FP) \
   _(ANY,    cmath_tanh,            1,   N, NUM, XA_FP) \
+  _(ANY,    cmath_fmod,            2,   N, NUM, XA2_FP) \
   _(ANY,    fputc,                 2,   S, INT, 0) \
   _(ANY,    fwrite,                4,   S, INT, 0) \
   _(ANY,    fflush,                1,   S, INT, 0) \

--- a/src/tiri/jit/src/lj_opt_fold.cpp
+++ b/src/tiri/jit/src/lj_opt_fold.cpp
@@ -216,6 +216,7 @@ LJFOLDF(kfold_fpcall1)
 }
 
 LJFOLD(CALLN CARG IRCALL_cmath_atan2)
+LJFOLD(CALLN CARG IRCALL_cmath_fmod)
 LJFOLDF(kfold_fpcall2)
 {
    if (irref_isk(fleft->op1) and irref_isk(fleft->op2)) {

--- a/src/tiri/jit/src/lj_opt_narrow.cpp
+++ b/src/tiri/jit/src/lj_opt_narrow.cpp
@@ -13,6 +13,7 @@
 
 #include "lj_bc.h"
 #include "lj_ir.h"
+#include "lj_ircall.h"
 #include "lj_jit.h"
 #include "lj_iropt.h"
 #include "lj_trace.h"
@@ -560,10 +561,9 @@ TRef lj_opt_narrow_unm(jit_State* J, TRef rc, TValue* vc)
    return emitir(IRTN(IR_NEG), rc, lj_ir_ksimd(J, LJ_KSIMD_NEG));
 }
 
-// Narrowing of modulo operator.
+// Narrowing of remainder operator.
 TRef lj_opt_narrow_mod(jit_State* J, TRef rb, TRef rc, TValue* vb, TValue* vc)
 {
-   TRef tmp;
    rb = conv_str_tonum(J, rb, vb);
    rc = conv_str_tonum(J, rc, vc);
    if ((LJ_DUALNUM or (J->flags & JIT_F_OPT_NARROW)) &&
@@ -572,13 +572,10 @@ TRef lj_opt_narrow_mod(jit_State* J, TRef rb, TRef rc, TValue* vb, TValue* vc)
       emitir(IRTGI(IR_NE), rc, lj_ir_kint(J, 0));
       return emitir(IRTI(IR_MOD), rb, rc);
    }
-   // b % c ==> b - floor(b/c)*c
+   // Floating-point remainder follows fmod(): b - trunc(b/c)*c, with the sign of b.
    rb = lj_ir_tonum(J, rb);
    rc = lj_ir_tonum(J, rc);
-   tmp = emitir(IRTN(IR_DIV), rb, rc);
-   tmp = emitir(IRTN(IR_FPMATH), tmp, IRFPM_FLOOR);
-   tmp = emitir(IRTN(IR_MUL), tmp, rc);
-   return emitir(IRTN(IR_SUB), rb, tmp);
+   return lj_ir_call(J, IRCALL_cmath_fmod, rb, rc);
 }
 
 // Narrowing of power operator or math.pow.

--- a/src/tiri/jit/src/runtime/lj_cmath.cpp
+++ b/src/tiri/jit/src/runtime/lj_cmath.cpp
@@ -20,6 +20,7 @@ extern "C" {
    double cmath_sinh(double x) { return sinh(x); }
    double cmath_cosh(double x) { return cosh(x); }
    double cmath_tanh(double x) { return tanh(x); }
+   double cmath_fmod(double x, double y) { return fmod(x, y); }
    double cmath_sqrt(double x) { return sqrt(x); }
    double cmath_log(double x) { return log(x); }
    double cmath_log2(double x) { return log2(x); }

--- a/src/tiri/jit/src/runtime/lj_vm.h
+++ b/src/tiri/jit/src/runtime/lj_vm.h
@@ -78,6 +78,7 @@ LJ_ASMF double cmath_atan(double);
 LJ_ASMF double cmath_sinh(double);
 LJ_ASMF double cmath_cosh(double);
 LJ_ASMF double cmath_tanh(double);
+LJ_ASMF double cmath_fmod(double, double);
 LJ_ASMF double cmath_sqrt(double);
 LJ_ASMF double cmath_log(double);
 LJ_ASMF double cmath_log2(double);

--- a/src/tiri/jit/src/runtime/lj_vmmath.cpp
+++ b/src/tiri/jit/src/runtime/lj_vmmath.cpp
@@ -85,7 +85,7 @@ double lj_vm_foldarith(double x, double y, int op)
    case IR_SUB - IR_ADD: return x - y; break;
    case IR_MUL - IR_ADD: return x * y; break;
    case IR_DIV - IR_ADD: return x / y; break;
-   case IR_MOD - IR_ADD: return x - lj_vm_floor(x / y) * y; break;
+   case IR_MOD - IR_ADD: return fmod(x, y); break;
    case IR_POW - IR_ADD: return lj_vm_pow(x, y); break;
    case IR_NEG - IR_ADD: return -x; break;
    case IR_ABS - IR_ADD: return fabs(x); break;
@@ -105,13 +105,11 @@ int32_t lj_vm_modi(int32_t a, int32_t b)
 {
    uint32_t y, ua, ub;
    // This must be checked before using this function.
-   lj_assertX(b != 0, "modulo with zero divisor");
-   ua = a < 0 ? (uint32_t)-a : (uint32_t)a;
-   ub = b < 0 ? (uint32_t)-b : (uint32_t)b;
+   lj_assertX(b != 0, "remainder with zero divisor");
+   ua = a < 0 ? 0u - uint32_t(a) : uint32_t(a);
+   ub = b < 0 ? 0u - uint32_t(b) : uint32_t(b);
    y = ua % ub;
-   if (y != 0 and (a ^ b) < 0) y = y - ub;
-   if (((int32_t)y ^ b) < 0) y = (uint32_t)-(int32_t)y;
-   return (int32_t)y;
+   return a < 0 ? -int32_t(y) : int32_t(y);
 }
 #endif
 

--- a/src/tiri/jit/src/runtime/unit_test_vm_asm.cpp
+++ b/src/tiri/jit/src/runtime/unit_test_vm_asm.cpp
@@ -763,7 +763,7 @@ static bool test_trunc_register_preservation(kt::Log& Log)
 #endif // LJ_HASJIT
 
 //********************************************************************************************************************
-// lj_vm_modi tests (integer modulo with Lua semantics)
+// lj_vm_modi tests (integer remainder with truncation towards zero)
 
 #if LJ_HASJIT && !(LJ_TARGET_ARM || LJ_TARGET_ARM64 || LJ_TARGET_PPC)
 
@@ -783,10 +783,9 @@ static bool test_modi_positive_positive(kt::Log& Log)
 
 static bool test_modi_negative_positive(kt::Log& Log)
 {
-   // Lua modulo: result has same sign as divisor
    int32_t a = -17;
    int32_t b = 5;
-   int32_t expected = 3;  // -17 % 5 = 3 in Lua (not -2 as in C)
+   int32_t expected = -2;
    int32_t result = lj_vm_modi(a, b);
 
    if (result != expected) {
@@ -798,10 +797,9 @@ static bool test_modi_negative_positive(kt::Log& Log)
 
 static bool test_modi_positive_negative(kt::Log& Log)
 {
-   // Lua modulo: result has same sign as divisor
    int32_t a = 17;
    int32_t b = -5;
-   int32_t expected = -3;  // 17 % -5 = -3 in Lua (not 2 as in C)
+   int32_t expected = 2;
    int32_t result = lj_vm_modi(a, b);
 
    if (result != expected) {
@@ -844,6 +842,34 @@ static bool test_modi_exact_divisor(kt::Log& Log)
    int32_t a = 15;
    int32_t b = 5;
    int32_t expected = 0;
+   int32_t result = lj_vm_modi(a, b);
+
+   if (result != expected) {
+      Log.error("modi(%d, %d) = %d, expected %d", a, b, result, expected);
+      return false;
+   }
+   return true;
+}
+
+static bool test_modi_minimum_over_negative_one(kt::Log& Log)
+{
+   int32_t a = (std::numeric_limits<int32_t>::min)();
+   int32_t b = -1;
+   int32_t expected = 0;
+   int32_t result = lj_vm_modi(a, b);
+
+   if (result != expected) {
+      Log.error("modi(%d, %d) = %d, expected %d", a, b, result, expected);
+      return false;
+   }
+   return true;
+}
+
+static bool test_modi_minimum_over_positive(kt::Log& Log)
+{
+   int32_t a = (std::numeric_limits<int32_t>::min)();
+   int32_t b = 3;
+   int32_t expected = -2;
    int32_t result = lj_vm_modi(a, b);
 
    if (result != expected) {
@@ -1730,13 +1756,15 @@ extern void vm_asm_unit_tests(int &Passed, int &Total)
 
 #if !(LJ_TARGET_ARM || LJ_TARGET_ARM64 || LJ_TARGET_PPC)
    // lj_vm_modi tests (separate array due to conditional compilation)
-   constexpr std::array<TestCase, 6> ModiTests = { {
+   constexpr std::array<TestCase, 8> ModiTests = { {
       { "modi_positive_positive", test_modi_positive_positive },
       { "modi_negative_positive", test_modi_negative_positive },
       { "modi_positive_negative", test_modi_positive_negative },
       { "modi_negative_negative", test_modi_negative_negative },
       { "modi_zero_dividend", test_modi_zero_dividend },
       { "modi_exact_divisor", test_modi_exact_divisor },
+      { "modi_minimum_over_negative_one", test_modi_minimum_over_negative_one },
+      { "modi_minimum_over_positive", test_modi_minimum_over_positive },
    } };
 
    for (const TestCase& Test : ModiTests) {

--- a/src/tiri/tests/test_numeric_limits.tiri
+++ b/src/tiri/tests/test_numeric_limits.tiri
@@ -5,6 +5,10 @@
 @BeforeEach(hotpath=true)
 function enforce_hotpath() end
 
+function dynamic_remainder(Dividend:num, Divisor:num):num
+   return Dividend % Divisor
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- IEEE 754 special values: NaN
 
@@ -219,22 +223,37 @@ end
 -- Modulo and remainder edge cases
 
 @Test function ModuloWithNegativeOperands()
-   -- Tiri/Lua % follows the sign of the divisor (Euclidean-style)
+   -- Tiri % is a truncating remainder, so a non-zero result follows the sign of the dividend.
    assert(7 % 3 is 1, '7 % 3 should be 1')
-   assert(-7 % 3 is 2, '-7 % 3 should be 2 (sign of divisor)')
-   assert(7 % -3 is -2, '7 % -3 should be -2 (sign of divisor)')
-   assert(-7 % -3 is -1, '-7 % -3 should be -1 (sign of divisor)')
+   assert(-7 % 3 is -1, '-7 % 3 should be -1 (sign of dividend)')
+   assert(7 % -3 is 1, '7 % -3 should be 1 (sign of dividend)')
+   assert(-7 % -3 is -1, '-7 % -3 should be -1 (sign of dividend)')
+   assert(dynamic_remainder(-17, 5) is -2, 'Runtime integer remainder should retain the dividend sign')
+   assert(dynamic_remainder(17, -5) is 2, 'Runtime integer remainder should ignore the divisor sign')
+   assert(dynamic_remainder(-2147483648, -1) is 0, 'Minimum int remainder by -1 should avoid overflow')
+   assert(dynamic_remainder(-2147483648, 3) is -2, 'Minimum int remainder should retain the dividend sign')
 end
 
 @Test function ModuloWithFloats()
-   result = 5.5 % 2.0
-   assert(math.abs(result - 1.5) < 1e-15, '5.5 % 2.0 should be 1.5')
+   assert(math.abs((5.5 % 2.0) - 1.5) < 1e-15, '5.5 % 2.0 should be 1.5')
+   assert(math.abs((-5.5 % 2.0) - -1.5) < 1e-15, '-5.5 % 2.0 should be -1.5')
+   assert(math.abs((5.5 % -2.0) - 1.5) < 1e-15, '5.5 % -2.0 should be 1.5')
+   assert(math.abs(dynamic_remainder(-5.5, 2.0) - -1.5) < 1e-15,
+      'Runtime floating-point remainder should retain the dividend sign')
+
+   negative_zero = dynamic_remainder(-4.5, 1.5)
+   assert(negative_zero is 0 and 1 / negative_zero is -math.huge,
+      'An exact negative floating-point remainder should preserve negative zero')
 end
 
-@Test function FmodConsistency()
-   -- fmod should match % behaviour for positive values
-   assert(math.fmod(7, 3) is 7 % 3, 'fmod(7,3) should match 7 % 3')
-   assert(math.fmod(5.5, 2.0) is 5.5 % 2.0, 'fmod(5.5, 2.0) should match 5.5 % 2.0')
+@Test function CompoundRemainderUsesTruncation()
+   value = -17
+   value %= 5
+   assert(value is -2, 'value %= 5 should retain the dividend sign')
+end
+
+@Test function FmodIsRemoved()
+   assert(math.fmod is nil, 'math.fmod() should not remain available after % adopts truncating remainder semantics')
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -444,8 +463,8 @@ end
    expect_string_arithmetic_error(function() return 3 + text end, 'Number plus string')
    expect_string_arithmetic_error(function() return text + 3 end, 'String plus number')
    expect_string_arithmetic_error(function() return text + other_text end, 'String plus string')
-   expect_string_arithmetic_error(function() return text % 3 end, 'String modulo number')
-   expect_string_arithmetic_error(function() return 3 % text end, 'Number modulo string')
+   expect_string_arithmetic_error(function() return text % 3 end, 'String remainder number')
+   expect_string_arithmetic_error(function() return 3 % text end, 'Number remainder string')
    expect_string_arithmetic_error(function() return 2 ** text end, 'Number to a string power')
    assert(3 + tonumber('4') is 7, '3 + tonumber("4") should be 7')
 

--- a/src/tiri/tests/test_tempus.tiri
+++ b/src/tiri/tests/test_tempus.tiri
@@ -134,6 +134,8 @@ end
    assert(tempus.localDate(2024, 2, 29).isLeapYear(), '2024 should be a leap year')
    assert(tempus.localDate(2000, 2, 29).daysInYear() is 366, 'Years divisible by 400 should leap')
    assert(tempus.localDate(1970, 1, 1).dayOfWeek() is 4, 'Unix epoch date should be Thursday')
+   assert(tempus.localDate(1969, 12, 28).dayOfWeek() is 7,
+      'Dates before the Unix epoch should retain a positive ISO weekday')
    assert(tempus.localDate(2026, 5, 16) < date, 'LocalDate ordering should compare dates')
    assert(tempus.localDate.parse('2026-05-17') is date, 'LocalDate parse should produce equal values')
 end

--- a/tools/tiri_lsp/include/lsp_parsing.tiri
+++ b/tools/tiri_lsp/include/lsp_parsing.tiri
@@ -1183,7 +1183,7 @@ global function tokenizeTiri(Source:str, ModulePrefixes:table):array<table>
             pos += 2
             col += 2
          else
-            -- % modulo
+            -- % remainder
             addToken(line, op_start, 1, 1, 0)
             pos++
             col++


### PR DESCRIPTION
* Applied dividend-signed remainder behaviour across interpreter, JIT, constant folding and compound assignment
* Removed math.fmod and advanced the bytecode ABI for changed fast-function ordering
* Updated dependent scripts and expanded remainder edge-case coverage