### PR TITLE
[Tiri] Renamed the object state accessor to state

### DIFF
--- a/scripts/gui.tiri
+++ b/scripts/gui.tiri
@@ -618,7 +618,7 @@ gui.getTheme = function(Object:obj):table
       error(f'Provided object class {Object.class()} is unsupported.')
    end
 
-   state = scene._state()
+   state = scene.state()
    themeName = state.theme -- Get pre-defined theme
    if not themeName then -- Theme undefined, apply the default
       state.theme = gui.theme
@@ -648,7 +648,7 @@ gui.setTheme = function(Object:obj, Theme:str!):table
          error(f'Provided object class {Object.class()} is unsupported.')
       end
 
-      state = scene._state()
+      state = scene.state()
    end
 
    if not gui.themes[Theme] then

--- a/scripts/gui/scrollbar.tiri
+++ b/scripts/gui/scrollbar.tiri
@@ -122,7 +122,7 @@ gui.scrollbar = function(Options)
       if Direction is 'V' then
          vp = lTarget.new('VectorViewport', { name='VBarVP', y = 0, xOffset = 0, yOffset = 0, width = lBreadth, overflow = VOF_HIDDEN })
 
-         bar = vp._state()
+         bar = vp.state()
          bar.viewport  = vp
          bar.direction = 'V'
 
@@ -150,7 +150,7 @@ gui.scrollbar = function(Options)
          vp = lTarget.new('VectorViewport', { name='HBarVP', x = 0, xOffset = 0, yOffset = 0, height = lBreadth })
          if self.vbar?.viewport.visibility is VIS_VISIBLE then vp.xOffset = lBreadth end
 
-         bar = vp._state()
+         bar = vp.state()
          bar.viewport  = vp
          bar.direction = 'H'
 

--- a/scripts/net/httpserver.tiri
+++ b/scripts/net/httpserver.tiri
@@ -654,7 +654,7 @@ end
 
 function isHeadRequest(Client):bool
    try
-      state = Client._state()
+      state = Client.state()
       if state?.request?.method is 'HEAD' then return true end
    end
 
@@ -1520,7 +1520,7 @@ end
 
 @Doc(text="Incoming data handler for client sockets.  acRead() is used to read data from the ClientSocket.")
 function serverIncoming(self, ClientSocket)
-   state = ClientSocket._state()
+   state = ClientSocket.state()
 
    if not state.initialised then
       state.buffer            = ''

--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -54,9 +54,9 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // and range collection compatibility callables. Version 0x9a adds BC_CHECKALLENTER and BC_CHECKALLLEAVE. Version 0x9b
 // adds BC_DEFERARM and BC_DEFERCONSUME. Version 0x9c removes math.fmod from the generated fast-function ordering.
 // Version 0x9d removes math.pow from that ordering.  Older chunks are rejected rather than retaining compatibility
-// shims.
+// shims.  Version 0x9e renames the canonical object._state callable to object.state.
 
-constexpr uint8_t BCDUMP_VERSION = 0x9d;
+constexpr uint8_t BCDUMP_VERSION = 0x9e;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/debug/lj_ff.h
+++ b/src/tiri/jit/src/debug/lj_ff.h
@@ -66,7 +66,7 @@ static_assert(FF__MAX <= BUILTIN_CALLABLE_CAPACITY);
 static_assert(FF__MAX - 1 <= (std::numeric_limits<uint16_t>::max)());
 static_assert(builtin_callable_index(BuiltinCallableID::Invalid) >= FF__MAX);
 #ifdef FFDEF_BFUNC_ABI
-static_assert(builtin_callable_abi_fingerprint() IS 0xc82ea51615b9ae33ull,
+static_assert(builtin_callable_abi_fingerprint() IS 0x8ae27c7ef692122eull,
    "fast-function ordering changed: bump BCDUMP_VERSION and update the BC_BFUNC ABI fingerprint");
 #endif
 

--- a/src/tiri/jit/src/lib/lib_object.cpp
+++ b/src/tiri/jit/src/lib/lib_object.cpp
@@ -469,8 +469,10 @@ extern int object_newindex(lua_State *Lua)
 
    // Escaped intrinsic methods must not manufacture bound closures.  Other failed field reads retain the usual
    // NoFieldAccess error, including accesses through an any receiver or a computed key.
-   const std::string_view key(strdata(keystr), keystr->len);
-   if ((key IS "new") or (key IS "_state")) return 0;
+
+   constexpr auto hash_new = kt::strhash("new");
+   constexpr auto hash_state = kt::strhash("state");
+   if ((keystr->hash IS hash_new) or (keystr->hash IS hash_state)) return 0;
 
    luaL_error(Lua, ERR::NoFieldAccess, "Field does not exist or is unreadable: %s.%s",
       def->classptr ? def->classptr->ClassName.c_str() : "?", strdata(keystr));
@@ -691,7 +693,7 @@ ERR push_object_id(lua_State *Lua, OBJECTID ObjectID)
 //********************************************************************************************************************
 // Object instance methods. State is maintained globally, so other object variables reference the same state table.
 
-LJLIB_INTRINSIC LJLIB_CF(object__state)
+LJLIB_INTRINSIC LJLIB_CF(object_state)
 {
    auto def = lj_get_object_fast(L, 1);
 
@@ -1118,7 +1120,7 @@ extern "C" int luaopen_object(lua_State *L)
    reg_intrinsic_method(L, "obj", "new", TiriType::Object, builtin_callable_id(FastFunc::object_new),
       { TiriType::Object }, { TiriType::Object, TiriType::Any, TiriType::Table }, FProtoFlags::None,
       FProtoArity::required(2));
-   reg_intrinsic_method(L, "obj", "_state", TiriType::Object, builtin_callable_id(FastFunc::object__state),
+   reg_intrinsic_method(L, "obj", "state", TiriType::Object, builtin_callable_id(FastFunc::object_state),
       { TiriType::Table }, { TiriType::Object });
    reg_iface_method(L, "obj", "class", TiriType::Object, builtin_callable_id(FastFunc::object_class),
       { TiriType::Object }, { TiriType::Object });

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -6959,7 +6959,7 @@ static bool test_builtin_method_registry(kt::Log &Log)
    const fprototype *struct_clone = get_method_prototype(TiriType::Struct, "clone");
    const fprototype *object_exists = get_method_prototype(TiriType::Object, "exists");
    const fprototype *object_new = get_method_prototype(TiriType::Object, "new");
-   const fprototype *object_state = get_method_prototype(TiriType::Object, "_state");
+   const fprototype *object_state = get_method_prototype(TiriType::Object, "state");
    const fprototype *namespace_new = get_prototype("obj", "new");
    lua_getglobal(L, "obj");
    lua_getfield(L, -1, "new");
@@ -6971,12 +6971,12 @@ static bool test_builtin_method_registry(kt::Log &Log)
        struct_clone->builtin_callable_id != builtin_callable_id(FastFunc::struct_clone) or
        object_exists->builtin_callable_id != builtin_callable_id(FastFunc::object_exists) or
        object_new->builtin_callable_id != builtin_callable_id(FastFunc::object_new) or
-       object_state->builtin_callable_id != builtin_callable_id(FastFunc::object__state) or
+       object_state->builtin_callable_id != builtin_callable_id(FastFunc::object_state) or
        object_new IS namespace_new or object_new->param_count != 3 or
        object_new->param_types()[0] != TiriType::Object or object_new->param_types()[1] != TiriType::Any or
        object_new->param_types()[2] != TiriType::Table or object_state->param_count != 1 or
        object_state->param_types()[0] != TiriType::Object or namespace_new->is_method() or
-       namespace_new->builtin_callable_id != BuiltinCallableID::Invalid or get_prototype("obj", "_state") or
+       namespace_new->builtin_callable_id != BuiltinCallableID::Invalid or get_prototype("obj", "state") or
        public_create != lj_builtin_callable(L, builtin_callable_id(FastFunc::object_create)) or
        array_insert IS table_insert or get_method_prototype(TiriType::Array, "contains") or
        get_method_prototype(TiriType::Range, "contains") or get_method_prototype(TiriType::Str, "contains") or
@@ -7602,21 +7602,21 @@ static bool test_builtin_method_bytecode_emission(kt::Log &Log)
 
    error.clear();
    auto object_methods = compile_snapshot(L,
-      "local parent = obj.new('time')\nlocal child = parent.new('time')\nreturn parent._state()\n", true, error);
+      "local parent = obj.new('time')\nlocal child = parent.new('time')\nreturn parent.state()\n", true, error);
    if (not object_methods or not find_builtin_callable_opcode(*object_methods,
          builtin_callable_id(FastFunc::object_new)) or not find_builtin_callable_opcode(*object_methods,
-         builtin_callable_id(FastFunc::object__state)) or count_opcode(*object_methods, BC_BFUNC) != 2 or
+         builtin_callable_id(FastFunc::object_state)) or count_opcode(*object_methods, BC_BFUNC) != 2 or
        count_opcode(*object_methods, BC_TGETS) != 1 or count_opcode(*object_methods, BC_TGETV) != 0) {
-      Log.error("proved Object new and _state calls did not use canonical lookup-free emission: %s", error.c_str());
+      Log.error("proved Object new and state calls did not use canonical lookup-free emission: %s", error.c_str());
       return false;
    }
 
    error.clear();
    auto dynamic_object_methods = compile_snapshot(L,
-      "local function use(Parent:any):any\nParent.new('time')\nreturn Parent._state()\nend\nreturn use\n", true, error);
+      "local function use(Parent:any):any\nParent.new('time')\nreturn Parent.state()\nend\nreturn use\n", true, error);
    if (not dynamic_object_methods or count_opcode_tree(*dynamic_object_methods, BC_BMETH) != 2 or
        count_opcode_tree(*dynamic_object_methods, BC_BFUNC) != 0) {
-      Log.error("runtime Object new and _state calls did not retain BC_BMETH dispatch: %s", error.c_str());
+      Log.error("runtime Object new and state calls did not retain BC_BMETH dispatch: %s", error.c_str());
       return false;
    }
 

--- a/src/tiri/tests/test_builtin_methods.tiri
+++ b/src/tiri/tests/test_builtin_methods.tiri
@@ -228,22 +228,59 @@ end
    local child = parent.new('time')
    assert(child.owner.id is parent.id, 'Parent.new should preserve the receiving object as the child owner')
 
-   local state = parent._state()
+   local state = parent.state()
    state.marker = 11
-   assert(parent._state().marker is 11, '_state should return the same per-object table')
+   assert(parent.state().marker is 11, 'state should return the same per-object table')
 
    local dynamic_parent:any = parent
    local dynamic_child = dynamic_parent.new('time')
    assert(dynamic_child.owner.id is parent.id, 'An any receiver should select canonical Parent.new at runtime')
-   assert(dynamic_parent._state().marker is 11, 'An any receiver should select canonical _state at runtime')
+   assert(dynamic_parent.state().marker is 11, 'An any receiver should select canonical state at runtime')
 end
 
 @Test function ObjectNewAndStateSafeCalls()
    local maybe:any = nil
    local evaluated = false
    maybe?.new(function():str evaluated = true; return 'time' end())
-   maybe?._state()
+   maybe?.state()
    assert(not evaluated, 'Nil safe Object methods should skip written arguments')
+end
+
+@Test @Requires(network=true)
+function ObjectStateFieldAndMethod()
+   include 'network'
+   local socket <close> = obj.new('netsocket')
+   local original = socket.state
+   local state = socket.state()
+   state.marker = 23
+
+   assert(type(original) is 'number', 'The native state field should remain numeric')
+   assert(socket.state is original and socket['state'] is original,
+      'Dot and computed reads should return the native state field')
+   socket.state = NTC_RESOLVING
+   assert(socket.state is NTC_RESOLVING, 'Dot assignment should update the native state field')
+   socket['state'] = original
+   assert(socket.state is original, 'Computed assignment should update the native state field')
+   assert(socket.state().marker is 23, 'Native field writes should preserve the attached state table')
+
+   local dynamic_socket:any = socket
+   assert(dynamic_socket.state is original and dynamic_socket['state'] is original,
+      'An any receiver should read the native state field')
+   dynamic_socket.state = NTC_CONNECTING
+   assert(dynamic_socket.state is NTC_CONNECTING, 'An any receiver should write the native state field')
+   assert(dynamic_socket.state().marker is 23, 'An any receiver should call the state method')
+   assert(dynamic_socket?.state().marker is 23, 'Safe calls should select the state method')
+end
+
+@Test function ObjectOldStateMethodRemoved()
+   local parent <close> = obj.new('time')
+   local dynamic_parent:any = parent
+   try
+      dynamic_parent._state()
+   except error_value when ERR_NoFieldAccess
+   success
+      error('The removed _state method should fail instead of retaining an alias')
+   end
 end
 
 @Test function ObjectNewNamespaceRebindingAndEscapes()
@@ -254,11 +291,11 @@ end
    local child = parent.new('time')
    obj.new = original
    assert(child.owner.id is parent.id, 'Parent.new should ignore obj.new namespace rebinding')
-   assert(obj._state is nil, 'The hidden Object _state callable must not be published on obj')
+   assert(obj.state is nil, 'The hidden Object state callable must not be published on obj')
    local function read_member(Value:any, Key:str):any
       return Value[Key]
    end
-   assert(read_member(parent, 'new') is nil and read_member(parent, '_state') is nil,
+   assert(read_member(parent, 'new') is nil and read_member(parent, 'state') is nil,
       'Computed Object method reads should remain ordinary fields instead of bound closures')
 end
 

--- a/src/tiri/tests/test_object.tiri
+++ b/src/tiri/tests/test_object.tiri
@@ -274,33 +274,33 @@ end
 end
 
 -----------------------------------------------------------------------------------------------------------------------
--- Test obj._state() for per-object state storage
+-- Test obj.state() for per-object state storage
 
 @Test(hotpath=true) function ObjState()
    f = obj.new('file')
 
-   state = f._state()
-   assert(type(state) is 'table', "Expected _state() to return a table")
+   state = f.state()
+   assert(type(state) is 'table', "Expected state() to return a table")
 
    -- Store something in state
    state.myvalue = 42
 
    -- Retrieve state again and verify
-   state2 = f._state()
+   state2 = f.state()
    assert(state2.myvalue is 42, "Expected state to persist value")
 
    f.free()
    caught = false
    try
-      f._state()
+      f.state()
    except e
       caught = true
    end
-   assert(caught, 'Expected _state() to reject a dead object')
+   assert(caught, 'Expected state() to reject a dead object')
 end
 
 -----------------------------------------------------------------------------------------------------------------------
--- Registered obj.* methods, including new and _state, are dispatched as canonical built-in methods with the object
+-- Registered obj.* methods, including new and state, are dispatched as canonical built-in methods with the object
 -- supplied as an explicit receiver.
 
 @Test(hotpath=true) @Requires(display=true)
@@ -316,9 +316,9 @@ function RegisteredMethodsUseExplicitReceiver()
    assert(err is ERR_Okay, "set() should update a field through the explicit receiver")
    assert(math.abs(vp.get('opacity') - 0.5) < 0.0001, "set() should have persisted the field value")
 
-   state = f._state()
+   state = f.state()
    state.marker = 7
-   assert(f._state().marker is 7, "_state() should use the explicit receiver and persist state")
+   assert(f.state().marker is 7, "state() should use the explicit receiver and persist state")
 end
 
 -----------------------------------------------------------------------------------------------------------------------
@@ -326,9 +326,9 @@ end
 @Test function ObjectMethodEscapePaths()
    parent = obj.new('time')
    assert(parent.new is nil, 'Bare new access should not manufacture a bound closure')
-   assert(parent._state is nil, 'Bare _state access should not manufacture a bound closure')
+   assert(parent.state is nil, 'Bare state access should not manufacture a bound closure')
    assert(parent['new'] is nil, 'Computed new access should not manufacture a bound closure')
-   assert(parent['_state'] is nil, 'Computed _state access should not manufacture a bound closure')
+   assert(parent['state'] is nil, 'Computed state access should not manufacture a bound closure')
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/tools/tiri_lsp/include/lsp_lib.tiri
+++ b/tools/tiri_lsp/include/lsp_lib.tiri
@@ -701,7 +701,7 @@ function runStdioServer(Self:table)
    disconnected = false
 
    client = {
-      _state = function()
+      state = function()
          return stdio_state
       end,
       acWrite = function(Data)

--- a/tools/tiri_lsp/include/lsp_protocol.tiri
+++ b/tools/tiri_lsp/include/lsp_protocol.tiri
@@ -152,7 +152,7 @@ end
 -- Incoming Data Handling
 
 function initClientState(Self:table, ClientSocket:any):table
-   state = ClientSocket._state()
+   state = ClientSocket.state()
 
    if not state.initialised then
       state.buffer             = ''


### PR DESCRIPTION
* Updated intrinsic dispatch, bytecode compatibility metadata and parser coverage for object.state()
* [Script] Migrated GUI, HTTP server and LSP callers to the renamed accessor
* [Test] Covered native state-field and method dispatch while removing the old accessor