### PR TITLE
[Tiri] Enable JIT compilation with closed upvalues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1112,6 +1112,8 @@ add_subdirectory (src/regex)
 
 add_subdirectory (src/origo)
 
+add_subdirectory (docs/tiri)
+
 add_subdirectory (apps)
 add_subdirectory (tools/tiri_lsp)
 

--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -919,7 +919,8 @@ set (TIRI_TESTS
    array_functional array_typed_syntax recursive_array_types bitshift bitwise has_operator approx if_empty if_empty_guard
    presence blank ternary table stress unit_tests
    jitoptions fstring const const_optimisation import_scope unicode ellipsis safe_nav close type_annotations type_fixing
-   type_inference jit jit_uclo jit_arrays jit_objects jit_try_regex pipe for_each arrow_functions result_filter thunks deferred_expr
+   type_inference jit jit_uclo jit_fnew jit_arrays jit_objects jit_try_regex pipe for_each arrow_functions
+   result_filter thunks deferred_expr
    shadow_assert
    ranges contains bare_iteration compiler_intrinsics
    annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options type_name

--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -919,7 +919,7 @@ set (TIRI_TESTS
    array_functional array_typed_syntax recursive_array_types bitshift bitwise has_operator approx if_empty if_empty_guard
    presence blank ternary table stress unit_tests
    jitoptions fstring const const_optimisation import_scope unicode ellipsis safe_nav close type_annotations type_fixing
-   type_inference jit jit_arrays jit_objects jit_try_regex pipe for_each arrow_functions result_filter thunks deferred_expr
+   type_inference jit jit_uclo jit_arrays jit_objects jit_try_regex pipe for_each arrow_functions result_filter thunks deferred_expr
    shadow_assert
    ranges contains bare_iteration compiler_intrinsics
    annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options type_name

--- a/src/tiri/jit/src/debug/lj_jit.h
+++ b/src/tiri/jit/src/debug/lj_jit.h
@@ -513,6 +513,7 @@ struct jit_State {
   TRef context_call_receiver[LJ_MAX_JSLOTS+LJ_STACK_EXTRA];
   TRef context_call_result[LJ_MAX_JSLOTS+LJ_STACK_EXTRA];
   uint8_t context_call_state[LJ_MAX_JSLOTS+LJ_STACK_EXTRA];
+   bool context_tail_call[LJ_MAX_JSLOTS + LJ_STACK_EXTRA];  // Physical tail transfers emitted in this trace.
   uint16_t context_call_activation_count;
   int32_t context_virtual_slot;
 

--- a/src/tiri/jit/src/jit/jit_unit_tests.cpp
+++ b/src/tiri/jit/src/jit/jit_unit_tests.cpp
@@ -1,4 +1,4 @@
-// Unit tests for JIT frame management abstractions.
+// Unit tests for JIT frame management abstractions and upvalue range guards.
 // Copyright © 2025-2026 Paul Manias
 //
 // These tests verify the correctness of the FrameManager class and FRC constants used in the JIT trace recorder. They
@@ -10,8 +10,15 @@
 
 #include "frame_manager.h"
 #include "../debug/lj_jit.h"
+#include "../lj_ircall.h"
+#include "../lj_dispatch.h"
 #include <array>
 #include <cstring>
+#include <memory>
+#include "../lauxlib.h"
+#include "../lualib.h"
+#include "../runtime/lj_state.h"
+#include "../../../defs.h"
 
 namespace {
 
@@ -837,6 +844,272 @@ static bool test_irbuilder_guard_helpers(kt::Log& log)
    return true;
 }
 
+//********************************************************************************************************************
+// A valid UCLO range that the parser cannot currently emit: capture before loop entry, close inside the loop.
+// This isolates the compiled range guard from the still-unsupported FNEW recorder path.
+
+static bool test_uclo_range_guard(kt::Log& Log)
+{
+   struct ScriptOwner {
+      objTiri* object = nullptr;
+      ~ScriptOwner() { if (object) FreeResource(object); }
+   } script;
+   if (NewObject(CLASSID::TIRI, &script.object) != ERR::Okay) return false;
+   if (script.object->setStatement("") != ERR::Okay or Action(AC::Init, script.object, nullptr) != ERR::Okay)
+      return false;
+   std::unique_ptr<lua_State, decltype(&lua_close)> state(luaL_newstate((extTiri*)script.object), lua_close);
+   if (not state) return false;
+   lua_State* lua = state.get();
+   luaL_openlibs(lua);
+   lua_pushcfunction(lua, [](lua_State* Lua) {
+      lj_state_growstack(Lua, 128);
+      lua_gc(Lua, LUA_GCCOLLECT, 0);
+      return 0;
+   });
+   lua_setglobal(lua, "range_resize");
+   constexpr auto source = R"tiri(
+global glGrow = false
+global glReadBefore = false
+global function range_worker(Mode:num):num
+   local boundary = 11
+   local above = 22
+   local payload = { value=31 }
+   local read:func = nil
+   local twin:func = nil
+   if Mode is 1 then
+      read = function(Delta:num):num boundary += Delta; return boundary end
+      twin = (() => boundary)
+   elseif Mode is 2 then
+      read = function(Delta:num):num above += Delta; return above end
+      twin = (() => above)
+   elseif Mode is 3 then
+      read = function(Delta:num):num boundary += Delta; return boundary + above end
+      twin = (() => boundary + above)
+   elseif Mode is 4 then
+      read = function(Delta:num):num payload.value += Delta; return payload.value end
+      twin = (() => payload.value)
+   end
+   if glGrow then range_resize() end
+   local index = 0
+   while index < 1000 do
+      if index < (glReadBefore and 4 or 1) then
+         index++
+         continue
+      end
+      boundary += 1
+      above += 2
+      payload = { value=index + 40 }
+      if glReadBefore then
+         assert(read(0) is twin(), 'Open references must see the latest SSA values')
+      end
+      do
+         local marker = index
+         if Mode < 0 then
+            local function unused():num return marker end
+         end
+      end
+      if index is (glReadBefore and 4 or 1) and read then
+         local previous = read(0)
+         assert(twin() is previous)
+         assert(read(1) is previous + 1)
+         assert(twin() is previous + 1, 'Closures must share the cell after closing')
+      end
+      index++
+   end
+   boundary = 111
+   above = 222
+   if read then
+      local result = read(0)
+      assert(twin() is result)
+      assert(read(1) is result + 1)
+      assert(twin() is result + 1)
+      range_resize()
+      assert(twin() is result + 1, 'Closed captures must survive GC and stack-slot reuse')
+      return result
+   end
+   return index
+end
+global function range_caller(Mode:num):num
+   local lower = 7
+   local function read():num return lower end
+   local result = range_worker(Mode)
+   lower = 9
+   assert(read() is 9, 'A caller capture below the range must remain open')
+   return result
+end
+)tiri";
+   if (lua_load(lua, source, "=uclo-range-functions") or lua_pcall(lua, 0, 0, 0)) {
+      Log.error("UCLO fixture setup: %s", lua_tostring(lua, -1));
+      return false;
+   }
+   lua_getglobal(lua, "range_worker");
+   GCproto* prototype = funcproto(funcV(lua->top - 1));
+   BCIns* bytecode = proto_bc(prototype);
+   unsigned patched = 0;
+   const BCIns* close_pc = nullptr;
+   bool boundary_slot = false;
+   bool above_slot = false;
+   for (BCPOS pc = 1; pc < prototype->sizebc; ++pc) {
+      BCIns ins = bytecode[pc];
+      if (bc_op(ins) IS BC_KSHORT and bc_a(ins) IS 1 and bc_d(ins) IS 11) boundary_slot = true;
+      if (bc_op(ins) IS BC_KSHORT and bc_a(ins) IS 2 and bc_d(ins) IS 22) above_slot = true;
+      if (bc_op(ins) IS BC_UCLO and bc_a(ins) > 3) {
+         setbc_a(&bytecode[pc], 1);
+         close_pc = &bytecode[pc];
+         ++patched;
+      }
+   }
+   lua_pop(lua, 1);
+   if (patched != 1 or not boundary_slot or not above_slot) {
+      Log.error("UCLO fixture bytecode layout changed");
+      return false;
+   }
+   constexpr auto checks = R"tiri(
+global glRangeTraces = {}
+global glRangeTrace = 0
+global glRangeExit = -1
+global glRangeFailures = 0
+global glRangeRestarts = 0
+global glRangeFallbacks = 0
+global function range_trace(Event, Trace, Func, Pc, ParentOrReason, ExitOrInfo)
+   if Event is 'start' then
+      glRangeTraces[Trace] = { func=Func }
+      if ParentOrReason is glRangeTrace and ExitOrInfo is glRangeExit then
+         local ins = jit.util.funcBC(Func, Pc)
+         assert(Func is range_worker and (ins & 255) is 51 and ((ins >> 8) & 255) is 1,
+            'The range guard must restore the exact UCLO closing level')
+         glRangeRestarts++
+      end
+   elseif Event is 'stop' then glRangeTraces[Trace].done = true
+   elseif Event is 'abort' and Func is range_worker and ParentOrReason is 7 and ExitOrInfo is 51 then
+      glRangeFallbacks++
+   end
+end
+global function range_exit(Trace, Exit)
+   if Trace is glRangeTrace and Exit is glRangeExit then glRangeFailures++ end
+end
+jit.off()
+assert(range_caller(0) is 1000)
+assert(range_caller(1) is 13)
+assert(range_caller(2) is 25)
+assert(range_caller(3) is 37)
+assert(range_caller(4) is 42)
+jit.on()
+jit.flush()
+jit.opt.start('hotloop=3', 'hotexit=1000')
+jit.attach(range_trace, 'trace')
+assert(range_caller(0) is 1000)
+jit.attach(range_trace)
+for trace, entry in pairs(glRangeTraces) do
+   local info = jit.util.traceInfo(trace)
+   if entry.done and entry.func is range_worker and info.linktype is 'loop' then
+      glRangeTrace = trace
+      local comparison = 0
+      for index in {1 into info.nins} do
+         local _, ot = jit.util.traceIR(trace, index)
+         if ((ot >> 8) is 4 or (ot >> 8) is 7) and comparison is 0 then comparison = index end
+      end
+      assert(comparison > 0, 'The original loop must contain an unsigned range guard')
+      for exit in {0 to info.nexit} do
+         local snap = jit.util.traceSnap(trace, exit)
+         if snap[0] <= comparison then glRangeExit = exit end
+      end
+   end
+end
+assert(glRangeTrace > 0 and glRangeExit >= 0, 'The intended range-guard trace must compile')
+jit.opt.start('hotexit=1')
+jit.attach(range_trace, 'trace')
+jit.attach(range_exit, 'texit')
+glGrow = true
+assert(range_caller(1) is 13, 'A capture exactly at the level must close before its slot is reused')
+assert(glRangeFailures > 0 and glRangeRestarts > 0 and glRangeFallbacks is 0,
+   f'Boundary: failures={glRangeFailures}, restarts={glRangeRestarts}, fallbacks={glRangeFallbacks}')
+glRangeFailures = 0
+glRangeRestarts = 0
+glRangeFallbacks = 0
+assert(range_caller(2) is 25, 'A capture above the level must close before its slot is reused')
+assert(glRangeFallbacks is 0,
+   f'Above: failures={glRangeFailures}, restarts={glRangeRestarts}, fallbacks={glRangeFallbacks}')
+assert(range_caller(3) is 37, 'The highest cell must guard closing of every cell in the range')
+assert(range_caller(1) is 13, 'Re-entering a close trace must use fresh cells')
+assert(range_caller(2) is 25)
+assert(range_caller(3) is 37)
+assert(range_caller(4) is 42, 'Closing must materialise a newly allocated SSA table')
+assert(range_caller(4) is 42, 'A repeated GC-value close must use the new cell and table')
+jit.attach(range_trace)
+jit.attach(range_exit)
+)tiri";
+   if (lua_load(lua, checks, "=uclo-range-checks") or lua_pcall(lua, 0, 0, 0)) {
+      Log.error("UCLO range guard: %s", lua_tostring(lua, -1));
+      return false;
+   }
+   bool close_call = false;
+   jit_State* jit = L2J(lua);
+   for (TraceNo number = 1; number < jit->sizetrace; ++number) {
+      GCtrace* trace = traceref(jit, number);
+      if (not trace) continue;
+      for (IRRef ref = REF_BASE; ref < trace->nins; ++ref) {
+         IRIns* ins = &trace->ir[ref];
+         if (ins->o IS IR_CALLS and ins->op2 IS IRCALL_lj_func_closeuv) close_call = true;
+      }
+   }
+   if (not close_call) {
+      Log.error("No compiled trace contains the actual UCLO close helper");
+      return false;
+   }
+   // Start with open cells so allocation, open UREFs, SSA updates and closing share one trace.
+   for (int mode = 1; mode <= 4; ++mode) {
+      const int expected[] = { 0, 13, 25, 37, 45 };
+      char check[512];
+      snprintf(check, sizeof(check),
+         "jit.flush(); jit.opt.start('hotloop=1', 'hotexit=1'); glReadBefore=true; "
+         "assert(range_caller(%d) is %d); assert(range_caller(%d) is %d)",
+         mode, expected[mode], mode, expected[mode]);
+      if (lua_load(lua, check, "=uclo-close-root") or lua_pcall(lua, 0, 0, 0)) {
+         Log.error("UCLO actual-close root mode %d: %s", mode, lua_tostring(lua, -1));
+         return false;
+      }
+      bool close_trace = false;
+      for (TraceNo number = 1; number < jit->sizetrace; ++number) {
+         GCtrace* trace = traceref(jit, number);
+         if (not trace or gco_to_proto(gcref(trace->startpt)) != prototype) continue;
+         bool allocated = false;
+         bool open_ref = false;
+         for (IRRef ref = REF_BASE; ref < trace->nins; ++ref) {
+            IRIns* ins = &trace->ir[ref];
+            if (ins->o IS IR_TNEW or ins->o IS IR_TDUP) allocated = true;
+            if (ins->o IS IR_UREFO) open_ref = true;
+            if (ins->o IS IR_CALLS and ins->op2 IS IRCALL_lj_func_closeuv and allocated and open_ref) {
+               bool pre_snapshot = false;
+               bool post_snapshot = false;
+               bool closed_ref = false;
+               for (SnapNo snapshot_index = 0; snapshot_index < trace->nsnap; ++snapshot_index) {
+                  SnapShot* snapshot = &trace->snap[snapshot_index];
+                  const BCIns* resume = snap_pc(&trace->snapmap[snapshot->mapofs + snapshot->nent]);
+                  if (snapshot->ref <= ref) {
+                     pre_snapshot = resume IS close_pc;
+                     continue;
+                  }
+                  // Snapshot merging may advance over pure bytecodes after the jump destination.
+                  post_snapshot = resume >= close_pc + 1 + bc_j(*close_pc)
+                     and resume < bytecode + prototype->sizebc;
+                  break;
+               }
+               for (IRRef next = ref + 1; next < trace->nins; ++next) {
+                  if (trace->ir[next].o IS IR_UREFC) closed_ref = true;
+               }
+               close_trace = close_trace or (pre_snapshot and post_snapshot and closed_ref);
+            }
+         }
+      }
+      if (not close_trace) {
+         Log.error("Mode %d lacks a close trace with allocation, open/closed references and close snapshots", mode);
+         return false;
+      }
+   }
+   return true;
+}
+
 struct TestCase {
    const char* name;
    bool (*fn)(kt::Log&);
@@ -849,7 +1122,7 @@ struct TestCase {
 
 extern void jit_frame_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 27> tests = { {
+   constexpr std::array<TestCase, 28> tests = { {
       // FrameManager and FRC constants
       { "frc_constants", test_frc_constants },
       { "frame_push_pop_symmetry", test_frame_push_pop_symmetry },
@@ -880,7 +1153,8 @@ extern void jit_frame_unit_tests(int &Passed, int &Total)
       { "irbuilder_typed_helpers", test_irbuilder_typed_helpers },
       { "irbuilder_fload_helpers", test_irbuilder_fload_helpers },
       { "irbuilder_conv_helpers", test_irbuilder_conv_helpers },
-      { "irbuilder_guard_helpers", test_irbuilder_guard_helpers }
+      { "irbuilder_guard_helpers", test_irbuilder_guard_helpers },
+      { "uclo_range_guard", test_uclo_range_guard }
    } };
 
    for (const TestCase& test : tests) {

--- a/src/tiri/jit/src/lj_dispatch.cpp
+++ b/src/tiri/jit/src/lj_dispatch.cpp
@@ -11,6 +11,7 @@
 #include "lj_str.h"
 #include "lj_tab.h"
 #include "lj_meta.h"
+#include "lj_contract.h"
 #include "lj_debug.h"
 #include "lj_state.h"
 #include "lj_frame.h"
@@ -366,6 +367,15 @@ static BCREG cur_topslot(GCproto* pt, const BCIns* pc, uint32_t nres)
          BCIns call_ins = pc[-2];
          if (bc_b(call_ins) or not nres) return pt->framesize;
          return bc_a(ins) + nres - 1;
+      }
+      case BC_CONTRACT: {
+         RuntimeContractDescriptor descriptor;
+         GCstr *encoded = gco_to_string(proto_kgc(pt, ~(ptrdiff_t)bc_d(ins)));
+         if (decode_runtime_contract(encoded, descriptor) and descriptor.dynamic_count()) {
+            BCREG result_top = bc_a(ins) + descriptor.static_value_count + nres - 1;
+            return result_top > pt->framesize ? result_top : pt->framesize;
+         }
+         return pt->framesize;
       }
       case BC_RETM: return bc_a(ins) + bc_d(ins) + nres - 1;
       case BC_TSETM: return bc_a(ins) + nres - 1;

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -794,8 +794,9 @@ static void recff_array_getString(jit_State* J, RecordFFData* rd)
    TRef elem_type_ref = emitir(IRT(IR_FLOAD, IRT_U8), array_ref, IRFL_ARRAY_ELEMTYPE);
    emitir(IRTGI(IR_EQ), elem_type_ref, lj_ir_kint(J, int32_t(AET::BYTE)));
 
+   // Only the first slot beyond the arguments is cleared; later slots can retain refs from previous calls.
    TRef start_ref = lj_ir_kint(J, 0);
-   if (J->base[1] and not tref_isnil(J->base[1])) {
+   if (J->maxslot > 1 and not tref_isnil(J->base[1])) {
       if (not tvisnumber(&rd->argv[1])) {
          recff_nyi(J, rd);
          return;
@@ -804,7 +805,7 @@ static void recff_array_getString(jit_State* J, RecordFFData* rd)
    }
 
    TRef len_ref = lj_ir_kint(J, -1);
-   if (J->base[2] and not tref_isnil(J->base[2])) {
+   if (J->maxslot > 2 and not tref_isnil(J->base[2])) {
       if (not tvisnumber(&rd->argv[2])) {
          recff_nyi(J, rd);
          return;

--- a/src/tiri/jit/src/lj_ir.cpp
+++ b/src/tiri/jit/src/lj_ir.cpp
@@ -19,6 +19,7 @@
 #include "lj_jit.h"
 #include "lj_ircall.h"
 #include "runtime/lj_state.h"
+#include "runtime/lj_func.h"
 #include "lj_iropt.h"
 #include "lj_trace.h"
 #include "lj_record.h"

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -279,6 +279,8 @@ typedef struct CCallInfo {
   _(ANY,        lj_context_begin_block_jit, 5, S, NIL, CCI_L) \
   _(ANY,        lj_context_end_block_jit,   3, S, NIL, CCI_L) \
   _(ANY,        lj_context_has_call_jit,    2, FS, INT, CCI_L) \
+  /* Non-allocating upvalue close; bracketed by lifetime XBARs. */ \
+  _(ANY,        lj_func_closeuv,            2, S, NIL, CCI_L) \
   \
   // End of list.
 

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -283,6 +283,8 @@ typedef struct CCallInfo {
   _(ANY,        lj_context_has_call_jit,    2, FS, INT, CCI_L) \
   /* Non-allocating upvalue close; bracketed by lifetime XBARs. */ \
   _(ANY,        lj_func_closeuv,            2, S, NIL, CCI_L) \
+  _(ANY,        lj_func_newL_local,         4, A, FUNC, CCI_L|CCI_T) \
+  _(ANY,        lj_context_leave_tail_jit,  2, S, NIL, CCI_L) \
   \
   // End of list.
 

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -157,6 +157,8 @@ typedef struct CCallInfo {
   _(ANY,    lj_tab_new_ah,         3,   A, TAB, CCI_L|CCI_T) \
   _(ANY,    lj_tab_new1,           2,  FA, TAB, CCI_L|CCI_T) \
   _(ANY,    lj_tab_dup,            2,  FA, TAB, CCI_L|CCI_T) \
+  _(ANY,    lj_func_newL_zero,     3,   A, FUNC, CCI_L|CCI_T) \
+  _(ANY,    lj_func_newL_inherited,3,   A, FUNC, CCI_L|CCI_T) \
   _(ANY,    lj_tab_clear,          1,  FS, NIL, 0) \
   _(ANY,    lj_tab_newkey,         3,   S, PGC, CCI_L|CCI_T) \
   _(ANY,    lj_tab_keyindex,       2,  FL, INT, 0) \

--- a/src/tiri/jit/src/lj_opt_fold.cpp
+++ b/src/tiri/jit/src/lj_opt_fold.cpp
@@ -875,9 +875,11 @@ LJFOLDF(kfold_strto)
 
 // -- Constant folding of equality checks ---------------------------------
 
-// Don't constant-fold away FLOAD checks against KNULL.
+// Field and external loads may contain null pointers; retain their runtime checks.
 LJFOLD(EQ FLOAD KNULL)
 LJFOLD(NE FLOAD KNULL)
+LJFOLD(EQ XLOAD KNULL)
+LJFOLD(NE XLOAD KNULL)
 LJFOLDX(lj_opt_cse)
 
 // But fold all other KNULL compares, since only KNULL is equal to KNULL.
@@ -2086,7 +2088,7 @@ LJFOLD(ALEN any any)
 LJFOLDX(lj_opt_fwd_alen)
 
 /* Upvalue refs are really loads, but there are no corresponding stores.
-** So CSE is ok for them, except for UREFO across a GC step (see below).
+** CSE is limited by XBAR lifetime boundaries, and for UREFO by GC steps (see below).
 ** If the referenced function is const, its upvalue addresses are const, too.
 ** This can be used to improve CSE by looking for the same address,
 ** even if the upvalues originate from a different function.
@@ -2099,7 +2101,7 @@ LJFOLDF(cse_uref)
       IRRef ref = J->chain[fins->o];
       GCfunc* fn = ir_kfunc(fleft);
       GCupval* uv = gco_to_upval(gcref(fn->l.uvptr[(fins->op2 >> 8)]));
-      while (ref > 0) {
+      while (ref > J->chain[IR_XBAR]) {
          IRIns* ir = IR(ref);
          if (irref_isk(ir->op1)) {
             GCfunc* fn2 = ir_kfunc(IR(ir->op1));
@@ -2300,10 +2302,12 @@ LJFOLDF(fold_base)
 LJFOLD(TBAR any)
 LJFOLD(OBAR any any)
 LJFOLD(UREFO any any)
+LJFOLD(UREFC any any)
 LJFOLDF(barrier_tab)
 {
    TRef tr = lj_opt_cse(J);
-   if (gcstep_barrier(J, tref_ref(tr)))  //  CSE across GC step?
+   // References and barriers cannot be reused across a lifetime transition or GC step.
+   if (tref_ref(tr) <= J->chain[IR_XBAR] or gcstep_barrier(J, tref_ref(tr)))
       return EMITFOLD;  //  Raw emit. Assumes fins is left intact by CSE.
    return tr;
 }

--- a/src/tiri/jit/src/lj_opt_mem.cpp
+++ b/src/tiri/jit/src/lj_opt_mem.cpp
@@ -474,7 +474,8 @@ static AliasRet aa_uref(IRIns* refa, IRIns* refb)
 TRef lj_opt_fwd_uload(jit_State* J)
 {
    IRRef uref = fins->op1;
-   IRRef lim = REF_BASE;  //  Search limit.
+   IRRef lim = J->chain[IR_XBAR];  // Upvalue lifetime boundary.
+   if (lim < REF_BASE) lim = REF_BASE;
    IRIns* xr = IR(uref);
    IRRef ref;
 
@@ -511,7 +512,9 @@ TRef lj_opt_dse_ustore(jit_State* J)
    IRIns* xr = IR(xref);
    IRRef1* refp = &J->chain[IR_USTORE];
    IRRef ref = *refp;
-   while (ref > xref) {  // Search for redundant or conflicting stores.
+   IRRef limit = xref;
+   if (J->chain[IR_XBAR] > limit) limit = J->chain[IR_XBAR];
+   while (ref > limit) {  // Do not eliminate stores across an upvalue lifetime transition.
       IRIns* store = IR(ref);
       switch (aa_uref(xr, IR(store->op1))) {
       case ALIAS_NO:

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1392,7 +1392,8 @@ static bool rec_is_fresh_function(jit_State *J, TRef Ref)
    if (tref_isk(Ref)) return false;
    const IRIns *allocation = IR(tref_ref(Ref));
    return allocation->o IS IR_CALLA and
-      (allocation->op2 IS IRCALL_lj_func_newL_zero or allocation->op2 IS IRCALL_lj_func_newL_inherited);
+      (allocation->op2 IS IRCALL_lj_func_newL_zero or allocation->op2 IS IRCALL_lj_func_newL_inherited or
+       allocation->op2 IS IRCALL_lj_func_newL_local);
 }
 
 // Specialise to the runtime value of the called function or its prototype.
@@ -1826,6 +1827,7 @@ void lj_record_metamethod_tailcall(jit_State *J, BCREG Func, ptrdiff_t ArgumentC
    }
    J->base[Func + 1] = TREF_FRAME;
    rec_tailcall_compact(J, Func);
+   if (tref_istab(Receiver)) J->context_tail_call[J->baseslot] = true;
 }
 
 static void rec_context_tailcall(jit_State *J, BCREG CallBase, ptrdiff_t ArgumentCount)
@@ -1863,6 +1865,7 @@ static void rec_context_tailcall(jit_State *J, BCREG CallBase, ptrdiff_t Argumen
 
    J->base[CallBase + 1] = TREF_FRAME;
    rec_tailcall_compact(J, CallBase);
+   if (tref_istab(receiver) and contextual_receiver) J->context_tail_call[J->baseslot] = true;
 }
 
 //********************************************************************************************************************
@@ -1901,11 +1904,22 @@ void lj_record_ret(jit_State *J, BCREG rbase, ptrdiff_t gotresults)
 
    rec_context_leave_metamethod(J);
 
-   if (not J->L->context_stack.empty() and J->L->context_stack.back().tail_transfer and
-         J->L->context_stack.back().owner_base IS savestack(J->L, J->L->base)) {
+   // Tail transfers may be created by a helper earlier in this very recording step (notably fast calls), or by
+   // another entry to the same prototype.  Test the executing activation rather than the recording-time stack.
+   int32_t context_baseslot = int32_t(J->baseslot);
+   TValue *context_base = J->L->base;
+   if (frame_isvarg(frame)) {
+      context_baseslot -= int32_t(frame_delta(frame));
+      context_base -= frame_delta(frame);
+   }
+   // An owner below the trace root is left to the interpreter's return path.
+   if (context_baseslot >= int32_t(FRC::MIN_BASESLOT) and (J->context_tail_call[context_baseslot] or
+       (not J->L->context_stack.empty() and J->L->context_stack.back().tail_transfer and
+        J->L->context_stack.back().owner_base IS savestack(J->L, context_base)))) {
       IRBuilder ir(J);
-      TRef owner_base = rec_stack_slot_addr(J, ir, int32_t(J->baseslot));
-      lj_ir_call(J, IRCALL_lj_context_leave_jit, owner_base);
+      TRef owner_base = rec_stack_slot_addr(J, ir, int32_t(context_baseslot));
+      lj_ir_call(J, IRCALL_lj_context_leave_tail_jit, owner_base);
+      J->context_tail_call[context_baseslot] = false;
    }
 
    for (i = 0; i < gotresults; i++) (void)getslot(J, rbase + i);  //  Ensure all results have a reference.
@@ -5572,11 +5586,15 @@ void lj_record_ins(jit_State *J)
       break;
 
    case BC_FNEW: {
+      IRBuilder ir(J);
       GCproto *prototype = gco_to_proto(proto_kgc(J->pt, ~(ptrdiff_t)rc));
+      bool local_captures = false;
       for (MSize index = 0; index < prototype->sizeuv; ++index) {
          if (proto_uv(prototype)[index] & PROTO_UV_LOCAL) {
-            setintV(&J->errinfo, (int32_t)op);
-            lj_trace_err_info(J, LJ_TRERR_NYIBC);
+            local_captures = true;
+            BCREG slot = proto_uv(prototype)[index] & 0xff;
+            getslot(J, slot);
+            if (J->maxslot <= slot) J->maxslot = slot + 1;
          }
       }
       // Root the prototype in the trace and inherit the logical current frame's environment, including inlining.
@@ -5584,7 +5602,21 @@ void lj_record_ins(jit_State *J)
       TRef parent = getcurrf(J);
       TRef environment = prototype->sizeuv ? 0 : emitir(IRT(IR_FLOAD, IRT_TAB), parent, IRFL_FUNC_ENV);
       lj_snap_add(J);
-      rc = prototype->sizeuv ? lj_ir_call(J, IRCALL_lj_func_newL_inherited, proto_ref, parent) :
+      if (local_captures) {
+         // Publish all captured values after type guards, before exposing their addresses to the open-cell list.
+         for (MSize index = 0; index < prototype->sizeuv; ++index) {
+            uint32_t capture = proto_uv(prototype)[index];
+            if (capture & PROTO_UV_LOCAL) {
+               BCREG slot = capture & 0xff;
+               rec_emit_tvalue_store(J, rec_stack_slot_addr(J, ir, J->baseslot + slot), J->base[slot]);
+            }
+         }
+         emitir_raw(IRT(IR_XBAR, IRT_NIL), 0, 0);
+         TRef frame = rec_stack_slot_addr(J, ir, J->baseslot);
+         rc = lj_ir_call(J, IRCALL_lj_func_newL_local, proto_ref, parent, frame);
+         emitir_raw(IRT(IR_XBAR, IRT_NIL), 0, 0);
+      }
+      else rc = prototype->sizeuv ? lj_ir_call(J, IRCALL_lj_func_newL_inherited, proto_ref, parent) :
          lj_ir_call(J, IRCALL_lj_func_newL_zero, proto_ref, environment);
       // CALLA has a weak allocation guard.  Keep even unused closures for allocation-counter and failure semantics.
       emitir(IRT(IR_USE, IRT_FUNC), rc, 0);
@@ -5722,6 +5754,7 @@ void lj_record_setup(jit_State *J)
    memset(J->context_call_receiver, 0, sizeof(J->context_call_receiver));
    memset(J->context_call_result, 0, sizeof(J->context_call_result));
    memset(J->context_call_state, 0, sizeof(J->context_call_state));
+   memset(J->context_tail_call, 0, sizeof(J->context_tail_call));
    J->context_call_activation_count = 0;
    J->context_virtual_slot = -1;
    memset(J->trymat, 0, sizeof(J->trymat));

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1385,6 +1385,16 @@ static bool rec_proto_specialise_by_prototype(const GCproto *Proto)
    return false;
 }
 
+// Identify closures whose identity necessarily changes on each allocation.
+
+static bool rec_is_fresh_function(jit_State *J, TRef Ref)
+{
+   if (tref_isk(Ref)) return false;
+   const IRIns *allocation = IR(tref_ref(Ref));
+   return allocation->o IS IR_CALLA and
+      (allocation->op2 IS IRCALL_lj_func_newL_zero or allocation->op2 IS IRCALL_lj_func_newL_inherited);
+}
+
 // Specialise to the runtime value of the called function or its prototype.
 
 static TRef rec_call_specialise(jit_State *J, GCfunc *Function, TRef Ref, bool PrototypeSpecialisation)
@@ -1393,6 +1403,8 @@ static TRef rec_call_specialise(jit_State *J, GCfunc *Function, TRef Ref, bool P
    TRef kfunc;
    if (isluafunc(Function)) {
       GCproto* pt = funcproto(Function);
+      // Fresh allocations cannot specialise on the recording-time closure identity, even before CLC_POLY.
+      if (rec_is_fresh_function(J, Ref)) PrototypeSpecialisation = true;
       // Too many closures created? Probably not a monomorphic function.
       if (PrototypeSpecialisation or rec_proto_specialise_by_prototype(pt)) {  // Specialise to prototype instead.
          TRef trpt = ir.fload_ptr(Ref, IRFL_FUNC_PC);
@@ -2943,7 +2955,7 @@ static TRef rec_upvalue(jit_State *J, uint32_t uv, TRef val)
       TRef tr, kfunc;
       lj_assertJ(val IS 0, "bad usage");
       if (not tref_isk(fn)) {  // Late specialisation of current function.
-         if (rec_proto_specialise_by_prototype(J->pt)) goto noconstify;
+         if (rec_is_fresh_function(J, fn) or rec_proto_specialise_by_prototype(J->pt)) goto noconstify;
          kfunc = ir.kfunc(J->fn);
          ir.guard_eq(fn, kfunc, IRT_FUNC);
          J->base[-2] = kfunc;
@@ -3163,6 +3175,8 @@ static void rec_func_jit(jit_State *J, TraceNo lnk)
       return;
    }
    J->instunroll = 0;  //  Cannot continue across a compiled function.
+   // The target trace reads the physical context stack; it cannot inherit this trace's virtual activations.
+   rec_context_materialise(J, ContextMaterialisationReason::UnsupportedBoundary);
    if (J->pc IS J->startpc and FRC::at_trace_root(J)) {
       lj_record_stop(J, TraceLink::TAILREC, J->cur.traceno);  //  Extra tail-rec.
    }
@@ -5557,13 +5571,34 @@ void lj_record_ins(jit_State *J)
       lj_trace_err(J, LJ_TRERR_CJITOFF);
       break;
 
+   case BC_FNEW: {
+      GCproto *prototype = gco_to_proto(proto_kgc(J->pt, ~(ptrdiff_t)rc));
+      for (MSize index = 0; index < prototype->sizeuv; ++index) {
+         if (proto_uv(prototype)[index] & PROTO_UV_LOCAL) {
+            setintV(&J->errinfo, (int32_t)op);
+            lj_trace_err_info(J, LJ_TRERR_NYIBC);
+         }
+      }
+      // Root the prototype in the trace and inherit the logical current frame's environment, including inlining.
+      TRef proto_ref = lj_ir_kgc(J, obj2gco(prototype), IRT_PROTO);
+      TRef parent = getcurrf(J);
+      TRef environment = prototype->sizeuv ? 0 : emitir(IRT(IR_FLOAD, IRT_TAB), parent, IRFL_FUNC_ENV);
+      lj_snap_add(J);
+      rc = prototype->sizeuv ? lj_ir_call(J, IRCALL_lj_func_newL_inherited, proto_ref, parent) :
+         lj_ir_call(J, IRCALL_lj_func_newL_zero, proto_ref, environment);
+      // CALLA has a weak allocation guard.  Keep even unused closures for allocation-counter and failure semantics.
+      emitir(IRT(IR_USE, IRT_FUNC), rc, 0);
+      // Publish through the normal destination-slot path below before taking the next bytecode's snapshot.
+      J->needsnap = 1;
+      J->mergesnap = 0;
+      break;
+   }
+
    default:
       if (op >= BC__MAX) {
          lj_ffrecord_func(J);
          break;
       }
-      [[fallthrough]];
-   case BC_FNEW:
       setintV(&J->errinfo, (int32_t)op);
       lj_trace_err_info(J, LJ_TRERR_NYIBC);
       break;
@@ -5574,7 +5609,8 @@ void lj_record_ins(jit_State *J)
       SlotView slots(J);
       slots[ra] = rc;
       if (ra >= slots.maxslot()) {
-         if (ra > slots.maxslot()) slots.clear(ra - 1);
+         // A call may leave stale scratch references above maxslot.  A later high destination must not revive them.
+         if (ra > slots.maxslot()) slots.clear_range(slots.maxslot(), ra - slots.maxslot());
          slots.set_maxslot(ra + 1);
       }
    }

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -2997,6 +2997,69 @@ noconstify:
    }
 }
 
+// Record a close with a guarded list shape.  Cell identities may differ on each trace entry.
+static void rec_close_upvalues(jit_State *J, BCREG Level)
+{
+   IRBuilder ir(J);
+   TRef values[LJ_MAX_JSLOTS];
+   TRef addresses[LJ_MAX_JSLOTS];
+   unsigned count = 0;
+   // Extend snapshot coverage before adding the pre-effect snapshot.  snap_usedef() and snap_useuv()
+   // already preserve captured SSA slots, even when ordinary bytecode liveness would discard them.
+   for (GCobj* cell = gcref(J->L->openupval); cell; cell = gcref(cell->gch.nextgc)) {
+      ptrdiff_t slot = uvval(gco_to_upval(cell)) - J->L->base;
+      if (slot < Level) break;
+      if (slot >= J->pt->framesize or int32_t(J->baseslot) + slot >= LJ_MAX_JSLOTS) {
+         setintV(&J->errinfo, int32_t(BC_UCLO));
+         lj_trace_err_info(J, LJ_TRERR_NYIBC);
+      }
+      if (J->maxslot <= slot) J->maxslot = BCREG(slot + 1);
+   }
+   lj_snap_add(J);
+   TRef state_ref = ir.emit(IRT(IR_LREF, IRT_PTR), 0, 0);
+   TRef list_addr = ir.emit(IRT(IR_ADD, IRT_PTR), state_ref, lj_ir_kintp(J, offsetof(lua_State, openupval)));
+   TRef head = ir.emit(IRT(IR_XLOAD, IRT_PTR), list_addr, IRXLOAD_VOLATILE);
+   TRef trace_base = ir.emit(IRT(IR_XLOAD, IRT_PTR), ir.kptr(&J2G(J)->jit_base), IRXLOAD_VOLATILE);
+   int32_t frame_offset = int32_t(J->baseslot) - int32_t(FRC::MIN_BASESLOT);
+   TRef close_level = ir.emit(IRT(IR_ADD, IRT_PTR), trace_base,
+      lj_ir_kintp(J, (frame_offset + int32_t(Level)) * sizeof(TValue)));
+   GCobj* cell = gcref(J->L->openupval);
+   while (cell and uvval(gco_to_upval(cell)) >= J->L->base + Level) {
+      GCupval* uv = gco_to_upval(cell);
+      ptrdiff_t slot = uvval(uv) - J->L->base;
+      if (slot < 0 or slot >= J->pt->framesize or count >= LJ_MAX_JSLOTS) {
+         setintV(&J->errinfo, int32_t(BC_UCLO));
+         lj_trace_err_info(J, LJ_TRERR_NYIBC);
+      }
+      ir.guard_ne(head, ir.knull(IRT_PTR), IRT_PTR);
+      TRef value_addr = ir.emit(IRT(IR_ADD, IRT_PTR), head, lj_ir_kintp(J, offsetof(GCupval, v)));
+      TRef value_slot = ir.emit(IRT(IR_XLOAD, IRT_PTR), value_addr, IRXLOAD_VOLATILE);
+      addresses[count] = ir.emit(IRT(IR_ADD, IRT_PTR), trace_base,
+         lj_ir_kintp(J, (frame_offset + int32_t(slot)) * sizeof(TValue)));
+      ir.guard_eq(value_slot, addresses[count], IRT_PTR);
+      values[count++] = getslot(J, BCREG(slot));
+      TRef next_addr = ir.emit(IRT(IR_ADD, IRT_PTR), head, lj_ir_kintp(J, offsetof(GCupval, nextgc)));
+      head = ir.emit(IRT(IR_XLOAD, IRT_PTR), next_addr, IRXLOAD_VOLATILE);
+      cell = gcref(uv->nextgc);
+   }
+   if (cell) {
+      ir.guard_ne(head, ir.knull(IRT_PTR), IRT_PTR);
+      TRef value_addr = ir.emit(IRT(IR_ADD, IRT_PTR), head, lj_ir_kintp(J, offsetof(GCupval, v)));
+      TRef value_slot = ir.emit(IRT(IR_XLOAD, IRT_PTR), value_addr, IRXLOAD_VOLATILE);
+      ir.guard(IR_ULT, IRT_PTR, value_slot, close_level);
+   }
+   else ir.guard_eq(head, ir.knull(IRT_PTR), IRT_PTR);
+   // All guards precede publication.  The helper cannot allocate, throw or run script.
+   for (unsigned index = 0; index < count; ++index) {
+      rec_emit_tvalue_store(J, addresses[index], values[index]);
+   }
+   emitir_raw(IRT(IR_XBAR, IRT_NIL), 0, 0);
+   lj_ir_call(J, IRCALL_lj_func_closeuv, close_level);
+   // Lifetime boundary for UREF CSE, ULOAD forwarding and USTORE elimination, including loop replay.
+   emitir_raw(IRT(IR_XBAR, IRT_NIL), 0, 0);
+   J->needsnap = 1;
+}
+
 //********************************************************************************************************************
 // Record calls to Lua functions
 
@@ -5293,6 +5356,37 @@ void lj_record_ins(jit_State *J)
       rec_loop_op(J, &ops, pc);
       break;
 
+   case BC_UCLO: {
+      GCobj* head = gcref(J->L->openupval);
+      if (head and uvval(gco_to_upval(head)) >= J->L->base + ra) {
+         rec_close_upvalues(J, ra);
+         break;
+      }
+      // Exit before UCLO so the interpreter closes and follows its jump exactly once.
+      lj_snap_add(J);
+      TRef state_ref = emitir(IRT(IR_LREF, IRT_PTR), 0, 0);
+      TRef list_addr = emitir(IRT(IR_ADD, IRT_PTR), state_ref, lj_ir_kintp(J, offsetof(lua_State, openupval)));
+      // Never fold, forward or hoist this load: FNEW, helpers and GC may change the list.
+      TRef open_list = emitir(IRT(IR_XLOAD, IRT_PTR), list_addr, IRXLOAD_VOLATILE);
+      if (head) {
+         // func_finduv() orders open cells by descending stack address.  If the head is below
+         // the closing level, every cell is below it.  Guard before dereferencing a nullable head.
+         emitir(IRTG(IR_NE, IRT_PTR), open_list, lj_ir_knull(J, IRT_PTR));
+         TRef value_addr = emitir(IRT(IR_ADD, IRT_PTR), open_list, lj_ir_kintp(J, offsetof(GCupval, v)));
+         TRef value_slot = emitir(IRT(IR_XLOAD, IRT_PTR), value_addr, IRXLOAD_VOLATILE);
+         // Reload the live trace base too: relocation updates jit_base and every open cell's v.
+         // The global state belongs to the trace; only its address, never its contents, is constant.
+         TRef trace_base = emitir(IRT(IR_XLOAD, IRT_PTR), lj_ir_kptr(J, &J2G(J)->jit_base), IRXLOAD_VOLATILE);
+         int32_t slot_offset = int32_t(J->baseslot) - int32_t(FRC::MIN_BASESLOT) + int32_t(ra);
+         TRef close_level = emitir(IRT(IR_ADD, IRT_PTR), trace_base, lj_ir_kintp(J, slot_offset * sizeof(TValue)));
+         emitir(IRTG(IR_ULT, IRT_PTR), value_slot, close_level);
+      }
+      else emitir(IRTG(IR_EQ, IRT_PTR), open_list, lj_ir_knull(J, IRT_PTR));
+      // As with JMP, dispatch supplies the jump destination on the next recorder entry.
+      // UCLO's A is a closing level, not JMP's live-slot limit; preserve the SSA slots.
+      break;
+   }
+
    case BC_JMP:
       if (ra < J->maxslot) J->maxslot = ra;  //  Shrink used slots.
       break;
@@ -5469,7 +5563,6 @@ void lj_record_ins(jit_State *J)
          break;
       }
       [[fallthrough]];
-   case BC_UCLO:
    case BC_FNEW:
       setintV(&J->errinfo, (int32_t)op);
       lj_trace_err_info(J, LJ_TRERR_NYIBC);

--- a/src/tiri/jit/src/lj_trace.cpp
+++ b/src/tiri/jit/src/lj_trace.cpp
@@ -138,6 +138,8 @@ void lj_trace_err(jit_State *J, TraceError e)
 
    // Prefer the interpreter's view of the current frame to avoid clobbering live locals.
    TValue *safe_top = curr_top(J->L);
+   // MULTRES may extend past the fixed frame size; never overwrite those live results with the abort error.
+   if (safe_top < J->L->top) safe_top = J->L->top;
    if (safe_top < J->L->base) safe_top = J->L->base;
    trace_abort_stack_snapshot(J, e, safe_top);
    J->L->top = safe_top;
@@ -162,6 +164,8 @@ void lj_trace_err_info(jit_State *J, TraceError e)
    // Ensure L->top is valid before pushing error
    // Prefer the interpreter's view of the current frame to avoid clobbering live locals.
    TValue *safe_top = curr_top(J->L);
+   // MULTRES may extend past the fixed frame size; never overwrite those live results with the abort error.
+   if (safe_top < J->L->top) safe_top = J->L->top;
    if (safe_top < J->L->base) safe_top = J->L->base;
    trace_abort_stack_snapshot(J, e, safe_top);
    J->L->top = safe_top;

--- a/src/tiri/jit/src/runtime/lj_func.cpp
+++ b/src/tiri/jit/src/runtime/lj_func.cpp
@@ -152,6 +152,30 @@ static GCfunc* func_newL(lua_State *L, GCproto *pt, GCtab *env)
    return fn;
 }
 
+// Trace allocation must not collect or inspect the interpreter frame.  CALLA supplies GC checks and snapshots.
+
+GCfunc *lj_func_newL_zero(lua_State *L, GCproto *Proto, GCtab *Environment)
+{
+   lj_assertL(Proto->sizeuv IS 0, "trace closure allocation with captures");
+   return func_newL(L, Proto, Environment);
+}
+
+// Share existing cells without collecting, creating open cells or inspecting the interpreter frame.
+
+GCfunc *lj_func_newL_inherited(lua_State *L, GCproto *Proto, GCfuncL *Parent)
+{
+   GCfunc *function = func_newL(L, Proto, tabref(Parent->env));
+   for (MSize index = 0; index < Proto->sizeuv; ++index) {
+      uint32_t capture = proto_uv(Proto)[index];
+      lj_assertL(not (capture & PROTO_UV_LOCAL), "trace closure allocation with local capture");
+      lj_assertL(capture < Parent->nupvalues, "invalid inherited capture index");
+      // NOBARRIER: The function is new and white; preserve the cell's immutable flag and disambiguation hash.
+      setgcrefr(function->l.uvptr[index], Parent->uvptr[capture]);
+   }
+   function->l.nupvalues = uint8_t(Proto->sizeuv);
+   return function;
+}
+
 // Create a new Lua function with empty upvalues.
 
 GCfunc * lj_func_newL_empty(lua_State *L, GCproto *pt, GCtab *env)

--- a/src/tiri/jit/src/runtime/lj_func.cpp
+++ b/src/tiri/jit/src/runtime/lj_func.cpp
@@ -176,6 +176,31 @@ GCfunc *lj_func_newL_inherited(lua_State *L, GCproto *Proto, GCfuncL *Parent)
    return function;
 }
 
+// Trace-local captures use the logical frame supplied by the recorder.  Neither allocation path collects or
+// resizes the stack.  Create cells first so allocation failure never leaves a partially sized function in the GC list.
+
+GCfunc *lj_func_newL_local(lua_State *L, GCproto *Proto, GCfuncL *Parent, TValue *Base)
+{
+   GCupval *captures[LJ_MAX_UPVAL];
+   for (MSize index = 0; index < Proto->sizeuv; ++index) {
+      uint32_t capture = proto_uv(Proto)[index];
+      if (capture & PROTO_UV_LOCAL) {
+         GCupval *cell = func_finduv(L, Base + (capture & 0xff));
+         cell->immutable = ((capture / PROTO_UV_IMMUTABLE) & 1);
+         cell->dhash = uint32_t(uintptr_t(mref<char>(Parent->pc))) ^ (capture << 24);
+         captures[index] = cell;
+      }
+      else captures[index] = gco_to_upval(gcref(Parent->uvptr[capture]));
+   }
+   GCfunc *function = func_newL(L, Proto, tabref(Parent->env));
+   for (MSize index = 0; index < Proto->sizeuv; ++index) {
+      // NOBARRIER: The function is white, and no allocation or collection intervenes before publication.
+      setgcref(function->l.uvptr[index], obj2gco(captures[index]));
+   }
+   function->l.nupvalues = uint8_t(Proto->sizeuv);
+   return function;
+}
+
 // Create a new Lua function with empty upvalues.
 
 GCfunc * lj_func_newL_empty(lua_State *L, GCproto *pt, GCtab *env)

--- a/src/tiri/jit/src/runtime/lj_func.h
+++ b/src/tiri/jit/src/runtime/lj_func.h
@@ -15,6 +15,7 @@ LJ_FUNC void lj_func_freeuv(global_State *g, GCupval *uv);
 // Functions (closures).
 LJ_FUNC [[nodiscard]] GCfunc *lj_func_newC(lua_State *L, MSize nelems, GCtab *env);
 LJ_FUNC [[nodiscard]] GCfunc *lj_func_newL_empty(lua_State *L, GCproto *pt, GCtab *env);
+LJ_FUNC [[nodiscard]] GCfunc *lj_func_newL_zero(lua_State *L, GCproto *Proto, GCtab *Environment);
+LJ_FUNC [[nodiscard]] GCfunc *lj_func_newL_inherited(lua_State *L, GCproto *Proto, GCfuncL *Parent);
 LJ_FUNCA [[nodiscard]] GCfunc *lj_func_newL_gc(lua_State *L, GCproto *pt, GCfuncL *parent);
 LJ_FUNC void lj_func_free(global_State *g, GCfunc *c);
-

--- a/src/tiri/jit/src/runtime/lj_func.h
+++ b/src/tiri/jit/src/runtime/lj_func.h
@@ -17,5 +17,6 @@ LJ_FUNC [[nodiscard]] GCfunc *lj_func_newC(lua_State *L, MSize nelems, GCtab *en
 LJ_FUNC [[nodiscard]] GCfunc *lj_func_newL_empty(lua_State *L, GCproto *pt, GCtab *env);
 LJ_FUNC [[nodiscard]] GCfunc *lj_func_newL_zero(lua_State *L, GCproto *Proto, GCtab *Environment);
 LJ_FUNC [[nodiscard]] GCfunc *lj_func_newL_inherited(lua_State *L, GCproto *Proto, GCfuncL *Parent);
+LJ_FUNC [[nodiscard]] GCfunc *lj_func_newL_local(lua_State *L, GCproto *Proto, GCfuncL *Parent, TValue *Base);
 LJ_FUNCA [[nodiscard]] GCfunc *lj_func_newL_gc(lua_State *L, GCproto *pt, GCfuncL *parent);
 LJ_FUNC void lj_func_free(global_State *g, GCfunc *c);

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -1146,6 +1146,8 @@ static void apply_cached_contract(lua_State *L, TValue *Base, uint32_t DynamicCo
    L->top = curr_topL(L);
    uint32_t available_value_count = (Record.flags & contract_flag(ContractDescriptorFlag::DynamicCount)) ?
       DynamicCount + Record.static_value_count : Record.static_value_count;
+   // Expanded results are live stack values even when they exceed the prototype's fixed frame size.
+   if (L->top < Base + available_value_count) L->top = Base + available_value_count;
    uint32_t value_count = available_value_count > Record.contract_count ?
       available_value_count : Record.contract_count;
    bool variadic = (Record.flags & contract_flag(ContractDescriptorFlag::Variadic)) != 0;
@@ -1412,6 +1414,8 @@ extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCou
 
    uint32_t available_value_count = descriptor.dynamic_count() ?
       DynamicCount + descriptor.static_value_count : descriptor.static_value_count;
+   // Expanded results are live stack values even when they exceed the prototype's fixed frame size.
+   if (L->top < Base + available_value_count) L->top = Base + available_value_count;
    uint32_t value_count = available_value_count > descriptor.contract_count ?
       available_value_count : descriptor.contract_count;
    ptrdiff_t base_offset = savestack(L, Base);

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -329,6 +329,13 @@ extern "C" void lj_context_leave_jit(lua_State *L, TValue *OwnerBase) noexcept
    }
 }
 
+extern "C" void lj_context_leave_tail_jit(lua_State *L, TValue *OwnerBase) noexcept
+{
+   if (not L->context_stack.empty() and L->context_stack.back().tail_transfer) {
+      lj_context_leave_jit(L, OwnerBase);
+   }
+}
+
 extern "C" void lj_context_tail_jit(
    lua_State *L, GCtab *Table, TValue *PreparedOwner, TValue *OutgoingOwner)
 {

--- a/src/tiri/jit/src/runtime/lj_state.h
+++ b/src/tiri/jit/src/runtime/lj_state.h
@@ -55,6 +55,7 @@ extern "C" LJ_FUNC void lj_context_load(lua_State *L, TValue *Destination) noexc
 extern "C" LJ_FUNC GCtab * lj_context_current_jit(lua_State *L) noexcept;
 extern "C" LJ_FUNC void lj_context_enter_jit(lua_State *L, GCtab *Table, TValue *OwnerBase);
 extern "C" LJ_FUNC void lj_context_leave_jit(lua_State *L, TValue *OwnerBase) noexcept;
+extern "C" LJ_FUNC void lj_context_leave_tail_jit(lua_State *L, TValue *OwnerBase) noexcept;
 extern "C" LJ_FUNC uint32_t lj_context_has_call_jit(lua_State *L, TValue *OwnerBase) noexcept;
 extern "C" LJ_FUNC void lj_context_tail_jit(
    lua_State *L, GCtab *Table, TValue *PreparedOwner, TValue *OutgoingOwner);

--- a/src/tiri/jit/src/runtime/lj_tab.cpp
+++ b/src/tiri/jit/src/runtime/lj_tab.cpp
@@ -732,7 +732,7 @@ void lj_tab_set_global_contract(lua_State *L, GCtab *Environment, const GCstr *N
    if (not contracts) {
       contracts = lj_tab_new(L, 0, 1);
       setgcref(Environment->global_type_contracts, obj2gco(contracts));
-      lj_gc_objbarrier(L, Environment, contracts);
+      lj_gc_objbarriert(L, Environment, contracts);
    }
 
    TValue *policy_slot = lj_tab_setstr(L, contracts, Name);

--- a/src/tiri/tests/test_compound.tiri
+++ b/src/tiri/tests/test_compound.tiri
@@ -527,6 +527,27 @@ end
    assert(result.getString() is 'prefix_data', 'byte array concat assignment should preserve RHS __concat semantics')
 end
 
+@Test function GetStringOmittedLengthAfterOtherCalls()
+   local script = obj.new('tiri', { statement=[=[
+jit.opt.start('hotloop=1', 'hotexit=1')
+function workload()
+   local mt = {
+      __concat = function(Other, Lhs)
+         if Lhs then return &val .. Other end
+         return Other .. &val
+      end
+   }
+   local value = setmetatable({ val='data' }, mt)
+   local result = array<byte>
+   result ..= 'prefix_' .. value
+   assert(result.getString() is 'prefix_data', 'Omitted length must not read previous call arguments')
+end
+for _ in {0 to 1000} do workload() end
+]=] })
+   check script.acActivate()
+   assert(script.error is 0, script.errorMessage)
+end
+
 @Test function ArrayConcatAssignmentSelfAppendUsesOriginalBytes()
    result = string.toArray('ab')
 

--- a/src/tiri/tests/test_context_materialisation.tiri
+++ b/src/tiri/tests/test_context_materialisation.tiri
@@ -111,7 +111,7 @@ end
       'Explicitly context-independent built-ins should not materialise their inherited context')
 end
 
-@Test function ArbitraryNativeReentryRemainsConservative()
+function run_native_reentry_case(Preheat:bool)
    if not reset_context_counters() then return end
    local worker = entity {
       name = 'worker',
@@ -128,10 +128,31 @@ end
       return result
    end
 
+   if Preheat then
+      assert(worker.read() is 'worker')
+      assert(worker.read() is 'worker')
+   end
+
    assert(workload() is 'worker', 'A native re-entry should observe the materialised receiver context')
    local counters = jit.util.contextStats()
-   assert(counters.materialisations.nativeCall >= 1 and counters.jitEnterCalls > 0,
-      'An unclassified native callable should conservatively materialise a virtual context')
+   -- A callee compiled before its caller requires materialisation at the trace link, before the native call.
+   local boundaries = counters.materialisations.nativeCall + counters.materialisations.unsupportedBoundary
+   assert(boundaries >= 1 and counters.jitEnterCalls > 0,
+      'Native re-entry must execute with a context materialised at the native call or the compiled callee boundary')
+   assert(counters.physicalContextEntries is counters.physicalContextLeaves,
+      'Native re-entry must leave physical context ownership balanced')
+   if Preheat then
+      assert(counters.materialisations.unsupportedBoundary >= 1,
+         'Entering a precompiled contextual callee must materialise the caller context')
+   end
+end
+
+@Test function ArbitraryNativeReentryRemainsConservative()
+   run_native_reentry_case(false)
+end
+
+@Test function PrecompiledNativeReentryRemainsConservative()
+   run_native_reentry_case(true)
 end
 
 @Test function SideExitsReconstructEveryVirtualReceiver()

--- a/src/tiri/tests/test_jit_fnew.tiri
+++ b/src/tiri/tests/test_jit_fnew.tiri
@@ -1,0 +1,533 @@
+-- Isolated states allow trace assertions without Flute's own callbacks and captures.
+local harness = [=[
+global glTraces = {}
+global glFnewAborts = 0
+global glExits = 0
+global glRecordedFnew = false
+global glRecordedUclo = false
+global function trace_event(Event, Trace, Func, Pc, Reason, Info)
+   if Event is 'start' then glTraces[Trace] = { func=Func, pc=Pc }
+   elseif Event is 'stop' then glTraces[Trace].done = true
+   elseif Event is 'abort' and Reason is 7 and Info is 52 then glFnewAborts++ end
+end
+global function record_event(Trace, Func, Pc)
+   local ins = jit.util.funcBC(Func, Pc)
+   if (ins & 255) is 52 then glRecordedFnew = true end
+   if (ins & 255) is 51 then glRecordedUclo = true end
+end
+global function exit_event(Trace, Exit)
+   if Trace is glTargetTrace then glExits++ end
+end
+jit.off()
+assert(driver(1000) is 500500, 'Interpreter closure baseline')
+jit.on()
+jit.flush()
+jit.opt.start('hotloop=1', 'hotexit=1000')
+if glOptimisation then jit.opt.start(glOptimisation) end
+jit.attach(trace_event, 'trace')
+jit.attach(record_event, 'record')
+assert(driver(1000) is 500500, 'Compiled closure calls must match the interpreter')
+jit.attach(record_event)
+jit.attach(trace_event)
+assert(glRecordedFnew, 'Record the allocating bytecode')
+assert(glRecordedUclo, 'The inlined factory must record its UCLO exit')
+assert(glFnewAborts is 0, 'Zero-upvalue FNEW must not abort')
+jit.off()
+global glTargetTrace = 0
+for trace, entry in pairs(glTraces) do
+   if entry.done and entry.func is driver then
+      local info = jit.util.traceInfo(trace)
+      if info.linktype is 'loop' then
+         local in_loop = false
+         local allocations = 0
+         for index in {1 into info.nins} do
+            local _, ot = jit.util.traceIR(trace, index)
+            if (ot >> 8) is 17 then in_loop = true end
+            if in_loop and (ot >> 8) is 96 then
+               assert((ot & 31) is 8, 'Closure allocation must have function IR type')
+               allocations++
+            end
+         end
+         assert(allocations > 0, 'Fresh allocation must remain in the intended loop body')
+         glTargetTrace = trace
+      end
+   end
+end
+assert(glTargetTrace > 0, 'The allocating driver loop must compile')
+jit.on()
+jit.attach(exit_event, 'texit')
+assert(driver(10000) is 50005000)
+jit.attach(exit_event)
+assert(glExits < 20, f'Fresh identities must not cause iteration exits: {glExits}')
+processing.collect()
+for index in {0 to 10000} do
+   assert(glSaved[index](index) is index + 1, 'Escaping closure survives GC')
+   assert(glKeys[glSaved[index]] is index, 'Functions remain distinct table keys')
+   if index > 0 then assert(glSaved[index] != glSaved[index - 1]) end
+end
+]=]
+
+function run_case(Factory, Optimisation)
+   local source = [[
+global glSaved = {}
+global glKeys = {}
+]] .. Factory .. [[
+global function driver(Count:num):num
+   local total = 0
+   local index = 0
+   while index < Count do
+      local callback = factory()
+      glSaved[index] = callback
+      glKeys[callback] = index
+      total += callback(index)
+      index++
+   end
+   return total
+end
+]] .. harness
+   if Optimisation then source = f'global glOptimisation = "{Optimisation}"\n' .. source end
+   local script = obj.new('tiri', { statement=source })
+   check script.acActivate()
+   assert(script.error is 0, script.errorMessage)
+end
+
+@Test function FreshOrdinaryFunctions()
+   run_case([[
+global function factory():func
+   local function callback(Value:num):num return Value + 1 end
+   return callback
+end
+]])
+end
+
+@Test function FreshArrowFunctions()
+   run_case([[
+global function factory():func
+   return Value => Value + 1
+end
+]])
+end
+
+@Test function FreshImmediateCallsAndUnusedAllocations()
+   local script = obj.new('tiri', { statement=[[
+global glTraces = {}
+global glExits = 0
+global function events(Event, Trace, Func)
+   if Event is 'start' then glTraces[Trace] = { func=Func }
+   elseif Event is 'stop' then glTraces[Trace].done = true end
+end
+global function exits(Trace)
+   if Trace is glTarget then glExits++ end
+end
+global function driver(Count:num):num
+   local total = 0
+   local index = 0
+   while index < Count do
+      local function callback(Value:num):num return Value + 1 end
+      local unused = () => 99
+      total += callback(index)
+      index++
+   end
+   return total
+end
+jit.opt.start('hotloop=1', 'hotexit=1000')
+jit.attach(events, 'trace')
+assert(driver(1000) is 500500)
+jit.attach(events)
+jit.off()
+global glTarget = 0
+for trace, entry in pairs(glTraces) do
+   if entry.done and entry.func is driver then
+      local info = jit.util.traceInfo(trace)
+      if info.linktype is 'loop' then
+         local in_loop = false
+         local allocations = 0
+         for index in {1 into info.nins} do
+            local _, ot = jit.util.traceIR(trace, index)
+            if (ot >> 8) is 17 then in_loop = true end
+            if in_loop and (ot >> 8) is 96 then allocations++ end
+         end
+         assert(allocations is 2, f'DCE must preserve both allocations and their counters: {allocations}')
+         glTarget = trace
+      end
+   end
+end
+assert(glTarget > 0, 'First fresh calls must compile before the closure counter saturates')
+jit.on()
+jit.attach(exits, 'texit')
+assert(driver(10000) is 50005000)
+jit.attach(exits)
+assert(glExits < 20, 'Immediate fresh calls must remain on trace')
+jit.off()
+assert(driver(1000) is 500500)
+]] })
+   check script.acActivate()
+   assert(script.error is 0, script.errorMessage)
+end
+
+@Test function LocalCapturesStillFallBack()
+   local script = obj.new('tiri', { statement=[[
+global glAborts = 0
+global function events(Event, Trace, Func, Pc, Reason, Info)
+   if Event is 'abort' and Reason is 7 and Info is 52 then glAborts++ end
+end
+global function driver():table
+   local saved = {}
+   local index = 0
+   while index < 100 do
+      local value = index
+      saved[index] = () => value
+      index++
+   end
+   return saved
+end
+jit.opt.start('hotloop=1')
+jit.attach(events, 'trace')
+local saved = driver()
+jit.attach(events)
+assert(glAborts > 0, 'Local captures must retain conservative FNEW fallback')
+processing.collect()
+for index in {0 to 100} do assert(saved[index]() is index) end
+global function owner(Inherited:num):func
+   local function parent(Value:num):func
+      local function read():num return Inherited + Value end
+      return read
+   end
+   return parent
+end
+local parent = owner(100)
+jit.flush()
+glAborts = 0
+jit.attach(events, 'trace')
+for index in {0 to 100} do saved[index] = parent(index) end
+jit.attach(events)
+assert(glAborts > 0, 'Mixed inherited/local descriptors must retain FNEW fallback')
+processing.collect()
+for index in {0 to 100} do assert(saved[index]() is index + 100) end
+]] })
+   check script.acActivate()
+   assert(script.error is 0, script.errorMessage)
+end
+
+function environment_recovery(Inherited)
+   local source = [=[
+global glOffset = 0
+global glCaught:func
+global glPick = -1
+global glAllocatingTrace = 0
+global glPostAllocationExit = false
+global glTraces = {}
+global function events(Event, Trace, Func, Pc, Parent)
+   if Event is 'start' then
+      glTraces[Trace] = { func=Func }
+      if Parent is glAllocatingTrace and Parent > 0 then
+         -- The comparison immediately following FNEW must resume without replaying allocation.
+         local previous = jit.util.funcBC(Func, Pc - 1)
+         if previous and (previous & 255) is 52 then glPostAllocationExit = true end
+      end
+   elseif Event is 'stop' then glTraces[Trace].done = true end
+end
+global function make_parent():func
+   local function parent(Value:num):func
+      local function callback(Value:num):num return Value + glOffset end
+      if Value is glPick then glCaught = callback end
+      return callback
+   end
+   return parent
+end
+global function driver(Parent:func, Count:num):table
+   local saved = {}
+   local index = 0
+   while index < Count do
+      local callback = Parent(index)
+      saved[index] = callback
+      index++
+   end
+   return saved
+end
+local first = make_parent()
+local second = make_parent()
+-- Saturate parent specialisation without sharing the actual function environments.
+for index in {0 to 10} do make_parent() end
+local first_env = { glOffset=17, glPick=-1 }
+local second_env = { glOffset=29, glPick=700 }
+debug.setEnv(first, first_env)
+debug.setEnv(second, second_env)
+jit.opt.start('hotloop=1', 'hotexit=1')
+jit.attach(events, 'trace')
+local initial = driver(first, 1000)
+jit.off()
+for trace, entry in pairs(glTraces) do
+   if entry.done and entry.func is driver and jit.util.traceInfo(trace).linktype is 'loop' then
+      glAllocatingTrace = trace
+   end
+end
+assert(glAllocatingTrace > 0, 'Environment and recovery driver must compile')
+jit.on()
+local changed = driver(second, 1000)
+assert(second_env.glCaught is changed[700], 'Exit after allocation must preserve the returned identity')
+first_env.glPick = 300
+local reentered = driver(first, 1000)
+jit.attach(events)
+assert(glPostAllocationExit, 'A side exit must resume immediately after FNEW')
+assert(first_env.glCaught is reentered[300], 'Side traces and re-entry must preserve allocation identity')
+processing.collect()
+for index in {0 to 1000} do
+   assert(initial[index](index) is index + 17, 'Initial parent environment')
+   assert(changed[index](index) is index + 29, 'Different parent instance environment')
+   assert(reentered[index](index) is index + 17, 'Original environment after re-entry')
+   assert(debug.getEnv(initial[index]) is first_env, 'Child inherits the logical parent environment')
+   assert(debug.getEnv(changed[index]) is second_env)
+end
+]=]
+   if Inherited then
+      source = source.replace('global function make_parent():func', 'global function make_parent(Captured:num):func')
+      source = source.replace('return Value + glOffset end', 'return Value + glOffset + Captured end')
+      source = source.replace('local first = make_parent()', 'local first = make_parent(3)')
+      source = source.replace('local second = make_parent()', 'local second = make_parent(5)')
+      source = source.replace('do make_parent() end', 'do make_parent(0) end')
+      source = source.replace('index + 17', 'index + 20').replace('index + 29', 'index + 34')
+   end
+   local script = obj.new('tiri', { statement=source })
+   check script.acActivate()
+   assert(script.error is 0, script.errorMessage)
+end
+
+@Test function InlinedParentEnvironmentsAndRecovery()
+   environment_recovery(false)
+end
+
+@Test function InheritedEnvironmentsAndRecovery()
+   environment_recovery(true)
+end
+
+@Test function FreshFunctionsWithoutSinkingOrCse()
+   for _, optimisation in ipairs({ '-sink', '-cse', '-fold' }) do
+      run_case([[
+global function factory():func
+   local function callback(Value:num):num return Value + 1 end
+   return callback
+end
+]], optimisation)
+   end
+end
+
+-- The owner creates local cells in the interpreter; only its descendants allocate on the driver trace.
+local inherited_harness = [=[
+global glTraces = {}
+global glAborts = 0
+global glTarget = 0
+global glExits = 0
+global glUclo = false
+global function events(Event, Trace, Func, Pc, Reason, Info)
+   if Event is 'start' then glTraces[Trace] = { func=Func }
+   elseif Event is 'stop' then glTraces[Trace].done = true
+   elseif Event is 'abort' and Reason is 7 and Info is 52 then glAborts++ end
+end
+global function recording(Trace, Func, Pc)
+   if not jit.util.funcInfo(Func).proto then return end
+   if (jit.util.funcBC(Func, Pc) & 255) is 51 then glUclo = true end
+end
+global function exits(Trace)
+   if Trace is glTarget then glExits++ end
+end
+global function driver(Parent:func, Label:num, Count:num):table
+   local saved = table.new(Count, 0)
+   local index = 0
+   while index < Count do
+      local read, write = Parent()
+      write(index)
+      assert(read() is index + Label, 'Sibling closures must share the mutable cell')
+      saved[index] = { read=read, write=write }
+      index++
+   end
+   return saved
+end
+global function owner(Label:num, Open:bool):<func, table>
+   local shared = 0
+   local function parent():<func, func>
+      local function read():num return shared + Label end
+      local function write(Value:num) shared = Value end
+      return read, write
+   end
+   local saved = {}
+   if Open then
+      saved = driver(parent, Label, 2000)
+      jit.off()
+      for trace, entry in pairs(glTraces) do
+         if entry.done and entry.func is driver and jit.util.traceInfo(trace).linktype is 'loop' then
+            glTarget = trace
+         end
+      end
+      assert(glTarget > 0, 'The cold inherited loop must compile')
+      jit.on()
+      jit.attach(exits, 'texit')
+      saved = driver(parent, Label, 2000)
+      jit.attach(exits)
+      assert(glExits < 20, 'Immutable upvalues must not introduce per-instance identity guards')
+      assert(shared is 1999, 'An inherited write must reach the still-open owner slot')
+      shared = 7000
+      assert(saved[0].read() is 7000 + Label, 'Owner mutation must reach all descendants')
+   end
+   return parent, saved
+end
+global function check_saved(Saved:table, Label:num)
+   Saved[0].write(8000)
+   processing.collect()
+   for index in {0 to 2000} do
+      assert(Saved[index].read() is 8000 + Label, 'Shared cells survive GC and owner return')
+      if index > 0 then
+         assert(Saved[index].read != Saved[index - 1].read, 'Inherited closures keep fresh identity')
+      end
+   end
+end
+]=]
+
+function run_inherited_case(Body)
+   local script = obj.new('tiri', { statement=inherited_harness .. Body })
+   check script.acActivate()
+   assert(script.error is 0, script.errorMessage)
+end
+
+@Test function InheritedClosedCellsAndDifferentParents()
+   run_inherited_case([[
+local first = owner(17, false)
+local second = owner(29, false)
+-- Permit prototype specialisation of the parent while keeping distinct cells and labels.
+for index in {0 to 10} do owner(index, false) end
+jit.off()
+local baseline = driver(first, 17, 2000)
+check_saved(baseline, 17)
+jit.on()
+jit.flush()
+jit.opt.start('hotloop=1', 'hotexit=1000')
+jit.attach(events, 'trace')
+jit.attach(recording, 'record')
+local initial = driver(first, 17, 2000)
+jit.attach(recording)
+jit.attach(events)
+assert(glAborts is 0, 'Inherited FNEW must not abort')
+assert(glUclo, 'The inherited factory must record UCLO')
+jit.off()
+for trace, entry in pairs(glTraces) do
+   if entry.done and entry.func is driver then
+      local info = jit.util.traceInfo(trace)
+      if info.linktype is 'loop' then
+         local in_loop = false
+         local allocations = 0
+         for index in {1 into info.nins} do
+            local _, ot = jit.util.traceIR(trace, index)
+            if (ot >> 8) is 17 then in_loop = true end
+            if in_loop and (ot >> 8) is 96 and (ot & 31) is 8 then allocations++ end
+         end
+         assert(allocations is 2, 'Both inherited allocations must remain inside the driver loop')
+         glTarget = trace
+      end
+   end
+end
+assert(glTarget > 0, 'The inherited allocating driver must compile')
+jit.on()
+jit.attach(exits, 'texit')
+local changed = driver(second, 29, 2000)
+jit.attach(exits)
+assert(glExits < 20, f'Parent variation must not cause per-instance exits: {glExits}')
+check_saved(initial, 17)
+check_saved(changed, 29)
+assert(initial[0].read() is 8017, 'Different parents must retain independent mutable cells')
+]])
+end
+
+@Test function InheritedOpenCellsAndClosing()
+   run_inherited_case([[
+jit.opt.start('hotloop=1', 'hotexit=1')
+jit.attach(events, 'trace')
+jit.attach(recording, 'record')
+local parent, saved = owner(37, true)
+jit.attach(recording)
+jit.attach(events)
+assert(glAborts is 0, 'Inherited FNEW over open cells must not abort')
+assert(glUclo, 'Open inherited cells must permit the factory UCLO range guard')
+jit.off()
+for trace, entry in pairs(glTraces) do
+   if entry.done and entry.func is driver and jit.util.traceInfo(trace).linktype is 'loop' then glTarget = trace end
+end
+assert(glTarget > 0, 'The allocating loop must compile while inherited cells are open')
+jit.on()
+check_saved(saved, 37)
+-- Re-enter the open-cell trace after the owner closed its cells; guards must recover safely.
+local closed = driver(parent, 37, 2000)
+check_saved(closed, 37)
+assert(saved[0].read() is 8037, 'Closures created before and after closing must share the cell')
+]])
+end
+
+@Test function FreshImmutableInheritedCalls()
+   run_case([[
+global function owner(Offset:num):func
+   local function parent():func
+      local function read(Value:num):num return Value + Offset end
+      return read
+   end
+   return parent
+end
+global factory = owner(1)
+]])
+end
+
+@Test function InheritedAllocationThroughFreshInlinedParents()
+   for _, optimisation in ipairs({ '3', '-sink', '-cse', '-fold' }) do
+      run_case([[
+global function owner(Offset:num):func
+   local function parent():func
+      local function intermediate():func
+         local function read(Value:num):num return Value + Offset end
+         return read
+      end
+      return intermediate()
+   end
+   return parent
+end
+global factory = owner(1)
+]], optimisation)
+   end
+end
+
+@Test function InheritedGcValuesAndSiblingAliasing()
+   local script = obj.new('tiri', { statement=[=[
+global function owner():<func, func>
+   local shared = { value=0 }
+   local function parent():<func, func>
+      local function read():table return shared end
+      local function write(Value:table) shared = Value end
+      return read, write
+   end
+   local function peek():table return shared end
+   return parent, peek
+end
+global function driver(Parent:func, Peek:func):table
+   local saved = table.new(2000, 0)
+   local index = 0
+   while index < 2000 do
+      local read, write = Parent()
+      local before = Peek()
+      local replacement = { value=index }
+      write(replacement)
+      assert(read() is replacement, 'Sibling read must observe a new GC value')
+      assert(Peek() is replacement, 'Pre-existing closure must observe the aliased store')
+      assert(before != replacement, 'The store must not forward the earlier load')
+      saved[index] = read
+      index++
+   end
+   return saved
+end
+local parent, peek = owner()
+jit.opt.start('hotloop=1')
+local saved = driver(parent, peek)
+parent = nil
+processing.collect()
+for index in {0 to 2000} do assert(saved[index]().value is 1999) end
+assert(peek().value is 1999)
+]=] })
+   check script.acActivate()
+   assert(script.error is 0, script.errorMessage)
+end

--- a/src/tiri/tests/test_jit_fnew.tiri
+++ b/src/tiri/tests/test_jit_fnew.tiri
@@ -165,7 +165,7 @@ assert(driver(1000) is 500500)
    assert(script.error is 0, script.errorMessage)
 end
 
-@Test function LocalCapturesStillFallBack()
+@Test function LocalAndMixedCaptures()
    local script = obj.new('tiri', { statement=[[
 global glAborts = 0
 global function events(Event, Trace, Func, Pc, Reason, Info)
@@ -185,7 +185,7 @@ jit.opt.start('hotloop=1')
 jit.attach(events, 'trace')
 local saved = driver()
 jit.attach(events)
-assert(glAborts > 0, 'Local captures must retain conservative FNEW fallback')
+assert(glAborts is 0, 'Local captures must record FNEW')
 processing.collect()
 for index in {0 to 100} do assert(saved[index]() is index) end
 global function owner(Inherited:num):func
@@ -201,7 +201,7 @@ glAborts = 0
 jit.attach(events, 'trace')
 for index in {0 to 100} do saved[index] = parent(index) end
 jit.attach(events)
-assert(glAborts > 0, 'Mixed inherited/local descriptors must retain FNEW fallback')
+assert(glAborts is 0, 'Mixed inherited/local descriptors must record FNEW')
 processing.collect()
 for index in {0 to 100} do assert(saved[index]() is index + 100) end
 ]] })
@@ -528,6 +528,301 @@ processing.collect()
 for index in {0 to 2000} do assert(saved[index]().value is 1999) end
 assert(peek().value is 1999)
 ]=] })
+   check script.acActivate()
+   assert(script.error is 0, script.errorMessage)
+end
+
+function run_local_case(Optimisation)
+   local source = [=[
+global glTraces = {}
+global glAborts = 0
+global glExits = 0
+global glTarget = 0
+global glSaved = table.new(10000, 0)
+global function events(Event, Trace, Func, Pc, Reason, Info)
+   if Event is 'start' then glTraces[Trace] = { func=Func }
+   elseif Event is 'stop' then glTraces[Trace].done = true
+   elseif Event is 'abort' and Reason is 7 and (Info is 52 or Info is 51) then glAborts++ end
+end
+global function exits(Trace)
+   if Trace is glTarget then glExits++ end
+end
+global function factory(Value:num):<func, func>
+   local value = Value
+   local function read():num return value end
+   local function write(New:num) value = New end
+   value += 1
+   write(value + 2)
+   assert(read() is Value + 3, 'Sibling writes must update the owning SSA slot')
+   value += 4
+   return read, write
+end
+global function driver(Count:num):num
+   local total = 0
+   local index = 0
+   while index < Count do
+      local read, write = factory(index)
+      glSaved[index] = { read=read, write=write }
+      total += read()
+      index++
+   end
+   return total
+end
+jit.off()
+local expected = driver(1000)
+assert(expected is 506500)
+jit.on()
+jit.flush()
+jit.opt.start('hotloop=1', 'hotexit=1000')
+if glOptimisation then jit.opt.start(glOptimisation) end
+jit.attach(events, 'trace')
+assert(driver(1000) is expected)
+jit.attach(events)
+assert(glAborts is 0, 'Local allocation and actual closing must record')
+jit.off()
+for trace, entry in pairs(glTraces) do
+   if entry.done and entry.func is driver then
+      local info = jit.util.traceInfo(trace)
+      if info.linktype is 'loop' then
+         local in_loop = false
+         local allocations = 0
+         local calls = {}
+         local allocation_call = 0
+         for index in {1 into info.nins} do
+            local _, ot, _, operand = jit.util.traceIR(trace, index)
+            if (ot >> 8) is 17 then in_loop = true end
+            if in_loop and (ot >> 8) is 96 and (ot & 31) is 8 then
+               allocations++
+               allocation_call = operand
+            end
+            if in_loop and (ot >> 8) is 98 then calls[operand] = true end
+         end
+         assert(allocations is 2, f'Both sibling allocations must execute inside the loop: {allocations} {glOptimisation} trace={trace}')
+         -- The appended local allocator immediately follows closeuv in IRCALLDEF.
+         assert(calls[allocation_call - 1], 'Actual closing must remain in the allocating loop')
+         glTarget = trace
+      end
+   end
+end
+assert(glTarget > 0, 'The local-capture allocating loop must compile')
+jit.on()
+jit.attach(exits, 'texit')
+assert(driver(10000) is 50065000)
+jit.attach(exits)
+assert(glExits < 30, f'Local closures must remain on trace: {glExits}')
+processing.collect()
+for index in {0 to 10000} do
+   assert(glSaved[index].read() is index + 7, 'Iteration cells must stay distinct after close and GC')
+   glSaved[index].write(index + 100)
+   assert(glSaved[index].read() is index + 100, 'Closed siblings must share their cell')
+   if index > 0 then assert(glSaved[index].read != glSaved[index - 1].read) end
+end
+]=]
+   if Optimisation then source = f'global glOptimisation = "{Optimisation}"\n' .. source end
+   local script = obj.new('tiri', { statement=source })
+   check script.acActivate()
+   assert(script.error is 0, script.errorMessage)
+end
+
+@Test function LocalSiblingMutationAndIntegratedClosing()
+   run_local_case()
+end
+
+@Test function LocalCaptureOptimisationVariants()
+   for _, option in ipairs({ '-sink', '-cse', '-fold' }) do run_local_case(option) end
+end
+
+@Test function LocalGcValuesDescendantsAndRecovery()
+   local script = obj.new('tiri', { statement=[[
+global function observer(Read:func):num
+   processing.collect()
+   return Read().value
+end
+jit.off(observer)
+global function grow(Depth:num):num
+   if Depth is 0 then return 0 end
+   return 1 + grow(Depth - 1)
+end
+jit.off(grow)
+global function owner(Offset:num):func
+   local function factory(Index:num, Cold:bool):<func, func>
+      local value = { value=Index }
+      local function parent():func
+         local function read():table return value end
+         return read
+      end
+      local read = parent()
+      local function write(New:table) value = New end
+      value = { value=Index + Offset }
+      if Cold then
+         assert(grow(200) is 200)
+         assert(observer(read) is Index + Offset, 'Exit must restore reassigned captured GC values')
+      end
+      assert(read().value is Index + Offset)
+      return read, write
+   end
+   return factory
+end
+global function driver(Factory:func, Count:num, Cold:bool):table
+   local saved = {}
+   for index in {0 to Count} do
+      local read, write = Factory(index, Cold and index is 27)
+      saved[index] = { read=read, write=write }
+   end
+   return saved
+end
+local first = owner(100)
+local second = owner(200)
+for index in {0 to 10} do owner(index) end
+jit.off()
+local baseline = driver(first, 100, true)
+jit.on()
+jit.flush()
+jit.opt.start('hotloop=1', 'hotexit=1')
+local warm = driver(first, 1000, false)
+for iteration in {0 to 6} do
+   local saved = driver(second, 100, true)
+   processing.collect()
+   for index in {0 to 100} do
+      assert(baseline[index].read().value is index + 100)
+      assert(warm[index].read().value is index + 100)
+      assert(saved[index].read().value is index + 200)
+      saved[index].write({ value=index + 300 })
+      assert(saved[index].read().value is index + 300, 'Descendants share the local cell after closing')
+   end
+end
+]] })
+   check script.acActivate()
+   assert(script.error is 0, script.errorMessage)
+end
+
+@Test function CapturingDeferCleanupAndExceptions()
+   local script = obj.new('tiri', { statement=[[
+global glTraces = {}
+global function events(Event, Trace, Func)
+   if Event is 'start' then glTraces[Trace] = { func=Func }
+   elseif Event is 'stop' then glTraces[Trace].done = true end
+end
+global function worker(Index:num, Mode:num, Order:table):num
+   local value = Index
+   defer Order.insert(value + 10000) end
+   defer Order.insert(value) end
+   value += 1
+   if Mode is 1 then return value end
+   if Mode is 2 then raise 'expected cleanup' end
+   return value
+end
+global function driver(Count:num):table
+   local order = {}
+   for index in {0 to Count} do
+      worker(index, index % 2, order)
+   end
+   return order
+end
+jit.off()
+local baseline = driver(1000)
+jit.on()
+jit.flush()
+jit.opt.start('hotloop=1', 'hotexit=1')
+jit.attach(events, 'trace')
+local actual = driver(1000)
+jit.attach(events)
+jit.off()
+local allocated = false
+for trace, entry in pairs(glTraces) do
+   if entry.done and entry.func is driver then
+      local info = jit.util.traceInfo(trace)
+      local count = 0
+      for index in {1 into info.nins} do
+         local _, ot = jit.util.traceIR(trace, index)
+         if (ot >> 8) is 96 and (ot & 31) is 8 then count++ end
+      end
+      if count >= 2 then allocated = true end
+   end
+end
+assert(allocated, 'The driver trace must allocate both capturing defer blocks')
+jit.on()
+assert(#actual is 2000, 'Each capturing defer executes exactly once')
+for index in {0 to #actual} do assert(actual[index] is baseline[index]) end
+local failed = {}
+try
+   worker(42, 2, failed)
+except e
+   assert(#failed is 2 and failed[0] is 43 and failed[1] is 10043, 'Exception cleanup preserves LIFO order')
+success
+   assert(false, 'Expected worker exception')
+end
+local loop_order = {}
+for index in {0 to 100} do
+   local value = index
+   defer loop_order.insert(value) end
+   value += 1
+   if index < 50 then continue end
+   break
+end
+assert(#loop_order is 51)
+for index in {0 to 51} do assert(loop_order[index] is index + 1) end
+]] })
+   check script.acActivate()
+   assert(script.error is 0, script.errorMessage)
+end
+
+@Test function FreshFactoriesPreserveTailContexts()
+   local script = obj.new('tiri', { statement=[[
+global function driver(Count:num):num
+   local total = 0
+   for index in {0 to Count} do
+      local calls = 0
+      local target = { value=index }
+      setmetatable(target, {
+         __clear = function(...)
+            assert(&& is target)
+            assert(#{...} is 0)
+            calls++
+         end,
+         __pairs = function(...):<func, table, nil>
+            assert(&& is target)
+            assert(#{...} is 0)
+            return next, { value=index }, nil
+         end
+      })
+      target.clear()
+      assert(calls is 1)
+      for _, value in pairs(target) do total += value end
+   end
+   return total
+end
+jit.opt.start('hotloop=1', 'hotexit=1')
+jit.util.contextStats(true)
+assert(driver(2000) is 1999000)
+local stats = jit.util.contextStats()
+if stats and stats.enabled then
+   assert(stats.physicalContextEntries is stats.physicalContextLeaves,
+      'Fresh local factories must balance contexts transferred by fast-function tail calls')
+end
+]] })
+   check script.acActivate()
+   assert(script.error is 0, script.errorMessage)
+end
+
+@Test function VarargOwnersBelowTheTraceRoot()
+   local script = obj.new('tiri', { statement=[[
+global function worker(Count:num, ...):num
+   local total = 0
+   local index = 0
+   while index < Count do
+      local value = index
+      local read = () => value
+      total += read()
+      index++
+   end
+   return total
+end
+jit.opt.start('hotloop=1', 'hotexit=1')
+for iteration in {0 to 100} do
+   assert(worker(100, 11, 22, 33, 44) is 4950, 'Loop-root returns must preserve the outer vararg owner')
+end
+]] })
    check script.acActivate()
    assert(script.error is 0, script.errorMessage)
 end

--- a/src/tiri/tests/test_jit_uclo.tiri
+++ b/src/tiri/tests/test_jit_uclo.tiri
@@ -1,0 +1,197 @@
+-- Isolated states keep Flute's own open captures out of the empty-list tests.
+local harness = [[
+global glTraces = {}
+global glAborts = 0
+global glExits = 0
+global glResumeUclo = false
+global glNonemptyAborts = 0
+global glZeroJump = false
+global glNonzeroJump = false
+global function record_event(Trace, Func, Pc)
+   if Func is worker then
+      local ins = jit.util.funcBC(Func, Pc)
+      if (ins & 255) is 51 then -- BC_UCLO.
+         if ((ins >> 16) - 32768) is 0 then glZeroJump = true else glNonzeroJump = true end
+      end
+   end
+end
+global function trace_event(Event, Trace, Func, Pc, ParentOrReason, ExitOrInfo)
+   if Event is 'start' then
+      glTraces[Trace] = { func=Func, pc=Pc }
+      if ParentOrReason is glTargetTrace and ExitOrInfo is glGuardExit then
+         local ins = jit.util.funcBC(Func, Pc)
+         glResumeUclo = Func is worker and (ins & 255) is 51
+      end
+   elseif Event is 'stop' then glTraces[Trace].done = true
+   elseif Event is 'abort' then
+      glAborts++
+      if Func is worker and ParentOrReason is 7 and ExitOrInfo is 51 then
+         glNonemptyAborts++ -- NYIBC, BC_UCLO.
+      end
+   end
+end
+global function exit_event(Trace, Exit)
+   if Trace is glTargetTrace and Exit is glGuardExit then glExits++ end
+end
+global function driver(Count:num):num
+   local total = 0
+   local index = 0
+   while index < Count do
+      total += worker(index, false)
+      index++
+   end
+   return total
+end
+jit.off()
+local expected = driver(1000)
+jit.on()
+jit.flush()
+jit.opt.start('hotloop=3', 'hotexit=1000')
+jit.attach(trace_event, 'trace')
+jit.attach(record_event, 'record')
+assert(driver(1000) is expected, 'Empty UCLO must match the interpreter')
+jit.attach(trace_event)
+jit.attach(record_event)
+assert(glZeroJump or glNonzeroJump, 'The worker must reach UCLO while recording')
+assert(glNonzeroJump is glExpectJump, 'The worker must exercise the requested UCLO jump shape')
+assert(glAborts is 0, f'Empty UCLO aborted {glAborts} recordings')
+global glTargetTrace = 0
+global glGuardExit = -1
+for trace, entry in pairs(glTraces) do
+   if entry.done and entry.func is driver then
+      local info = jit.util.traceInfo(trace)
+      if info.linktype is 'loop' then
+         local loop = 0
+         local loads = 0
+         local body_loads = 0
+         local first_load = 0
+         for index in {1 into info.nins} do
+            local _, ot, _, flags = jit.util.traceIR(trace, index)
+            if (ot >> 8) is 17 then loop = index end
+            if (ot >> 8) is 70 and flags is 2 then
+               loads++
+               if first_load is 0 then first_load = index end
+               if loop > 0 then body_loads++ end
+            end
+         end
+         assert(loads >= 2 and body_loads >= 1, 'Volatile UCLO load must remain inside the loop')
+         glTargetTrace = trace
+         for exit in {0 to info.nexit} do
+            local snap = jit.util.traceSnap(trace, exit)
+            if snap[0] <= first_load then glGuardExit = exit end
+         end
+      end
+   end
+end
+assert(glTargetTrace > 0, 'The intended caller loop must compile')
+assert(glGuardExit >= 0, 'UCLO must have a pre-instruction snapshot')
+-- The same trace is entered with an unrelated caller capture below the close level.
+-- A hot guard exposes the restored PC when side recording specialises for an unrelated capture.
+global function captured_call():num
+   local value = { number=19 }
+   local function read():num return value.number end
+   local result = driver(1000)
+   value.number = 23
+   assert(read() is 23, 'Caller capture must remain open across callee UCLO')
+   return result
+end
+jit.opt.start('hotexit=1')
+jit.attach(trace_event, 'trace')
+jit.attach(exit_event, 'texit')
+assert(captured_call() is expected, 'Nonempty-list guard exit must preserve the result')
+jit.attach(exit_event)
+jit.attach(trace_event)
+assert(glExits > 0, 'The UCLO guard on the original empty-list trace must exit')
+assert(glResumeUclo, 'The guard snapshot must restart at the worker UCLO')
+assert(glNonemptyAborts is 0, 'Unrelated caller captures must allow UCLO recording')
+-- Record directly with a nonempty list to identify the specialised caller loop.
+jit.flush()
+jit.opt.start('hotloop=3', 'hotexit=1000')
+glTraces = {}
+glAborts = 0
+jit.attach(trace_event, 'trace')
+assert(captured_call() is expected)
+jit.attach(trace_event)
+assert(glAborts is 0, 'A capture below the closing level must not abort recording')
+local range_trace = 0
+for trace, entry in pairs(glTraces) do
+   if entry.done and entry.func is driver then
+      local info = jit.util.traceInfo(trace)
+      if info.linktype is 'loop' then
+         local in_loop = false
+         local loads = 0
+         local comparisons = 0
+         for index in {1 into info.nins} do
+            local _, ot, _, flags = jit.util.traceIR(trace, index)
+            if (ot >> 8) is 17 then in_loop = true end
+            if in_loop then
+               if (ot >> 8) is 70 and flags is 2 then loads++ end
+               if (ot >> 8) is 4 or (ot >> 8) is 7 then comparisons++ end -- IR_ULT or swapped IR_UGT.
+            end
+         end
+         assert(loads >= 3 and comparisons >= 1, 'Range guard must reload head, slot and base inside the loop')
+         range_trace = trace
+      end
+   end
+end
+assert(range_trace > 0, 'The caller loop must compile with an unrelated capture')
+-- Re-enter with no head; the nonnull guard must exit before dereferencing it.
+assert(driver(1000) is expected, 'The nonempty specialisation must safely handle an empty list')
+]]
+
+function run_case(Worker, NonzeroJump)
+   local source = Worker .. "\nglobal glExpectJump = " .. tostring(NonzeroJump) .. "\n" .. harness
+   local script = obj.new('tiri', { statement=source })
+   check script.acActivate()
+   assert(script.error is 0, script.errorMessage)
+end
+
+@Test function EmptyCloseReturn()
+   run_case([[
+global function worker(Value:num, Capture:bool):num
+   if Capture then
+      local function read():num return Value end
+      return read()
+   end
+   return Value + 1
+end
+]], false)
+end
+
+@Test function EmptyCloseJump()
+   -- A return emitted before the first child prototype is fixed up to UCLO plus a forward jump.
+   run_case([[
+global function worker(Value:num, Capture:bool):num
+   if not Capture then return Value + 1 end
+   local function read():num return Value end
+   return read()
+end
+]], true)
+end
+
+@Test function ExistingClosuresCrossScopeExit()
+   local script = obj.new('tiri', { statement=[[
+global function escape(Value:num):<func, func>
+   local shared = { number=Value }
+   local function read():num return shared.number end
+   local function write(New:num) shared.number = New end
+   shared.number += 1
+   return read, write
+end
+for enabled in {0 to 2} do
+   jit.flush()
+   if enabled is 0 then jit.off() else jit.on() end
+   for index in {0 to 200} do
+      local read, write = escape(index)
+      local reused = { number=-1 }
+      assert(read() is index + 1, 'Close must preserve the latest captured value')
+      write(index + 10)
+      processing.collect()
+      assert(read() is index + 10, 'Closed closures must share the cell across GC and slot reuse')
+      assert(reused.number is -1)
+   end
+end
+]] })
+   check script.acActivate()
+   assert(script.error is 0, script.errorMessage)
+end

--- a/src/tiri/tests/test_return_types.tiri
+++ b/src/tiri/tests/test_return_types.tiri
@@ -823,6 +823,33 @@ end
    assert(c is 3, "third from varargs should be 3")
 end
 
+@Test function DynamicReturnContractsPreserveExpandedResults()
+   local script = obj.new('tiri', { statement=[=[
+jit.opt.start('hotloop=1', 'hotexit=1')
+local aborts = 0
+function trace_event(Event, Trace, Func, Pc, Reason)
+   if Event is 'abort' then aborts++ end
+end
+jit.attach(trace_event, 'trace')
+function firstAndRest(...):<num, any, ...>
+   return ...
+end
+for i in {0 to 100} do
+   local a, b, c, d = firstAndRest(1, 2, 'third', nil)
+   assert(a is 1 and b is 2 and c is 'third' and d is nil,
+      f'Expanded results must survive trace abortion: {a}, {b}, {c}, {d}')
+end
+jit.attach(trace_event)
+assert(aborts > 0, 'The dynamic contract must exercise trace abortion')
+jit.off()
+local deferred = <{ 1 }>
+local a, b, c = firstAndRest(deferred, 2, 3)
+assert(a is 1 and b is 2 and c is 3, 'Thunk resolution must preserve the other expanded results')
+]=] })
+   check script.acActivate()
+   assert(script.error is 0, script.errorMessage)
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- ERROR MESSAGE QUALITY
 


### PR DESCRIPTION
## Summary

* enable JIT compilation for fresh closures and UCLO upvalue closing
* record closures with local captures for correct JIT handling
* add the Tiri Reference Manual build target, including PDF and navigable HTML output

## Validation

* `cmake -S . -B build/agents -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=build/agents-install -DRUN_ANYWHERE=TRUE -DKOTUKU_STATIC=OFF -DUNIT_TESTS=ON -DORIGO_CONSOLE=ON`
* `cmake --build build/agents --target tiri_reference_manual --parallel`