### PR TITLE
[Tiri] Enforced explicit assignment value arity

### DIFF
--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -235,6 +235,8 @@ private:
       std::string_view, const SourceSpan &, bool Implicit);
    [[nodiscard]] GCstr *module_function_binding(ModuleDependency &, GCstr *CanonicalFunction);
    [[nodiscard]] StmtNodePtr make_dependency_activation(ModuleDependency &, const SourceSpan &);
+   [[nodiscard]] ParserResult<StmtNodePtr> make_assignment_statement(const Token &, AssignmentOperator,
+      ExprNodeList, ExprNodeList);
    void finalise_module_dependencies();
    void publish_dependency_descriptors();
    void prepend_implicit_dependencies(BlockStmt &);

--- a/src/tiri/jit/src/parser/ast/choose.cpp
+++ b/src/tiri/jit/src/parser/ast/choose.cpp
@@ -387,11 +387,14 @@ ParserResult<ExprNodePtr> AstBuilder::parse_choose_expr()
             return ParserResult<ExprNodePtr>::failure(values.error_ref());
          }
 
-         auto stmt = std::make_unique<StmtNode>(AstNodeKind::AssignmentStmt, op.span());
-         AssignmentStmtPayload payload(assignment_op, std::move(targets), std::move(values.value_ref()));
-         stmt->data = std::move(payload);
+         auto stmt = this->make_assignment_statement(
+            op, assignment_op, std::move(targets), std::move(values.value_ref()));
+         if (not stmt.ok()) {
+            this->in_choose_expression = false;
+            return ParserResult<ExprNodePtr>::failure(stmt.error_ref());
+         }
 
-         case_arm.result_stmt = std::move(stmt);
+         case_arm.result_stmt = std::move(stmt.value_ref());
          case_arm.has_statement_result = true;
       }
       else { // Parse as expression (original behaviour)

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -68,6 +68,25 @@ ParserResult<Token> AstBuilder::consume_ternary_separator()
 }
 
 //********************************************************************************************************************
+// Builds an assignment after enforcing Tiri's explicit value-list arity.  A single trailing call or vararg expression
+// remains free to produce more results than the target list consumes because it occupies only one explicit list entry.
+
+ParserResult<StmtNodePtr> AstBuilder::make_assignment_statement(const Token &Operator, AssignmentOperator Assignment,
+   ExprNodeList Targets, ExprNodeList Values)
+{
+   if (Values.size() > Targets.size()) {
+      const ExprNodePtr &surplus = Values[Targets.size()];
+      Token error_token = surplus ? Token::from_span(surplus->span) : Operator;
+      return this->fail<StmtNodePtr>(ParserErrorCode::InvalidAssignment, error_token,
+         "Assignment has more explicit values than targets; surplus results are only permitted from a trailing "
+         "function call or vararg expression");
+   }
+
+   return ParserResult<StmtNodePtr>::success(
+      make_assignment_stmt(Operator.span(), Assignment, std::move(Targets), std::move(Values)));
+}
+
+//********************************************************************************************************************
 // Parses expression statements, handling assignments, compound assignments, conditional shorthands, and standalone expressions.
 
 ParserResult<StmtNodePtr> AstBuilder::parse_expression_stmt()
@@ -111,10 +130,8 @@ ParserResult<StmtNodePtr> AstBuilder::parse_expression_stmt()
       this->ctx.tokens().advance();
       auto values = this->parse_expression_list();
       if (not values.ok()) return ParserResult<StmtNodePtr>::failure(values.error_ref());
-      auto stmt = std::make_unique<StmtNode>(AstNodeKind::AssignmentStmt, op.span());
-      AssignmentStmtPayload payload(assignment, std::move(targets), std::move(values.value_ref()));
-      stmt->data = std::move(payload);
-      return ParserResult<StmtNodePtr>::success(std::move(stmt));
+      return this->make_assignment_statement(
+         op, assignment, std::move(targets), std::move(values.value_ref()));
    }
 
    // Guard shorthand pattern: value ?! return/break/continue/raise/check

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -156,8 +156,9 @@ ParserResult<StmtNodePtr> AstBuilder::parse_local_name_list(const Token &StartTo
             reference.identifier = std::move(identifier);
             targets.push_back(make_identifier_expr(reference.identifier.span, reference));
          }
-         return ParserResult<StmtNodePtr>::success(
-            make_assignment_stmt(StartToken.span(), assign_op, std::move(targets), std::move(values)));
+         Token assignment_token = Token::from_span(StartToken.span(), TokenKind::Equals);
+         return this->make_assignment_statement(
+            assignment_token, assign_op, std::move(targets), std::move(values));
       }
    }
 

--- a/src/tiri/tests/test_locality.tiri
+++ b/src/tiri/tests/test_locality.tiri
@@ -452,6 +452,20 @@ end
 end
 
 -----------------------------------------------------------------------------------------------------------------------
+-- Surplus function results remain valid even though surplus explicit values are rejected.
+
+@Test(hotpath=true) function MultiReturnSurplusResults()
+   function three_values()
+      return 'first', 'second', 'discarded'
+   end
+
+   first, second = three_values()
+
+   assert(first is 'first', 'first should receive the first function result')
+   assert(second is 'second', 'second should receive the second function result')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
 -- Test multi-return where undeclared target is first, existing local is second
 
 @Test(hotpath=true) function MultiReturnUndeclaredFirst()

--- a/src/tiri/tests/test_malformed_syntax.tiri
+++ b/src/tiri/tests/test_malformed_syntax.tiri
@@ -54,6 +54,24 @@ end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Assignment value-list arity
+
+@Test function ValidateSurplusExplicitAssignmentValues()
+   local result = debug.validate('a, b = 1, 2, 3')
+   assert(result.success is false, 'An assignment with surplus explicit values should fail validation')
+   assert(result.diagnostics[0].code is 'InvalidAssignment',
+      'A surplus explicit value should report InvalidAssignment')
+   assert(result.diagnostics[0].message.find('more explicit values than targets') != nil,
+      'The diagnostic should distinguish explicit values from multi-return results')
+
+   result = debug.validate([[
+      function three():<num, num, num> return 1, 2, 3 end
+      a, b = three()
+   ]])
+   assert(result.success is true, 'Surplus results from a function call should remain valid')
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Removed Lua-style numeric for syntax
 
 @Test function ValidateDeprecatedNumericForDiagnostic()


### PR DESCRIPTION
* Centralised assignment creation and reject surplus explicit values
* Preserved trailing call and vararg multi-return behaviour
* Added parser regression coverage for invalid and valid assignments