### PR TITLE
[Tiri] Specialise Tiri module-call dispatch

### DIFF
--- a/src/tiri/MODULE_REGISTRY.md
+++ b/src/tiri/MODULE_REGISTRY.md
@@ -87,3 +87,20 @@ This boundary is deliberate:
 
 Serialised bytecode format `0x87` carries names and `BC_MODACT` operands, never native pointers or export-list indices.
 Older formats are rejected rather than retaining the removed compiler-private dependency binder.
+
+## Invocation storage and output ownership
+
+Published callable metadata still contains no invocation storage.  The cached-CIF bridge uses aligned eight-byte
+argument/result slots inside its existing 256-byte buffer, plus exact-type bounded stores for C++ temporaries.
+Preparation and result traversal use the same padding rules.
+
+The bridge holds native owners outside `protected_tiri_call()`, which uses a protected runtime C frame without adding
+another Lua call frame or changing the closure upvalue.  Caller try handlers are saved and suspended while the bridge
+runs; checkall's immediate-scope identity remains intact.  On an error, the runtime returns to this boundary before
+native storage is released, then the original error is rethrown.  Ownership is cleared after a copied allocation is
+freed or a GC wrapper successfully adopts it.  The same protection releases structure conversion's temporary registry
+references.  This does not depend on platform-specific C++ destructor unwinding.
+
+See the [output contract audit](../../docs/plans/tiri/tiri_module_calls_phase_4_contracts.md) for result order, legacy
+null/unsigned representations, native-error behaviour and resource transfer rules.  Supported output signatures remain
+on cached CIF; Phase 4 adds no new production dispatch or state pointer to a callable.

--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -436,6 +436,10 @@ ERR load_module_defs(std::string_view);
 [[nodiscard]] std::string_view static_module_function_name(StaticModuleHandle, std::string_view) noexcept;
 [[nodiscard]] APTR proto_dependency_callable(struct GCproto *, uint32_t);
 #ifdef UNIT_TESTS
+[[nodiscard]] std::string test_module_zero_call(lua_State *, APTR, uint32_t Type, bool ForceBridge, CSTRING Source);
+[[nodiscard]] std::string test_module_zero_eligibility();
+[[nodiscard]] std::string test_module_simple_call(lua_State *, APTR, uint32_t Type,
+   std::span<const uint32_t> Inputs, bool ForceBridge, bool Eligible, CSTRING Source);
 [[nodiscard]] std::string test_module_string_view_call(lua_State *, APTR,
    std::span<const std::string> Inputs);
 

--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -439,7 +439,8 @@ ERR load_module_defs(std::string_view);
 [[nodiscard]] std::string test_module_zero_call(lua_State *, APTR, uint32_t Type, bool ForceBridge, CSTRING Source);
 [[nodiscard]] std::string test_module_zero_eligibility();
 [[nodiscard]] std::string test_module_simple_call(lua_State *, APTR, uint32_t Type,
-   std::span<const uint32_t> Inputs, bool ForceBridge, bool Eligible, CSTRING Source);
+   std::span<const uint32_t> Inputs, bool ForceBridge, bool Eligible, CSTRING Source, bool Probe = true);
+[[nodiscard]] int test_module_live_temporaries();
 [[nodiscard]] std::string test_module_string_view_call(lua_State *, APTR,
    std::span<const std::string> Inputs);
 

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -271,6 +271,7 @@ typedef struct CCallInfo {
   _(ANY,        lj_tab_mark_contextual_jit, 1, S, NIL, 0) \
   _(ANY,        lj_context_begin_block_jit, 5, S, NIL, CCI_L) \
   _(ANY,        lj_context_end_block_jit,   3, S, NIL, CCI_L) \
+  _(ANY,        lj_context_has_call_jit,    2, FS, INT, CCI_L) \
   \
   // End of list.
 

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1918,10 +1918,10 @@ void lj_record_ret(jit_State *J, BCREG rbase, ptrdiff_t gotresults)
       contextual_caller = caller_op IS BC_CTXCALL or caller_op IS BC_CTXCALLM;
    }
 
-   // A return-root trace has no CTXENTER metadata for a contextual caller below its root. Let the interpreter perform
-   // that return so it can restore the caller activation and compact the result slots before tracing resumes.
+   // A return-root trace has no entry metadata for a contextual activation below its root. Let the interpreter
+   // perform that return, including physical metamethod contexts entered through an ordinary CALL instruction.
    if (FRC::at_root_depth(J) and J->pt and bc_isret(bc_op(*J->pc)) and
-      (not frame_islua(frame) or contextual_caller or
+      (not frame_islua(frame) or contextual_caller or lj_context_has_call_jit(J->L, J->L->base) or
        (J->parent IS 0 and J->exitno IS 0 and !bc_isret(bc_op(J->cur.startins))))) {
       // NYI: specialise to frame type and return directly, not via RET*.
       slots.clear_range(0, rbase);  //  Purge dead slots.
@@ -1980,6 +1980,10 @@ void lj_record_ret(jit_State *J, BCREG rbase, ptrdiff_t gotresults)
          IRBuilder ir(J);
          TRef trpt = lj_ir_kgc(J, obj2gco(pt), IRT_PROTO);
          TRef trpc = ir.kptr((void*)frame_pc(frame));
+         // The same return site can be reached by an ordinary function or by a table's __call handler. Guard
+         // traces recorded without a physical activation so reuse cannot bypass the interpreter's context leave.
+         TRef has_context = lj_ir_call(J, IRCALL_lj_context_has_call_jit, REF_BASE);
+         ir.guard_eq_int(has_context, ir.kint(0));
          ir.guard(IR_RETF, IRT_PGC, trpt, trpc);
          J->retdepth++;
          J->needsnap = 1;

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -612,6 +612,20 @@ static bool array_copy_identity_compatible(const GCarray *Destination, const GCa
    return lj_array_identity_matches(Source, destination_name);
 }
 
+// Publish an empty, collectable owner before allocating its payload.  If payload allocation raises, GC can
+// reclaim the header; allocating the payload first would leak it when header allocation fails.
+static GCarray * array_allocate_owned(lua_State *Lua, AET Type, MSize ElemSize, uint32_t Length,
+   uint8_t Flags, struct_record *StructDef, GCstr *NestedIdentity = nullptr)
+{
+   auto array = (GCarray *)lj_mem_newgco(Lua, sizeof(GCarray));
+   array->init(nullptr, Type, ElemSize, 0, 0, Flags, StructDef, NestedIdentity);
+   size_t byte_size = size_t(Length) * ElemSize;
+   array->storage = byte_size ? lj_mem_new(Lua, byte_size) : nullptr;
+   array->len = Length;
+   array->capacity = Length;
+   return array;
+}
+
 extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Data, uint8_t Flags,
    std::string_view StructName, struct_record *StructDef, GCstr *NestedIdentity)
 {
@@ -646,10 +660,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
          // Cached data - copy into owned storage
          if (Type IS AET::CSTR or Type IS AET::STR_CPP) {
             // String caching: store CSTRING pointers that point into strcache
-            size_t byte_size = Length * sizeof(CSTRING);
-            void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
-            auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-            arr->init(storage, AET::CSTR, sizeof(CSTRING), Length, Length, 0, sdef);
+            auto arr = array_allocate_owned(L, AET::CSTR, sizeof(CSTRING), Length, 0, sdef);
             array_attach_basemt(L, arr);
 
             // Calculate total string content size
@@ -707,11 +718,12 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
             // Object arrays returned by the Kōtuku API contain native OBJECTPTR values.  Tiri object arrays store
             // GCobject references, so wrap each native object before exposing the array to the script.
             size_t byte_size = Length * elem_size;
-            void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
-            auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-            arr->init(storage, Type, elem_size, Length, Length, Flags, sdef, NestedIdentity);
+            auto arr = array_allocate_owned(L, Type, elem_size, Length, Flags, sdef, NestedIdentity);
+            void *storage = arr->storage;
             array_attach_basemt(L, arr);
 
+            // Failed wrapping must leave the remaining GC references safe to visit during collection.
+            if (byte_size) std::memset(storage, 0, byte_size);
             auto refs = arr->get<GCRef>();
             auto objects = (OBJECTPTR *)Data;
             for (uint32_t i=0; i < Length; i++) {
@@ -729,9 +741,8 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
             // Non-string cached array - allocate storage via GC, then copy data
             // Capacity equals length for cached arrays
             size_t byte_size = Length * elem_size;
-            void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
-            auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-            arr->init(storage, Type, elem_size, Length, Length, Flags, sdef, NestedIdentity);
+            auto arr = array_allocate_owned(L, Type, elem_size, Length, Flags, sdef, NestedIdentity);
+            void *storage = arr->storage;
             array_attach_basemt(L, arr);
             if (byte_size > 0) {
                if (Type IS AET::ANY) lj_bulk_copy_tvalue((TValue *)storage, (const TValue *)Data, Length);
@@ -745,9 +756,9 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
       // New empty array with owned storage allocated via GC
       // Capacity equals length for newly created arrays
       size_t byte_size = Length * elem_size;
-      void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
-      auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-      arr->init(storage, Type, elem_size, Length, Length, Flags & ~(ARRAY_EXTERNAL|ARRAY_CACHED), sdef, NestedIdentity);
+      auto arr = array_allocate_owned(L, Type, elem_size, Length, Flags & ~(ARRAY_EXTERNAL|ARRAY_CACHED),
+         sdef, NestedIdentity);
+      void *storage = arr->storage;
       array_attach_basemt(L, arr);
       if (storage) {
          if (Type IS AET::ANY) {

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -308,6 +308,13 @@ extern "C" void lj_context_enter_jit(lua_State *L, GCtab *Table, TValue *OwnerBa
    lj_context_push(L, Table, OwnerBase);
 }
 
+extern "C" uint32_t lj_context_has_call_jit(lua_State *L, TValue *OwnerBase) noexcept
+{
+   return not L->context_stack.empty() and
+      L->context_stack.back().owner_kind IS lua_State::ContextFrame::OwnerKind::Call and
+      L->context_stack.back().owner_base IS savestack(L, OwnerBase);
+}
+
 extern "C" void lj_context_leave_jit(lua_State *L, TValue *OwnerBase) noexcept
 {
 #ifdef LUA_USE_ASSERT

--- a/src/tiri/jit/src/runtime/lj_state.h
+++ b/src/tiri/jit/src/runtime/lj_state.h
@@ -55,6 +55,7 @@ extern "C" LJ_FUNC void lj_context_load(lua_State *L, TValue *Destination) noexc
 extern "C" LJ_FUNC GCtab * lj_context_current_jit(lua_State *L) noexcept;
 extern "C" LJ_FUNC void lj_context_enter_jit(lua_State *L, GCtab *Table, TValue *OwnerBase);
 extern "C" LJ_FUNC void lj_context_leave_jit(lua_State *L, TValue *OwnerBase) noexcept;
+extern "C" LJ_FUNC uint32_t lj_context_has_call_jit(lua_State *L, TValue *OwnerBase) noexcept;
 extern "C" LJ_FUNC void lj_context_tail_jit(
    lua_State *L, GCtab *Table, TValue *PreparedOwner, TValue *OutgoingOwner);
 extern "C" LJ_FUNC void lj_context_prepare_metamethod_tail_jit(

--- a/src/tiri/jit/src/runtime/lj_str.h
+++ b/src/tiri/jit/src/runtime/lj_str.h
@@ -40,13 +40,14 @@ LJ_FUNC void lj_str_free(global_State* g, GCstr* s);
 LJ_FUNC void lj_str_init(lua_State* L);
 
 // Intern a null-terminated C string.
-[[nodiscard]] inline GCstr* lj_str_newz(lua_State* L, const char* s) noexcept {
-   return lj_str_new(L, s, strlen(s));
+// Interning can raise a Lua allocation error through the platform unwinder.
+[[nodiscard]] inline GCstr* lj_str_newz(lua_State *Lua, const char *String) {
+   return lj_str_new(Lua, String, strlen(String));
 }
 
 // Intern a string from std::string_view.
-[[nodiscard]] inline GCstr* lj_str_newsv(lua_State* L, std::string_view sv) noexcept {
-   return lj_str_new(L, sv.data(), sv.size());
+[[nodiscard]] inline GCstr* lj_str_newsv(lua_State *Lua, std::string_view String) {
+   return lj_str_new(Lua, String.data(), String.size());
 }
 
 [[nodiscard]] inline bool lj_str_ismutable(const GCstr *s) noexcept {

--- a/src/tiri/protected_call.h
+++ b/src/tiri/protected_call.h
@@ -1,0 +1,33 @@
+// Native ownership must remain outside this boundary: Lua errors need not unwind C++ frames on every platform.
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include "lj_obj.h"
+#include "lj_vm.h"
+#include "lj_err.h"
+
+template<class F> int protected_tiri_call(lua_State *Lua, F &Function)
+{
+   // Keep the Lua base/upvalue and immediate-scope checkall semantics.  Suspend caller try handlers so they cannot
+   // bypass this cleanup boundary.  Nested script calls can install their own handlers in the saved slots.
+   const int try_depth = Lua->try_stack.depth;
+   const int checkall_depth = Lua->checkall_stack->depth;
+   const auto handler = Lua->try_handler_pc;
+   std::array<TryFrame, LJ_MAX_TRY_DEPTH> try_frames;
+   std::array<CheckallFrame, LJ_MAX_CHECKALL_DEPTH> checkall_frames;
+   std::copy_n(Lua->try_stack.frames, try_depth, try_frames.begin());
+   std::copy_n(Lua->checkall_stack->frames, checkall_depth, checkall_frames.begin());
+   Lua->try_stack.depth = 0;
+   Lua->try_handler_pc = nullptr;
+   int status = lj_vm_cpcall(Lua, nullptr, &Function, [](lua_State *, lua_CFunction, void *Data) -> TValue * {
+      (*(F *)Data)();
+      return nullptr;
+   });
+   std::copy_n(try_frames.begin(), try_depth, Lua->try_stack.frames);
+   std::copy_n(checkall_frames.begin(), checkall_depth, Lua->checkall_stack->frames);
+   Lua->try_stack.depth = try_depth;
+   Lua->checkall_stack->depth = checkall_depth;
+   Lua->try_handler_pc = handler;
+   return status;
+}

--- a/src/tiri/tests/bench_module_calls.tiri
+++ b/src/tiri/tests/bench_module_calls.tiri
@@ -11,6 +11,12 @@
 
 module core as mCore
 module display as mDisplay
+@if(exists='modules:network')
+   include 'network'
+   module network as mNet
+   local bench_address = struct.new('IPAddress')
+   check mNet.StrToAddress('127.0.0.1', bench_address)
+@end
 
 local ITERATIONS <const> = tonumber(arg('iterations', '100000'))
 local REPEATS <const> = tonumber(arg('repeats', '9'))
@@ -156,6 +162,37 @@ function bench_cpp_string_result(Iterations: num): num
    return total
 end
 
+function bench_extracted_results(Iterations: num): num
+   local analyse = mCore.AnalysePath
+   local total = 0
+   for _ in {0 to Iterations} do
+      local err, kind = analyse('temp:')
+      total += err + kind
+   end
+   return total
+end
+
+@if(exists='modules:network')
+function bench_address_output(Iterations: num): num
+   local total = 0
+   for _ in {0 to Iterations} do
+      local err, text = mNet.AddressToStr(bench_address)
+      total += err + #text
+   end
+   return total
+end
+
+function bench_extracted_address(Iterations: num): num
+   local format = mNet.AddressToStr
+   local total = 0
+   for _ in {0 to Iterations} do
+      local err, text = format(bench_address)
+      total += err + #text
+   end
+   return total
+end
+@end
+
 --********************************************************************************************************************
 -- Activation workloads.  These measure the cost of descriptor activation rather than the call itself.
 
@@ -243,6 +280,11 @@ measure('  extracted pointer CRC', ITERATIONS, bench_extracted_crc)
 measure('  C-string result', ITERATIONS, bench_string_result)
 measure('  extracted callable', ITERATIONS, bench_extracted)
 measure('  multiple results', math.floor(ITERATIONS / 10), bench_multiple_results)
+measure('  extracted multiple results', math.floor(ITERATIONS / 10), bench_extracted_results)
+@if(exists='modules:network')
+   measure('  address output', ITERATIONS, bench_address_output)
+   measure('  extracted address output', ITERATIONS, bench_extracted_address)
+@end
 measure('  mutable C++ string result', math.floor(ITERATIONS / 10), bench_cpp_string_result)
 
 print('')

--- a/src/tiri/tests/bench_module_calls.tiri
+++ b/src/tiri/tests/bench_module_calls.tiri
@@ -13,7 +13,7 @@ module core as mCore
 module display as mDisplay
 
 local ITERATIONS <const> = tonumber(arg('iterations', '100000'))
-local REPEATS <const> = tonumber(arg('repeats', '5'))
+local REPEATS <const> = tonumber(arg('repeats', '9'))
 local ACTIVATIONS <const> = tonumber(arg('activations', '200'))
 
 -- Report the median of a set of samples.  Medians are used throughout because they resist the occasional outlier
@@ -34,6 +34,7 @@ function measure(Name: str, Iterations: num, Workload: func)
    local samples = array<double>
    local sink = 0
 
+   sink += Workload(math.min(Iterations, 1000)) -- Untimed warm-up, with the result consumed.
    for _ in {0 to REPEATS} do
       local start = mCore.PreciseTime()
       sink += Workload(Iterations)
@@ -95,6 +96,28 @@ end
 function bench_string_view(Iterations: num): num
    local total = 0
    for _ in {0 to Iterations} do total += mCore.ResolveClassName('Tiri') end
+   return total
+end
+
+-- Extracted string view separates namespace access from bridge conversion.
+function bench_extracted_view(Iterations: num): num
+   local resolve = mCore.ResolveClassName
+   local total = 0
+   for _ in {0 to Iterations} do total += resolve('Tiri') end
+   return total
+end
+
+-- Borrowed pointer input from a string, with unsigned scalar inputs and result.
+function bench_crc_pointer(Iterations: num): num
+   local total = 0
+   for _ in {0 to Iterations} do total += mCore.GenCRC32(0, '123456789', 9) end
+   return total
+end
+
+function bench_extracted_crc(Iterations: num): num
+   local crc = mCore.GenCRC32
+   local total = 0
+   for _ in {0 to Iterations} do total += crc(0, '123456789', 9) end
    return total
 end
 
@@ -184,6 +207,7 @@ local MULTI_SOURCE <const> = [[
 
 function measure_activation(Name: str, Source: str)
    local samples = array<double>
+   exec(Source) -- Untimed activation warm-up.
    for _ in {0 to REPEATS} do
       local start = mCore.PreciseTime()
       for _ in {0 to ACTIVATIONS} do exec(Source) end
@@ -213,6 +237,9 @@ measure('  scalar arg', ITERATIONS, bench_scalar_arg)
 measure('  extracted scalar arg', ITERATIONS, bench_extracted_scalar)
 measure('  double arg', ITERATIONS, bench_double_arg)
 measure('  C++ string-view arg', ITERATIONS, bench_string_view)
+measure('  extracted string-view arg', ITERATIONS, bench_extracted_view)
+measure('  unsigned/pointer CRC', ITERATIONS, bench_crc_pointer)
+measure('  extracted pointer CRC', ITERATIONS, bench_extracted_crc)
 measure('  C-string result', ITERATIONS, bench_string_result)
 measure('  extracted callable', ITERATIONS, bench_extracted)
 measure('  multiple results', math.floor(ITERATIONS / 10), bench_multiple_results)

--- a/src/tiri/tests/bench_module_calls.tiri
+++ b/src/tiri/tests/bench_module_calls.tiri
@@ -1,6 +1,6 @@
--- Module call benchmark for docs/plans/2-tiri-module-interface-efficiency-plan.md
+-- Module call benchmark for docs/plans/tiri/2-tiri-module-calls.md
 --
--- Measures steady-state module call cost across the signature families named in the plan's Phase 0 exit criteria, plus
+-- Measures steady-state module call cost across scalar and fallback signature families, plus
 -- dependency activation cost.  Run with the JIT enabled and disabled to record both modes:
 --
 --    build/agents-install/origo src/tiri/tests/bench_module_calls.tiri
@@ -10,6 +10,7 @@
 -- Accumulators are deliberately dependent on the call result so that dead-code elimination cannot remove the loop body.
 
 module core as mCore
+module display as mDisplay
 
 local ITERATIONS <const> = tonumber(arg('iterations', '100000'))
 local REPEATS <const> = tonumber(arg('repeats', '5'))
@@ -39,9 +40,16 @@ function measure(Name: str, Iterations: num, Workload: func)
       samples.push(mCore.PreciseTime() - start)
    end
 
+   local low, high = samples[0], samples[0]
+   for index in {0 to #samples} do
+      low = math.min(low, samples[index])
+      high = math.max(high, samples[index])
+   end
    local elapsed = median(samples)
    print(string.format('%-34s %10.0f us total  %8.4f us/call  sink=%s',
       Name, elapsed, elapsed / Iterations, tostring(sink != nil)))
+   print(string.format('  sample range: %.4f .. %.4f us/call',
+      low / Iterations, high / Iterations))
 end
 
 --********************************************************************************************************************
@@ -54,10 +62,32 @@ function bench_zero_arg(Iterations: num): num
    return total
 end
 
+-- Zero-argument signed 32-bit result.
+function bench_zero_int(Iterations: num): num
+   local total = 0
+   for _ in {0 to Iterations} do total += mCore.GetThreadID() end
+   return total
+end
+
 -- Scalar input, scalar result.
 function bench_scalar_arg(Iterations: num): num
    local total = 0
    for i in {0 to Iterations} do total += mCore.GetResource(i & 7) end
+   return total
+end
+
+-- Extracted scalar-input call.
+function bench_extracted_scalar(Iterations: num): num
+   local get_resource = mCore.GetResource
+   local total = 0
+   for i in {0 to Iterations} do total += get_resource(i & 7) end
+   return total
+end
+
+-- Double input and result.
+function bench_double_arg(Iterations: num): num
+   local total = 0
+   for i in {0 to Iterations} do total += mDisplay.ScaleToDPI(i + 0.5) end
    return total
 end
 
@@ -160,9 +190,15 @@ function measure_activation(Name: str, Source: str)
       samples.push(mCore.PreciseTime() - start)
    end
 
+   local low, high = samples[0], samples[0]
+   for index in {0 to #samples} do
+      low = math.min(low, samples[index])
+      high = math.max(high, samples[index])
+   end
    local elapsed = median(samples)
    print(string.format('%-34s %10.0f us total  %8.4f us/activation',
       Name, elapsed, elapsed / ACTIVATIONS))
+   print(string.format('  sample range: %.4f .. %.4f us/activation', low / ACTIVATIONS, high / ACTIVATIONS))
 end
 
 --********************************************************************************************************************
@@ -172,7 +208,10 @@ print('-'.rep(96))
 
 print('Steady state:')
 measure('  zero-arg scalar result', ITERATIONS, bench_zero_arg)
+measure('  zero-arg signed int', ITERATIONS, bench_zero_int)
 measure('  scalar arg', ITERATIONS, bench_scalar_arg)
+measure('  extracted scalar arg', ITERATIONS, bench_extracted_scalar)
+measure('  double arg', ITERATIONS, bench_double_arg)
 measure('  C++ string-view arg', ITERATIONS, bench_string_view)
 measure('  C-string result', ITERATIONS, bench_string_result)
 measure('  extracted callable', ITERATIONS, bench_extracted)

--- a/src/tiri/tests/test_contains.tiri
+++ b/src/tiri/tests/test_contains.tiri
@@ -43,7 +43,8 @@ function numeric_membership_call_address(Values:array<any>, Candidate:num):any
    local address:any
    for trace_no in {1 into 40} do
       local info = jit.util.traceInfo(trace_no)
-      if info is nil then continue end
+      -- Inspect the membership loop, excluding helper calls in return and exit traces.
+      if info is nil or info.linktype != 'loop' then continue end
 
       for instruction in {1 into info.nins} do
          local _, ir_ot, _, call_id = jit.util.traceIR(trace_no, instruction)

--- a/src/tiri/tests/test_metamethod_context_dispatch.tiri
+++ b/src/tiri/tests/test_metamethod_context_dispatch.tiri
@@ -158,6 +158,37 @@ end
    end
 end
 
+@Test(hotpath=1) function MetamethodReturnRootsRestoreContextBeforeTryEntry()
+   jit.flush()
+
+   function exercise_return()
+      local caller = { name = 'caller' }
+      local receiver = setmetatable({ name = 'receiver' }, {
+         __call = function(Fail:bool):str
+            if Fail then raise 'return root failure' end
+            return &name
+         end
+      })
+      using caller do
+         assert(receiver(false) is 'receiver')
+         assert(&name is 'caller', 'A compiled return must remove its receiver before entering try')
+         local caught = false
+         try
+            receiver(true)
+         except e
+            caught = true
+            assert(e.message.find('return root failure') != nil)
+            assert(&name is 'caller', 'The exception handler should retain the enclosing caller context')
+         end
+         assert(caught, 'The metamethod error should reach the handler')
+         assert(&name is 'caller', 'Exception cleanup should preserve the context saved at try entry')
+      end
+   end
+
+   for _ in {0 to 200} do exercise_return() end
+   jit.flush()
+end
+
 @Test function MetamethodCleanupRunsBeforeItsContextIsRestored()
    local events = {}
    local caller = { name = 'caller' }

--- a/src/tiri/tests/test_module_namespaces.tiri
+++ b/src/tiri/tests/test_module_namespaces.tiri
@@ -69,6 +69,20 @@ end
    assert(resolved_err is ERR_Okay and #resolved > 0, 'mutable C++ string result')
 end
 
+-- Independent published CRC vector verifies borrowed pointer representations and unsigned results.
+@Test function ComplexBridgeInputsPreserveLengthsAndPointerValues()
+   local crc = mCore.GenCRC32
+   assert(crc(0, '123456789', 9) is 3421780262, 'IEEE CRC-32 known vector')
+   local bytes = array<byte> { 49, 50, 51, 52, 53, 54, 55, 56, 57 }
+   assert(crc(0, bytes, 9) is 3421780262, 'Native array pointer must match string storage')
+   assert(crc(0, nil, 0) is 0, 'Null empty pointer input')
+   local resolve = mCore.ResolveClassName
+   assert(resolve('Tiri') > 0, 'Known class must resolve')
+   assert(resolve('Tiri\0suffix') is 0, 'String view must preserve embedded NUL and suffix')
+   processing.collect()
+   assert(crc(0, bytes, 9) is 3421780262, 'Extracted pointer call survives collection')
+end
+
 -- A callback argument holds a Lua registry reference that the bridge hands to the module.  Preparing the call
 -- interface in advance must not disturb that ownership transfer.
 

--- a/src/tiri/tests/test_module_namespaces.tiri
+++ b/src/tiri/tests/test_module_namespaces.tiri
@@ -58,7 +58,7 @@ end
    assert(mCore.GetResource(1) != nil, 'scalar argument')
    assert(#mCore.GetErrorMsg(0) > 0, 'C-string result')
    assert(mCore.ResolveClassName('Tiri') > 0, 'C++ string-view argument')
-   assert(mCore.GetThreadID() >= 0, 'unsigned scalar result')
+   assert(mCore.GetThreadID() >= 0, 'signed scalar result')
    assert(mCore.CurrentTask() != nil, 'object result')
    assert(mCore.ActionList() != nil, 'C++ array result')
 
@@ -88,7 +88,12 @@ end
       scripts.push(obj.new('tiri', { statement = [[
          module core as mConcurrent
          local total = 0
-         for _ in {0 to 500} do total += mConcurrent.PreciseTime() end
+         local resource = mConcurrent.GetResource
+         processing.collect()
+         for _ in {0 to 500} do
+            total += mConcurrent.PreciseTime()
+            assert(type(resource(1)) is 'number', 'Concurrent scalar input call lost its binding')
+         end
          assert(total > 0, 'concurrent module calls produced no result')
       ]] }))
    end

--- a/src/tiri/tests/test_module_result_contracts.tiri
+++ b/src/tiri/tests/test_module_result_contracts.tiri
@@ -1,5 +1,75 @@
 -- Runtime contracts for statically described module results.
 
+include 'core'
+module core as mCore
+
+@if(exists='modules:network')
+   include 'network'
+   module network as mNet
+@end
+
+local test_path = 'temp:tiri_module_output_contract.txt'
+
+@AfterAll function CleanupOutputFile()
+   mCore.DeleteFile(test_path)
+end
+
+@Test function ScalarOutputsAndSpanMutation()
+   do
+      local file <close> = obj.new('File', { path=test_path, flags=FL_NEW|FL_WRITE })
+      check file.acWrite('hello')
+   end
+   local buffer = array<byte, 8>
+   buffer.fill(42)
+   local err, count, extra = mCore.ReadFileToBuffer(test_path, buffer)
+   assert(err is ERR_Okay and count is 5 and extra is nil, 'Read count and result arity')
+   assert(buffer[0] is 104 and buffer[4] is 111 and buffer[5] is 42, 'Native span mutation is visible')
+   local empty_err, empty_count = mCore.ReadFileToBuffer(test_path, nil)
+   assert(empty_err is ERR_Args and empty_count is 0, 'Untouched output after empty-span error')
+   local path_err, path_type = mCore.AnalysePath(test_path)
+   assert(path_err is ERR_Okay and path_type is LOC_FILE, 'Independent path-type expectation')
+   local resolve = mCore.ResolvePath
+   processing.collect()
+   local resolve_err, resolved, surplus = resolve(test_path, 0)
+   assert(resolve_err is ERR_Okay and resolved.endsWith('tiri_module_output_contract.txt') and surplus is nil)
+end
+
+@Test function CopiedContainersAndResourceResultsSurviveCollection()
+   local actions = mCore.ActionList()
+   local err, classes = mCore.ClassDatabase()
+   assert(err is ERR_Okay and #actions > 0 and #classes > 0, 'Supported structure-pointer vectors')
+   local state = mCore.GetSystemState()
+   assert(type(state) is 'table', 'System state is copied to a table')
+   do
+      local directory_err, directory = mCore.OpenDir('temp:', 0)
+      assert(directory_err is ERR_Okay and directory != nil, 'Directory result transfers ownership')
+   end
+   processing.collect()
+   assert(#actions > 0 and #classes > 0 and type(state) is 'table', 'Results outlive conversion temporaries')
+end
+
+@if(exists='modules:network')
+@Test; @Requires(network=true)
+function AddressOutputCopiesAndErrors()
+   local address = struct.new('IPAddress')
+   check mNet.StrToAddress('127.0.0.1', address)
+   local format = mNet.AddressToStr
+   processing.collect()
+   for _ in {0 to 100} do
+      local err, text, extra = format(address)
+      assert(err is ERR_Okay and text is '127.0.0.1' and extra is nil, 'Address output copy and arity')
+   end
+   local err, text = format(nil)
+   assert(err is ERR_NullArgs and text is '', 'Native error preserves empty initial C++ output')
+   try
+      checkall format(nil) end
+   except e when ERR_NullArgs
+   success
+      assert(false, 'Address error must promote inside checkall')
+   end
+end
+@end
+
 @if(exists='modules:display')
    module display as mGfx
 @end

--- a/src/tiri/tests/unit_module_marshalling.cpp
+++ b/src/tiri/tests/unit_module_marshalling.cpp
@@ -13,6 +13,8 @@ Unit tests for module call marshalling.
 #include <array>
 #include <string>
 #include <string_view>
+#include <type_traits>
+#include <cstdlib>
 
 #include "../defs.h"
 
@@ -120,6 +122,413 @@ static bool test_max_string_view_signature(kt::Log &Log)
    return true;
 }
 
+static thread_local int glZeroCalls = 0;
+
+static void synthetic_void() { ++glZeroCalls; }
+static int synthetic_signed() { ++glZeroCalls; return INT32_MIN; }
+static uint32_t synthetic_unsigned() { ++glZeroCalls; return UINT32_MAX; }
+static int64_t synthetic_int64() { ++glZeroCalls; return -9007199254740991LL; }
+static double synthetic_double() { ++glZeroCalls; return -1234.125; }
+static ERR synthetic_okay() { ++glZeroCalls; return ERR::Okay; }
+static ERR synthetic_error() { ++glZeroCalls; return ERR::Args; }
+
+static bool test_zero_arg_calls(kt::Log &Log)
+{
+   if (auto failure = test_module_zero_eligibility(); not failure.empty()) {
+      Log.error("%s", failure.c_str());
+      return false;
+   }
+   struct scalar_case {
+      APTR Address;
+      uint32_t Type;
+      CSTRING Expected;
+   };
+   const scalar_case cases[] = {
+      { (APTR)synthetic_void, FD_VOID, "nil" },
+      { (APTR)synthetic_signed, FD_INT, "-2147483648" },
+      { (APTR)synthetic_unsigned, FD_INT|FD_UNSIGNED, "4294967295" },
+      { (APTR)synthetic_int64, FD_INT64, "-9007199254740991" },
+      { (APTR)synthetic_double, FD_DOUBLE, "-1234.125" },
+      { (APTR)synthetic_okay, FD_ERROR, "ERR_Okay" },
+      // A modifier outside the allowlist must still work through the bridge.
+      { (APTR)synthetic_signed, FD_INT|FD_ALLOC, "-2147483648" }
+   };
+   for (int state = 0; state < 2; ++state) {
+      ModuleMarshallingTestScript holder;
+      if (not holder.initialise(Log)) return false;
+      holder.get()->setStatement("local ready = true");
+      if (Action(AC::Query, holder.get(), nullptr) != ERR::Okay) {
+         Log.error("failed to prepare the synthetic script libraries");
+         return false;
+      }
+      for (bool force_bridge : { false, true }) {
+         for (bool jit_enabled : { false, true }) {
+            for (const auto &entry : cases) {
+               auto source = std::format(R"(
+                  jit.{}()
+                  local first, second = syntheticZero()
+                  assert(first is {}, 'Direct result differs')
+                  assert(second is nil, 'Unexpected second result')
+                  local extracted = syntheticZero
+                  processing.collect()
+                  for _ in {{0 to 200}} do
+                     local value, extra = extracted(nil, 'ignored')
+                     assert(value is {}, 'Extracted result differs')
+                     assert(extra is nil, 'Unexpected extracted result')
+                  end
+                  try
+                     syntheticZero(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17)
+                  except e when ERR_Args
+                  success
+                     assert(false, 'Surplus arguments must fail before invocation')
+                  end
+               )", jit_enabled ? "on" : "off", entry.Expected, entry.Expected);
+               glZeroCalls = 0;
+               auto failure = test_module_zero_call(holder.get()->Lua, entry.Address, entry.Type,
+                  force_bridge, source.c_str());
+               if ((not failure.empty()) or (glZeroCalls != 202)) {
+                  Log.error("Scalar type %x, bridge %d, JIT %d: %s (calls %d)", entry.Type,
+                     int(force_bridge), int(jit_enabled), failure.c_str(), glZeroCalls);
+                  return false;
+               }
+            }
+            glZeroCalls = 0;
+            auto failure = test_module_zero_call(holder.get()->Lua, (APTR)synthetic_error, FD_ERROR,
+               force_bridge, R"(
+                  assert(syntheticZero() is ERR_Args, 'Plain call returns error')
+                  try
+                     checkall
+                        syntheticZero()
+                     end
+                  except e when ERR_Args
+                     assert(e.message.find('SyntheticZero()'), 'Error retains native name')
+                  success
+                     assert(false, 'Direct error must be promoted')
+                  end
+                  function unchecked():num
+                     return syntheticZero()
+                  end
+                  checkall
+                     assert(unchecked() is ERR_Args, 'Checking must not enter a called Tiri function')
+                  end
+                  local extracted = syntheticZero
+                  try
+                     checkall
+                        extracted()
+                     end
+                  except e when ERR_Args
+                  success
+                     assert(false, 'Extracted error must be promoted')
+                  end
+               )");
+            if ((not failure.empty()) or (glZeroCalls != 5)) {
+               Log.error("Error result, bridge %d: %s (calls %d)", int(force_bridge),
+                  failure.c_str(), glZeroCalls);
+               return false;
+            }
+         }
+      }
+   }
+   return true;
+}
+
+static thread_local int glSimpleCalls = 0;
+
+template<class... Args> static double synthetic_numbers(Args... Values)
+{
+   ++glSimpleCalls;
+   const double values[] = { double(Values)... };
+   double result = 0;
+   int weight = 0;
+   for (double value : values) result += value * ++weight;
+   return result;
+}
+
+template<class T> static constexpr uint32_t numeric_descriptor()
+{
+   if constexpr (std::is_same_v<T, int>) return FD_INT;
+   else if constexpr (std::is_same_v<T, int64_t>) return FD_INT64;
+   else return FD_DOUBLE;
+}
+
+template<class... Args> static bool test_numeric_signature(extTiri *Script, kt::Log &Log)
+{
+   const std::array<uint32_t, sizeof...(Args)> types = { numeric_descriptor<Args>()... };
+   std::string arguments, nils, tail;
+   double expected = 0;
+   double first = 0;
+   for (size_t index = 0; index < types.size(); ++index) {
+      double value = types[index] IS FD_INT ? -100 - double(index) :
+         types[index] IS FD_INT64 ? -5000000000.0 - double(index) : 2.75 + double(index);
+      expected += value * double(index + 1);
+      if (not index) first = value;
+      else { arguments += ", "; nils += ", "; tail += ", " + std::format("{}", value); }
+      arguments += std::format("{}", value);
+      nils += "nil";
+   }
+   for (bool bridge : { false, true }) {
+      for (bool jit : { false, true }) {
+         auto source = std::format(R"(
+            jit.{}()
+            assert(syntheticZero({}) is {}, 'Direct numeric result differs')
+            local call = syntheticZero
+            processing.collect()
+            for _ in {{0 to 64}} do assert(call({}) is {}, 'Extracted numeric result differs') end
+            assert(call({}) is 0, 'Nil defaults differ')
+            assert(call() is 0, 'Missing defaults differ')
+            assert(call({}) is {}, 'Partial defaults differ')
+            local resolutions = 0
+            thunk deferred():num
+               resolutions++
+               processing.collect()
+               return {}
+            end
+            assert(call(deferred(){}) is {}, 'Deferred input differs')
+            assert(resolutions is 1, 'Deferred input must resolve once')
+            try
+               call('bad'{})
+            except e when ERR_InvalidType
+               assert(e.message.find("arg #1 (Arg1) expected number"), 'Numeric diagnostic differs')
+            success
+               assert(false, 'A string must not be accepted as a number')
+            end
+            try
+               call(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17)
+            except e when ERR_Args
+            success
+               assert(false, 'Too many arguments must fail')
+            end
+         )", jit ? "on" : "off", arguments, expected, arguments, expected, nils, first, first,
+            first, tail, expected, tail);
+         glSimpleCalls = 0;
+         auto failure = test_module_simple_call(Script->Lua, (APTR)synthetic_numbers<Args...>, FD_DOUBLE, types,
+            bridge, types.size() <= 4, source.c_str());
+         if ((not failure.empty()) or (glSimpleCalls != 70)) {
+            Log.error("Numeric inputs [%s], bridge %d, JIT %d: %s (calls %d)", arguments.c_str(),
+               int(bridge), int(jit), failure.c_str(), glSimpleCalls);
+            return false;
+         }
+      }
+   }
+   return true;
+}
+
+template<class... Args> static bool test_numeric_permutations(extTiri *Script, kt::Log &Log)
+{
+   if constexpr (sizeof...(Args) > 0) {
+      if (not test_numeric_signature<Args...>(Script, Log)) return false;
+   }
+   if constexpr (sizeof...(Args) < 4) {
+      return test_numeric_permutations<Args..., int>(Script, Log) and
+         test_numeric_permutations<Args..., int64_t>(Script, Log) and
+         test_numeric_permutations<Args..., double>(Script, Log);
+   }
+   return true;
+}
+
+template<class R> static R synthetic_simple_result(int, double, int64_t, double)
+{
+   ++glSimpleCalls;
+   if constexpr (std::is_same_v<R, ERR>) return ERR::Args;
+   else if constexpr (std::is_same_v<R, uint32_t>) return UINT32_MAX;
+   else if constexpr (not std::is_void_v<R>) return R(-123);
+}
+
+template<class R> static bool test_simple_result(extTiri *Script, kt::Log &Log, uint32_t Type, CSTRING Expected)
+{
+   const uint32_t types[] = { FD_INT, FD_DOUBLE, FD_INT64, FD_DOUBLE };
+   for (bool bridge : { false, true }) {
+      auto source = std::format(R"(
+         local value, extra = syntheticZero(1, 2.5, 5000000000, 4.5)
+         assert(value is {}, 'Mixed signature return differs')
+         assert(extra is nil, 'Unexpected extra return')
+      )", Expected);
+      if constexpr (std::is_same_v<R, ERR>) source += R"(
+         function unchecked():num
+            return syntheticZero(1, 2.5, 5000000000, 4.5)
+         end
+         checkall
+            assert(unchecked() is ERR_Args, 'Checking must not propagate into a called Tiri function')
+         end
+         try
+            checkall
+               syntheticZero(1, 2.5, 5000000000, 4.5)
+            end
+         except e when ERR_Args
+            assert(e.message.find('SyntheticZero() failed:'), 'Error message differs')
+         success
+            assert(false, 'Native error must be promoted')
+         end
+      )";
+      glSimpleCalls = 0;
+      auto failure = test_module_simple_call(Script->Lua, (APTR)synthetic_simple_result<R>, Type, types,
+         bridge, true, source.c_str());
+      if ((not failure.empty()) or (glSimpleCalls != (std::is_same_v<R, ERR> ? 4 : 2))) {
+         Log.error("Simple return type %x: %s (calls %d)", Type, failure.c_str(), glSimpleCalls);
+         return false;
+      }
+   }
+   return true;
+}
+
+static bool test_simple_conversion_errors(extTiri *Script, kt::Log &Log)
+{
+   for (uint32_t type : { uint32_t(FD_INT), uint32_t(FD_INT64), uint32_t(FD_DOUBLE) }) {
+      const uint32_t types[] = { type, type };
+      APTR address = type IS FD_INT ? (APTR)synthetic_numbers<int, int> :
+         type IS FD_INT64 ? (APTR)synthetic_numbers<int64_t, int64_t> : (APTR)synthetic_numbers<double, double>;
+      for (bool bridge : { false, true }) {
+         glSimpleCalls = 0;
+         auto failure = test_module_simple_call(Script->Lua, address, FD_DOUBLE, types, bridge, true, R"(
+            local resolutions = 0
+            thunk deferred():num
+               resolutions++
+               return 7
+            end
+            try
+               syntheticZero(false, deferred())
+            except e when ERR_InvalidType
+               assert(resolutions is 0, 'Later argument must remain unresolved after failure')
+            success
+               assert(false, 'Boolean must be rejected')
+            end
+            try
+               syntheticZero(deferred(), {})
+            except e when ERR_InvalidType
+               assert(resolutions is 1, 'Earlier deferred argument must resolve once')
+               assert(e.message.find('arg #2 (Arg2)'), 'Error argument position differs')
+            success
+               assert(false, 'Table must be rejected')
+            end
+         )");
+         // Only the helper's successful arity probe is allowed to execute native code.
+         if ((not failure.empty()) or (glSimpleCalls != 1)) {
+            Log.error("Conversion order: %s (calls %d)", failure.c_str(), glSimpleCalls);
+            return false;
+         }
+      }
+   }
+   return true;
+}
+
+template<class T> static T synthetic_identity(T Value)
+{
+   ++glSimpleCalls;
+   return Value;
+}
+
+static bool test_simple_boundaries(extTiri *Script, kt::Log &Log)
+{
+   struct boundary_case { uint32_t Type; APTR Address; CSTRING Source; };
+   const boundary_case cases[] = {
+      { FD_INT, (APTR)synthetic_identity<int>, R"(
+         assert(syntheticZero(-2147483648) is -2147483648)
+         assert(syntheticZero(2147483647) is 2147483647)
+         assert(syntheticZero(2147483648) is -2147483648)
+         assert(syntheticZero(4294967295) is -1)
+         assert(syntheticZero(-1.75) is -1)
+      )" },
+      { FD_INT64, (APTR)synthetic_identity<int64_t>, R"(
+         assert(syntheticZero(9007199254740991) is 9007199254740991)
+         assert(syntheticZero(-9007199254740991) is -9007199254740991)
+         assert(syntheticZero(-9223372036854775808) is -9223372036854775808)
+         assert(syntheticZero(-1.75) is -1)
+      )" },
+      { FD_DOUBLE, (APTR)synthetic_identity<double>, R"(
+         assert(syntheticZero(math.huge) is math.huge)
+         assert(syntheticZero(-math.huge) is -math.huge)
+         assert(1 / syntheticZero(-0.0) is -math.huge)
+         local nan = syntheticZero(0 / 0)
+         assert(nan != nan)
+         assert(syntheticZero(-1.75) is -1.75)
+      )" },
+      { FD_INT|FD_UNSIGNED, (APTR)synthetic_identity<uint32_t>, R"(
+         assert(syntheticZero(-1) is 4294967295)
+         assert(syntheticZero(4294967295) is 4294967295)
+      )" }
+   };
+   for (const auto &entry : cases) {
+      for (bool bridge : { false, true }) {
+         for (bool jit : { false, true }) {
+            auto source = std::format("jit.{}()\n{}", jit ? "on" : "off", entry.Source);
+            auto failure = test_module_simple_call(Script->Lua, entry.Address, entry.Type, { &entry.Type, 1 },
+               bridge, entry.Type != (FD_INT|FD_UNSIGNED), source.c_str());
+            if (not failure.empty()) {
+               Log.error("Boundary type %x, bridge %d: %s", entry.Type, int(bridge), failure.c_str());
+               return false;
+            }
+         }
+      }
+   }
+   return true;
+}
+
+// Explicitly requested microbenchmarks use separate native targets with no observation counters.  Samples are
+// printed after each timed loop and never affect test acceptance.
+
+template<class... Args> static double benchmark_numbers(Args... Values)
+{
+   return (double(Values) + ...);
+}
+
+template<class... Args> static bool benchmark_simple_signature(extTiri *Script, kt::Log &Log, CSTRING Arguments)
+{
+   const std::array<uint32_t, sizeof...(Args)> types = { numeric_descriptor<Args>()... };
+   std::string name;
+   for (uint32_t type : types) name += type IS FD_INT ? "i" : type IS FD_INT64 ? "l" : "d";
+   for (bool jit : { false, true }) {
+      for (bool bridge : { false, true }) {
+         auto source = std::format(R"(
+            jit.{}()
+            local call = syntheticZero
+            local samples = array<double>
+            local sink = 0
+            for _ in {{0 to 9}} do
+               local start = mSys.PreciseTime()
+               for _ in {{0 to 100000}} do sink += call({}) end
+               samples.push((mSys.PreciseTime() - start) / 100000)
+            end
+            samples.sort()
+            print('Simple {} JIT {} bridge {}: ' .. samples[4] .. ' [' .. samples[0] .. ', ' .. samples[8] .. ']')
+            assert(sink != 0)
+         )", jit ? "on" : "off", Arguments, name, jit ? "on" : "off", bridge ? "on" : "off");
+         auto failure = test_module_simple_call(Script->Lua, (APTR)benchmark_numbers<Args...>, FD_DOUBLE, types,
+            bridge, true, source.c_str());
+         if (not failure.empty()) { Log.error("%s", failure.c_str()); return false; }
+      }
+   }
+   return true;
+}
+
+static bool test_simple_calls(kt::Log &Log)
+{
+   ModuleMarshallingTestScript holder;
+   if (not holder.initialise(Log)) return false;
+   holder.get()->setStatement("local ready = true");
+   if (Action(AC::Query, holder.get(), nullptr) != ERR::Okay) return false;
+   auto script = holder.get();
+   if (not test_numeric_permutations<>(script, Log)) return false;
+   if (not test_numeric_signature<int, double, int64_t, double, int>(script, Log)) return false;
+   if (not test_simple_conversion_errors(script, Log)) return false;
+   if (not test_simple_boundaries(script, Log)) return false;
+   if (std::getenv("TIRI_MODULE_BENCH_SIMPLE")) {
+      if (not (benchmark_simple_signature<int>(script, Log, "-123") and
+          benchmark_simple_signature<int64_t>(script, Log, "-5000000000") and
+          benchmark_simple_signature<double>(script, Log, "2.75") and
+          benchmark_simple_signature<int, double>(script, Log, "-123, 2.75") and
+          benchmark_simple_signature<double, int64_t, int>(script, Log, "2.75, -5000000000, -123") and
+          benchmark_simple_signature<int, double, int64_t, double>(script, Log, "-123, 2.75, -5000000000, 3.25"))) {
+         return false;
+      }
+   }
+   return test_simple_result<void>(script, Log, FD_VOID, "nil") and
+      test_simple_result<int>(script, Log, FD_INT, "-123") and
+      test_simple_result<uint32_t>(script, Log, FD_INT|FD_UNSIGNED, "4294967295") and
+      test_simple_result<int64_t>(script, Log, FD_INT64, "-123") and
+      test_simple_result<double>(script, Log, FD_DOUBLE, "-123") and
+      test_simple_result<ERR>(script, Log, FD_ERROR, "ERR_Args");
+}
+
 } // namespace
 
 void module_marshalling_unit_tests(int &Passed, int &Total)
@@ -132,6 +541,20 @@ void module_marshalling_unit_tests(int &Passed, int &Total)
       log.msg("maximum string-view signature passed");
    }
    else log.error("maximum string-view signature failed");
+
+   Total++;
+   if (test_zero_arg_calls(log)) {
+      Passed++;
+      log.msg("zero-argument differential calls passed");
+   }
+   else log.error("zero-argument differential calls failed");
+
+   Total++;
+   if (test_simple_calls(log)) {
+      Passed++;
+      log.msg("simple-input differential calls passed");
+   }
+   else log.error("simple-input differential calls failed");
 }
 
 #endif // UNIT_TESTS

--- a/src/tiri/tests/unit_module_marshalling.cpp
+++ b/src/tiri/tests/unit_module_marshalling.cpp
@@ -122,6 +122,83 @@ static bool test_max_string_view_signature(kt::Log &Log)
    return true;
 }
 
+// Complex input contracts remain on CIF.  Separate native targets verify the actual reference ABI and distinguish
+// NUL-terminated strings from length-bearing views, with collection during resolution of a later argument.
+static thread_local int glComplexCalls = 0;
+
+static int synthetic_c_string(CSTRING Value, int Tail)
+{
+   ++glComplexCalls;
+   return (Value ? int(std::strlen(Value)) : -1) + Tail;
+}
+
+static int synthetic_string_view(const std::string_view &Value, int Tail)
+{
+   ++glComplexCalls;
+   return (Value.data() ? int(Value.size()) : -1) + Tail;
+}
+
+static bool test_complex_inputs(kt::Log &Log)
+{
+   ModuleMarshallingTestScript holder;
+   if (not holder.initialise(Log)) return false;
+   holder.get()->setStatement("local ready = true");
+   if (Action(AC::Query, holder.get(), nullptr) != ERR::Okay) return false;
+   for (bool cpp : { false, true }) {
+      const uint32_t types[] = { uint32_t(cpp ? FD_STR|FD_CPP : FD_STR), FD_INT };
+      for (bool bridge : { false, true }) {
+         for (bool jit : { false, true }) {
+            auto source = std::format(R"(
+               jit.{}()
+               local call = syntheticZero
+               local value, extra = call('abc', 4)
+               assert(value is 7 and extra is nil, 'String result contract')
+               assert(call(nil, 0) is -1, 'Nil must pass null storage')
+               assert(call() is -1, 'Missing must pass null storage')
+               assert(call('', 0) is 0, 'Empty string differs from nil')
+               assert(call('a\0b', 0) is {}, 'Embedded NUL contract')
+               local resolutions = 0
+               thunk later():num
+                  resolutions++
+                  local garbage = {{}}
+                  for i in {{0 to 500}} do garbage[i] = tostring(i) .. 'allocation' end
+                  processing.collect()
+                  return 2
+               end
+               thunk text():str
+                  return 'rooted-' .. tostring(12345)
+               end
+               assert(call(text(), later()) is 14, 'Earlier string must remain rooted')
+               try
+                  call(false, later())
+               except e when ERR_InvalidType
+                  assert(resolutions is 1, 'Early failure must not resolve later input')
+               success
+                  assert(false, 'Boolean string input must fail')
+               end
+               try
+                  call(text(), false)
+               except e when ERR_InvalidType
+                  assert(e.message.find('arg #2 (Arg2)'), 'Later conversion diagnostic')
+               success
+                  assert(false, 'Later conversion must fail before native invocation')
+               end
+            )", jit ? "on" : "off", cpp ? 3 : 1);
+            glComplexCalls = 0;
+            auto failure = test_module_simple_call(holder.get()->Lua,
+               cpp ? (APTR)synthetic_string_view : (APTR)synthetic_c_string, FD_INT, types,
+               bridge, false, source.c_str());
+            if ((not failure.empty()) or (glComplexCalls != 7)) {
+               Log.error("Complex input cpp %d, bridge %d, JIT %d: %s (calls %d)", int(cpp), int(bridge),
+                  int(jit), failure.c_str(), glComplexCalls);
+               return false;
+            }
+         }
+      }
+   }
+   return true;
+}
+
 static thread_local int glZeroCalls = 0;
 
 static void synthetic_void() { ++glZeroCalls; }
@@ -548,6 +625,13 @@ void module_marshalling_unit_tests(int &Passed, int &Total)
       log.msg("zero-argument differential calls passed");
    }
    else log.error("zero-argument differential calls failed");
+
+   Total++;
+   if (test_complex_inputs(log)) {
+      Passed++;
+      log.msg("complex input bridge contracts passed");
+   }
+   else log.error("complex input bridge contracts failed");
 
    Total++;
    if (test_simple_calls(log)) {

--- a/src/tiri/tests/unit_module_marshalling.cpp
+++ b/src/tiri/tests/unit_module_marshalling.cpp
@@ -17,8 +17,11 @@ Unit tests for module call marshalling.
 #include <cstdlib>
 
 #include "../defs.h"
+#include "lua.h"
 
 #ifdef UNIT_TESTS
+
+extern int test_struct_live_references();
 
 namespace {
 
@@ -195,6 +198,485 @@ static bool test_complex_inputs(kt::Log &Log)
             }
          }
       }
+   }
+   return true;
+}
+
+// Independent expected values also preserve the legacy signed conversion of unsigned output slots.
+static thread_local int glOutputCalls = 0;
+static thread_local bool glOutputAligned = true;
+
+static ERR synthetic_outputs(int Input, int *First, int64_t *Wide, double *Real, APTR *Pointer, int Tail)
+{
+   ++glOutputCalls;
+   glOutputAligned = glOutputAligned and (uintptr_t(First) % alignof(int) IS 0) and
+      (uintptr_t(Wide) % alignof(int64_t) IS 0) and (uintptr_t(Real) % alignof(double) IS 0) and
+      (uintptr_t(Pointer) % alignof(APTR) IS 0);
+   if ((*First != 0) or (*Wide != 0) or (*Real != 0) or (*Pointer != nullptr)) glOutputAligned = false;
+   *First = Input + Tail - 2147483647;
+   *Wide = (Input IS 99) ? 9007199254740993LL : -9007199254740991LL;
+   *Real = -1234.125;
+   return ERR::Okay;
+}
+
+static bool test_output_slots(kt::Log &Log)
+{
+   ModuleMarshallingTestScript holder;
+   if (not holder.initialise(Log)) return false;
+   holder.get()->setStatement("local ready = true");
+   if (Action(AC::Query, holder.get(), nullptr) != ERR::Okay) return false;
+   const std::array<uint32_t, 6> types = {
+      FD_INT, FD_INT|FD_RESULT|FD_UNSIGNED, FD_INT64|FD_RESULT, FD_DOUBLE|FD_RESULT, FD_PTR|FD_RESULT, FD_INT
+   };
+   for (bool bridge : { false, true }) {
+      for (bool jit : { false, true }) {
+         glOutputCalls = 0;
+         glOutputAligned = true;
+         auto source = std::format(R"(
+            jit.{}()
+            local call = syntheticZero
+            processing.collect()
+            for _ in {{0 to 100}} do
+               local err, first, wide, real, pointer, extra = call(4, nil, nil, nil, nil, 6, 'ignored')
+               assert(err is ERR_Okay and first is -2147483637, 'Interleaved inputs preserve positions')
+               assert(wide is -9007199254740991 and real is -1234.125, 'Exact numeric outputs')
+               assert(pointer != nil and type(pointer) is 'userdata', 'Null output is light userdata')
+               assert(extra is nil, 'Output arity')
+            end
+            local _, _, rounded = call(99)
+            assert(rounded is 9007199254740992, 'Int64 outputs use double precision above 2^53')
+            local err, first = call()
+            assert(err is ERR_Okay and first is -2147483647, 'Missing defaults')
+            try
+               call(1, nil, nil, nil, nil, false)
+            except e when ERR_InvalidType
+               assert(e.message.find('arg #6'), 'Output slots must not compact later input indices')
+            success
+               assert(false, 'Bad later input must fail')
+            end
+         )", jit ? "on" : "off");
+         auto failure = test_module_simple_call(holder.get()->Lua, (APTR)synthetic_outputs, FD_ERROR,
+            types, bridge, false, source.c_str());
+         if ((not failure.empty()) or (not glOutputAligned) or (glOutputCalls != 103)) {
+            Log.error("Output slots: %s, aligned %d, calls %d", failure.c_str(), int(glOutputAligned), glOutputCalls);
+            return false;
+         }
+      }
+   }
+   return true;
+}
+
+struct ownership_observation {
+   int Calls = 0;
+   int Allocations = 0;
+   int Releases = 0;
+   int FailAfter = -1;
+   int PendingFailure = -1;
+   int Failures = 0;
+   lua_Alloc Allocator = nullptr;
+   void *AllocatorData = nullptr;
+};
+
+static thread_local ownership_observation glOwnership;
+static thread_local uint64_t glOutputSerial = 0;
+
+static ERR synthetic_release(ResourceRecord &, APTR)
+{
+   ++glOwnership.Releases;
+   return ERR::Terminate; // Let Core free its AllocResource block after recording destruction.
+}
+
+static ResourceManager glOutputResourceManager{ "Module output fixture", synthetic_release, false };
+
+static STRING synthetic_allocate()
+{
+   APTR result = nullptr;
+   if (AllocResource(256, MEM::NIL, &result, &glOutputResourceManager) != ERR::Okay) return nullptr;
+   ++glOwnership.Allocations;
+   std::memset(result, 'x', 255);
+   auto serial = ++glOutputSerial;
+   for (int index = 0; index < 16; ++index) ((STRING)result)[index] = char('a' + ((serial >> (index * 4)) & 15));
+   return (STRING)result;
+}
+
+static void * synthetic_allocator(void *Data, void *Pointer, size_t OldSize, size_t NewSize)
+{
+   auto &state = *(ownership_observation *)Data;
+   if ((NewSize > OldSize) and (state.PendingFailure >= 0)) {
+      if (state.PendingFailure-- IS 0) {
+         ++state.Failures;
+         return nullptr;
+      }
+   }
+   return state.Allocator(state.AllocatorData, Pointer, OldSize, NewSize);
+}
+
+static ERR synthetic_owned_outputs(int Mode, STRING *First, STRING *Last, std::string *Text)
+{
+   ++glOwnership.Calls;
+   *First = synthetic_allocate();
+   *Last = synthetic_allocate();
+   Text->assign("full\0length", 11);
+   glOwnership.PendingFailure = glOwnership.FailAfter;
+   return Mode ? ERR::Args : ERR::Okay;
+}
+
+static STRING synthetic_owned_return(STRING *Output)
+{
+   ++glOwnership.Calls;
+   *Output = synthetic_allocate();
+   auto result = synthetic_allocate();
+   glOwnership.PendingFailure = glOwnership.FailAfter;
+   return result;
+}
+
+static ERR synthetic_mutable_boundaries(std::string *Text, int Mode, STRING *Output)
+{
+   ++glOwnership.Calls;
+   *Output = synthetic_allocate();
+   if (Mode IS 0) Text->clear();
+   else if (Mode IS 1) Text->assign(Text->size(), 'q');
+   else if (Mode IS 2) *Text = "abc";
+   else {
+      if (*Text != "abc") return ERR::InvalidData;
+      Text->clear();
+   }
+   return ERR::Args;
+}
+
+static ERR synthetic_deferred_input(std::string *, int)
+{
+   ++glOwnership.Calls;
+   return ERR::Okay;
+}
+
+static void synthetic_cpp_outputs(std::string *Text, std::string_view *View)
+{
+   ++glOwnership.Calls;
+   Text->assign("full\0length", 11);
+   *View = std::string_view("a\0b", 3);
+}
+
+static ERR synthetic_mutable_output(std::string *Text, STRING *Output)
+{
+   ++glOwnership.Calls;
+   *Output = synthetic_allocate();
+   Text->append("suffix");
+   return ERR::Args;
+}
+
+static ERR synthetic_vector_output(kt::vector<int> *Values, int Tail)
+{
+   ++glOwnership.Calls;
+   Values->push_back(-2147483647);
+   Values->push_back(Tail);
+   glOwnership.PendingFailure = glOwnership.FailAfter;
+   return ERR::Okay;
+}
+
+static ERR synthetic_struct_vector(kt::vector<APTR> *Values, int)
+{
+   static thread_local int value = -123;
+   ++glOwnership.Calls;
+   Values->push_back(&value);
+   glOwnership.PendingFailure = glOwnership.FailAfter;
+   return ERR::Okay;
+}
+
+static bool test_owned_outputs(kt::Log &Log)
+{
+   ModuleMarshallingTestScript holder;
+   if (not holder.initialise(Log)) return false;
+   auto lua = holder.get()->Lua;
+   holder.get()->setStatement("local ready = true");
+   if (Action(AC::Query, holder.get(), nullptr) != ERR::Okay) return false;
+   const std::array<uint32_t, 4> types = {
+      FD_INT, FD_STR|FD_RESULT|FD_ALLOC, FD_STR|FD_RESULT|FD_ALLOC, FDF_CPPSTRING|FD_RESULT|FD_MUTABLE
+   };
+   for (bool bridge : { false, true }) {
+      for (bool jit : { false, true }) {
+         glOwnership = { };
+         auto source = std::format(R"(
+            jit.{}()
+            local call = syntheticZero
+            local err:num, first:str, last:str, text:str, extra = call(0)
+            assert(err is ERR_Okay and #first is 255 and #last is 255 and #text is 11 and extra is nil)
+            err, first, last, text = call(1)
+            assert(err is ERR_Args and #first is 255 and #last is 255 and #text is 11)
+            try
+               checkall call(1) end
+            except e when ERR_Args
+               assert(e.message.find('SyntheticZero'), 'Native error diagnostic')
+            success
+               assert(false, 'checkall must promote native error')
+            end
+            try
+               check call(1)
+            except e when ERR_Args
+            success
+               assert(false, 'check must promote native error')
+            end
+            try
+               call(false)
+            except e when ERR_InvalidType
+            success
+               assert(false, 'Input failure must precede native execution')
+            end
+            function unchecked():num
+               local code = call(1)
+               return code
+            end
+            checkall assert(unchecked() is ERR_Args, 'checkall is immediate-scope only') end
+         )", jit ? "on" : "off");
+         auto failure = test_module_simple_call(lua, (APTR)synthetic_owned_outputs, FD_ERROR,
+            types, bridge, false, source.c_str(), false);
+         if ((not failure.empty()) or (glOwnership.Calls != 5) or (glOwnership.Allocations != 10) or
+             (glOwnership.Releases != 10) or test_module_live_temporaries()) {
+            Log.error("Owned outputs: %s, calls %d, allocations %d, releases %d, temporaries %d", failure.c_str(),
+               glOwnership.Calls, glOwnership.Allocations, glOwnership.Releases, test_module_live_temporaries());
+            return false;
+         }
+      }
+   }
+
+   // Real Lua allocator failure after native execution, including failure while pushing a later result.
+   for (int allocation = 0; allocation < 2; ++allocation) {
+      glOwnership = { };
+      glOwnership.FailAfter = allocation;
+      glOwnership.Allocator = lua_getallocf(lua, &glOwnership.AllocatorData);
+      lua_setallocf(lua, synthetic_allocator, &glOwnership);
+      auto failure = test_module_simple_call(lua, (APTR)synthetic_owned_outputs, FD_ERROR, types, true, false, R"(
+         local caught = false
+         try
+            syntheticZero(0)
+         except e when ERR_NoMemory
+            caught = true
+         end
+         assert(caught, 'Injected Lua allocation failure must raise')
+         processing.collect()
+      )", false);
+      lua_setallocf(lua, glOwnership.Allocator, glOwnership.AllocatorData);
+      if ((not failure.empty()) or (glOwnership.Calls != 1) or (glOwnership.Failures != 1) or
+          (glOwnership.Allocations != glOwnership.Releases) or
+          test_module_live_temporaries()) {
+         Log.error("Allocation failure %d: %s, allocations %d, releases %d, temporaries %d", allocation,
+            failure.c_str(), glOwnership.Allocations, glOwnership.Releases, test_module_live_temporaries());
+         return false;
+      }
+   }
+
+   const std::array<uint32_t, 1> return_types = { FD_STR|FD_RESULT|FD_ALLOC };
+   for (int allocation : { -1, 0, 1 }) {
+      glOwnership = { };
+      glOwnership.FailAfter = allocation;
+      glOwnership.Allocator = lua_getallocf(lua, &glOwnership.AllocatorData);
+      lua_setallocf(lua, synthetic_allocator, &glOwnership);
+      auto failure = test_module_simple_call(lua, (APTR)synthetic_owned_return, FD_STR|FD_ALLOC,
+         return_types, true, false, R"(
+         try
+            local first, last, extra = syntheticZero()
+            assert(#first is 255 and #last is 255 and extra is nil, 'Native return precedes output parameter')
+         except e when ERR_NoMemory
+         end
+      )", false);
+      glOwnership.PendingFailure = -1;
+      lua_setallocf(lua, glOwnership.Allocator, glOwnership.AllocatorData);
+      if ((not failure.empty()) or (glOwnership.Calls != 1) or (glOwnership.Allocations != 2) or
+          (glOwnership.Releases != 2)) {
+         Log.error("Native allocated return failure %d: %s", allocation, failure.c_str());
+         return false;
+      }
+   }
+
+   // Resource transfer commits only after the wrapper is pushed.  Later failures must keep the transferred
+   // wrapper alive while releasing the remaining native allocation, then let GC release the transferred value.
+   for (int allocation : { -1, 0, 1, 2 }) {
+      glOwnership = { };
+      glOwnership.FailAfter = allocation;
+      glOwnership.Allocator = lua_getallocf(lua, &glOwnership.AllocatorData);
+      lua_setallocf(lua, synthetic_allocator, &glOwnership);
+      auto resource_types = types;
+      resource_types[1] = FD_PTR|FD_STRUCT|FD_RESOURCE|FD_RESULT|FD_ALLOC;
+      auto failure = test_module_simple_call(lua, (APTR)synthetic_owned_outputs, FD_ERROR,
+         resource_types, true, false, R"(
+         try
+            local err, resource, text = syntheticZero(0)
+            assert(err is ERR_Okay and resource != nil and #text is 255)
+         except e when ERR_NoMemory
+         end
+         processing.collect()
+      )", false);
+      glOwnership.PendingFailure = -1;
+      lua_setallocf(lua, glOwnership.Allocator, glOwnership.AllocatorData);
+      lua_gc(lua, LUA_GCCOLLECT, 0);
+      if ((not failure.empty()) or (glOwnership.Allocations != glOwnership.Releases) or
+          test_module_live_temporaries()) {
+         Log.error("Resource transfer failure %d: %s, allocations %d, releases %d", allocation, failure.c_str(),
+            glOwnership.Allocations, glOwnership.Releases);
+         return false;
+      }
+   }
+
+   const std::array<uint32_t, 2> vector_types = { FDF_VECTOR|FD_MUTABLE|FD_RESULT|FD_INT, FD_INT };
+   for (int allocation : { -1, 0 }) {
+      glOwnership = { };
+      glOwnership.FailAfter = allocation;
+      glOwnership.Allocator = lua_getallocf(lua, &glOwnership.AllocatorData);
+      lua_setallocf(lua, synthetic_allocator, &glOwnership);
+      auto failure = test_module_simple_call(lua, (APTR)synthetic_vector_output, FD_ERROR,
+         vector_types, true, false, R"(
+         try
+            local err, values = syntheticZero(nil, 7)
+            assert(err is ERR_Okay and #values is 2 and values[0] is -2147483647 and values[1] is 7)
+         except e when ERR_NoMemory
+         end
+      )", false);
+      glOwnership.PendingFailure = -1;
+      lua_setallocf(lua, glOwnership.Allocator, glOwnership.AllocatorData);
+      if ((not failure.empty()) or (glOwnership.Calls != 1) or test_module_live_temporaries()) {
+         Log.error("Container failure %d: %s", allocation, failure.c_str());
+         return false;
+      }
+   }
+
+   if (make_struct(lua, "Arg1", "lValue") != ERR::Okay) return false;
+   const std::array<uint32_t, 2> structure_vector_types = {
+      FDF_VECTOR|FD_MUTABLE|FD_RESULT|FD_PTR|FD_STRUCT|FD_ALLOC, FD_INT
+   };
+   for (int allocation : { -1, 0, 1, 2, 3 }) {
+      glOwnership = { };
+      glOwnership.FailAfter = allocation;
+      glOwnership.Allocator = lua_getallocf(lua, &glOwnership.AllocatorData);
+      lua_setallocf(lua, synthetic_allocator, &glOwnership);
+      auto failure = test_module_simple_call(lua, (APTR)synthetic_struct_vector, FD_ERROR,
+         structure_vector_types, true, false, R"(
+         try
+            local err, values = syntheticZero(nil, 7)
+            assert(err is ERR_Okay and #values is 1 and values[0].value is -123)
+         except e when ERR_NoMemory
+         end
+      )", false);
+      glOwnership.PendingFailure = -1;
+      lua_setallocf(lua, glOwnership.Allocator, glOwnership.AllocatorData);
+      if ((not failure.empty()) or (glOwnership.Calls != 1) or test_module_live_temporaries() or
+          test_struct_live_references()) {
+         Log.error("Structure container failure %d: %s", allocation, failure.c_str());
+         return false;
+      }
+   }
+
+   // A registered output structure creates registry references while it is copied.  Fail after reference capture,
+   // while another owned result is still pending, and verify both the reference graph and native allocations.
+   if (make_struct(lua, "Arg2", "lValue") != ERR::Okay) return false;
+   for (int allocation : { -1, 0, 1, 2, 3 }) {
+      glOwnership = { };
+      glOwnership.FailAfter = allocation;
+      glOwnership.Allocator = lua_getallocf(lua, &glOwnership.AllocatorData);
+      lua_setallocf(lua, synthetic_allocator, &glOwnership);
+      auto copied_types = types;
+      copied_types[1] = FD_PTR|FD_STRUCT|FD_RESULT|FD_ALLOC;
+      auto failure = test_module_simple_call(lua, (APTR)synthetic_owned_outputs, FD_ERROR,
+         copied_types, true, false, R"(
+         try
+            local err, value, text = syntheticZero(0)
+            assert(err is ERR_Okay and type(value) is 'table' and #text is 255)
+         except e when ERR_NoMemory
+         end
+      )", false);
+      glOwnership.PendingFailure = -1;
+      lua_setallocf(lua, glOwnership.Allocator, glOwnership.AllocatorData);
+      if ((not failure.empty()) or (glOwnership.Allocations != glOwnership.Releases) or
+          test_module_live_temporaries() or test_struct_live_references()) {
+         Log.error("Copied structure failure %d: %s, references %d", allocation, failure.c_str(),
+            test_struct_live_references());
+         return false;
+      }
+   }
+
+   glOwnership = { };
+   const std::array<uint32_t, 2> mutable_types = { FDF_CPPSTRING|FD_MUTABLE, FD_STR|FD_RESULT|FD_ALLOC };
+   auto failure = test_module_simple_call(lua, (APTR)synthetic_mutable_output, FD_ERROR, mutable_types, true, false, R"(
+      local text = string.alloc(3)
+      try
+         checkall syntheticZero(text) end
+      except e when ERR_BufferOverflow
+         assert(e.message is 'Mutable buffer too small.', 'Copy-back failure takes precedence')
+      success
+         assert(false, 'Oversized copy-back must fail')
+      end
+   )", false);
+   if ((not failure.empty()) or (glOwnership.Calls != 1) or (glOwnership.Releases != 1) or
+       test_module_live_temporaries()) {
+      Log.error("Copy-back cleanup: %s, releases %d", failure.c_str(), glOwnership.Releases);
+      return false;
+   }
+   glOwnership = { };
+   const std::array<uint32_t, 3> boundary_types = { FDF_CPPSTRING|FD_MUTABLE, FD_INT, FD_STR|FD_RESULT|FD_ALLOC };
+   failure = test_module_simple_call(lua, (APTR)synthetic_mutable_boundaries, FD_ERROR,
+      boundary_types, true, false, R"(
+      local empty = string.alloc(0)
+      assert(syntheticZero(empty, 0) is ERR_Args and #empty is 0, 'Zero-capacity copy-back')
+      local exact = string.alloc(3)
+      assert(syntheticZero(exact, 2) is ERR_Args and exact.byte(0) is 97 and exact.byte(2) is 99,
+         'Exact capacity on native error')
+      assert(syntheticZero(exact, 3) is ERR_Args, 'Initial mutable contents are supplied to native code')
+      assert(exact.byte(0) is 0 and exact.byte(2) is 0, 'Shortened output zero-fills capacity')
+      local larger = string.alloc(8)
+      assert(syntheticZero(larger, 2) is ERR_Args and larger.byte(0) is 97 and
+         larger.byte(3) is 0 and larger.byte(7) is 0,
+         'Short copy-back')
+      try
+         syntheticZero(empty, 2)
+      except e when ERR_BufferOverflow
+      success
+         assert(false, 'Nonempty output cannot fit zero capacity')
+      end
+      try
+         syntheticZero('abc', 0)
+      except e when ERR_InvalidType
+      success
+         assert(false, 'Read-only string must be rejected before native execution')
+      end
+   )", false);
+   if ((not failure.empty()) or (glOwnership.Calls != 5) or (glOwnership.Releases != 5) or
+       test_module_live_temporaries()) {
+      Log.error("Mutable capacity contracts: %s, calls %d, releases %d", failure.c_str(), glOwnership.Calls,
+         glOwnership.Releases);
+      return false;
+   }
+
+   glOwnership = { };
+   const std::array<uint32_t, 2> cpp_types = { FDF_CPPSTRING|FD_RESULT|FD_MUTABLE, FDF_CPPSTRING|FD_RESULT };
+   failure = test_module_simple_call(lua, (APTR)synthetic_cpp_outputs, FD_VOID, cpp_types, true, false, R"(
+      local text, view, extra = syntheticZero()
+      assert(#text is 11 and text is 'full\0length', 'C++ string output copies embedded NUL')
+      assert(#view is 3 and view is 'a\0b' and extra is nil, 'C++ view output uses reference ABI and full length')
+   )");
+   if ((not failure.empty()) or (glOwnership.Calls != 2) or test_module_live_temporaries()) {
+      Log.error("C++ output copies: %s", failure.c_str());
+      return false;
+   }
+
+   glOwnership = { };
+   const std::array<uint32_t, 2> deferred_types = { FDF_CPPSTRING|FD_MUTABLE, FD_INT };
+   failure = test_module_simple_call(lua, (APTR)synthetic_deferred_input, FD_ERROR, deferred_types, true, false, R"(
+      local text = string.alloc(8)
+      thunk later():num
+         processing.collect()
+         raise ERR_Args, 'Deferred conversion failed'
+      end
+      try
+         syntheticZero(text, later())
+      except e when ERR_Args
+         assert(e.message is 'Deferred conversion failed', 'Deferred error is preserved')
+      success
+         assert(false, 'Deferred input must fail')
+      end
+   )", false);
+   if ((not failure.empty()) or glOwnership.Calls or test_module_live_temporaries()) {
+      Log.error("Deferred input cleanup: %s, calls %d, temporaries %d", failure.c_str(), glOwnership.Calls,
+         test_module_live_temporaries());
+      return false;
    }
    return true;
 }
@@ -611,6 +1093,20 @@ static bool test_simple_calls(kt::Log &Log)
 void module_marshalling_unit_tests(int &Passed, int &Total)
 {
    kt::Log log("ModuleMarshallingTests");
+   Total++;
+   if (test_output_slots(log)) {
+      Passed++;
+      log.msg("aligned output contracts passed");
+   }
+   else log.error("aligned output contracts failed");
+
+   Total++;
+   if (test_owned_outputs(log)) {
+      Passed++;
+      log.msg("owned output cleanup passed");
+   }
+   else log.error("owned output cleanup failed");
+
    log.branch("Running maximum string-view signature test");
    Total++;
    if (test_max_string_view_signature(log)) {

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -50,6 +50,7 @@ JUMPTABLE_CORE
 JUMPTABLE_REGEX
 
 #include "defs.h"
+#include "protected_call.h"
 
 namespace tiri {
 OBJECTPTR modDisplay = nullptr; // Required by tiri_input.c
@@ -688,22 +689,26 @@ ERR make_struct_ptr_array(lua_State *Lua, std::string_view StructName, int Eleme
    setarrayV(Lua, Lua->top++, arr); // Push to stack immediately to protect from GC during loop
    int arr_idx = lua_gettop(Lua);
 
+   int status = 0;
    if (Values) {
       std::vector<lua_ref> ref;
-      for (int i=0; i < Elements; i++) {
-         if (!struct_to_table(Lua, ref, *sdef, Values[i])) {
-            // Table is now on top of stack; retrieve arr from stack in case GC moved it
-            arr = arrayV(Lua->base + arr_idx - 1);
-            TValue *tv = Lua->top - 1;
-            GCtab *tab = tabV(tv);
-            setgcref(arr->get<GCRef>()[i], obj2gco(tab));
-            lj_gc_objbarrier(Lua, arr, tab);
+      auto convert = [&]() {
+         for (int i=0; i < Elements; i++) {
+            if (!struct_to_table(Lua, ref, *sdef, Values[i])) {
+               // Table is now on top of stack; retrieve arr from stack in case GC moved it
+               arr = arrayV(Lua->base + arr_idx - 1);
+               TValue *tv = Lua->top - 1;
+               GCtab *tab = tabV(tv);
+               setgcref(arr->get<GCRef>()[i], obj2gco(tab));
+               lj_gc_objbarrier(Lua, arr, tab);
+            }
+            Lua->top--;  // Pop the table
          }
-         Lua->top--;  // Pop the table
-      }
-
+      };
+      status = protected_tiri_call(Lua, convert);
       unref_struct_references(Lua, ref);
    }
+   if (status) lj_err_throw(Lua, status);
 
    return ERR::Okay;
 }
@@ -745,25 +750,28 @@ void make_struct_array(lua_State *Lua, std::string_view StructName, int Elements
    setarrayV(Lua, Lua->top++, arr); // Push to stack immediately to protect from GC during loop
    int arr_idx = lua_gettop(Lua);
 
+   int status = 0;
    if (Input) {
       std::vector<lua_ref> ref;
+      auto convert = [&]() {
+         for (int i=0; i < Elements; i++) {
+            if (!struct_to_table(Lua, ref, *sdef, Input)) {
+               // Table is now on top of stack; retrieve arr from stack in case GC moved it
+               arr = arrayV(Lua->base + arr_idx - 1);
+               TValue *tv = Lua->top - 1;
+               GCtab *tab = tabV(tv);
+               setgcref(arr->get<GCRef>()[i], obj2gco(tab));
+               lj_gc_objbarrier(Lua, arr, tab);
+            }
+            Lua->top--;  // Pop the table
 
-      for (int i=0; i < Elements; i++) {
-         if (!struct_to_table(Lua, ref, *sdef, Input)) {
-            // Table is now on top of stack; retrieve arr from stack in case GC moved it
-            arr = arrayV(Lua->base + arr_idx - 1);
-            TValue *tv = Lua->top - 1;
-            GCtab *tab = tabV(tv);
-            setgcref(arr->get<GCRef>()[i], obj2gco(tab));
-            lj_gc_objbarrier(Lua, arr, tab);
+            Input = (int8_t *)Input + struct_stride;
          }
-         Lua->top--;  // Pop the table
-
-         Input = (int8_t *)Input + struct_stride;
-      }
-
+      };
+      status = protected_tiri_call(Lua, convert);
       unref_struct_references(Lua, ref);
    }
+   if (status) lj_err_throw(Lua, status);
 }
 
 //********************************************************************************************************************
@@ -805,7 +813,8 @@ void make_any_array(lua_State *Lua, int Flags, std::string_view TypeName, int El
       }
       else make_struct_serial_array(Lua, TypeName, Elements, Values, StructDef);
    }
-   else make_array(Lua, ff_to_aet(Flags), Elements, Values, TypeName);
+   // A descriptor's argument name is not a structure type for scalar containers.
+   else make_array(Lua, ff_to_aet(Flags), Elements, Values);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -95,7 +95,7 @@ struct ModuleBinding;
 // Precomputed counts of the bridge-owned temporaries one signature can require.  Deriving these once per callable lets
 // the call bridge construct only the elements a signature actually uses, and lets preparation reject a signature whose
 // demands would exceed a bounded store instead of discovering the overflow mid-call.
-//
+
 struct marshalling_profile {
    uint8_t Strings = 0;         // Mutable std::string temporaries (FD_STR|FD_CPP with FD_MUTABLE or FD_RESULT)
    uint8_t StringViews = 0;     // std::string_view temporaries (FD_STR|FD_CPP, read-only)

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -13,6 +13,7 @@
 #include "lj_str.h"
 #include "lj_struct.h"
 #include "lj_tab.h"
+#include "protected_call.h"
 
 #include "defs.h"
 #include "lj_proto_registry.h"
@@ -75,6 +76,19 @@ constexpr int MAX_MODULE_ARGS = 16;
 constexpr size_t BUFFER_ELEMENT_SIZE = 16;
 constexpr size_t BUFFER_SIZE = MAX_MODULE_ARGS * BUFFER_ELEMENT_SIZE;
 constexpr size_t MAX_STRING_PREFIX_LENGTH = 200;
+
+// Every front slot and tail result starts on an eight-byte boundary.  At most sixteen pairs of eight-byte
+// slots fit the existing 256-byte limit, including mixed int/pointer/double signatures.
+constexpr size_t MODULE_SLOT_SIZE = 8;
+static_assert(sizeof(int) IS 4 and alignof(int) <= MODULE_SLOT_SIZE);
+static_assert(sizeof(APTR) <= MODULE_SLOT_SIZE and alignof(APTR) <= MODULE_SLOT_SIZE);
+static_assert(sizeof(double) <= MODULE_SLOT_SIZE and alignof(double) <= MODULE_SLOT_SIZE);
+static_assert(sizeof(int64_t) <= MODULE_SLOT_SIZE and alignof(int64_t) <= MODULE_SLOT_SIZE);
+
+static constexpr size_t align_module_slot(size_t Offset)
+{
+   return (Offset + MODULE_SLOT_SIZE - 1) & ~(MODULE_SLOT_SIZE - 1);
+}
 
 struct ModuleBinding;
 
@@ -154,6 +168,11 @@ struct ModuleCallable {
 // emplace() returns null when the store is full.  Preparation rejects any signature that could reach that point, so a
 // null return indicates a profile/marshaller disagreement rather than an expected condition.
 
+#ifdef UNIT_TESTS
+static thread_local int glModuleLiveTemporaries = 0;
+int test_module_live_temporaries() { return glModuleLiveTemporaries; }
+#endif
+
 template <class T, size_t Capacity> class bounded_store {
    alignas(T) uint8_t Storage[Capacity * sizeof(T)];
    size_t Count = 0;
@@ -166,13 +185,21 @@ template <class T, size_t Capacity> class bounded_store {
    bounded_store & operator=(const bounded_store &) = delete;
 
    ~bounded_store() {
-      while (Count) slot(--Count)->~T();
+      while (Count) {
+         slot(--Count)->~T();
+#ifdef UNIT_TESTS
+         --glModuleLiveTemporaries;
+#endif
+      }
    }
 
    template <class... Args> [[nodiscard]] T * emplace(Args &&...Arguments) {
       if (Count >= Capacity) return nullptr;
       auto element = new (slot(Count)) T(std::forward<Args>(Arguments)...);
       Count++;
+#ifdef UNIT_TESTS
+      ++glModuleLiveTemporaries;
+#endif
       return element;
    }
 
@@ -335,7 +362,7 @@ static int module_call(lua_State *);
 #ifdef UNIT_TESTS
 static lua_CFunction module_call_entry();
 #endif
-static ERR module_call_inner(lua_State *, std::string &, int &);
+static ERR module_call_inner(lua_State *, std::string &, int &, int &);
 static int process_results(extTiri *, APTR, const FunctionField *);
 
 static std::unique_ptr<const static_module_signature> make_module_signature(
@@ -737,6 +764,8 @@ static void prepare_module_callables(ModuleBinding *Module, const Function *Func
          // an argument slot at call time.  The front slot is sized as the marshaller sizes it; the back allocation
          // applies only to the result kinds that write into buffer-tail storage.
 
+         front_bytes = align_module_slot(front_bytes);
+         back_bytes = align_module_slot(back_bytes);
          const int argtype = args[arg].Type;
          if ((argtype & FDF_SPAN) IS FDF_SPAN) front_bytes += sizeof(APTR);
          else if (argtype & FD_RESULT) {
@@ -744,7 +773,7 @@ static void prepare_module_callables(ModuleBinding *Module, const Function *Func
             if (((argtype & FDF_VECTOR) IS FDF_VECTOR) and (argtype & FD_MUTABLE)) { }
             else if ((argtype & FD_STR) and (argtype & FD_CPP)) { }
             else if (argtype & (FD_STR|FD_PTR)) back_bytes += sizeof(APTR);
-            else if (argtype & FD_INT) back_bytes += sizeof(int);
+            else if (argtype & FD_INT) back_bytes += MODULE_SLOT_SIZE;
             else if (argtype & (FD_DOUBLE|FD_INT64)) back_bytes += sizeof(int64_t);
          }
          else if (argtype & FD_FUNCTION) front_bytes += sizeof(FUNCTION *);
@@ -1429,11 +1458,10 @@ extern "C" void tiri_module_activate(lua_State *Lua, uint32_t Dependency)
 //
 // RESULT|STR        = CSTRING *.  Function writes a non-allocated C string pointer; returned to Tiri as a string.
 // RESULT|STR|ALLOC  = CSTRING *.  Function writes an allocated C string pointer; returned to Tiri then freed.
-// RESULT|STR|CPP    = std::string *.  Tiri provides a temporary std::string; returned to Tiri as a string.
+// RESULT|STR|CPP    = std::string_view *.  With MUTABLE, std::string *; both copy their full length.
 //
 // RESULT|PTR        = APTR *.  Function writes a pointer; returned to Tiri as light userdata unless specialised.
-// RESULT|PTR|ALLOC  = APTR *.  Function writes an allocated block; returned as a byte array when BUFSIZE is
-//                     available, then freed.
+// RESULT|PTR|ALLOC  = APTR *.  No byte-array protocol is supported; pushes nil and frees the block.
 // RESULT|PTR|STRUCT = Struct **.  Function writes a struct pointer; returned as a Tiri table, or as a managed
 //                     struct when RESOURCE is set.
 // RESULT|ARRAY      = Unsupported.  Raw pointer-array marshalling has been removed.
@@ -1465,14 +1493,18 @@ static lua_CFunction module_call_entry()
 
 static int module_call(lua_State *Lua)
 {
-   std::string error_msg;
    int results = 0;
-
-   auto err = module_call_inner(Lua, error_msg, results);
-   if (err != ERR::Okay) {
-      if (error_msg.empty()) error_msg = GetErrorMsg(err);
-      luaL_error(Lua, err, std::move(error_msg));
+   int runtime_error = 0;
+   {
+      std::string error_msg;
+      auto err = module_call_inner(Lua, error_msg, results, runtime_error);
+      if (not runtime_error and (err != ERR::Okay)) {
+         if (error_msg.empty()) error_msg = GetErrorMsg(err);
+         luaL_error(Lua, err, std::move(error_msg));
+      }
    }
+   // All invocation-owned native storage has been released before resuming Lua's nonlocal error handling.
+   if (runtime_error) lj_err_throw(Lua, runtime_error);
    return results;
 }
 
@@ -1552,7 +1584,7 @@ static ERR call_simple_module(lua_State *Lua, const ModuleCallable &Callable, st
    return push_module_scalar(Lua, Callable, result, ErrorMsg);
 }
 
-static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results)
+static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results, int &RuntimeError)
 {
    kt::Log log("module_call");
 
@@ -1607,7 +1639,7 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
       return call_simple_module(Lua, *callable, ErrorMsg, Results);
    }
 
-   uint8_t buffer[BUFFER_SIZE]; // 16 bytes per argument accommodates output metadata such as sizes.
+   alignas(MODULE_SLOT_SIZE) uint8_t buffer[BUFFER_SIZE];
    int i;
 
    struct mutable_cpp_string_ref {
@@ -1664,178 +1696,212 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
    } func_guard{ Lua, func };
 
    module_scalar_result rc = { };
-   void * arg_values[MAX_MODULE_ARGS];
+   void * arg_values[MAX_MODULE_ARGS] = { };
    int in = 0;
 
-   int j = 0;
+   // This owner lives outside the protected C frame.  Result pointers are cleared after copying/freeing or
+   // successful transfer.  An early error therefore releases only values still owned by this invocation.
+   struct output_owner {
+      const FunctionField *Fields;
+      module_scalar_result &Return;
+      void **Arguments;
+      bool Called = false;
 
-   for (i=1; args[i].Name; i++) {
-      int argtype = args[i].Type;
-
-      if ((argtype & FDF_SPAN) IS FDF_SPAN) {
-         if (span_count >= span_args.size()) {
-            ErrorMsg = "Too many span arguments.";
-            return ERR::Args;
+      ~output_owner() {
+         if (not Called) return;
+         auto type = Fields[0].Type;
+         if ((type & FD_ALLOC) and (type & (FD_STR|FD_PTR|FD_OBJECT)) and Return.Arg) {
+            FreeResource((APTR)Return.Arg);
          }
-
-         if (argtype & (FD_RESULT|FD_ALLOC)) {
-            ErrorMsg = std::format("Function '{}' uses an unsupported span result.", callable->Name);
-            return ERR::NoSupport;
+         for (int index = 1; Fields[index].Name; ++index) {
+            type = Fields[index].Type;
+            if ((type & FD_RESULT) and (type & FD_ALLOC) and (type & (FD_STR|FD_PTR)) and
+                not (type & FD_CPP) and ((type & FDF_VECTOR) != FDF_VECTOR)) {
+               auto slot = *(APTR **)Arguments[index - 1];
+               if (slot and *slot) FreeResource(*slot);
+            }
          }
-
-         bool mutable_span = argtype & FD_MUTABLE;
-
-         AET element_type;
-         size_t element_size;
-         struct_record *struct_def;
-         if (auto error = module_span_element_metadata(Lua, args[i], &element_type, &element_size, &struct_def);
-             error != ERR::Okay) {
-            ErrorMsg = (error IS ERR::Search) ?
-               std::format("Function '{}' references an unknown span structure.", callable->Name) :
-               std::format("Function '{}' uses invalid span element metadata.", callable->Name);
-            return error;
-         }
-
-         CPTR data = nullptr;
-         size_t extent = 0;
-         auto &span_arg = span_args[span_count++];
-         auto value_type = lua_type(Lua, i);
-
-         if (value_type IS LUA_TARRAY) {
-            auto array = arrayV(Lua, i);
-            if (mutable_span and array->is_readonly()) {
-               ErrorMsg = std::format("Arg #{} ({}) requires a writable array.", i, args[i].Name);
-               return ERR::InvalidType;
-            }
-
-            if ((array->elemtype != element_type) or (size_t(array->elemsize) != element_size)) {
-               ErrorMsg = std::format("Arg #{} ({}) array element type does not match the span.", i, args[i].Name);
-               return ERR::InvalidType;
-            }
-            if ((element_type IS AET::STRUCT) and (array->struct_definition() != struct_def)) {
-               ErrorMsg = std::format("Arg #{} ({}) structure array type does not match the span.", i, args[i].Name);
-               return ERR::InvalidType;
-            }
-            data = array->arraydata();
-            extent = array->len;
-         }
-         else if (value_type IS LUA_TSTRING) {
-            if (element_type != AET::BYTE) {
-               ErrorMsg = std::format("Arg #{} ({}) only accepts string storage for a byte span.", i, args[i].Name);
-               return ERR::InvalidType;
-            }
-
-            auto string = string_arg(Lua, i);
-            if (mutable_span and not lj_str_ismutable(string)) {
-               ErrorMsg = std::format("Arg #{} ({}) requires a mutable string buffer.", i, args[i].Name);
-               return ERR::InvalidType;
-            }
-            data = mutable_span ? CPTR(strdatawr(string)) : CPTR(strdata(string));
-            extent = string->len;
-         }
-         else if ((value_type IS LUA_TNIL) or (value_type IS LUA_TNONE)) {
-            // The canonical empty span is constructed below.
-         }
-         else if (auto native_struct = lua_isstruct(Lua, i) ? lua_tostruct(Lua, i) : nullptr) {
-            if (element_type != AET::STRUCT) {
-               ErrorMsg = std::format("Arg #{} ({}) requires matching array storage.", i, args[i].Name);
-               return ERR::InvalidType;
-            }
-            if (lj_struct_stale(native_struct)) {
-               ErrorMsg = std::format("Arg #{} ({}) structure storage is stale.", i, args[i].Name);
-               return ERR::DoesNotExist;
-            }
-            if ((native_struct->def != struct_def) or (size_t(native_struct->structsize) != element_size)) {
-               ErrorMsg = std::format("Arg #{} ({}) structure type does not match the span.", i, args[i].Name);
-               return ERR::InvalidType;
-            }
-            if (not native_struct->data) {
-               ErrorMsg = std::format("Arg #{} ({}) structure storage is unavailable.", i, args[i].Name);
-               return ERR::InvalidData;
-            }
-            data = native_struct->data;
-            extent = 1;
-         }
-         else {
-            ErrorMsg = std::format("Arg #{} ({}) expected an array, string, structure or nil for a span, got {}.", i,
-               args[i].Name, lua_typename(Lua, value_type));
-            return ERR::InvalidType;
-         }
-
-         if (extent and not data) {
-            ErrorMsg = std::format("Arg #{} ({}) span storage is unavailable.", i, args[i].Name);
-            return ERR::InvalidData;
-         }
-
-         auto span_address = span_arg.set(data, extent);
-         ((APTR *)(buffer + j))[0] = span_address;
-         arg_values[in] = buffer + j;
-         in++;
-         j += sizeof(APTR);
       }
-      else if (argtype & FD_RESULT) {
-         // Result arguments are stored in the buffer with a pointer to an empty variable space (stored at the end of
-         // the buffer)
+   } outputs{ args, rc, arg_values };
 
-         RMSG("Result for arg %d stored at %p", i, end);
+   auto invoke = [&]() -> ERR {
+      int j = 0;
 
-         if (((argtype & FDF_VECTOR) IS FDF_VECTOR) and (argtype & FD_MUTABLE)) {
-            // Applicable to RESULT|MUTABLE only, which requires the client to provide an empty kt::vector<> to the function.
-            // We set this up here, then convert the resulting values to a Tiri array when the function returns.
-            cpp_array_result result_ref = { };
-            if ((argtype & FD_STRUCT) and (!(argtype & FD_PTR))) {
-               // TODO: args[i].Name will include the name of the struct that we need to use to build the array, e.g. "FontList:Result"
-               // where FontList is the struct name.  The kt::vector<T> data() will contain a serialised list of structs and the total
-               // count.  For this to work, the STRUCT type would need to host a kt::vector<> and the call site would need to
-               // make a TrackResource() call that associates its destruction process with the kt::vector<> address.
-               ErrorMsg = "C++ struct arrays are not supported.";
+      for (i=1; args[i].Name; i++) {
+         int argtype = args[i].Type;
+         j = int(align_module_slot(j));
+         end = buffer + (size_t(end - buffer) & ~(MODULE_SLOT_SIZE - 1));
+
+         if ((argtype & FDF_SPAN) IS FDF_SPAN) {
+            if (span_count >= span_args.size()) {
+               ErrorMsg = "Too many span arguments.";
+               return ERR::Args;
+            }
+
+            if (argtype & (FD_RESULT|FD_ALLOC)) {
+               ErrorMsg = std::format("Function '{}' uses an unsupported span result.", callable->Name);
                return ERR::NoSupport;
             }
-            else if (auto error = make_cpp_array_result(argtype, &result_ref); !error) {
-               ((APTR *)(buffer + j))[0] = result_ref.Data; // kt::vector<>
-               if (not cpp_arrays.emplace(std::move(result_ref))) {
-                  ErrorMsg = std::format("Function '{}' exceeded its C++ array result storage.", callable->Name);
-                  return ERR::BufferOverflow;
-               }
-               arg_values[in]  = buffer + j;
-               in++;
-               j += sizeof(APTR);
-            }
-            else {
-               ErrorMsg = std::format("Function '{}' uses an unsupported C++ array result type.", callable->Name);
+
+            bool mutable_span = argtype & FD_MUTABLE;
+
+            AET element_type;
+            size_t element_size;
+            struct_record *struct_def;
+            if (auto error = module_span_element_metadata(Lua, args[i], &element_type, &element_size, &struct_def);
+                error != ERR::Okay) {
+               ErrorMsg = (error IS ERR::Search) ?
+                  std::format("Function '{}' references an unknown span structure.", callable->Name) :
+                  std::format("Function '{}' uses invalid span element metadata.", callable->Name);
                return error;
             }
-         }
-         else if (argtype & FD_STR) { // FD_RESULT
-            if (argtype & FD_CPP) {
-               if (argtype & FD_MUTABLE) {
-                  // Use of MUTABLE enables support for std::string buffering.  We provide our own std::string that will be used as
-                  // the buffer, it gets converted to a Tiri string when the function returns.
 
-                  auto slot = strings.emplace();
-                  if (not slot) {
-                     ErrorMsg = std::format("Function '{}' exceeded its string storage.", callable->Name);
+            CPTR data = nullptr;
+            size_t extent = 0;
+            auto &span_arg = span_args[span_count++];
+            auto value_type = lua_type(Lua, i);
+
+            if (value_type IS LUA_TARRAY) {
+               auto array = arrayV(Lua, i);
+               if (mutable_span and array->is_readonly()) {
+                  ErrorMsg = std::format("Arg #{} ({}) requires a writable array.", i, args[i].Name);
+                  return ERR::InvalidType;
+               }
+
+               if ((array->elemtype != element_type) or (size_t(array->elemsize) != element_size)) {
+                  ErrorMsg = std::format("Arg #{} ({}) array element type does not match the span.", i, args[i].Name);
+                  return ERR::InvalidType;
+               }
+               if ((element_type IS AET::STRUCT) and (array->struct_definition() != struct_def)) {
+                  ErrorMsg = std::format("Arg #{} ({}) structure array type does not match the span.", i, args[i].Name);
+                  return ERR::InvalidType;
+               }
+               data = array->arraydata();
+               extent = array->len;
+            }
+            else if (value_type IS LUA_TSTRING) {
+               if (element_type != AET::BYTE) {
+                  ErrorMsg = std::format("Arg #{} ({}) only accepts string storage for a byte span.", i, args[i].Name);
+                  return ERR::InvalidType;
+               }
+
+               auto string = string_arg(Lua, i);
+               if (mutable_span and not lj_str_ismutable(string)) {
+                  ErrorMsg = std::format("Arg #{} ({}) requires a mutable string buffer.", i, args[i].Name);
+                  return ERR::InvalidType;
+               }
+               data = mutable_span ? CPTR(strdatawr(string)) : CPTR(strdata(string));
+               extent = string->len;
+            }
+            else if ((value_type IS LUA_TNIL) or (value_type IS LUA_TNONE)) {
+               // The canonical empty span is constructed below.
+            }
+            else if (auto native_struct = lua_isstruct(Lua, i) ? lua_tostruct(Lua, i) : nullptr) {
+               if (element_type != AET::STRUCT) {
+                  ErrorMsg = std::format("Arg #{} ({}) requires matching array storage.", i, args[i].Name);
+                  return ERR::InvalidType;
+               }
+               if (lj_struct_stale(native_struct)) {
+                  ErrorMsg = std::format("Arg #{} ({}) structure storage is stale.", i, args[i].Name);
+                  return ERR::DoesNotExist;
+               }
+               if ((native_struct->def != struct_def) or (size_t(native_struct->structsize) != element_size)) {
+                  ErrorMsg = std::format("Arg #{} ({}) structure type does not match the span.", i, args[i].Name);
+                  return ERR::InvalidType;
+               }
+               if (not native_struct->data) {
+                  ErrorMsg = std::format("Arg #{} ({}) structure storage is unavailable.", i, args[i].Name);
+                  return ERR::InvalidData;
+               }
+               data = native_struct->data;
+               extent = 1;
+            }
+            else {
+               ErrorMsg = std::format("Arg #{} ({}) expected an array, string, structure or nil for a span, got {}.", i,
+                  args[i].Name, lua_typename(Lua, value_type));
+               return ERR::InvalidType;
+            }
+
+            if (extent and not data) {
+               ErrorMsg = std::format("Arg #{} ({}) span storage is unavailable.", i, args[i].Name);
+               return ERR::InvalidData;
+            }
+
+            auto span_address = span_arg.set(data, extent);
+            ((APTR *)(buffer + j))[0] = span_address;
+            arg_values[in] = buffer + j;
+            in++;
+            j += sizeof(APTR);
+         }
+         else if (argtype & FD_RESULT) {
+            // Result arguments are stored in the buffer with a pointer to an empty variable space (stored at the end of
+            // the buffer)
+
+            RMSG("Result for arg %d stored at %p", i, end);
+
+            if (((argtype & FDF_VECTOR) IS FDF_VECTOR) and (argtype & FD_MUTABLE)) {
+               // RESULT|MUTABLE supplies an empty kt::vector<> to the native function.
+               // We set this up here, then convert the resulting values to a Tiri array when the function returns.
+               cpp_array_result result_ref = { };
+               if ((argtype & FD_STRUCT) and (!(argtype & FD_PTR))) {
+                  // Serialised structure vectors need a declared element layout and a resource owner that destroys
+                  // the exact vector type.  Pointer-to-structure vectors use the existing copied-table path.
+                  ErrorMsg = "C++ struct arrays are not supported.";
+                  return ERR::NoSupport;
+               }
+               else if (auto error = make_cpp_array_result(argtype, &result_ref); !error) {
+                  ((APTR *)(buffer + j))[0] = result_ref.Data; // kt::vector<>
+                  if (not cpp_arrays.emplace(std::move(result_ref))) {
+                     ErrorMsg = std::format("Function '{}' exceeded its C++ array result storage.", callable->Name);
                      return ERR::BufferOverflow;
                   }
-                  ((std::string **)(buffer + j))[0] = slot;
                   arg_values[in]  = buffer + j;
                   in++;
                   j += sizeof(APTR);
                }
                else {
-                  // Non-mutable string reference, supported as a std::string_view
-                  auto slot = string_views.emplace();
-                  if (not slot) {
-                     ErrorMsg = std::format("Function '{}' exceeded its string view storage.", callable->Name);
-                     return ERR::BufferOverflow;
+                  ErrorMsg = std::format("Function '{}' uses an unsupported C++ array result type.", callable->Name);
+                  return error;
+               }
+            }
+            else if (argtype & FD_STR) { // FD_RESULT
+               if (argtype & FD_CPP) {
+                  if (argtype & FD_MUTABLE) {
+                     // MUTABLE requests an owned std::string buffer, copied to a Tiri string after the call.
+
+                     auto slot = strings.emplace();
+                     if (not slot) {
+                        ErrorMsg = std::format("Function '{}' exceeded its string storage.", callable->Name);
+                        return ERR::BufferOverflow;
+                     }
+                     ((std::string **)(buffer + j))[0] = slot;
+                     arg_values[in]  = buffer + j;
+                     in++;
+                     j += sizeof(APTR);
                   }
-                  ((std::string_view **)(buffer + j))[0] = slot;
+                  else {
+                     // Non-mutable string reference, supported as a std::string_view
+                     auto slot = string_views.emplace();
+                     if (not slot) {
+                        ErrorMsg = std::format("Function '{}' exceeded its string view storage.", callable->Name);
+                        return ERR::BufferOverflow;
+                     }
+                     ((std::string_view **)(buffer + j))[0] = slot;
+                     arg_values[in]  = buffer + j;
+                     in++;
+                     j += sizeof(APTR);
+                  }
+               }
+               else { // C-style string reference, this parameter style is being deprecated.
+                  end -= sizeof(APTR);
+                  ((APTR *)(buffer + j))[0] = end;
+                  ((APTR *)end)[0] = nullptr;
                   arg_values[in]  = buffer + j;
                   in++;
                   j += sizeof(APTR);
                }
             }
-            else { // C-style string reference, this parameter style is being deprecated.
+            else if (argtype & FD_PTR) { // FD_RESULT
                end -= sizeof(APTR);
                ((APTR *)(buffer + j))[0] = end;
                ((APTR *)end)[0] = nullptr;
@@ -1843,335 +1909,342 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
                in++;
                j += sizeof(APTR);
             }
-         }
-         else if (argtype & FD_PTR) { // FD_RESULT
-            end -= sizeof(APTR);
-            ((APTR *)(buffer + j))[0] = end;
-            ((APTR *)end)[0] = nullptr;
-            arg_values[in]  = buffer + j;
-            in++;
-            j += sizeof(APTR);
-         }
-         else if (argtype & FD_INT) { // FD_RESULT
-            end -= sizeof(int);
-            ((APTR *)(buffer + j))[0] = end;
-            ((int *)end)[0] = 0;
-            arg_values[in]  = buffer + j;
-            in++;
-            j += sizeof(APTR);
-         }
-         else if (argtype & (FD_DOUBLE|FD_INT64)) { // FD_RESULT
-            end -= sizeof(int64_t);
-            ((APTR *)(buffer + j))[0] = end;
-            ((int64_t *)end)[0] = 0;
-            arg_values[in]  = buffer + j;
-            in++;
-            j += sizeof(APTR);
-         }
-         else {
-            ErrorMsg = std::format("Unrecognised arg {} type {}", i, argtype);
-            return ERR::InvalidType;
-         }
-      }
-      else if (argtype & FD_FUNCTION) {
-         if (func.defined()) { // Is the function reserve already used?
-            ErrorMsg = "Multiple function arguments are not supported.";
-            return ERR::Args;
-         }
-
-         // NOTE: The client is responsible for calling DerefProcedure() on the function reference when it is no longer needed,
-         // or it can mark the function as consumed.
-
-         switch(lua_type(Lua, i)) {
-            case LUA_TSTRING:
-            case LUA_TFUNCTION: {
-               if (auto error = capture_tiri_function(Lua, i, func); error != ERR::Okay) {
-                  ErrorMsg = std::format("Function argument #{} ({}) must resolve to a function.", i, args[i].Name);
-                  return error;
-               }
-               ((FUNCTION **)(buffer + j))[0] = &func;
-               break;
+            else if (argtype & FD_INT) { // FD_RESULT
+               end -= MODULE_SLOT_SIZE;
+               ((APTR *)(buffer + j))[0] = end;
+               ((int *)end)[0] = 0;
+               arg_values[in]  = buffer + j;
+               in++;
+               j += sizeof(APTR);
             }
-
-            case LUA_TNIL:
-            case LUA_TNONE:
-               ((FUNCTION **)(buffer + j))[0] = nullptr;
-               break;
-
-            default:
-               ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected function, got {} '{}'.", i, args[i].Name,
-                  lua_typename(Lua, lua_type(Lua, i)), value_string(Lua, i));
-               return ERR::InvalidType;
-         }
-
-         arg_values[in]  = buffer + j;
-         in++;
-         j += sizeof(FUNCTION *);
-      }
-      else if (argtype & FD_STR) {
-         // Resolve thunks before reading the type so a thunk that yields a string is marshalled by its resolved
-         // value rather than rejected as its unresolved userdata container.
-         resolve_index(Lua, i);
-         auto type = lua_type(Lua, i);
-         int type_size = sizeof(APTR);
-
-         if (argtype & FD_MUTABLE) {
-            // The client is expected to provide a mutable string with preallocated size, which can be acquired from string.alloc()
-            if (type != LUA_TSTRING) {
-               ErrorMsg = std::format("Arg #{} requires a mutable buffer.", i);
-               return ERR::InvalidType;
-            }
-
-            GCstr *string = string_arg(Lua, i);
-            if (not lj_str_ismutable(string)) {
-               ErrorMsg = std::format("Arg #{} requires a mutable buffer.", i);
-               return ERR::InvalidType;
-            }
-
-            if (argtype & FD_CPP) { // Function expects a pointer to std::string that it can mutate
-               size_t len;
-               auto str = lua_tolstring(Lua, i, &len);
-               auto cppstr = str ? strings.emplace(str, len) : strings.emplace();
-               if (not cppstr) {
-                  ErrorMsg = std::format("Function '{}' exceeded its string storage.", callable->Name);
-                  return ERR::BufferOverflow;
-               }
-               if (not mutable_cpp_strings.emplace(cppstr, string, i)) {
-                  ErrorMsg = std::format("Function '{}' exceeded its mutable string storage.", callable->Name);
-                  return ERR::BufferOverflow;
-               }
-               ((std::string **)(buffer + j))[0] = cppstr;
-            }
-            else ((CSTRING *)(buffer + j))[0] = strdatawr(string);
-         }
-         else if (argtype & FD_CPP) { // Read-only std::string_view; nil has null data and zero length.
-            if ((type != LUA_TSTRING) and (type != LUA_TNIL) and (type != LUA_TNONE)) {
-               ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected string, got {} '{}'.", i, args[i].Name,
-                  lua_typename(Lua, type), value_string(Lua, i));
-               return ERR::InvalidType;
-            }
-            size_t len;
-            auto str = lua_tolstring(Lua, i, &len);
-            auto view = str ? string_views.emplace(str, len) : string_views.emplace();
-            if (not view) {
-               ErrorMsg = std::format("Function '{}' exceeded its string view storage.", callable->Name);
-               return ERR::BufferOverflow;
-            }
-            ((std::string_view **)(buffer + j))[0] = view;
-         }
-         else if (type IS LUA_TSTRING) {
-            ((CSTRING *)(buffer + j))[0] = lua_tostring(Lua, i);
-         }
-         else if (type <= 0) {
-            ((CSTRING *)(buffer + j))[0] = nullptr;
-         }
-         else if ((type IS LUA_TUSERDATA) or (type IS LUA_TLIGHTUSERDATA)) {
-            ErrorMsg = std::format("Arg #{} ({}) requires a string and not untyped pointer.", i, args[i].Name);
-            return ERR::InvalidType;
-         }
-         else {
-            ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected string, got {} '{}'.", i, args[i].Name,
-               lua_typename(Lua, lua_type(Lua, i)), value_string(Lua, i));
-            return ERR::InvalidType;
-         }
-
-         arg_values[in] = buffer + j;
-         in++;
-         j += type_size;
-      }
-      else if ((argtype & FDF_VECTOR) IS FDF_VECTOR) {
-         ErrorMsg = "C++ array inputs are not supported.";
-         return ERR::NoSupport;
-      }
-      else if (argtype & FD_PTR) {
-         resolve_index(Lua, i); // Resolve thunks so the resolved value is marshalled, not the thunk userdata.
-         auto arg_type = lua_type(Lua, i);
-         if (arg_type IS LUA_TSTRING) {
-            // Lua strings need to be converted to C strings
-            auto string = string_arg(Lua, i);
-            if ((argtype & FD_MUTABLE) and (not lj_str_ismutable(string))) {
-               ErrorMsg = std::format("Arg #{} requires a mutable buffer.", i);
-               return ERR::InvalidType;
-            }
-
-            ((CSTRING *)(buffer + j))[0] = (argtype & FD_MUTABLE) ? strdatawr(string) : strdata(string);
-            arg_values[in] = buffer + j;
-            in++;
-            j += sizeof(CSTRING);
-         }
-         else if (auto native_struct = lua_isstruct(Lua, i) ? lua_tostruct(Lua, i) : nullptr) {
-            // Guard specific to lifecycle-bound struct views; structs without an object dependency skip it.
-            if (lj_struct_stale(native_struct)) {
-               ErrorMsg = "A struct argument's providing object has been destroyed.";
-               return ERR::DoesNotExist;
-            }
-            ((APTR *)(buffer + j))[0] = native_struct->data;
-            arg_values[in] = buffer + j;
-            in++;
-            j += sizeof(APTR);
-
-            log.trace("Struct address %p inserted to arg offset %d", native_struct->data, j);
-         }
-         else if (arg_type IS LUA_TOBJECT) {
-            auto obj = lua_toobject(Lua, i);
-            if (auto direct = direct_object_ptr(obj)) {
-               ((OBJECTPTR *)(buffer + j))[0] = direct;
+            else if (argtype & (FD_DOUBLE|FD_INT64)) { // FD_RESULT
+               end -= sizeof(int64_t);
+               ((APTR *)(buffer + j))[0] = end;
+               ((int64_t *)end)[0] = 0;
+               arg_values[in]  = buffer + j;
+               in++;
+               j += sizeof(APTR);
             }
             else {
-               OBJECTPTR ptr_obj;
-               if (auto error = access_object(obj, ptr_obj); error IS ERR::Okay) {
-                  ((OBJECTPTR *)(buffer + j))[0] = ptr_obj;
-                  release_object(obj);
+               ErrorMsg = std::format("Unrecognised arg {} type {}", i, argtype);
+               return ERR::InvalidType;
+            }
+         }
+         else if (argtype & FD_FUNCTION) {
+            if (func.defined()) { // Is the function reserve already used?
+               ErrorMsg = "Multiple function arguments are not supported.";
+               return ERR::Args;
+            }
+
+            // The client must call DerefProcedure() when it no longer needs the function reference,
+            // or it can mark the function as consumed.
+
+            switch(lua_type(Lua, i)) {
+               case LUA_TSTRING:
+               case LUA_TFUNCTION: {
+                  if (auto error = capture_tiri_function(Lua, i, func); error != ERR::Okay) {
+                     ErrorMsg = std::format("Function argument #{} ({}) must resolve to a function.", i, args[i].Name);
+                     return error;
+                  }
+                  ((FUNCTION **)(buffer + j))[0] = &func;
+                  break;
+               }
+
+               case LUA_TNIL:
+               case LUA_TNONE:
+                  ((FUNCTION **)(buffer + j))[0] = nullptr;
+                  break;
+
+               default:
+                  ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected function, got {} '{}'.", i, args[i].Name,
+                     lua_typename(Lua, lua_type(Lua, i)), value_string(Lua, i));
+                  return ERR::InvalidType;
+            }
+
+            arg_values[in]  = buffer + j;
+            in++;
+            j += sizeof(FUNCTION *);
+         }
+         else if (argtype & FD_STR) {
+            // Resolve thunks before reading the type so a thunk that yields a string is marshalled by its resolved
+            // value rather than rejected as its unresolved userdata container.
+            resolve_index(Lua, i);
+            auto type = lua_type(Lua, i);
+            int type_size = sizeof(APTR);
+
+            if (argtype & FD_MUTABLE) {
+               // The client supplies preallocated mutable storage, normally from string.alloc().
+               if (type != LUA_TSTRING) {
+                  ErrorMsg = std::format("Arg #{} requires a mutable buffer.", i);
+                  return ERR::InvalidType;
+               }
+
+               GCstr *string = string_arg(Lua, i);
+               if (not lj_str_ismutable(string)) {
+                  ErrorMsg = std::format("Arg #{} requires a mutable buffer.", i);
+                  return ERR::InvalidType;
+               }
+
+               if (argtype & FD_CPP) { // Function expects a pointer to std::string that it can mutate
+                  size_t len;
+                  auto str = lua_tolstring(Lua, i, &len);
+                  auto cppstr = str ? strings.emplace(str, len) : strings.emplace();
+                  if (not cppstr) {
+                     ErrorMsg = std::format("Function '{}' exceeded its string storage.", callable->Name);
+                     return ERR::BufferOverflow;
+                  }
+                  if (not mutable_cpp_strings.emplace(cppstr, string, i)) {
+                     ErrorMsg = std::format("Function '{}' exceeded its mutable string storage.", callable->Name);
+                     return ERR::BufferOverflow;
+                  }
+                  ((std::string **)(buffer + j))[0] = cppstr;
+               }
+               else ((CSTRING *)(buffer + j))[0] = strdatawr(string);
+            }
+            else if (argtype & FD_CPP) { // Read-only std::string_view; nil has null data and zero length.
+               if ((type != LUA_TSTRING) and (type != LUA_TNIL) and (type != LUA_TNONE)) {
+                  ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected string, got {} '{}'.", i, args[i].Name,
+                     lua_typename(Lua, type), value_string(Lua, i));
+                  return ERR::InvalidType;
+               }
+               size_t len;
+               auto str = lua_tolstring(Lua, i, &len);
+               auto view = str ? string_views.emplace(str, len) : string_views.emplace();
+               if (not view) {
+                  ErrorMsg = std::format("Function '{}' exceeded its string view storage.", callable->Name);
+                  return ERR::BufferOverflow;
+               }
+               ((std::string_view **)(buffer + j))[0] = view;
+            }
+            else if (type IS LUA_TSTRING) {
+               ((CSTRING *)(buffer + j))[0] = lua_tostring(Lua, i);
+            }
+            else if (type <= 0) {
+               ((CSTRING *)(buffer + j))[0] = nullptr;
+            }
+            else if ((type IS LUA_TUSERDATA) or (type IS LUA_TLIGHTUSERDATA)) {
+               ErrorMsg = std::format("Arg #{} ({}) requires a string and not untyped pointer.", i, args[i].Name);
+               return ERR::InvalidType;
+            }
+            else {
+               ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected string, got {} '{}'.", i, args[i].Name,
+                  lua_typename(Lua, lua_type(Lua, i)), value_string(Lua, i));
+               return ERR::InvalidType;
+            }
+
+            arg_values[in] = buffer + j;
+            in++;
+            j += type_size;
+         }
+         else if ((argtype & FDF_VECTOR) IS FDF_VECTOR) {
+            ErrorMsg = "C++ array inputs are not supported.";
+            return ERR::NoSupport;
+         }
+         else if (argtype & FD_PTR) {
+            resolve_index(Lua, i); // Resolve thunks so the resolved value is marshalled, not the thunk userdata.
+            auto arg_type = lua_type(Lua, i);
+            if (arg_type IS LUA_TSTRING) {
+               // Lua strings need to be converted to C strings
+               auto string = string_arg(Lua, i);
+               if ((argtype & FD_MUTABLE) and (not lj_str_ismutable(string))) {
+                  ErrorMsg = std::format("Arg #{} requires a mutable buffer.", i);
+                  return ERR::InvalidType;
+               }
+
+               ((CSTRING *)(buffer + j))[0] = (argtype & FD_MUTABLE) ? strdatawr(string) : strdata(string);
+               arg_values[in] = buffer + j;
+               in++;
+               j += sizeof(CSTRING);
+            }
+            else if (auto native_struct = lua_isstruct(Lua, i) ? lua_tostruct(Lua, i) : nullptr) {
+               // Guard specific to lifecycle-bound struct views; structs without an object dependency skip it.
+               if (lj_struct_stale(native_struct)) {
+                  ErrorMsg = "A struct argument's providing object has been destroyed.";
+                  return ERR::DoesNotExist;
+               }
+               ((APTR *)(buffer + j))[0] = native_struct->data;
+               arg_values[in] = buffer + j;
+               in++;
+               j += sizeof(APTR);
+
+               log.trace("Struct address %p inserted to arg offset %d", native_struct->data, j);
+            }
+            else if (arg_type IS LUA_TOBJECT) {
+               auto obj = lua_toobject(Lua, i);
+               if (auto direct = direct_object_ptr(obj)) {
+                  ((OBJECTPTR *)(buffer + j))[0] = direct;
                }
                else {
-                  // Referenced object probably does not exist
-                  ErrorMsg = std::format("Unable to resolve object #{}: {}", obj->uid, GetErrorMsg(error));
-                  return error;
-               }
-            }
-
-            arg_values[in] = buffer + j;
-            in++;
-            j += sizeof(APTR);
-         }
-         else if (arg_type IS LUA_TARRAY) {
-            GCarray *array = lua_toarray(Lua, i);
-
-            ((APTR *)(buffer + j))[0] = array->arraydata();
-            arg_values[in] = buffer + j;
-            in++;
-            j += sizeof(APTR);
-         }
-         else if ((arg_type IS LUA_TUSERDATA) or (arg_type IS LUA_TLIGHTUSERDATA) or (arg_type IS LUA_TNIL) or
-                  (arg_type IS LUA_TNONE)) {
-            ((APTR *)(buffer + j))[0] = lua_touserdata(Lua, i); //lua_topointer?
-            arg_values[in] = buffer + j;
-            in++;
-            j += sizeof(APTR);
-         }
-         else {
-            ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected pointer-compatible storage, got {} '{}'.", i,
-               args[i].Name, lua_typename(Lua, arg_type), value_string(Lua, i));
-            return ERR::InvalidType;
-         }
-      }
-      else if ((argtype & FD_INT) and (argtype & FD_OBJECT)) {
-         auto tv = resolve_index(Lua, i);
-         if (tvisobject(tv)) ((int *)(buffer + j))[0] = objectV(tv)->uid;
-         else if (lua_type(Lua, i) <= LUA_TNIL) ((int *)(buffer + j))[0] = 0;
-         else if (lua_type(Lua, i) IS LUA_TNUMBER) ((int *)(buffer + j))[0] = lua_tointeger(Lua, i);
-         else {
-            ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected object or number, got {} '{}'.", i,
-               args[i].Name, lua_typename(Lua, lua_type(Lua, i)), value_string(Lua, i));
-            return ERR::InvalidType;
-         }
-         arg_values[in++] = buffer + j;
-         j += sizeof(int);
-      }
-      else if (argtype & (FD_INT|FD_DOUBLE|FD_INT64)) {
-         module_scalar_input value;
-         if (auto error = read_module_number(Lua, i, args[i], value, ErrorMsg); error != ERR::Okay) return error;
-         size_t size;
-         if (argtype & FD_INT) {
-            size = sizeof(int);
-            if (argtype & FD_UNSIGNED) copymem(&value.Unsigned, buffer + j, size);
-            else copymem(&value.Int, buffer + j, size);
-         }
-         else if (argtype & FD_DOUBLE) {
-            size = sizeof(double);
-            copymem(&value.Double, buffer + j, size);
-         }
-         else {
-            size = sizeof(int64_t);
-            copymem(&value.Int64, buffer + j, size);
-         }
-         arg_values[in++] = buffer + j;
-         j += size;
-      }
-      else if (argtype & (FD_TAGS|FD_VARTAGS)) {
-         ErrorMsg = "Functions using tags are not supported.";
-         return ERR::NoSupport;
-      }
-      else {
-         ErrorMsg = std::format("{}() unsupported arg '{}', flags ${:08x}.", callable->Name, args[i].Name, argtype);
-         return ERR::NoSupport;
-      }
-   }
-
-   // Call the function.  The call interface and return type were prepared when the module was resolved, so the hot
-   // path only has to verify that the marshaller produced the argument count the interface was built for.
-
-   int restype = args->Type;
-   int result = (callable->Cif.rtype IS &ffi_type_void) ? 0 : 1;
-
-   // The buffer is allocated from both ends: argument slots grow forwards from 'buffer' and result storage grows
-   // backwards from 'end'.  Preparation proves the two cannot meet for an accepted signature, so this check confirms
-   // the marshaller honoured the sizes preparation measured rather than guarding an expected condition.
-
-   if (buffer + j > end) {
-      ErrorMsg = std::format("Function '{}' overran its call buffer.", callable->Name);
-      return ERR::BufferOverflow;
-   }
-
-   if (in != int(callable->Cif.nargs)) {
-      ErrorMsg = std::format("Function '{}' marshalled {} args but its call interface expects {}.",
-         callable->Name, in, callable->Cif.nargs);
-      return ERR::Mismatch;
-   }
-
-   {
-      func_guard.OwnsReference = false;
-      ffi_call(&callable->Cif, (void (*)())function, &rc, arg_values);
-      copy_mutable_cpp_strings();
-      if (not ErrorMsg.empty()) return ERR::BufferOverflow;
-
-      // Process the result based on the return type
-      if (restype & FD_STR) {
-         lua_pushstring(Lua, (CSTRING)rc.Arg);
-         if ((restype & FD_ALLOC) and ((CSTRING)rc.Arg)) FreeResource((APTR)rc.Arg);
-      }
-      else if (restype & FD_OBJECT) {
-         if ((OBJECTPTR)rc.Arg) {
-            push_object(Lua, (OBJECTPTR)rc.Arg,  (restype & FD_ALLOC) ? false : true);
-         }
-         else lua_pushnil(Lua);
-      }
-      else if (restype & FD_PTR) {
-         if (restype & FD_STRUCT) {
-            if (auto structptr = (APTR)rc.Arg) {
-               ERR error;
-               // A structure marked as a resource will be returned as an accessible struct pointer.  This is typically
-               // needed when a struct's use is beyond informational and can be passed to other functions.
-               //
-               // Otherwise, the default behaviour is to convert the struct's content to a regular Lua table.
-               if (restype & FD_RESOURCE) push_struct(Lua->script, structptr, args->Name, (restype & FD_ALLOC) ? TRUE : FALSE, TRUE);
-               else if ((error = named_struct_to_table(Lua, args->Name, structptr)) != ERR::Okay) {
-                  if (error IS ERR::Search) {
-                     // Unknown structs are returned as pointers - this is mainly to indicate that there is a value
-                     // and not a nil.
-                     lua_pushlightuserdata(Lua, (APTR)structptr);
+                  OBJECTPTR ptr_obj;
+                  if (auto error = access_object(obj, ptr_obj); error IS ERR::Okay) {
+                     ((OBJECTPTR *)(buffer + j))[0] = ptr_obj;
+                     release_object(obj);
                   }
                   else {
-                     ErrorMsg = std::format("Failed to resolve struct {}, error: {}", args->Name, GetErrorMsg(error));
-                     return ERR::Search;
+                     // Referenced object probably does not exist
+                     ErrorMsg = std::format("Unable to resolve object #{}: {}", obj->uid, GetErrorMsg(error));
+                     return error;
                   }
                }
+
+               arg_values[in] = buffer + j;
+               in++;
+               j += sizeof(APTR);
+            }
+            else if (arg_type IS LUA_TARRAY) {
+               GCarray *array = lua_toarray(Lua, i);
+
+               ((APTR *)(buffer + j))[0] = array->arraydata();
+               arg_values[in] = buffer + j;
+               in++;
+               j += sizeof(APTR);
+            }
+            else if ((arg_type IS LUA_TUSERDATA) or (arg_type IS LUA_TLIGHTUSERDATA) or (arg_type IS LUA_TNIL) or
+                     (arg_type IS LUA_TNONE)) {
+               ((APTR *)(buffer + j))[0] = lua_touserdata(Lua, i); //lua_topointer?
+               arg_values[in] = buffer + j;
+               in++;
+               j += sizeof(APTR);
+            }
+            else {
+               ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected pointer-compatible storage, got {} '{}'.",
+                  i,
+                  args[i].Name, lua_typename(Lua, arg_type), value_string(Lua, i));
+               return ERR::InvalidType;
+            }
+         }
+         else if ((argtype & FD_INT) and (argtype & FD_OBJECT)) {
+            auto tv = resolve_index(Lua, i);
+            if (tvisobject(tv)) ((int *)(buffer + j))[0] = objectV(tv)->uid;
+            else if (lua_type(Lua, i) <= LUA_TNIL) ((int *)(buffer + j))[0] = 0;
+            else if (lua_type(Lua, i) IS LUA_TNUMBER) ((int *)(buffer + j))[0] = lua_tointeger(Lua, i);
+            else {
+               ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected object or number, got {} '{}'.", i,
+                  args[i].Name, lua_typename(Lua, lua_type(Lua, i)), value_string(Lua, i));
+               return ERR::InvalidType;
+            }
+            arg_values[in++] = buffer + j;
+            j += sizeof(int);
+         }
+         else if (argtype & (FD_INT|FD_DOUBLE|FD_INT64)) {
+            module_scalar_input value;
+            if (auto error = read_module_number(Lua, i, args[i], value, ErrorMsg); error != ERR::Okay) return error;
+            size_t size;
+            if (argtype & FD_INT) {
+               size = sizeof(int);
+               if (argtype & FD_UNSIGNED) copymem(&value.Unsigned, buffer + j, size);
+               else copymem(&value.Int, buffer + j, size);
+            }
+            else if (argtype & FD_DOUBLE) {
+               size = sizeof(double);
+               copymem(&value.Double, buffer + j, size);
+            }
+            else {
+               size = sizeof(int64_t);
+               copymem(&value.Int64, buffer + j, size);
+            }
+            arg_values[in++] = buffer + j;
+            j += size;
+         }
+         else if (argtype & (FD_TAGS|FD_VARTAGS)) {
+            ErrorMsg = "Functions using tags are not supported.";
+            return ERR::NoSupport;
+         }
+         else {
+            ErrorMsg = std::format("{}() unsupported arg '{}', flags ${:08x}.", callable->Name, args[i].Name, argtype);
+            return ERR::NoSupport;
+         }
+      }
+
+      // Call the function.  The call interface and return type were prepared when the module was resolved, so the hot
+      // path only has to verify that the marshaller produced the argument count the interface was built for.
+
+      int restype = args->Type;
+      int result = (callable->Cif.rtype IS &ffi_type_void) ? 0 : 1;
+
+      // The buffer is allocated from both ends: argument slots grow forwards from 'buffer' and result storage grows
+      // backwards from 'end'.  Preparation proves the two cannot meet for an accepted signature, so this check confirms
+      // the marshaller honoured the sizes preparation measured rather than guarding an expected condition.
+
+      if (buffer + j > end) {
+         ErrorMsg = std::format("Function '{}' overran its call buffer.", callable->Name);
+         return ERR::BufferOverflow;
+      }
+
+      if (in != int(callable->Cif.nargs)) {
+         ErrorMsg = std::format("Function '{}' marshalled {} args but its call interface expects {}.",
+            callable->Name, in, callable->Cif.nargs);
+         return ERR::Mismatch;
+      }
+
+      {
+         func_guard.OwnsReference = false;
+         outputs.Called = true;
+         ffi_call(&callable->Cif, (void (*)())function, &rc, arg_values);
+         copy_mutable_cpp_strings();
+         if (not ErrorMsg.empty()) return ERR::BufferOverflow;
+
+         // Process the result based on the return type
+         if (restype & FD_STR) {
+            lua_pushstring(Lua, (CSTRING)rc.Arg);
+            if ((restype & FD_ALLOC) and rc.Arg) { FreeResource((APTR)rc.Arg); rc.Arg = 0; }
+         }
+         else if (restype & FD_OBJECT) {
+            if ((OBJECTPTR)rc.Arg) {
+               auto object = push_object(Lua, (OBJECTPTR)rc.Arg, true);
+               if (restype & FD_ALLOC) { object->flags &= ~GCOBJ_DETACHED; rc.Arg = 0; }
             }
             else lua_pushnil(Lua);
          }
-         else {
-            if ((APTR)rc.Arg) lua_pushlightuserdata(Lua, (APTR)rc.Arg);
-            else lua_pushnil(Lua);
+         else if (restype & FD_PTR) {
+            if (restype & FD_STRUCT) {
+               if (auto structptr = (APTR)rc.Arg) {
+                  ERR error;
+                  // A resource structure is returned as an accessible struct pointer, typically
+                  // needed when a struct's use is beyond informational and can be passed to other functions.
+                  //
+                  // Otherwise, the default behaviour is to convert the struct's content to a regular Lua table.
+                  if (restype & FD_RESOURCE) {
+                     auto structure = push_struct(Lua->script, structptr, args->Name, false, true);
+                     if (restype & FD_ALLOC) { structure->flags |= STRUCT_DEALLOCATE; rc.Arg = 0; }
+                  }
+                  else if ((error = named_struct_to_table(Lua, args->Name, structptr)) != ERR::Okay) {
+                     if (error IS ERR::Search) {
+                        // Unknown structs are returned as pointers - this is mainly to indicate that there is a value
+                        // and not a nil.
+                        lua_pushlightuserdata(Lua, (APTR)structptr);
+                        rc.Arg = 0; // Legacy raw-pointer ownership passes to the caller.
+                     }
+                     else {
+                        ErrorMsg = std::format("Failed to resolve struct {}, error: {}",
+                           args->Name, GetErrorMsg(error));
+                        return ERR::Search;
+                     }
+                  }
+                  if ((restype & FD_ALLOC) and rc.Arg) { FreeResource((APTR)rc.Arg); rc.Arg = 0; }
+               }
+               else lua_pushnil(Lua);
+            }
+            else {
+               if ((APTR)rc.Arg) lua_pushlightuserdata(Lua, (APTR)rc.Arg);
+               else lua_pushnil(Lua);
+               rc.Arg = 0; // Plain pointer returns retain their existing caller-owned representation.
+            }
          }
+         else if (auto error = push_module_scalar(Lua, *callable, rc, ErrorMsg); error != ERR::Okay) {
+            return error;
+         }
+         // Void functions don't push anything to the stack
       }
-      else if (auto error = push_module_scalar(Lua, *callable, rc, ErrorMsg); error != ERR::Okay) {
-         return error;
-      }
-      // Void functions don't push anything to the stack
-   }
 
-   Results = process_results(tiri, buffer, args) + result;
-   return ERR::Okay;
+      Results = process_results(tiri, buffer, args) + result;
+      return ERR::Okay;
+   };
+
+   ERR error = ERR::Okay;
+   auto run = [&]() { error = invoke(); };
+   RuntimeError = protected_tiri_call(Lua, run);
+   return error;
 }
 
 //********************************************************************************************************************
@@ -2187,6 +2260,7 @@ static int process_results(extTiri *Tiri, APTR resultsidx, const FunctionField *
    int results = 0;
    for (int i=1; args[i].Name; i++) {
       const auto argtype = args[i].Type;
+      scan = (uint8_t *)resultsidx + align_module_slot(size_t(scan - (uint8_t *)resultsidx));
 
       if ((argtype & FDF_SPAN) IS FDF_SPAN) {
          scan += sizeof(APTR);
@@ -2220,7 +2294,10 @@ static int process_results(extTiri *Tiri, APTR resultsidx, const FunctionField *
                }
                else {
                   lua_pushstring(lua, ((STRING *)var)[0]);
-                  if ((argtype & FD_ALLOC) and (((STRING *)var)[0])) FreeResource(((STRING *)var)[0]);
+                  if ((argtype & FD_ALLOC) and (((STRING *)var)[0])) {
+                     FreeResource(((STRING *)var)[0]);
+                     ((APTR *)var)[0] = nullptr;
+                  }
                }
             }
             else lua_pushnil(lua);
@@ -2235,7 +2312,11 @@ static int process_results(extTiri *Tiri, APTR resultsidx, const FunctionField *
             if (var) {
                if (argtype & FD_OBJECT) {
                   if (((APTR *)var)[0]) {
-                     push_object(lua, ((OBJECTPTR *)var)[0], (argtype & FD_ALLOC) ? false : true);
+                     auto object = push_object(lua, ((OBJECTPTR *)var)[0], true);
+                     if (argtype & FD_ALLOC) {
+                        object->flags &= ~GCOBJ_DETACHED;
+                        ((APTR *)var)[0] = nullptr;
+                     }
                   }
                   else lua_pushnil(lua);
                }
@@ -2243,11 +2324,18 @@ static int process_results(extTiri *Tiri, APTR resultsidx, const FunctionField *
                   if (((APTR *)var)[0]) {
                      if (argtype & FD_RESOURCE) {
                         // Resource structures are managed with direct data addresses.
-                        push_struct(Tiri, ((APTR *)var)[0], args[i].Name, (argtype & FD_ALLOC) ? TRUE : FALSE, TRUE);
+                        auto structure = push_struct(Tiri, ((APTR *)var)[0], args[i].Name, false, true);
+                        if (argtype & FD_ALLOC) {
+                           structure->flags |= STRUCT_DEALLOCATE;
+                           ((APTR *)var)[0] = nullptr;
+                        }
                      }
                      else {
                         if (named_struct_to_table(lua, args[i].Name, ((APTR *)var)[0]) != ERR::Okay) lua_pushnil(lua);
-                        if (argtype & FD_ALLOC) FreeResource(((APTR *)var)[0]);
+                        if (argtype & FD_ALLOC) {
+                           FreeResource(((APTR *)var)[0]);
+                           ((APTR *)var)[0] = nullptr;
+                        }
                      }
                   }
                   else lua_pushnil(lua);
@@ -2255,7 +2343,10 @@ static int process_results(extTiri *Tiri, APTR resultsidx, const FunctionField *
                else if (argtype & FD_ALLOC) {
                   // Misconfigured or unsupported parameter
                   lua_pushnil(lua);
-                  if (((APTR *)var)[0]) FreeResource(((APTR *)var)[0]);
+                  if (((APTR *)var)[0]) {
+                     FreeResource(((APTR *)var)[0]);
+                     ((APTR *)var)[0] = nullptr;
+                  }
                }
                else lua_pushlightuserdata(lua, ((APTR *)var)[0]);
             }
@@ -2377,7 +2468,7 @@ std::string test_module_string_view_call(lua_State *Lua, APTR Address, std::span
 
 // A stack-owned synthetic record lives until the script finishes; no published callable is mutated.
 
-static std::string run_synthetic_scalar(lua_State *Lua, ModuleCallable &Callable, CSTRING Source)
+static std::string run_synthetic_scalar(lua_State *Lua, ModuleCallable &Callable, CSTRING Source, bool Probe = true)
 {
    int base = lua_gettop(Lua);
    lua_pushlightuserdata(Lua, &Callable);
@@ -2388,12 +2479,16 @@ static std::string run_synthetic_scalar(lua_State *Lua, ModuleCallable &Callable
       failure = lua_tostring(Lua, -1) ? lua_tostring(Lua, -1) : "Unknown synthetic call failure.";
    }
    lua_settop(Lua, base);
-   if (failure.empty()) {
+   if (failure.empty() and Probe) {
       // Inspect the actual C closure result count, so a void call returning one nil cannot pass unnoticed.
       lua_getglobal(Lua, "syntheticZero");
       if (lua_pcall(Lua, 0, LUA_MULTRET, 0)) failure = "Result arity probe failed.";
-      else if (lua_gettop(Lua) - base != ((Callable.Cif.rtype IS &ffi_type_void) ? 0 : 1)) {
-         failure = "Incorrect scalar result arity.";
+      else if (lua_gettop(Lua) - base != ([&]() {
+         int count = (Callable.Cif.rtype IS &ffi_type_void) ? 0 : 1;
+         for (auto field = Callable.Fields + 1; field->Name; ++field) if (field->Type & FD_RESULT) ++count;
+         return count;
+      })()) {
+         failure = "Incorrect native result arity.";
       }
       lua_settop(Lua, base);
    }
@@ -2418,7 +2513,7 @@ std::string test_module_zero_call(lua_State *Lua, APTR Address, uint32_t Type, b
 }
 
 std::string test_module_simple_call(lua_State *Lua, APTR Address, uint32_t Type,
-   std::span<const uint32_t> Inputs, bool ForceBridge, bool Eligible, CSTRING Source)
+   std::span<const uint32_t> Inputs, bool ForceBridge, bool Eligible, CSTRING Source, bool Probe)
 {
    if (Inputs.size() > MAX_MODULE_ARGS) return "Synthetic signature exceeds the argument limit.";
    std::vector<FunctionField> fields;
@@ -2443,7 +2538,7 @@ std::string test_module_simple_call(lua_State *Lua, APTR Address, uint32_t Type,
    auto specialised = classify_simple_call(callable);
    if (bool(specialised) != Eligible) return "Incorrect simple signature eligibility.";
    if (not ForceBridge) callable.SimpleCall = specialised;
-   return run_synthetic_scalar(Lua, callable, Source);
+   return run_synthetic_scalar(Lua, callable, Source, Probe);
 }
 
 std::string test_module_zero_eligibility()

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -121,6 +121,9 @@ union module_scalar_input {
 using simple_module_call = void (*)(APTR, module_scalar_result &, const module_scalar_input *);
 
 struct ModuleCallable {
+#ifdef UNIT_TESTS
+   CSTRING InspectionModule = "synthetic"; // Binding-owned name, used only by explicit observation runs
+#endif
    CSTRING Name = nullptr;               // Canonical name, owned by the binding's immutable signature
    APTR Address = nullptr;               // Native function address; leave as null if function wasn't processed
    const FunctionField *Fields = nullptr; // Argument metadata, owned by the binding's immutable signature
@@ -329,6 +332,9 @@ struct definition_batch {
 [[nodiscard]] static CSTRING load_include_constant(CSTRING, std::string_view, definition_batch &);
 
 static int module_call(lua_State *);
+#ifdef UNIT_TESTS
+static lua_CFunction module_call_entry();
+#endif
 static ERR module_call_inner(lua_State *, std::string &, int &);
 static int process_results(extTiri *, APTR, const FunctionField *);
 
@@ -618,6 +624,62 @@ static void prepare_scalar_calls(ModuleCallable &Callable)
 // A preparation failure is recorded on the individual callable rather than propagated, because one unsupported
 // signature must not prevent the rest of the module from being used.
 
+#ifdef UNIT_TESTS
+// Emit complete copied descriptors, including rejected signatures.  One stdio operation per row avoids interleaving
+// concurrent preparation candidates; consumers sort and deduplicate identical rows.  No native addresses are exposed.
+static void inspect_module_callable(const ModuleCallable &Callable, size_t Front, size_t Back)
+{
+   auto enabled = std::getenv("TIRI_MODULE_INSPECT");
+   if ((not enabled) or (std::string_view(enabled) != "1")) return;
+   std::string descriptors;
+   std::string reason;
+   unsigned arity = 0;
+   marshalling_profile profile;
+   if (Callable.Fields) {
+      for (auto field = Callable.Fields; field->Name; ++field) {
+         if (not descriptors.empty()) descriptors += ";";
+         descriptors += std::format("{}:0x{:08x}", field->Name, uint32_t(field->Type));
+         if (field IS Callable.Fields) continue;
+         ++arity;
+         profile_arg(*field, profile);
+         ffi_type *type = nullptr;
+         std::string error;
+         if ((callable_arg_type(*field, type, error) != ERR::Okay) and reason.empty()) reason = error;
+      }
+   }
+   if (arity > MAX_MODULE_ARGS) reason = "Native argument limit exceeded";
+   if (Front + Back > BUFFER_SIZE) reason = "Call buffer limit exceeded";
+   if ((not Callable.Address) and reason.empty()) reason = "Missing address or preparation failure";
+   CSTRING dispatch = not Callable.Address ? "unsupported" : not Callable.Fields ? "trivial" :
+      Callable.ZeroArg != zero_arg_call::Bridge ? "zero" : Callable.SimpleCall ? "numeric" : "cif";
+   if (reason.empty()) {
+      if (std::string_view(dispatch) != "cif") reason = "Exact specialised descriptor";
+      else if ((classify_zero_arg(Callable) != zero_arg_call::Bridge) or classify_simple_call(Callable)) {
+         reason = "Forced CIF";
+      }
+      else {
+         if (classify_scalar_return(Callable.Fields[0].Type) IS zero_arg_call::Bridge) {
+            reason = std::format("Return descriptor 0x{:08x} outside scalar allowlist", Callable.Fields[0].Type);
+         }
+         if (arity > 4) {
+            if (not reason.empty()) reason += "; ";
+            reason += "More than four native inputs";
+         }
+         for (unsigned index = 1; index <= arity; ++index) {
+            auto type = Callable.Fields[index].Type;
+            if ((type IS FD_INT) or (type IS FD_INT64) or (type IS FD_DOUBLE)) continue;
+            if (not reason.empty()) reason += "; ";
+            reason += std::format("Input {} descriptor 0x{:08x} outside numeric allowlist", index, type);
+         }
+      }
+   }
+   auto row = std::format("MODULE_INVENTORY\t{}\t{}\t{}\t{}\t{}\t{},{},{},{},{}\t{},{}\t{}\n",
+      Callable.InspectionModule, Callable.Name, descriptors, arity, dispatch, profile.Strings, profile.StringViews,
+      profile.MutableStrings, profile.Arrays, profile.Spans, Front, Back, reason);
+   std::fputs(row.c_str(), stderr);
+}
+#endif
+
 static void prepare_module_callables(ModuleBinding *Module, const Function *Functions)
 {
    kt::Log log(__FUNCTION__);
@@ -632,12 +694,18 @@ static void prepare_module_callables(ModuleBinding *Module, const Function *Func
       const auto &signature = signatures[index];
       auto callable = std::make_unique<ModuleCallable>();
 
+#ifdef UNIT_TESTS
+      callable->InspectionModule = Module->Name.c_str();
+#endif
       callable->Name    = signature.Name.c_str();
       callable->Address = function.Address;
       callable->Fields  = function.Args ? signature.Fields.data() : nullptr;
 
       if (not function.Args) {
          // A function with no argument list takes no parameters and returns nothing, so libffi is unnecessary.
+#ifdef UNIT_TESTS
+         inspect_module_callable(*callable, 0, 0);
+#endif
          Module->Callables.push_back(std::move(callable));
          continue;
       }
@@ -717,6 +785,9 @@ static void prepare_module_callables(ModuleBinding *Module, const Function *Func
          else prepare_scalar_calls(*callable);
       }
 
+#ifdef UNIT_TESTS
+      inspect_module_callable(*callable, front_bytes, back_bytes);
+#endif
       Module->Callables.push_back(std::move(callable));
    }
 }
@@ -1315,7 +1386,11 @@ extern "C" void tiri_module_activate(lua_State *Lua, uint32_t Dependency)
          luaL_error(Lua, ERR::InvalidData, "Module dependency %u has an unresolved callable slot.", Dependency);
       }
       lua_pushlightuserdata(Lua, callable);
+#ifdef UNIT_TESTS
+      lua_pushcclosure(Lua, module_call_entry(), 1);
+#else
       lua_pushcclosure(Lua, module_call, 1);
+#endif
    }
 }
 
@@ -1367,6 +1442,26 @@ extern "C" void tiri_module_activate(lua_State *Lua, uint32_t Dependency)
 //
 // MUTABLE|RESULT|CPP = An empty C++ buffer is supplied as input (e.g. std::string or kt::vector<>) and it will be
 //                      used to store the result.
+
+#ifdef UNIT_TESTS
+// Select observation when creating a closure, keeping its disabled cost out of native call timing.
+static int observed_module_call(lua_State *Lua)
+{
+   auto callable = (ModuleCallable *)lua_touserdata(Lua, lua_upvalueindex(1));
+   if (callable) std::fprintf(stderr, "MODULE_CALL\t%s\t%s\n", callable->InspectionModule, callable->Name);
+   return module_call(Lua);
+}
+
+static lua_CFunction module_call_entry()
+{
+   static const bool observe = []() {
+      auto value = std::getenv("TIRI_MODULE_OBSERVE");
+      return value and (std::string_view(value) IS "1");
+   }();
+   if (observe) return observed_module_call;
+   return module_call;
+}
+#endif
 
 static int module_call(lua_State *Lua)
 {
@@ -2268,7 +2363,7 @@ std::string test_module_string_view_call(lua_State *Lua, APTR Address, std::span
 
    int base = lua_gettop(Lua);
    lua_pushlightuserdata(Lua, &synthetic->Callable);
-   lua_pushcclosure(Lua, module_call, 1);
+   lua_pushcclosure(Lua, module_call_entry(), 1);
    for (const auto &input : Inputs) lua_pushstring(Lua, input);
 
    if (lua_pcall(Lua, count, LUA_MULTRET, 0) != 0) {
@@ -2286,7 +2381,7 @@ static std::string run_synthetic_scalar(lua_State *Lua, ModuleCallable &Callable
 {
    int base = lua_gettop(Lua);
    lua_pushlightuserdata(Lua, &Callable);
-   lua_pushcclosure(Lua, module_call, 1);
+   lua_pushcclosure(Lua, module_call_entry(), 1);
    lua_setglobal(Lua, "syntheticZero");
    std::string failure;
    if (lua_load(Lua, std::string_view(Source), "synthetic_zero") or lua_pcall(Lua, 0, 0, 0)) {
@@ -2353,6 +2448,25 @@ std::string test_module_simple_call(lua_State *Lua, APTR Address, uint32_t Type,
 
 std::string test_module_zero_eligibility()
 {
+   // Preparation must keep rejected families distinct from supported CIF inputs with the same pointer ABI.
+   struct descriptor_case { uint32_t Type; bool Supported; };
+   const descriptor_case complex[] = {
+      { FD_STR, true }, { FDF_CPPSTRING, true }, { FD_PTR, true }, { FD_FUNCTIONPTR, true },
+      { FDF_SPAN|FD_BYTE, true }, { FDF_VECTOR|FD_MUTABLE|FD_RESULT|FD_INT, true },
+      { FD_TAGS, false }, { FD_VARTAGS, false }, { FD_ARRAY|FD_BYTE, false },
+      { FDF_VECTOR|FD_INT, false }, { FDF_SPAN|FD_RESULT|FD_BYTE, false },
+      { FDF_SPAN|FD_ALLOC|FD_BYTE, false }
+   };
+   for (const auto &entry : complex) {
+      FunctionField field = { "Input", entry.Type };
+      ffi_type *type = nullptr;
+      std::string message;
+      bool supported = callable_arg_type(field, type, message) IS ERR::Okay;
+      if (supported != entry.Supported) return "Complex descriptor ABI classification differs.";
+      if (supported and (type != &ffi_type_pointer)) return "Complex descriptor lost its pointer ABI.";
+      if ((not supported) and message.empty()) return "Rejected descriptor lost its diagnostic.";
+   }
+
    FunctionField fields[] = { { "Result", FD_INT }, { nullptr, 0 } };
    ModuleCallable callable;
    callable.Fields = fields;

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -18,7 +18,9 @@
 #include "lj_proto_registry.h"
 
 #include <ffi.h>
+#include <cstdlib>
 #include <utility>
+#include <type_traits>
 #include <unordered_map>
 #include <algorithm>
 #include <mutex>
@@ -101,6 +103,23 @@ struct marshalling_profile {
 // Every field is written once during preparation and is immutable afterwards, so concurrent calls from independent
 // Tiri states can share one record without synchronisation.
 
+enum class zero_arg_call { Bridge, Void, Int, Unsigned, Error, Int64, Double };
+
+union module_scalar_result {
+   ffi_arg Arg;
+   double Double;
+   int64_t Int64;
+};
+
+union module_scalar_input {
+   int Int;
+   uint32_t Unsigned;
+   int64_t Int64;
+   double Double;
+};
+
+using simple_module_call = void (*)(APTR, module_scalar_result &, const module_scalar_input *);
+
 struct ModuleCallable {
    CSTRING Name = nullptr;               // Canonical name, owned by the binding's immutable signature
    APTR Address = nullptr;               // Native function address; leave as null if function wasn't processed
@@ -108,6 +127,8 @@ struct ModuleCallable {
 
    marshalling_profile Profile;          // Upper bounds on the bridge-owned temporaries this signature can require
 
+   zero_arg_call ZeroArg = zero_arg_call::Bridge;
+   simple_module_call SimpleCall = nullptr;
    ffi_cif Cif = { };
    ffi_type *ArgTypes[MAX_MODULE_ARGS] = { };
 
@@ -482,6 +503,109 @@ static ffi_type * callable_return_type(int ResultType)
    return &ffi_type_void;
 }
 
+// Exact descriptors only: ownership, pointer and C++ modifiers must retain the bridge.
+
+static zero_arg_call classify_scalar_return(uint32_t Type)
+{
+   switch (Type) {
+      case FD_VOID: return zero_arg_call::Void;
+      case FD_INT: return zero_arg_call::Int;
+      case FD_INT|FD_UNSIGNED: return zero_arg_call::Unsigned;
+      case FD_ERROR: return zero_arg_call::Error;
+      case FD_INT64: return zero_arg_call::Int64;
+      case FD_DOUBLE: return zero_arg_call::Double;
+      default: return zero_arg_call::Bridge;
+   }
+}
+
+static zero_arg_call classify_zero_arg(const ModuleCallable &Callable)
+{
+   if ((not Callable.Fields) or Callable.Cif.nargs or Callable.Fields[1].Name) return zero_arg_call::Bridge;
+   return classify_scalar_return(Callable.Fields[0].Type);
+}
+
+// C++ emits the platform ABI for each finite signature.  Selection happens before publication; invocation performs
+// no recursive type dispatch and never allocates executable memory.
+
+template<class T> static T scalar_input_value(const module_scalar_input &Input)
+{
+   if constexpr (std::is_same_v<T, int>) return Input.Int;
+   else if constexpr (std::is_same_v<T, int64_t>) return Input.Int64;
+   else return Input.Double;
+}
+
+template<class R, class... Args, size_t... Index>
+static void invoke_simple_module(APTR Address, module_scalar_result &Result, const module_scalar_input *Inputs,
+   std::index_sequence<Index...>)
+{
+   auto function = (R (*)(Args...))Address;
+   if constexpr (std::is_void_v<R>) function(scalar_input_value<Args>(Inputs[Index])...);
+   else {
+      auto value = function(scalar_input_value<Args>(Inputs[Index])...);
+      if constexpr (std::is_same_v<R, double>) Result.Double = value;
+      else if constexpr (std::is_same_v<R, int64_t>) Result.Int64 = value;
+      else Result.Arg = ffi_arg(value);
+   }
+}
+
+template<class R, class... Args>
+static void simple_module_wrapper(APTR Address, module_scalar_result &Result, const module_scalar_input *Inputs)
+{
+   invoke_simple_module<R, Args...>(Address, Result, Inputs, std::index_sequence_for<Args...>{ });
+}
+
+template<class... Args> static simple_module_call select_simple_module(const ModuleCallable &Callable)
+{
+   if (sizeof...(Args) IS Callable.Cif.nargs) {
+      switch (classify_scalar_return(Callable.Fields[0].Type)) {
+         case zero_arg_call::Void: return simple_module_wrapper<void, Args...>;
+         case zero_arg_call::Int: return simple_module_wrapper<int, Args...>;
+         case zero_arg_call::Unsigned: return simple_module_wrapper<uint32_t, Args...>;
+         case zero_arg_call::Error: return simple_module_wrapper<ERR, Args...>;
+         case zero_arg_call::Int64: return simple_module_wrapper<int64_t, Args...>;
+         case zero_arg_call::Double: return simple_module_wrapper<double, Args...>;
+         default: return nullptr;
+      }
+   }
+   if constexpr (sizeof...(Args) < 4) {
+      switch (Callable.Fields[sizeof...(Args) + 1].Type) {
+         case FD_INT: return select_simple_module<Args..., int>(Callable);
+         case FD_INT64: return select_simple_module<Args..., int64_t>(Callable);
+         case FD_DOUBLE: return select_simple_module<Args..., double>(Callable);
+         default: return nullptr;
+      }
+   }
+   return nullptr;
+}
+
+static simple_module_call classify_simple_call(const ModuleCallable &Callable)
+{
+   if ((not Callable.Fields) or (Callable.Cif.nargs < 1) or (Callable.Cif.nargs > 4)) return nullptr;
+   if (classify_scalar_return(Callable.Fields[0].Type) IS zero_arg_call::Bridge) return nullptr;
+   // Check the complete input list before selecting a wrapper.  Unsupported modifiers never imply an ABI type.
+   for (unsigned index = 1; index <= Callable.Cif.nargs; ++index) {
+      if (not Callable.Fields[index].Name) return nullptr;
+      auto type = Callable.Fields[index].Type;
+      if ((type != FD_INT) and (type != FD_INT64) and (type != FD_DOUBLE)) return nullptr;
+   }
+   if (Callable.Fields[Callable.Cif.nargs + 1].Name) return nullptr;
+   return select_simple_module<>(Callable);
+}
+
+static void prepare_scalar_calls(ModuleCallable &Callable)
+{
+#ifdef UNIT_TESTS
+   // Read once, outside invocation and before publication.  Differential runs use a fresh process.
+   static const bool force_bridge = []() {
+      auto value = std::getenv("TIRI_MODULE_FORCE_CIF");
+      return value and (std::string_view(value) IS "1");
+   }();
+   if (force_bridge) return;
+#endif
+   Callable.ZeroArg = classify_zero_arg(Callable);
+   Callable.SimpleCall = classify_simple_call(Callable);
+}
+
 //********************************************************************************************************************
 // Build the process-wide callable records for a module.  Called once, while the module is being resolved and before
 // it is published to the registry, so no other thread can observe a partially prepared record.
@@ -590,6 +714,7 @@ static void prepare_module_callables(ModuleBinding *Module, const Function *Func
             callable->invalidate();
             log.msg("Failed to prepare the call interface for '%s'.", callable->Name);
          }
+         else prepare_scalar_calls(*callable);
       }
 
       Module->Callables.push_back(std::move(callable));
@@ -1256,9 +1381,136 @@ static int module_call(lua_State *Lua)
    return results;
 }
 
+// Both dispatch paths use the same scalar conversion and immediate-scope error promotion.
+
+static ERR push_module_scalar(lua_State *Lua, const ModuleCallable &Callable, const module_scalar_result &Result,
+   std::string &ErrorMsg)
+{
+   int restype = Callable.Fields[0].Type;
+   if (restype & (FD_INT|FD_ERROR)) {
+      if (restype & FD_UNSIGNED) lua_pushnumber(Lua, (uint32_t)Result.Arg);
+      else {
+         lua_pushinteger(Lua, (int)Result.Arg);
+         if ((restype & FD_ERROR) and (Result.Arg >= int(ERR::ExceptionThreshold)) and
+             in_checkall_immediate_scope(Lua)) {
+            auto error = ERR(Result.Arg);
+            ErrorMsg = std::format("{}() failed: {}", Callable.Name, GetErrorMsg(error));
+            return error;
+         }
+      }
+   }
+   else if (restype & FD_DOUBLE) lua_pushnumber(Lua, Result.Double);
+   else if (restype & FD_INT64) lua_pushnumber(Lua, Result.Int64);
+   return ERR::Okay;
+}
+
+static ERR call_zero_arg(lua_State *Lua, const ModuleCallable &Callable, std::string &ErrorMsg, int &Results)
+{
+   module_scalar_result result = { };
+   switch (Callable.ZeroArg) {
+      case zero_arg_call::Void: ((void (*)())Callable.Address)(); break;
+      case zero_arg_call::Int: result.Arg = ((int (*)())Callable.Address)(); break;
+      case zero_arg_call::Unsigned: result.Arg = ((uint32_t (*)())Callable.Address)(); break;
+      case zero_arg_call::Error: result.Arg = ffi_arg(((ERR (*)())Callable.Address)()); break;
+      case zero_arg_call::Int64: result.Int64 = ((int64_t (*)())Callable.Address)(); break;
+      case zero_arg_call::Double: result.Double = ((double (*)())Callable.Address)(); break;
+      case zero_arg_call::Bridge: return ERR::InvalidState; // No retry after native invocation.
+   }
+   Results = (Callable.ZeroArg IS zero_arg_call::Void) ? 0 : 1;
+   return push_module_scalar(Lua, Callable, result, ErrorMsg);
+}
+
+// Resolve and convert one number at a time, in signature order.  A deferred value may relocate the Lua stack;
+// only copied native scalars survive the next resolution.  The bridge and direct path share errors and defaults.
+
+static ERR read_module_number(lua_State *Lua, int Index, const FunctionField &Field, module_scalar_input &Result,
+   std::string &ErrorMsg)
+{
+   resolve_index(Lua, Index);
+   auto type = lua_type(Lua, Index);
+   if ((type > LUA_TNIL) and (type != LUA_TNUMBER)) {
+      auto string = lua_tostring(Lua, Index);
+      ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected number, got {} '{}'.", Index, Field.Name,
+         lua_typename(Lua, type), string ? string : "");
+      return ERR::InvalidType;
+   }
+   if (Field.Type & FD_INT) {
+      auto value = (type <= LUA_TNIL) ? 0 : lua_tointeger(Lua, Index);
+      if (Field.Type & FD_UNSIGNED) Result.Unsigned = uint32_t(value);
+      else Result.Int = int(value);
+   }
+   else if (Field.Type & FD_DOUBLE) Result.Double = (type <= LUA_TNIL) ? 0.0 : lua_tonumber(Lua, Index);
+   else Result.Int64 = (type <= LUA_TNIL) ? 0 : lua_tointeger(Lua, Index);
+   return ERR::Okay;
+}
+
+static ERR call_simple_module(lua_State *Lua, const ModuleCallable &Callable, std::string &ErrorMsg, int &Results)
+{
+   module_scalar_input inputs[4];
+   for (unsigned index = 0; index < Callable.Cif.nargs; ++index) {
+      if (auto error = read_module_number(Lua, int(index + 1), Callable.Fields[index + 1], inputs[index], ErrorMsg);
+          error != ERR::Okay) return error;
+   }
+   module_scalar_result result = { };
+   Callable.SimpleCall(Callable.Address, result, inputs);
+   Results = (Callable.Cif.rtype IS &ffi_type_void) ? 0 : 1;
+   return push_module_scalar(Lua, Callable, result, ErrorMsg);
+}
+
 static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results)
 {
    kt::Log log("module_call");
+
+   auto tiri = Lua->script;
+   if (not tiri) return ERR::ObjectCorrupt;
+
+   auto value_string = [](lua_State *Lua, int Index) -> CSTRING {
+      if (auto string = lua_tostring(Lua, Index)) return string;
+      else return "";
+   };
+
+   // One light-userdata upvalue holds the process-wide callable record, which carries the native address, the argument
+   // metadata and the libffi call interface that was prepared when the module was resolved.
+
+   auto callable = (ModuleCallable *)lua_touserdata(Lua, lua_upvalueindex(1));
+   if (not callable) {
+      ErrorMsg = "module_call() expected a callable record in its upvalue.";
+      return ERR::Args;
+   }
+
+   // Signature problems are detected during preparation and reported here, so that an unsupported function fails
+   // consistently whether it is called directly or through an extracted callable.
+   if (not callable->valid()) {
+      ErrorMsg = "Function not compatible with Tiri";
+      return ERR::NoSupport;
+   }
+
+   // The script and native argument limits are one contract: the marshaller reads script index i for signature
+   // argument i, so a value beyond MAX_MODULE_ARGS could never be marshalled.  Previously this clamped a local that
+   // nothing else consumed, which silently discarded the diagnostic; the surplus is now rejected outright.
+
+   int nargs = lua_gettop(Lua);
+   if (nargs > MAX_MODULE_ARGS) {
+      ErrorMsg = std::format("Function '{}' received {} arguments, exceeding the limit of {}.",
+         callable->Name, nargs, MAX_MODULE_ARGS);
+      return ERR::Args;
+   }
+
+   log.trace("%s() Args: %d", callable->Name, nargs);
+
+   if (callable->trivial()) {
+      auto function = (void (*)(void))callable->Address;
+      function();
+      return ERR::Okay;
+   }
+
+   if (callable->ZeroArg != zero_arg_call::Bridge) {
+      return call_zero_arg(Lua, *callable, ErrorMsg, Results);
+   }
+
+   if (callable->SimpleCall) {
+      return call_simple_module(Lua, *callable, ErrorMsg, Results);
+   }
 
    uint8_t buffer[BUFFER_SIZE]; // 16 bytes per argument accommodates output metadata such as sizes.
    int i;
@@ -1297,50 +1549,7 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
       }
    };
 
-   auto tiri = Lua->script;
-   if (not tiri) return ERR::ObjectCorrupt;
-
-   auto value_string = [](lua_State *Lua, int Index) -> CSTRING {
-      if (auto string = lua_tostring(Lua, Index)) return string;
-      else return "";
-   };
-
-   // One light-userdata upvalue holds the process-wide callable record, which carries the native address, the argument
-   // metadata and the libffi call interface that was prepared when the module was resolved.
-
-   auto callable = (ModuleCallable *)lua_touserdata(Lua, lua_upvalueindex(1));
-   if (not callable) {
-      ErrorMsg = "module_call() expected a callable record in its upvalue.";
-      return ERR::Args;
-   }
-
-   // Signature problems are detected during preparation and reported here, so that an unsupported function fails
-   // consistently whether it is called directly or through an extracted callable.
-   if (not callable->valid()) {
-      ErrorMsg = "Function not compatible with Tiri";
-      return ERR::NoSupport;
-   }
-
-   // The script and native argument limits are one contract: the marshaller reads script index i for signature
-   // argument i, so a value beyond MAX_MODULE_ARGS could never be marshalled.  Previously this clamped a local that
-   // nothing else consumed, which silently discarded the diagnostic; the surplus is now rejected outright.
-
-   int nargs = lua_gettop(Lua);
-   if (nargs > MAX_MODULE_ARGS) {
-      ErrorMsg = std::format("Function '{}' received {} arguments, exceeding the limit of {}.",
-         callable->Name, nargs, MAX_MODULE_ARGS);
-      return ERR::Args;
-   }
-
    uint8_t *end = buffer + sizeof(buffer);
-
-   log.trace("%s() Args: %d", callable->Name, nargs);
-
-   if (callable->trivial()) {
-      auto function = (void (*)(void))callable->Address;
-      function();
-      return ERR::Okay;
-   }
 
    const FunctionField *args = callable->Fields;
    APTR function = callable->Address;
@@ -1359,11 +1568,7 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
       }
    } func_guard{ Lua, func };
 
-   union {
-      ffi_arg Arg;
-      double  Double;
-      int64_t Int64;
-   } rc = { };
+   module_scalar_result rc = { };
    void * arg_values[MAX_MODULE_ARGS];
    int in = 0;
 
@@ -1755,60 +1960,38 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
             return ERR::InvalidType;
          }
       }
-      else if (argtype & FD_INT) {
+      else if ((argtype & FD_INT) and (argtype & FD_OBJECT)) {
          auto tv = resolve_index(Lua, i);
-
-         if (argtype & FD_OBJECT) {
-            if (tvisobject(tv)) ((int *)(buffer + j))[0] = objectV(tv)->uid;
-            else if (lua_type(Lua, i) <= LUA_TNIL) ((int *)(buffer + j))[0] = 0;
-            else if (lua_type(Lua, i) IS LUA_TNUMBER) ((int *)(buffer + j))[0] = lua_tointeger(Lua, i);
-            else {
-               ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected object or number, got {} '{}'.", i,
-                  args[i].Name, lua_typename(Lua, lua_type(Lua, i)), value_string(Lua, i));
-               return ERR::InvalidType;
-            }
-         }
+         if (tvisobject(tv)) ((int *)(buffer + j))[0] = objectV(tv)->uid;
+         else if (lua_type(Lua, i) <= LUA_TNIL) ((int *)(buffer + j))[0] = 0;
+         else if (lua_type(Lua, i) IS LUA_TNUMBER) ((int *)(buffer + j))[0] = lua_tointeger(Lua, i);
          else {
-            if (lua_type(Lua, i) <= LUA_TNIL) {
-               ((int *)(buffer + j))[0] = 0;
-            }
-            else if (lua_type(Lua, i) != LUA_TNUMBER) {
-               ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected number, got {} '{}'.", i, args[i].Name,
-                  lua_typename(Lua, lua_type(Lua, i)), value_string(Lua, i));
-               return ERR::InvalidType;
-            }
-            else if (argtype & FD_UNSIGNED) ((uint32_t *)(buffer + j))[0] = lua_tointeger(Lua, i);
-            else ((int *)(buffer + j))[0] = lua_tointeger(Lua, i);
+            ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected object or number, got {} '{}'.", i,
+               args[i].Name, lua_typename(Lua, lua_type(Lua, i)), value_string(Lua, i));
+            return ERR::InvalidType;
          }
-         arg_values[in] = buffer + j;
-         in++;
+         arg_values[in++] = buffer + j;
          j += sizeof(int);
       }
-      else if (argtype & FD_DOUBLE) {
-         resolve_index(Lua, i); // Resolve thunks so a number-yielding thunk is accepted by the strict check.
-         if (lua_type(Lua, i) <= LUA_TNIL) ((double *)(buffer + j))[0] = 0.0;
-         else if (lua_type(Lua, i) != LUA_TNUMBER) {
-            ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected number, got {} '{}'.", i, args[i].Name,
-               lua_typename(Lua, lua_type(Lua, i)), value_string(Lua, i));
-            return ERR::InvalidType;
+      else if (argtype & (FD_INT|FD_DOUBLE|FD_INT64)) {
+         module_scalar_input value;
+         if (auto error = read_module_number(Lua, i, args[i], value, ErrorMsg); error != ERR::Okay) return error;
+         size_t size;
+         if (argtype & FD_INT) {
+            size = sizeof(int);
+            if (argtype & FD_UNSIGNED) copymem(&value.Unsigned, buffer + j, size);
+            else copymem(&value.Int, buffer + j, size);
          }
-         else ((double *)(buffer + j))[0] = lua_tonumber(Lua, i);
-         arg_values[in] = buffer + j;
-         in++;
-         j += sizeof(double);
-      }
-      else if (argtype & FD_INT64) {
-         resolve_index(Lua, i); // Resolve thunks so a number-yielding thunk is accepted by the strict check.
-         if (lua_type(Lua, i) <= LUA_TNIL) ((int64_t *)(buffer + j))[0] = 0;
-         else if (lua_type(Lua, i) != LUA_TNUMBER) {
-            ErrorMsg = std::format("Type mismatch, arg #{} ({}) expected number, got {} '{}'.", i, args[i].Name,
-               lua_typename(Lua, lua_type(Lua, i)), value_string(Lua, i));
-            return ERR::InvalidType;
+         else if (argtype & FD_DOUBLE) {
+            size = sizeof(double);
+            copymem(&value.Double, buffer + j, size);
          }
-         else ((int64_t *)(buffer + j))[0] = lua_tointeger(Lua, i);
-         arg_values[in] = buffer + j;
-         in++;
-         j += sizeof(int64_t);
+         else {
+            size = sizeof(int64_t);
+            copymem(&value.Int64, buffer + j, size);
+         }
+         arg_values[in++] = buffer + j;
+         j += size;
       }
       else if (argtype & (FD_TAGS|FD_VARTAGS)) {
          ErrorMsg = "Functions using tags are not supported.";
@@ -1886,26 +2069,8 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
             else lua_pushnil(Lua);
          }
       }
-      else if (restype & (FD_INT|FD_ERROR)) {
-         if (restype & FD_UNSIGNED) {
-            lua_pushnumber(Lua, (uint32_t)rc.Arg);
-         }
-         else {
-            lua_pushinteger(Lua, (int)rc.Arg);
-            if ((restype & FD_ERROR) and (rc.Arg >= int(ERR::ExceptionThreshold)) and
-                in_checkall_immediate_scope(Lua)) {
-               // Scope isolation: Only throw exceptions for direct calls within the try block.
-               auto error = ERR(rc.Arg);
-               ErrorMsg = std::format("{}() failed: {}", callable->Name, GetErrorMsg(error));
-               return error;
-            }
-         }
-      }
-      else if (restype & FD_DOUBLE) {
-         lua_pushnumber(Lua, rc.Double);
-      }
-      else if (restype & FD_INT64) {
-         lua_pushnumber(Lua, rc.Int64);
+      else if (auto error = push_module_scalar(Lua, *callable, rc, ErrorMsg); error != ERR::Okay) {
+         return error;
       }
       // Void functions don't push anything to the stack
    }
@@ -2112,6 +2277,119 @@ std::string test_module_string_view_call(lua_State *Lua, APTR Address, std::span
       return std::format("Synthetic call of arity {} failed: {}", count, message);
    }
    lua_settop(Lua, base);
+   return { };
+}
+
+// A stack-owned synthetic record lives until the script finishes; no published callable is mutated.
+
+static std::string run_synthetic_scalar(lua_State *Lua, ModuleCallable &Callable, CSTRING Source)
+{
+   int base = lua_gettop(Lua);
+   lua_pushlightuserdata(Lua, &Callable);
+   lua_pushcclosure(Lua, module_call, 1);
+   lua_setglobal(Lua, "syntheticZero");
+   std::string failure;
+   if (lua_load(Lua, std::string_view(Source), "synthetic_zero") or lua_pcall(Lua, 0, 0, 0)) {
+      failure = lua_tostring(Lua, -1) ? lua_tostring(Lua, -1) : "Unknown synthetic call failure.";
+   }
+   lua_settop(Lua, base);
+   if (failure.empty()) {
+      // Inspect the actual C closure result count, so a void call returning one nil cannot pass unnoticed.
+      lua_getglobal(Lua, "syntheticZero");
+      if (lua_pcall(Lua, 0, LUA_MULTRET, 0)) failure = "Result arity probe failed.";
+      else if (lua_gettop(Lua) - base != ((Callable.Cif.rtype IS &ffi_type_void) ? 0 : 1)) {
+         failure = "Incorrect scalar result arity.";
+      }
+      lua_settop(Lua, base);
+   }
+   lua_pushnil(Lua);
+   lua_setglobal(Lua, "syntheticZero");
+   return failure;
+}
+
+std::string test_module_zero_call(lua_State *Lua, APTR Address, uint32_t Type, bool ForceBridge, CSTRING Source)
+{
+   FunctionField fields[] = { { "Result", Type }, { nullptr, 0 } };
+   ModuleCallable callable;
+   callable.Name = "SyntheticZero";
+   callable.Address = Address;
+   callable.Fields = fields;
+   if (ffi_prep_cif(&callable.Cif, FFI_DEFAULT_ABI, 0, callable_return_type(Type), callable.ArgTypes) != FFI_OK) {
+      return "Failed to prepare the synthetic zero-argument CIF.";
+   }
+   if (not ForceBridge) callable.ZeroArg = classify_zero_arg(callable);
+
+   return run_synthetic_scalar(Lua, callable, Source);
+}
+
+std::string test_module_simple_call(lua_State *Lua, APTR Address, uint32_t Type,
+   std::span<const uint32_t> Inputs, bool ForceBridge, bool Eligible, CSTRING Source)
+{
+   if (Inputs.size() > MAX_MODULE_ARGS) return "Synthetic signature exceeds the argument limit.";
+   std::vector<FunctionField> fields;
+   std::vector<std::string> names;
+   names.reserve(Inputs.size());
+   fields.push_back({ "Result", Type });
+   for (size_t index = 0; index < Inputs.size(); ++index) {
+      names.push_back(std::format("Arg{}", index + 1));
+      fields.push_back({ names.back().c_str(), Inputs[index] });
+   }
+   fields.push_back({ nullptr, 0 });
+   ModuleCallable callable;
+   callable.Name = "SyntheticZero";
+   callable.Address = Address;
+   callable.Fields = fields.data();
+   for (size_t index = 0; index < Inputs.size(); ++index) {
+      std::string error;
+      if (callable_arg_type(fields[index + 1], callable.ArgTypes[index], error) != ERR::Okay) return error;
+   }
+   if (ffi_prep_cif(&callable.Cif, FFI_DEFAULT_ABI, unsigned(Inputs.size()), callable_return_type(Type),
+       callable.ArgTypes) != FFI_OK) return "Failed to prepare synthetic numeric CIF.";
+   auto specialised = classify_simple_call(callable);
+   if (bool(specialised) != Eligible) return "Incorrect simple signature eligibility.";
+   if (not ForceBridge) callable.SimpleCall = specialised;
+   return run_synthetic_scalar(Lua, callable, Source);
+}
+
+std::string test_module_zero_eligibility()
+{
+   FunctionField fields[] = { { "Result", FD_INT }, { nullptr, 0 } };
+   ModuleCallable callable;
+   callable.Fields = fields;
+   // Every bit outside each exact allowlist must fall back, even if the bridge interprets it as a scalar.
+   const uint32_t allowed[] = { FD_VOID, FD_INT, FD_INT|FD_UNSIGNED, FD_ERROR, FD_INT64, FD_DOUBLE };
+   for (uint32_t type : allowed) {
+      fields[0].Type = type;
+      if (classify_zero_arg(callable) IS zero_arg_call::Bridge) return "Eligible scalar was rejected.";
+      for (unsigned bit = 0; bit < 32; ++bit) {
+         uint32_t modified = type | (uint32_t(1) << bit);
+         if (std::find(std::begin(allowed), std::end(allowed), modified) != std::end(allowed)) continue;
+         fields[0].Type = modified;
+         if (classify_zero_arg(callable) != zero_arg_call::Bridge) return "Unsupported modifier was specialised.";
+      }
+   }
+   fields[0].Type = FD_INT;
+   callable.Cif.nargs = 1;
+   if (classify_zero_arg(callable) != zero_arg_call::Bridge) return "Native input was specialised.";
+   callable.Cif.nargs = 0;
+   fields[1].Name = "Input";
+   if (classify_zero_arg(callable) != zero_arg_call::Bridge) return "Metadata input was specialised.";
+   callable.Fields = nullptr;
+   if (classify_zero_arg(callable) != zero_arg_call::Bridge) return "Null metadata lost its separate path.";
+
+   FunctionField numeric[] = { { "Result", FD_DOUBLE }, { "Arg1", FD_INT }, { nullptr, 0 } };
+   callable.Fields = numeric;
+   callable.Cif.nargs = 1;
+   for (uint32_t type : { uint32_t(FD_INT), uint32_t(FD_INT64), uint32_t(FD_DOUBLE) }) {
+      numeric[1].Type = type;
+      if (not classify_simple_call(callable)) return "Simple numeric input was rejected.";
+      for (unsigned bit = 0; bit < 32; ++bit) {
+         uint32_t modified = type | (uint32_t(1) << bit);
+         if (modified IS type) continue;
+         numeric[1].Type = modified;
+         if (classify_simple_call(callable)) return "Modified numeric input was specialised.";
+      }
+   }
    return { };
 }
 

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -49,6 +49,12 @@ null terminated arrays, use [0].
 #include "lib.h"
 #include "lj_obj.h"
 #include "defs.h"
+#include "protected_call.h"
+
+#ifdef UNIT_TESTS
+static thread_local int glStructLiveReferences = 0;
+int test_struct_live_references() { return glStructLiveReferences; }
+#endif
 
 static constexpr int MAX_STRUCT_DEF = 2048; // Struct definitions are typically 100 - 400 bytes.
 
@@ -211,9 +217,15 @@ void destroy_struct_cpp_strings(lua_State *Lua, const struct_record &StructDef, 
 {
    // NB: Custom comparator will stop if a colon is encountered in StructName
    if (auto def = find_struct(Lua, StructName)) {
-      std::vector<lua_ref> ref;
-      auto error = struct_to_table(Lua, ref, *def, Address);
-      unref_struct_references(Lua, ref);
+      ERR error = ERR::Okay;
+      int status;
+      {
+         std::vector<lua_ref> ref;
+         auto convert = [&]() { error = struct_to_table(Lua, ref, *def, Address); };
+         status = protected_tiri_call(Lua, convert);
+         unref_struct_references(Lua, ref);
+      }
+      if (status) lj_err_throw(Lua, status);
       return error;
    }
    else if (StructName.starts_with("KeyValue")) {
@@ -234,7 +246,12 @@ void destroy_struct_cpp_strings(lua_State *Lua, const struct_record &StructDef, 
 void unref_struct_references(lua_State *Lua, std::vector<lua_ref> &References)
 {
    for (auto &rec : References) {
-      if ((rec.Ref != LUA_NOREF) and (rec.Ref != LUA_REFNIL)) luaL_unref(Lua, LUA_REGISTRYINDEX, rec.Ref);
+      if ((rec.Ref != LUA_NOREF) and (rec.Ref != LUA_REFNIL)) {
+         luaL_unref(Lua, LUA_REGISTRYINDEX, rec.Ref);
+#ifdef UNIT_TESTS
+         --glStructLiveReferences;
+#endif
+      }
    }
 
    References.clear();
@@ -496,6 +513,9 @@ static ERR value_to_cpp_vector(lua_State *Lua, int StackIndex, const struct_fiel
 
    int table_ref = luaL_ref(Lua, LUA_REGISTRYINDEX);
    References.push_back({ Address, &StructDef, table_ref });
+#ifdef UNIT_TESTS
+   ++glStructLiveReferences;
+#endif
    lua_rawgeti(Lua, LUA_REGISTRYINDEX, table_ref); // Retrieve the struct table
 
    for (auto &field : StructDef.Fields) {


### PR DESCRIPTION
## Summary

* Add specialised zero-argument and scalar module-call paths, with bridge fallback for unsupported signatures.
* Harden module-call ABI marshalling, result ownership, and protected cleanup boundaries.
* Restore metamethod caller context correctly through return-root traces.

## Validation

* `cmake --build build/agents --config Debug --target tiri --parallel`
* `cmake --install build/agents --config Debug`
* `ctest --build-config Debug --test-dir build/agents --output-on-failure -R "^tiri_(module_namespaces|module_result_contracts|metamethod_context_dispatch)$"`
* `ctest --build-config Debug --test-dir build/agents --output-on-failure -R "^tiri_unit_tests$"`

The PR contains the four existing commits on `test/tiri-module-call-specialisation`. Local untracked files and the dirty `docs/wiki` submodule are excluded.