### PR TITLE
[Tiri] Zero-initialised mutable string buffers

### DIFF
--- a/src/tiri/jit/src/lib/lib_string.cpp
+++ b/src/tiri/jit/src/lib/lib_string.cpp
@@ -154,12 +154,12 @@ LJLIB_CF(string_rep)      LJLIB_REC(.)
 }
 
 //********************************************************************************************************************
-// string.alloc() is a quicker version of string.rep() for reserving space without filling it.
+// string.alloc() creates a distinct mutable byte buffer whose complete payload is NUL-filled.
 //
 // 1. Takes a size parameter - Uses lj_lib_checkint(L, 1) to get the size from the first argument
 // 2. Validates the size - Checks that size is not negative and throws an error if it is
 // 3. Allocates a mutable GC string buffer outside the normal string interning table.
-// 4. Returns the mutable string with the requested length.
+// 4. Returns the NUL-filled mutable string with the requested length.
 
 LJLIB_CF(string_alloc)
 {

--- a/src/tiri/jit/src/runtime/lj_str.cpp
+++ b/src/tiri/jit/src/runtime/lj_str.cpp
@@ -167,8 +167,8 @@ GCstr * lj_str_newbuf(lua_State *L, MSize len)
    s->reserved = 0;
    s->flags    = STRF_MUTABLE_BUFFER;
 
-   // Clear last 4 bytes of allocated memory. Implies zero-termination, too.
-   *(uint32_t *)(strdatawr(s) + (len & ~MSize(3))) = 0;
+   // Clear the visible payload and the aligned terminator/padding word.  Mutable buffers are readable immediately.
+   memset(strdatawr(s), 0, (len + 4) & ~MSize(3));
    return s;
 }
 

--- a/src/tiri/jit/src/runtime/lj_str.h
+++ b/src/tiri/jit/src/runtime/lj_str.h
@@ -30,7 +30,7 @@ LJ_FUNC void lj_str_resize(lua_State* L, MSize newmask);
 // Intern a string and return the interned string object.
 LJ_FUNCA GCstr* lj_str_new(lua_State* L, const char* str, size_t len);
 
-// Allocate a mutable string buffer outside the interning table.
+// Allocate a distinct, NUL-filled mutable string buffer outside the interning table.
 LJ_FUNCA GCstr* lj_str_newbuf(lua_State* L, MSize len);
 
 // Free a string object (called during GC).

--- a/src/tiri/jit/src/runtime/lj_tab.h
+++ b/src/tiri/jit/src/runtime/lj_tab.h
@@ -53,7 +53,7 @@ inline constexpr uint64_t HASH_MIX64_MUL2 = 0x94d049bb133111ebull;
    return &n[hash & t->hmask];
 }
 
-// String IDs are generated when a string is interned.
+// Every string object has an immutable ID.  Mutable buffers therefore remain stable identity keys as bytes change.
 [[nodiscard]] inline constexpr Node* hashstr(const GCtab* t, const GCstr* s) noexcept
 {
    return hashmask(t, s->sid);

--- a/src/tiri/jit/src/runtime/unit_test_indexing.cpp
+++ b/src/tiri/jit/src/runtime/unit_test_indexing.cpp
@@ -556,6 +556,68 @@ static bool test_table_string_hash_keys_unchanged(kt::Log& Log)
    return true;
 }
 
+static bool test_mutable_string_table_keys_use_identity(kt::Log& Log)
+{
+   LuaStateHolder holder;
+   lua_State *lua = holder.get();
+   if (not lua) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   GCtab *table = lj_tab_new(lua, 0, 1);
+   settabV(lua, lua->top, table);
+   incr_top(lua);
+   GCstr *key = lj_str_newbuf(lua, 4);
+   setstrV(lua, lua->top, key);
+   incr_top(lua);
+   GCstr *equal_buffer = lj_str_newbuf(lua, 4);
+   setstrV(lua, lua->top, equal_buffer);
+   incr_top(lua);
+   memcpy(strdatawr(key), "key1", 4);
+   memcpy(strdatawr(equal_buffer), "key1", 4);
+
+   TValue value;
+   setnumV(&value, 42.0);
+   copyTV(lua, lj_tab_setstr(lua, table, key), &value);
+
+   cTValue *found = lj_tab_getstr(table, key);
+   if (not found or not tvisnum(found) or numV(found) != 42.0) {
+      Log.error("mutable string key did not retrieve its table value");
+      return false;
+   }
+   if (lj_tab_getstr(table, equal_buffer) or lj_tab_getstr(table, lj_str_newlit(lua, "key1"))) {
+      Log.error("equal-content strings unexpectedly matched a mutable identity key");
+      return false;
+   }
+
+   const uint32_t sid = key->sid;
+   memcpy(strdatawr(key), "key2", 4);
+   GCstr *mutated_content = lj_str_newlit(lua, "key2");
+   if (key->sid != sid or key->hash != 0 or lj_str_cmp(key, mutated_content) != 0) {
+      Log.error("mutable string metadata or content comparison changed unexpectedly after mutation");
+      return false;
+   }
+   if (lj_tab_getstr(table, key) != found or lj_tab_getstr(table, mutated_content)) {
+      Log.error("mutable string mutation invalidated identity-key lookup semantics");
+      return false;
+   }
+
+   for (int index = 0; index < 32; index++) {
+      std::string name = "rehash_key_" + std::to_string(index);
+      GCstr *ordinary_key = lj_str_new(lua, name.data(), name.size());
+      setnumV(&value, lua_Number(index));
+      copyTV(lua, lj_tab_setstr(lua, table, ordinary_key), &value);
+   }
+   found = lj_tab_getstr(table, key);
+   if (not found or not tvisnum(found) or numV(found) != 42.0) {
+      Log.error("table rehash invalidated a mutable identity key");
+      return false;
+   }
+
+   return true;
+}
+
 // The permanent non-numeric key classification underpins the Tiri '#' operator returning nil for associative tables.
 
 static bool test_table_flags_initialise_clear(kt::Log& Log)
@@ -787,7 +849,7 @@ static bool test_table_layout_offsets_stable(kt::Log& Log)
 
 extern void indexing_unit_tests(int& Passed, int& Total)
 {
-   constexpr std::array<TestCase, 22> Tests = { {
+   constexpr std::array<TestCase, 23> Tests = { {
       { "array_first_element_access", test_array_first_element_access },
       { "table_length_operator", test_table_length_operator },
       { "ipairs_starting_index", test_ipairs_starting_index },
@@ -804,6 +866,7 @@ extern void indexing_unit_tests(int& Passed, int& Total)
       { "table_numeric_hash_keys_roundtrip", test_table_numeric_hash_keys_roundtrip },
       { "table_gc_hash_keys_roundtrip", test_table_gc_hash_keys_roundtrip },
       { "table_string_hash_keys_unchanged", test_table_string_hash_keys_unchanged },
+      { "mutable_string_table_keys_use_identity", test_mutable_string_table_keys_use_identity },
       { "table_flags_initialise_clear", test_table_flags_initialise_clear },
       { "table_numeric_keys_do_not_classify", test_table_numeric_keys_do_not_classify },
       { "table_non_numeric_keys_classify", test_table_non_numeric_keys_classify },

--- a/src/tiri/jit/src/runtime/unit_tests_allocator.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_allocator.cpp
@@ -4,7 +4,11 @@
 
 #ifdef UNIT_TESTS
 
+#include "lua.h"
+#include "lauxlib.h"
+
 #include "lj_alloc.h"
+#include "lj_str.h"
 #include "lj_prng.h"
 
 #include <array>
@@ -16,6 +20,23 @@ namespace {
 struct TestCase {
    const char* name;
    bool (*fn)(kt::Log &Log);
+};
+
+struct LuaStateHolder {
+   LuaStateHolder()
+   {
+      this->state = luaL_newstate(nullptr);
+   }
+
+   ~LuaStateHolder()
+   {
+      if (this->state) lua_close(this->state);
+   }
+
+   lua_State* get() const { return this->state; }
+
+private:
+   lua_State* state = nullptr;
 };
 
 #ifndef LUAJIT_USE_SYSMALLOC
@@ -127,13 +148,45 @@ static bool test_allocator_realloc_preserves_16_byte_alignment(kt::Log &Log)
 #endif
 }
 
+static bool test_mutable_string_buffers_are_zero_initialised(kt::Log &Log)
+{
+   LuaStateHolder holder;
+   lua_State *lua = holder.get();
+   if (not lua) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   constexpr std::array<MSize, 10> Lengths = { { 0, 1, 2, 3, 4, 5, 7, 8, 9, 4096 } };
+   for (MSize length : Lengths) {
+      GCstr *buffer = lj_str_newbuf(lua, length);
+      if (buffer->len != length or not lj_str_ismutable(buffer)) {
+         Log.error("mutable string allocation of %u bytes has incorrect metadata", (unsigned)length);
+         return false;
+      }
+
+      const MSize storage_size = (length + 4) & ~MSize(3);
+      const uint8_t *data = (const uint8_t *)strdata(buffer);
+      for (MSize index = 0; index < storage_size; index++) {
+         if (data[index] != 0) {
+            Log.error("mutable string allocation of %u bytes contains 0x%02x at storage offset %u",
+               (unsigned)length, (unsigned)data[index], (unsigned)index);
+            return false;
+         }
+      }
+   }
+
+   return true;
+}
+
 } // namespace
 
 extern void allocator_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 2> Tests = { {
+   constexpr std::array<TestCase, 3> Tests = { {
       { "allocator_returns_16_byte_aligned_blocks", test_allocator_returns_16_byte_aligned_blocks },
-      { "allocator_realloc_preserves_16_byte_alignment", test_allocator_realloc_preserves_16_byte_alignment }
+      { "allocator_realloc_preserves_16_byte_alignment", test_allocator_realloc_preserves_16_byte_alignment },
+      { "mutable_string_buffers_are_zero_initialised", test_mutable_string_buffers_are_zero_initialised }
    } };
 
    for (const TestCase& Test : Tests) {

--- a/src/tiri/tests/test_strings.tiri
+++ b/src/tiri/tests/test_strings.tiri
@@ -17,8 +17,17 @@ function expect_nil_string_error(Callback:func, Name:str)
 end
 
 @Test function Alloc()
+   local sizes = array<int> { 0, 1, 2, 3, 4, 5, 7, 8, 9, 1000 }
+   for _, size in sizes do
+      local buffer = string.alloc(size)
+      assert(#buffer is size, f"string.alloc({size}) returned {#buffer} bytes")
+      for index in {0 to size} do
+         assert(buffer.byte(index) is 0,
+            f"string.alloc({size}) byte {index} was not NUL-filled")
+      end
+   end
+
    s = string.alloc(10)
-   assert(#s is 10, "String size is not 10 characters, got " .. #s)
 
    s2 = string.alloc(10)
    assert(not (s is s2), "Same-sized string.alloc() buffers should be distinct objects")
@@ -36,6 +45,24 @@ end
 
    slice = s.sub(#s, #s)
    assert(slice is "", "Slices copied from mutable buffers should be normal interned strings")
+end
+
+@Test function AllocatedBuffersAreIdentityTableKeys()
+   local key = string.alloc(4)
+   local equal_content = string.alloc(4)
+   local values = { [key] = 'buffer' }
+
+   assert(values[key] is 'buffer', 'A mutable buffer should retrieve its own table entry')
+   assert(values[equal_content] is nil,
+      'A distinct mutable buffer with equal content must be a different table key')
+   assert(values['\0\0\0\0'] is nil,
+      'An interned string with equal content must be a different table key')
+
+   local matches = 0
+   for _ in {0 to 100} do
+      if values[key] is 'buffer' then matches++ end
+   end
+   assert(matches is 100, 'Mutable-buffer table lookup must remain stable after JIT warming')
 end
 
 @Test function Index()


### PR DESCRIPTION
* Ensured string.alloc() returns NUL-filled buffers with stable identity table keys
* Added runtime and Flute coverage for buffer initialisation and table lookups