### PR TITLE
[Tiri] Correct JIT constant remainder traces on x64

### DIFF
--- a/src/tiri/jit/src/lj_asm_x86.h
+++ b/src/tiri/jit/src/lj_asm_x86.h
@@ -698,6 +698,13 @@ static void asm_conv(ASMState* as, IRIns* ir)
    int stfp = (st == IRT_NUM or st == IRT_FLOAT);
    IRRef lref = ir->op1;
    lj_assertA(irt_type(ir->t) != st, "inconsistent types for CONV");
+   if (ir->op2 & IRCONV_BITCAST) {
+      lj_assertA(LJ_TARGET_X64 and st IS IRT_NUM and irt_isu64(ir->t), "bad bitcast types");
+      Reg dest = ra_dest(as, ir, RSET_GPR);
+      Reg source = ra_alloc1(as, lref, RSET_FPR);
+      emit_rr(as, XO_MOVDto, source | REX_64, dest);
+      return;
+   }
    if (irt_isfp(ir->t)) {
       Reg dest = ra_dest(as, ir, RSET_FPR);
       if (stfp) {  // FP to FP conversion.

--- a/src/tiri/jit/src/lj_ir.h
+++ b/src/tiri/jit/src/lj_ir.h
@@ -261,6 +261,7 @@ constexpr int IRBUFHDR_WRITE = 2;    // Write to string buffer.
 constexpr int IRCONV_SRCMASK = 0x001f;   // Source IRType.
 constexpr int IRCONV_DSTMASK = 0x03e0;   // Dest. IRType (also in ir->t).
 constexpr int IRCONV_DSH = 5;
+constexpr int IRCONV_BITCAST = 0x0400;   // x64 NUM to U64 bit reinterpretation, without numeric conversion.
 constexpr int IRCONV_SEXT = 0x0800;      // Sign-extend integer to integer.
 constexpr int IRCONV_MODEMASK = 0x0fff;
 constexpr int IRCONV_CONVMASK = 0xf000;

--- a/src/tiri/jit/src/lj_opt_fold.cpp
+++ b/src/tiri/jit/src/lj_opt_fold.cpp
@@ -423,13 +423,26 @@ LJFOLD(ULE KINT64 KINT64)
 LJFOLD(UGT KINT64 KINT64)
 LJFOLDF(kfold_int64comp)
 {
-   lj_assertJ(0, "FFI IR op without FFI"); return FAILFOLD;
+   uint64_t left = ir_k64(fleft)->u64;
+   uint64_t right = ir_k64(fright)->u64;
+   switch (fins->o) {
+      case IR_LT:  return CONDFOLD(int64_t(left) < int64_t(right));
+      case IR_GE:  return CONDFOLD(int64_t(left) >= int64_t(right));
+      case IR_LE:  return CONDFOLD(int64_t(left) <= int64_t(right));
+      case IR_GT:  return CONDFOLD(int64_t(left) > int64_t(right));
+      case IR_ULT: return CONDFOLD(left < right);
+      case IR_UGE: return CONDFOLD(left >= right);
+      case IR_ULE: return CONDFOLD(left <= right);
+      case IR_UGT: return CONDFOLD(left > right);
+      default: lj_assertJ(0, "bad 64-bit comparison %d", fins->o); return FAILFOLD;
+   }
 }
 
 LJFOLD(UGE any KINT64)
 LJFOLDF(kfold_int64comp0)
 {
-   lj_assertJ(0, "FFI IR op without FFI"); return FAILFOLD;
+   if (ir_k64(fright)->u64 IS 0) return DROPFOLD;
+   return NEXTFOLD;
 }
 
 // -- Constant folding for strings ----------------------------------------
@@ -834,6 +847,7 @@ LJFOLDF(kfold_conv_knum_i64_num)
 LJFOLD(CONV KNUM IRCONV_U64_NUM)
 LJFOLDF(kfold_conv_knum_u64_num)
 {
+   if (fins->op2 & IRCONV_BITCAST) return INT64FOLD(ir_knum(fleft)->u64);
    return INT64FOLD(lj_num2u64(knumleft));
 }
 
@@ -1098,6 +1112,7 @@ LJFOLD(CONV CONV IRCONV_I64_NUM)  //  _INT or _U32
 LJFOLD(CONV CONV IRCONV_U64_NUM)  //  _INT or _U32
 LJFOLDF(simplify_conv_i64_num)
 {
+   if (fins->op2 & IRCONV_BITCAST) return NEXTFOLD;
    PHIBARRIER(fleft);
    if ((fleft->op2 & IRCONV_SRCMASK) == IRT_INT) {
       // Reduce to a sign-extension.

--- a/src/tiri/jit/src/lj_opt_narrow.cpp
+++ b/src/tiri/jit/src/lj_opt_narrow.cpp
@@ -8,6 +8,7 @@
 #define LUA_CORE
 
 #include "lj_obj.h"
+#include <cmath>
 
 #if LJ_HASJIT
 
@@ -562,38 +563,30 @@ TRef lj_opt_narrow_unm(jit_State* J, TRef rc, TValue* vc)
 }
 
 #if LJ_TARGET_X64
-// Inline remainder for a constant integer divisor and a bounded non-zero dividend, including fractional dividends.
+// Inline remainder for a constant integer divisor and a bounded dividend, including fractional dividends.
 static TRef narrow_mod_const(jit_State* J, TRef Dividend, TRef Divisor, lua_Number Value, lua_Number Modulus)
 {
    if (!(J->flags & JIT_F_OPT_NARROW) or !(J->flags & JIT_F_SSE4_1) or !tref_isk(Divisor) or
          !numisint(Modulus) or Modulus IS 0 or !(Value >= -0x1p52 and Value <= 0x1p52)) return 0;
 
-   bool negative = Value < 0;
+   bool negative = std::signbit(Value);
    lua_Number modulus = Modulus < 0 ? -Modulus : Modulus;
 
-   // A correctly rounded quotient cannot round across a multiple of an integer modulus, so truncating it always
-   // yields fmod()'s quotient and no result guard is needed.  With a magnitude of at most 2^52 the product of the
-   // truncated quotient and the modulus never exceeds the dividend, so it stays an exact integer, and the final
-   // subtraction is exact because both terms are multiples of the dividend's ulp.  The guarded dividend is never
-   // negative here, so discarding the truncated quotient's sign only rewrites the negative zero produced by an
-   // opposite-signed zero dividend.  That keeps fmod()'s signed zero on exact multiples, which in turn lets the sign
-   // guards admit a zero dividend instead of exiting the trace on it.
+   // Non-negative IEEE doubles are ordered by their unsigned bit patterns.  A single unsigned bound check
+   // therefore excludes negative values (including -0), infinities and NaNs.  Normalise negative traces first;
+   // opposite-signed zeros use a side trace, while +0 stays on the ordinary positive trace.
    TRef dividend = lj_ir_tonum(J, Dividend);
    TRef divisor = lj_ir_knum(J, modulus);
-   TRef zero = lj_ir_knum_zero(J);
-   if (negative) {
-      emitir(IRTG(IR_LE, IRT_NUM), dividend, zero);
-      emitir(IRTG(IR_GE, IRT_NUM), dividend, lj_ir_knum(J, -0x1p52));
-      dividend = emitir(IRTN(IR_NEG), dividend, lj_ir_ksimd(J, LJ_KSIMD_NEG));
-   }
-   else {
-      emitir(IRTG(IR_GE, IRT_NUM), dividend, zero);
-      emitir(IRTG(IR_LE, IRT_NUM), dividend, lj_ir_knum(J, 0x1p52));
-   }
+   if (negative) dividend = emitir(IRTN(IR_NEG), dividend, lj_ir_ksimd(J, LJ_KSIMD_NEG));
+   TRef bits = emitir(IRT(IR_CONV, IRT_U64), dividend, (IRT_U64 << IRCONV_DSH) | IRT_NUM | IRCONV_BITCAST);
+   emitir(IRTG(IR_ULE, IRT_U64), bits, lj_ir_kint64(J, UINT64_C(0x4330000000000000)));
+
+   // The existing bounded integer-divisor identity is unchanged: division cannot round across an integer
+   // multiple, the truncated quotient times the modulus is an exact integer <= 2^52, and subtraction is exact.
+   // The bit guard also proves that the quotient has a positive sign, so no ABS is needed before multiplication.
    TRef quotient = emitir(IRTN(IR_DIV), dividend, divisor);
    TRef truncated = emitir(IRTN(IR_FPMATH), quotient, IRFPM_TRUNC);
-   TRef magnitude = emitir(IRTN(IR_ABS), truncated, lj_ir_ksimd(J, LJ_KSIMD_ABS));
-   TRef product = emitir(IRTN(IR_MUL), magnitude, divisor);
+   TRef product = emitir(IRTN(IR_MUL), truncated, divisor);
    TRef remainder = emitir(IRTN(IR_SUB), dividend, product);
    return negative ? emitir(IRTN(IR_NEG), remainder, lj_ir_ksimd(J, LJ_KSIMD_NEG)) : remainder;
 }

--- a/src/tiri/tests/test_numeric_limits.tiri
+++ b/src/tiri/tests/test_numeric_limits.tiri
@@ -342,6 +342,8 @@ end
       100.25, 101.0, 102.5, 103.0, 104.75, 105.0, 106.25, 107.0,
       99.99999999999999, 100.0, 100.00000000000001, 299.99999999999994, 300.00000000000006,
       2147483647.9999998, 2147483648.0, 2147483648.0000005,
+      4503599627370495.5, 4503599627370496.0, 4503599627370497.0,
+      -4503599627370495.5, -4503599627370496.0, -4503599627370497.0,
       0.0, -0.0, 5e-324, -5e-324, -100.0, -100.25, 1e100, -1e100, math.huge, -math.huge, 0 / 0
    }
    local expected = {}
@@ -729,4 +731,34 @@ end
       raised = true
    end
    assert(raised, 'JIT bitwise on a string must raise a type error, not coerce')
+end
+
+@Test function ConstantRemainderNegativeTraceZeros()
+   defer
+      jit.on()
+      jit.flush()
+      jit.opt.start()
+   end
+
+   -- Record the negative trace first, then exercise both zero signs and sign-changing side traces.
+   local values = array<double> { -100.25, -200.0, -0.0, 0.0, 100.25, 200.0, -5e-324, 5e-324 }
+   local expected = {}
+   jit.off()
+   jit.flush()
+   for i in {0 to #values} do
+      local a, b, c = constant_remainders(values[i])
+      expected[i] = { a, b, c }
+   end
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1')
+   for i in {0 to #values} do
+      for _ in {0 to 80} do
+         local a, b, c = constant_remainders(values[i])
+         assert_same_remainder(a, expected[i][0])
+         assert_same_remainder(b, expected[i][1])
+         assert_same_remainder(c, expected[i][2])
+      end
+   end
 end


### PR DESCRIPTION
* Added NUM-to-U64 bitcasts for efficient finite dividend guards
* Preserved signed-zero semantics on negative constant remainder traces
* Added numeric-limit coverage for boundary values and sign-changing zero traces