### PR TITLE
[Tiri] Removed deprecated base library functions

### DIFF
--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -61,7 +61,8 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // Version 0xa0 adds BC_RETHROW, the hidden exception debug variable and a portable exception metadata trailer.
 // Version 0xa1 removes the public error callable and shifts the generated fast-function ordering.
 // Version 0xa2 removes string.len and shifts the generated fast-function ordering.
-constexpr uint8_t BCDUMP_VERSION = 0xa2;
+// Version 0xa3 removes collectgarbage and newproxy from the generated fast-function ordering.
+constexpr uint8_t BCDUMP_VERSION = 0xa3;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/debug/lj_ff.h
+++ b/src/tiri/jit/src/debug/lj_ff.h
@@ -66,7 +66,7 @@ static_assert(FF__MAX <= BUILTIN_CALLABLE_CAPACITY);
 static_assert(FF__MAX - 1 <= (std::numeric_limits<uint16_t>::max)());
 static_assert(builtin_callable_index(BuiltinCallableID::Invalid) >= FF__MAX);
 #ifdef FFDEF_BFUNC_ABI
-static_assert(builtin_callable_abi_fingerprint() IS 0x9fd682d9ff27f4b8ull,
+static_assert(builtin_callable_abi_fingerprint() IS 0x0fb4eae36e100111ull,
    "fast-function ordering changed: bump BCDUMP_VERSION and update the BC_BFUNC ABI fingerprint");
 #endif
 

--- a/src/tiri/jit/src/lib/lib_base.cpp
+++ b/src/tiri/jit/src/lib/lib_base.cpp
@@ -839,45 +839,6 @@ LJLIB_ASM(tostring)      LJLIB_REC(.)
    return FFH_RES(1);
 }
 
-LJLIB_CF(collectgarbage)
-{
-   kt::Log("collectgarbage").warning("DEPRECATED - Use processing.collect()");
-   return 0;
-}
-
-//********************************************************************************************************************
-// newproxy() is deprecated and not published for client use.  It remains only to assist some tests that need a
-// userdata return type.
-
-LJLIB_PUSH(top-2)  //  Upvalue holds weak table.
-LJLIB_CF(newproxy)
-{
-   lua_settop(L, 1);
-   lua_newuserdata(L, 0);
-   if (lua_toboolean(L, 1) IS 0) {  // newproxy(): without metatable.
-      return 1;
-   }
-   else if (lua_isboolean(L, 1)) {  // newproxy(true): with metatable.
-      lua_newtable(L);
-      lua_pushvalue(L, -1);
-      lua_pushboolean(L, 1);
-      lua_rawset(L, lua_upvalueindex(1));  //  Remember mt in weak table.
-   }
-   else {  // newproxy(proxy): inherit metatable.
-      int validproxy = 0;
-      if (lua_getmetatable(L, 1)) {
-         lua_rawget(L, lua_upvalueindex(1));
-         validproxy = lua_toboolean(L, -1);
-         lua_pop(L, 1);
-      }
-      if (!validproxy) lj_err_arg(L, 1, ErrMsg::NOPROXY);
-      lua_getmetatable(L, 1);
-   }
-   lua_setmetatable(L, 2);
-   return 1;
-}
-
-//********************************************************************************************************************
 // RAII Pattern: Uses StackFrame to ensure L->top is restored if tostring conversion
 // fails or triggers an error during the print loop, preventing stack corruption.
 
@@ -927,7 +888,7 @@ LJLIB_CF(print)
    return 0;
 }
 
-LJLIB_PUSH(top-3)
+LJLIB_PUSH(top-2)
 LJLIB_SET(_VERSION)
 
 //********************************************************************************************************************
@@ -1163,25 +1124,12 @@ LJLIB_INTRINSIC LJLIB_CF(__setmetatable_ctx)
 
 //********************************************************************************************************************
 
-static void newproxy_weaktable(lua_State* L)
-{
-   // NOBARRIER: The table is new (marked white). This internal metatable only defines __mode.
-   GCtab *t = lj_tab_new(L, 0, 1);
-   settabV(L, L->top++, t);
-   setgcref(t->metatable, obj2gco(t));
-   setstrV(L, lj_tab_setstr(L, t, lj_str_newlit(L, "__mode")), lj_str_newlit(L, "kv"));
-   t->nomm = (uint8_t)(~(1u << MM_mode));
-}
-
-//********************************************************************************************************************
-
 extern int luaopen_base(lua_State* L)
 {
    // NOBARRIER: Table and value are the same.
    GCtab *env = tabref(L->env);
    settabV(L, lj_tab_setstr(L, env, lj_str_newlit(L, "_G")), env);
-   lua_pushliteral(L, "5.4");  //  top-3. // Lua version number, set as _VERSION
-   newproxy_weaktable(L);  //  top-2.
+   lua_pushliteral(L, "5.4");  //  top-2. // Lua version number, set as _VERSION
    LJ_LIB_REG(L, "_G", base);
 
    // Register function prototypes for compile-time type inference
@@ -1201,12 +1149,8 @@ extern int luaopen_base(lua_State* L)
    reg_func_prototype("rawset", { TiriType::Table }, { TiriType::Table, TiriType::Any, TiriType::Any });
    reg_func_prototype("getmetatable", { TiriType::Any }, { TiriType::Any });
    reg_func_prototype("setmetatable", { TiriType::Table }, { TiriType::Table, TiriType::Table });
-   reg_func_prototype("select", { TiriType::Any }, { TiriType::Any }, FProtoFlags::Variadic,
-      FProtoArity::required(1));
    reg_func_prototype("next", { TiriType::Any, TiriType::Any }, { TiriType::Table, TiriType::Any }, FProtoFlags::None,
       FProtoArity::required(1));
-   reg_func_prototype("newproxy", { TiriType::Userdata }, { TiriType::Any }, FProtoFlags::None,
-      FProtoArity::required(0));
    reg_func_prototype("ltr", { TiriType::Str }, { TiriType::Str });
    reg_func_prototype("resolve", { TiriType::Any }, { TiriType::Any });
 

--- a/src/tiri/tests/test_choose_from.tiri
+++ b/src/tiri/tests/test_choose_from.tiri
@@ -346,7 +346,7 @@ end
    assert(classify({ key='value' }) is 'table', 'tables should match <table>')
    assert(classify(function() end) is 'func', 'functions should match <func>')
    assert(classify({0 to 1}) is 'range', 'ranges should match <range>')
-   assert(classify(newproxy(true)) is 'userdata', 'full userdata should match <userdata>')
+   assert(classify(regex.new('')) is 'userdata', 'full userdata should match <userdata>')
    assert(classify(array<int> { 1 }) is 'array', 'native arrays should match <array>')
    assert(classify(record_value) is 'struct', 'structures should match <struct>')
    assert(classify(clock) is 'obj', 'objects should match <obj>')

--- a/src/tiri/tests/test_malformed_syntax.tiri
+++ b/src/tiri/tests/test_malformed_syntax.tiri
@@ -100,6 +100,12 @@ end
       'unknown variable read in local declaration')
    assertInvalidCode("local code = ERR_ThisDoesNotExist", 'UndefinedVariable',
       'unknown constant read in local declaration')
+   assertInvalidCode("collectgarbage()", 'UndefinedVariable',
+      'removed collectgarbage function')
+   assertInvalidCode("newproxy()", 'UndefinedVariable',
+      'removed newproxy function')
+   assertInvalidCode("select(0)", 'UndefinedVariable',
+      'removed select function')
 
    result = debug.validate("local something = print")
    assert(result.success is true, "Known global read should validate")

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -150,7 +150,7 @@ end
    local native_struct = struct<ContractAlpha> { Value=1 }
    local object = obj.new('time')
    local sequence = {0 to 2}
-   local proxy = newproxy(true)
+   local proxy = regex.new('')
    local captured = 1
    function capture() return captured end
    local pointer = debug.upvalueID(capture, 0)
@@ -448,7 +448,7 @@ end
    local bravo = struct<ContractBravo> { Value=5 }
    local object = obj.new('time')
    local sequence = {0 to 3}
-   local proxy = newproxy(true)
+   local proxy = regex.new('')
    local callable = setmetatable({}, { __call = function():bool return true end })
 
    assert(checked_nil(nil) is nil, 'nil should satisfy a nil result contract')
@@ -1379,11 +1379,11 @@ end
 end
 
 @Test function UserdataContractBoundaries()
-   function userdata_source():any return newproxy(true) end
+   function userdata_source():any return regex.new('') end
    function typed_userdata_result():userdata return userdata_source() end
 
    local first = typed_userdata_result()
-   assert(type(first) is 'userdata', 'a userdata result contract should preserve full userdata')
+   assert(rawtype(first) is 'userdata', 'a userdata result contract should preserve full userdata')
 
    local typed_local:userdata = first
    typed_local = userdata_source()
@@ -1395,12 +1395,12 @@ end
    end
    write_userdata(userdata_source())
    expect_contract_failure(function() write_userdata('wrong') end, 'upvalue')
-   assert(type(captured) is 'userdata', 'a rejected userdata upvalue store must preserve its value')
+   assert(rawtype(captured) is 'userdata', 'a rejected userdata upvalue store must preserve its value')
 
    global glContractUserdata:userdata = userdata_source()
    glContractUserdata = userdata_source()
    expect_contract_failure(function() glContractUserdata = dynamic_value(3) end, 'global')
-   assert(type(glContractUserdata) is 'userdata', 'a rejected userdata global store must preserve its value')
+   assert(rawtype(glContractUserdata) is 'userdata', 'a rejected userdata global store must preserve its value')
 
    function wrong_userdata_result():userdata return dynamic_value({}) end
    expect_contract_failure(function() wrong_userdata_result() end, 'result')
@@ -1409,10 +1409,10 @@ end
 @Test function DeferredUserdataContracts()
    function accept_userdata(Value:userdata):userdata return Value end
 
-   local deferred_proxy = <{ newproxy(true) }>
+   local deferred_proxy = <{ regex.new('') }>
    assert(type(deferred_proxy) is 'userdata', 'a typed deferred proxy should advertise userdata')
    local resolved_proxy = accept_userdata(deferred_proxy)
-   assert(type(resolved_proxy) is 'userdata', 'a deferred proxy should resolve before its contract')
+   assert(rawtype(resolved_proxy) is 'userdata', 'a deferred proxy should resolve before its contract')
 
    local captured = 2
    function capture() return captured end
@@ -1498,7 +1498,7 @@ end
    end
    local dynamic:any = hot
    local compatible_callable:any = function():num return 2 end
-   local proxy = newproxy(true)
+   local proxy = regex.new('')
    local matching_time = obj.new('time')
    for i in {0 to 200} do
       assert(dynamic(i) is i + 1, 'Valid hot call should preserve its argument')

--- a/src/tiri/tests/test_type_guided_jit_signatures.tiri
+++ b/src/tiri/tests/test_type_guided_jit_signatures.tiri
@@ -132,7 +132,7 @@ end
    assert(count_guarded_field(irfl_udata_meta, ir_eq) > 0,
       'A range contract should guard the exact userdata metatable field')
 
-   expect_jit_contract_failure(function() callback(dynamic_contract_value(newproxy(true))) end, 'range')
+   expect_jit_contract_failure(function() callback(dynamic_contract_value(regex.new(''))) end, 'range')
 
    local registry = debug.getRegistry()
    local saved_metatable = registry['Tiri.range']
@@ -153,7 +153,7 @@ end
       return Value
    end
 
-   local proxy = newproxy(true)
+   local proxy = regex.new('')
    local captured = 3
    function capture() return captured end
    local pointer = debug.upvalueID(capture, 0)
@@ -286,7 +286,7 @@ end
    assert(total is 2040 and metrics.traces > 0,
       'Named-structure and range result contracts should remain traceable')
    expect_jit_contract_failure(function() checked_structure(bravo) end, 'JitContractAlpha')
-   expect_jit_contract_failure(function() checked_range(newproxy(true)) end, 'range')
+   expect_jit_contract_failure(function() checked_range(regex.new('')) end, 'range')
 end
 
 @Test function ReloadedComplexContractRetainsTracingAndIdentity()
@@ -342,7 +342,7 @@ end
    local alpha = struct<JitContractAlpha> { Value=3 }
    local bravo = struct<JitContractBravo> { Value=5 }
    local sequence = {0 to 4}
-   local proxy = newproxy(true)
+   local proxy = regex.new('')
    local callable = setmetatable({ offset=2 }, {
       __call = function(Value) return &offset + Value end
    })

--- a/src/tiri/tests/test_type_name.tiri
+++ b/src/tiri/tests/test_type_name.tiri
@@ -148,7 +148,7 @@ end
    local stop = 2
    assert(rawtype({0 to stop}) is 'range', 'variable-bound ranges should be recognised')
    assert(rawtype({2 to -1 by -1}) is 'range', 'descending ranges should be recognised')
-   assert(rawtype(newproxy(true)) is 'userdata', 'full userdata should retain its category name')
+   assert(rawtype(regex.new('')) is 'userdata', 'full userdata should retain its category name')
    local captured = 1
    function capture() return captured end
    assert(rawtype(debug.upvalueID(capture, 0)) is 'userdata', 'light userdata should retain its category name')
@@ -228,7 +228,7 @@ end
    local point = struct<RawTypeNamePoint> { Value=5 }
    local clock = obj.new('time')
    local objects = array<obj> { clock }
-   local proxy = newproxy(true)
+   local proxy = regex.new('')
    local sequence = {0 to 2}
    local deferred:any = <{ 1 }>
 

--- a/src/tiri/tests/test_type_tests.tiri
+++ b/src/tiri/tests/test_type_tests.tiri
@@ -18,6 +18,7 @@ function dynamic_value(Value):any
 end
 
 @Test function PrimitiveDescriptors()
+   assert(_VERSION is '5.4', 'the base library should expose the Tiri compatibility version')
    assert(nil is <nil>, 'nil should match <nil>')
    assert(nil is <any>, '<any> should include nil')
    assert(true is <bool>, 'boolean should match <bool>')
@@ -26,7 +27,7 @@ end
    assert({} is <table>, 'table should match <table>')
    assert((function() end) is <func>, 'function should match <func>')
    assert({0 to 2} is <range>, 'range should match <range>')
-   assert(newproxy(true) is <userdata>, 'full userdata should match <userdata>')
+   assert(regex.new('') is <userdata>, 'full userdata should match <userdata>')
 
    assert(1 is not <str>, 'negated mismatch should be true')
    assert(not (1 is not <num>), 'negated match should be false')

--- a/tools/tiri_lsp/include/lsp_defs.tiri
+++ b/tools/tiri_lsp/include/lsp_defs.tiri
@@ -120,7 +120,7 @@ glBuiltins = {
    -- Memory management
    ['processing.collect'] = {
       comment = 'Runs the garbage collection process manually.',
-      prototype = 'collectgarbage([opt], [arg])'
+      prototype = 'processing.collect([mode], [options])'
    },
 
    -- Script parameters

--- a/tools/tiri_lsp/include/lsp_lib.tiri
+++ b/tools/tiri_lsp/include/lsp_lib.tiri
@@ -325,7 +325,7 @@ global FLUID_BUILTINS = {
    ['rawget'] = true, ['rawset'] = true, ['rawequal'] = true,
 
    -- Script/module loading
-   ['collectgarbage'] = true, ['require'] = true, ['include'] = true,
+   ['require'] = true, ['include'] = true,
    ['loadFile'] = true, ['load'] = true, ['exec'] = true,
 
    -- Script parameters

--- a/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
+++ b/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
@@ -329,7 +329,7 @@
             },
             {
                "name": "support.function.builtin.tiri",
-               "match": "\\b(pcall|xpcall|print|msg|type|resolve|tonumber|tostring|pairs|ipairs|next|select|unpack|setmetatable|getmetatable|rawget|rawset|collectgarbage)\\b"
+               "match": "\\b(pcall|xpcall|print|msg|type|resolve|tonumber|tostring|pairs|ipairs|next|unpack|setmetatable|getmetatable|rawget|rawset)\\b"
             },
             {
                "name": "constant.other.error.tiri",


### PR DESCRIPTION
* Removed collectgarbage, newproxy and select from the generated Tiri base library
* Updated bytecode compatibility metadata, tests and LSP builtin definitions