### PR TITLE
[Tiri] Harden closure allocation and zero-closure sinking

### DIFF
--- a/src/tiri/jit/src/debug/lj_err.cpp
+++ b/src/tiri/jit/src/debug/lj_err.cpp
@@ -474,10 +474,13 @@ static bool check_try_handler(lua_State *L, int errcode)
             }
          }
 
-         // If we've reached the try block's function, stop searching
+         // Match the activation, not merely the closure: recursive calls can share one function object.
+         if (pf + 1 IS try_base) break;
 
-         GCfunc *func = frame_func(pf);
-         if (func IS try_frame->func) break;  // Reached the try frame's function
+         // A language handler below a native re-entry must resume in its own VM C frame.  Let the platform
+         // unwinder discard the intervening C frame first; resuming in this frame leaves abandoned native calls
+         // on the machine stack and eventually returns through stale frame links.
+         if (pf_type IS FRAME_C or (pf_type IS FRAME_CONT and frame_iscont_fficb(pf))) return false;
 
          // Move to previous frame based on frame type
 
@@ -504,7 +507,7 @@ static bool check_try_handler(lua_State *L, int errcode)
       int ftype = frame_typep(frame);
       log.trace("  Frame %d: frame=%p, func=%p, pc=%p, type=%d", frame_count++, frame, func, pc, ftype);
 
-      if (func IS try_frame->func) {
+      if (func IS try_frame->func and frame + 1 IS restorestack(L, try_frame->frame_base)) {
          log.trace("  Found try_frame->func at frame %d", frame_count - 1);
          found_try_func = true;
          break;
@@ -721,14 +724,18 @@ void * err_unwind(lua_State *L, void *StopCatchFrame, int errcode)
             if (errcode) {
                const ptrdiff_t frame_offset = savestack(L, frame);
                const ptrdiff_t top_offset = savestack(L, top);
-               lj_checkall_cleanup_to_base(L, top);
-               unwind_cleanup_all(L, L->base - 1, top);
-               frame = restorestack(L, frame_offset);
-               top = restorestack(L, top_offset);
-               lj_meta_multres_unwind(L, top);
+               // Snapshot restoration uses an out-of-stack sentinel to catch allocation errors without
+               // discarding the partly restored VM stack. It is not a lexical cleanup boundary.
+               if (top <= tvref(L->maxstack)) {
+                  lj_checkall_cleanup_to_base(L, top);
+                  unwind_cleanup_all(L, L->base - 1, top);
+                  frame = restorestack(L, frame_offset);
+                  top = restorestack(L, top_offset);
+                  lj_meta_multres_unwind(L, top);
+               }
                L->base = frame + 1;
                L->cframe = cframe_prev(cf);
-               unwindstack(L, top);
+               if (top <= tvref(L->maxstack)) unwindstack(L, top);
             }
             J->abort_in_progress = false;
             return cf;

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -2216,6 +2216,7 @@ LJLIB_CF(array_each)
 }
 
 //********************************************************************************************************************
+
 static int array_map_same(lua_State *L)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
@@ -2274,10 +2275,57 @@ LJLIB_CF(array_map)
 // Usage: array.mapSame(arr, transform)
 //
 // Maps values into a new array with the source array's exact storage descriptor.
+//
+// Zero denotes an uninitialised worker; a function is the cached worker.
 
+LJLIB_PUSH(0)
 LJLIB_CF(array_mapSame)
 {
-   return array_map_same(L);
+   GCarray *source = lj_lib_checkarray(L, 1);
+   luaL_checktype(L, 2, LUA_TFUNCTION);
+   if (not source->len) return array_map_same(L);
+
+   GCfunc *method = curr_func(L);
+   TValue *worker = &method->c.upvalue[0];
+   if (tvisnumber(worker)) {
+      // Diagnostic parsing owns script-level variable metadata; internal compilation must not replace it.
+      if ((L->script->JitOptions & JOF::DIAGNOSE) != JOF::NIL) return array_map_same(L);
+
+      // Compile only on first use, retaining canonical BFUNC identity.  Publish after successful compilation so
+      // an allocation failure leaves the worker retryable.  The active native frame roots the method and arguments.
+
+      constexpr auto worker_source = R"tiri(
+return function(Source:array<any>, Callback:func, Result:array<any>, Count:num)
+   local index = 0
+   while index < Count do
+      if index >= #Source then break end
+      Result[index] = Callback(Source[index], index)
+      index++
+   end
+end
+)tiri";
+      if (lua_load(L, worker_source, "=array.mapSame") != 0) lua_error(L);
+      lua_call(L, 0, 1);
+      copyTV(L, worker, L->top - 1);
+      lj_gc_barrier(L, method, L->top - 1);
+      lua_pop(L, 1);
+   }
+
+   if (not tvisfunc(worker)) return array_map_same(L);
+
+   MSize count = source->len;
+   GCarray *result = lj_array_new_like(L, source, count);
+   setarrayV(L, L->top++, result);
+
+   // All values remain rooted in this native frame and the bytecode call frame.  Only one C boundary per pipeline.
+   
+   copyTV(L, L->top++, worker);
+   lua_pushvalue(L, 1);
+   lua_pushvalue(L, 2);
+   setarrayV(L, L->top++, result);
+   lua_pushinteger(L, count);
+   lua_call(L, 4, 0);
+   return 1;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/lj_asm.cpp
+++ b/src/tiri/jit/src/lj_asm.cpp
@@ -910,6 +910,12 @@ static void asm_snap_alloc1(ASMState* as, IRRef ref)
       if (ra_used(ir)) return;
       if (ir->r == RID_SINK) {
          ir->r = RID_SUNK;
+         if (ir->o IS IR_CALLA and ir->op2 IS IRCALL_lj_func_newL_zero) {
+            IRIns *args = IR(ir->op1);
+            asm_snap_alloc1(as, args->op1);
+            asm_snap_alloc1(as, args->op2);
+            return;
+         }
 #if LJ_HASFFI
          if (ir->o == IR_CNEWI) {  // Allocate CNEWI value.
             asm_snap_alloc1(as, ir->op2);
@@ -1698,8 +1704,13 @@ static void asm_ir(ASMState* as, IRIns* ir)
       lj_assertA(!ra_used(ir),
          "IR %04d not unused", (int)(ir - as->ir) - REF_BIAS);
       break;
-   case IR_USE:
-      ra_alloc1(as, ir->op1, irt_isfp(ir->t) ? RSET_FPR : RSET_GPR); break;
+   case IR_USE: {
+      IRIns *allocation = IR(ir->op1);
+      if (allocation->o IS IR_CALLA and allocation->op2 IS IRCALL_lj_func_newL_zero and
+          (allocation->r IS RID_SINK or allocation->r IS RID_SUNK)) break;
+      ra_alloc1(as, ir->op1, irt_isfp(ir->t) ? RSET_FPR : RSET_GPR);
+      break;
+   }
    case IR_PHI: asm_phi(as, ir); break;
    case IR_HIOP: asm_hiop(as, ir); break;
    case IR_GCSTEP: asm_gcstep(as, ir); break;

--- a/src/tiri/jit/src/lj_opt_fold.cpp
+++ b/src/tiri/jit/src/lj_opt_fold.cpp
@@ -2240,6 +2240,13 @@ LJFOLDF(fload_func_ffid_kgc)
    return NEXTFOLD;
 }
 
+LJFOLD(FLOAD CALLA IRFL_FUNC_ENV)
+LJFOLDF(fload_zero_closure_environment)
+{
+   if (fleft->op2 IS IRCALL_lj_func_newL_zero) return IR(fleft->op1)->op2;
+   return NEXTFOLD;
+}
+
 LJFOLD(FLOAD any IRFL_STR_LEN)
 LJFOLD(FLOAD any IRFL_FUNC_ENV)
 LJFOLD(FLOAD any IRFL_THREAD_ENV)

--- a/src/tiri/jit/src/lj_opt_sink.cpp
+++ b/src/tiri/jit/src/lj_opt_sink.cpp
@@ -14,6 +14,7 @@
 #include "lj_jit.h"
 #include "lj_iropt.h"
 #include "lj_target.h"
+#include "lj_ircall.h"
 
 // Some local macros to save typing. Undef'd at the end.
 #define IR(ref)      (&J->cur.ir[(ref)])
@@ -45,6 +46,25 @@ static int sink_phidep(jit_State* J, IRRef ref, int* workp)
    if (ir->op1 >= REF_FIRST and sink_phidep(J, ir->op1, workp)) return 1;
    if (ir->op2 >= REF_FIRST and sink_phidep(J, ir->op2, workp)) return 1;
    return 0;
+}
+
+// Only this allocating call has a reconstruction contract. Captures and arbitrary CALLA helpers are excluded.
+static bool sink_zero_closure(jit_State *J, IRIns *Allocation)
+{
+   if (J->chain[IR_XBAR]) return false;
+   if (Allocation->o != IR_CALLA or Allocation->op2 != IRCALL_lj_func_newL_zero) return false;
+   IRIns *args = IR(Allocation->op1);
+   if (args->o != IR_CARG or not irref_isk(args->op1) or IR(args->op1)->o != IR_KGC) return false;
+   auto *prototype = gco_to_proto(ir_kgc(IR(args->op1)));
+   if (prototype->sizeuv != 0) return false;
+   // Reconstruction may depend on an inherited environment, but not an allocation varying with the loop.
+   if (not irref_isk(args->op2) and (irt_isphi(IR(args->op2)->t) or
+       (J->loopref and args->op2 >= J->loopref))) return false;
+   if (not irref_isk(args->op2)) {
+      int work = 64;
+      if (sink_phidep(J, args->op2, &work)) return false;
+   }
+   return true;
 }
 
 // Check whether a value is a sinkable PHI or loop-invariant.
@@ -104,6 +124,14 @@ static void sink_mark_ins(jit_State* J)
       case IR_USTORE:
          irt_setmark(IR(ir->op2)->t);  //  Mark stored value.
          break;
+      case IR_CALLA:
+         if (sink_zero_closure(J, ir)) {
+            // Keep reconstruction inputs materialised even when only a snapshot observes the closure.
+            irt_setmark(IR(IR(ir->op1)->op2)->t);
+         }
+         else irt_setmark(IR(ir->op1)->t);
+         break;
+      case IR_CALLN: case IR_CALLL: case IR_CALLXS:
       case IR_CALLS:
          irt_setmark(IR(ir->op1)->t);  //  Mark (potentially) stored values.
          break;
@@ -181,6 +209,13 @@ static void sink_sweep_ins(jit_State* J)
             ir->prev = REGSP_INIT;
          }
          break;
+      case IR_CALLA:
+         if (not sink_zero_closure(J, ir)) {
+            irt_clearmark(ir->t);
+            ir->prev = REGSP_INIT;
+            break;
+         }
+         [[fallthrough]];
       case IR_TNEW: case IR_TDUP:
          if (!irt_ismarked(ir->t)) {
             ir->t.irt &= ~IRT_GUARD;
@@ -225,7 +260,7 @@ void lj_opt_sink(jit_State* J)
 {
    const uint32_t need = (JIT_F_OPT_SINK | JIT_F_OPT_FWD |
       JIT_F_OPT_DCE | JIT_F_OPT_CSE | JIT_F_OPT_FOLD);
-   if ((J->flags & need) == need and (J->chain[IR_TNEW] or J->chain[IR_TDUP])) {
+   if ((J->flags & need) IS need and (J->chain[IR_TNEW] or J->chain[IR_TDUP] or J->chain[IR_CALLA])) {
       if (!J->loopref) sink_mark_snap(J, &J->cur.snap[J->cur.nsnap - 1]);
       sink_mark_ins(J);
       if (J->loopref) sink_remark_phi(J);

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1405,7 +1405,11 @@ static TRef rec_call_specialise(jit_State *J, GCfunc *Function, TRef Ref, bool P
    if (isluafunc(Function)) {
       GCproto* pt = funcproto(Function);
       // Fresh allocations cannot specialise on the recording-time closure identity, even before CLC_POLY.
-      if (rec_is_fresh_function(J, Ref)) PrototypeSpecialisation = true;
+      if (rec_is_fresh_function(J, Ref)) {
+         // The allocator's constant prototype already proves the PC; a load would force virtual closures to escape.
+         if (IR(tref_ref(Ref))->op2 IS IRCALL_lj_func_newL_zero) return Ref;
+         PrototypeSpecialisation = true;
+      }
       // Too many closures created? Probably not a monomorphic function.
       if (PrototypeSpecialisation or rec_proto_specialise_by_prototype(pt)) {  // Specialise to prototype instead.
          TRef trpt = ir.fload_ptr(Ref, IRFL_FUNC_PC);
@@ -5618,7 +5622,7 @@ void lj_record_ins(jit_State *J)
       }
       else rc = prototype->sizeuv ? lj_ir_call(J, IRCALL_lj_func_newL_inherited, proto_ref, parent) :
          lj_ir_call(J, IRCALL_lj_func_newL_zero, proto_ref, environment);
-      // CALLA has a weak allocation guard.  Keep even unused closures for allocation-counter and failure semantics.
+      // Pin allocations through DCE. SINK may elide only proven non-escaping zero-upvalue allocations.
       emitir(IRT(IR_USE, IRT_FUNC), rc, 0);
       // Publish through the normal destination-slot path below before taking the next bytecode's snapshot.
       J->needsnap = 1;

--- a/src/tiri/jit/src/lj_snap.cpp
+++ b/src/tiri/jit/src/lj_snap.cpp
@@ -43,6 +43,8 @@
 #include "lj_frame.h"
 #include "lj_bc.h"
 #include "lj_ir.h"
+#include "lj_ircall.h"
+#include "lj_func.h"
 #include "lj_jit.h"
 #include "lj_iropt.h"
 #include "lib/lib_range.h"
@@ -687,6 +689,12 @@ void lj_snap_replay(jit_State* J, GCtrace* T)
          if (regsp_reg(ir->r) IS RID_SUNK) {
             if (J->slot[snap_slot(sn)] != snap_slot(sn)) continue;
             pass23 = 1;
+            if (ir->o IS IR_CALLA and ir->op2 IS IRCALL_lj_func_newL_zero) {
+               IRIns *args = &T->ir[ir->op1];
+               snap_pref(J, T, map, nent, seen, args->op1);
+               snap_pref(J, T, map, nent, seen, args->op2);
+               continue;
+            }
             lj_assertJ(ir->o IS IR_TNEW or ir->o IS IR_TDUP or
                ir->o IS IR_CNEW or ir->o IS IR_CNEWI,
                "sunk parent IR %04d has bad op %d", refp - REF_BIAS, ir->o);
@@ -717,6 +725,13 @@ void lj_snap_replay(jit_State* J, GCtrace* T)
             TRef op1, op2;
             if (J->slot[snap_slot(sn)] != snap_slot(sn)) {  // De-dup allocs.
                J->slot[snap_slot(sn)] = J->slot[J->slot[snap_slot(sn)]];
+               continue;
+            }
+            if (ir->o IS IR_CALLA and ir->op2 IS IRCALL_lj_func_newL_zero) {
+               IRIns *args = &T->ir[ir->op1];
+               TRef prototype = snap_pref(J, T, map, nent, seen, args->op1);
+               TRef environment = snap_pref(J, T, map, nent, seen, args->op2);
+               J->slot[snap_slot(sn)] = lj_ir_call(J, IRCALL_lj_func_newL_zero, prototype, environment);
                continue;
             }
             op1 = ir->op1;
@@ -819,6 +834,15 @@ static void snap_restoreval(jit_State* J, GCtrace* T, ExitState* ex, SnapNo snap
 static void snap_unsink(jit_State *J, GCtrace *T, ExitState *ex, SnapNo snapno, BloomFilter rfilt,
    IRIns* ir, TValue* o)
 {
+   if (ir->o IS IR_CALLA and ir->op2 IS IRCALL_lj_func_newL_zero) {
+      IRIns *args = &T->ir[ir->op1];
+      auto *prototype = gco_to_proto(ir_kgc(&T->ir[args->op1]));
+      TValue environment;
+      snap_restoreval(J, T, ex, snapno, rfilt, args->op2, &environment);
+      // The helper does not collect; the trace roots the prototype and the exit state retains the environment.
+      setfuncV(J->L, o, lj_func_newL_zero(J->L, prototype, tabV(&environment)));
+      return;
+   }
    lj_assertJ(ir->o IS IR_TNEW or ir->o IS IR_TDUP or ir->o IS IR_CNEW or ir->o IS IR_CNEWI,
       "sunk allocation with bad op %d", ir->o);
 

--- a/src/tiri/jit/src/runtime/lj_func.cpp
+++ b/src/tiri/jit/src/runtime/lj_func.cpp
@@ -14,6 +14,31 @@
 #include "lj_trace.h"
 #include "lj_vm.h"
 
+#ifdef UNIT_TESTS
+ClosureAllocationProbe &lj_func_allocation_probe()
+{
+   static thread_local ClosureAllocationProbe probe;
+   return probe;
+}
+
+static void func_probe_begin(lua_State *L, GCproto *Proto, int Helper)
+{
+   auto &probe = lj_func_allocation_probe();
+   probe.state = L;
+   probe.prototype = Proto;
+   probe.helper = Helper;
+   probe.site = -1;
+   probe.active = true;
+}
+#define FUNC_PROBE_BEGIN(L, Proto, Helper) func_probe_begin(L, Proto, Helper)
+#define FUNC_PROBE_SITE(Site) lj_func_allocation_probe().site = Site
+#define FUNC_PROBE_END() lj_func_allocation_probe().active = false
+#else
+#define FUNC_PROBE_BEGIN(L, Proto, Helper) ((void)0)
+#define FUNC_PROBE_SITE(Site) ((void)0)
+#define FUNC_PROBE_END() ((void)0)
+#endif
+
 // Prototypes
 
 void lj_func_freeproto(global_State *g, GCproto *pt)
@@ -157,13 +182,17 @@ static GCfunc* func_newL(lua_State *L, GCproto *pt, GCtab *env)
 GCfunc *lj_func_newL_zero(lua_State *L, GCproto *Proto, GCtab *Environment)
 {
    lj_assertL(Proto->sizeuv IS 0, "trace closure allocation with captures");
-   return func_newL(L, Proto, Environment);
+   FUNC_PROBE_BEGIN(L, Proto, 1);
+   GCfunc *function = func_newL(L, Proto, Environment);
+   FUNC_PROBE_END();
+   return function;
 }
 
 // Share existing cells without collecting, creating open cells or inspecting the interpreter frame.
 
 GCfunc *lj_func_newL_inherited(lua_State *L, GCproto *Proto, GCfuncL *Parent)
 {
+   FUNC_PROBE_BEGIN(L, Proto, 2);
    GCfunc *function = func_newL(L, Proto, tabref(Parent->env));
    for (MSize index = 0; index < Proto->sizeuv; ++index) {
       uint32_t capture = proto_uv(Proto)[index];
@@ -173,18 +202,20 @@ GCfunc *lj_func_newL_inherited(lua_State *L, GCproto *Proto, GCfuncL *Parent)
       setgcrefr(function->l.uvptr[index], Parent->uvptr[capture]);
    }
    function->l.nupvalues = uint8_t(Proto->sizeuv);
+   FUNC_PROBE_END();
    return function;
 }
 
 // Trace-local captures use the logical frame supplied by the recorder.  Neither allocation path collects or
 // resizes the stack.  Create cells first so allocation failure never leaves a partially sized function in the GC list.
 
-GCfunc *lj_func_newL_local(lua_State *L, GCproto *Proto, GCfuncL *Parent, TValue *Base)
+static GCfunc *func_newL_local(lua_State *L, GCproto *Proto, GCfuncL *Parent, TValue *Base)
 {
    GCupval *captures[LJ_MAX_UPVAL];
    for (MSize index = 0; index < Proto->sizeuv; ++index) {
       uint32_t capture = proto_uv(Proto)[index];
       if (capture & PROTO_UV_LOCAL) {
+         FUNC_PROBE_SITE(int(index));
          GCupval *cell = func_finduv(L, Base + (capture & 0xff));
          cell->immutable = ((capture / PROTO_UV_IMMUTABLE) & 1);
          cell->dhash = uint32_t(uintptr_t(mref<char>(Parent->pc))) ^ (capture << 24);
@@ -192,6 +223,7 @@ GCfunc *lj_func_newL_local(lua_State *L, GCproto *Proto, GCfuncL *Parent, TValue
       }
       else captures[index] = gco_to_upval(gcref(Parent->uvptr[capture]));
    }
+   FUNC_PROBE_SITE(-1);
    GCfunc *function = func_newL(L, Proto, tabref(Parent->env));
    for (MSize index = 0; index < Proto->sizeuv; ++index) {
       // NOBARRIER: The function is white, and no allocation or collection intervenes before publication.
@@ -201,20 +233,31 @@ GCfunc *lj_func_newL_local(lua_State *L, GCproto *Proto, GCfuncL *Parent, TValue
    return function;
 }
 
+GCfunc *lj_func_newL_local(lua_State *L, GCproto *Proto, GCfuncL *Parent, TValue *Base)
+{
+   FUNC_PROBE_BEGIN(L, Proto, 3);
+   GCfunc *function = func_newL_local(L, Proto, Parent, Base);
+   FUNC_PROBE_END();
+   return function;
+}
+
 // Create a new Lua function with empty upvalues.
 
 GCfunc * lj_func_newL_empty(lua_State *L, GCproto *pt, GCtab *env)
 {
-   GCfunc *fn = func_newL(L, pt, env);
+   GCupval *captures[LJ_MAX_UPVAL];
    MSize i, nuv = pt->sizeuv;
-   // NOBARRIER: The GCfunc is new (marked white).
+   // These allocations do not collect. Build every cell before publishing the full-sized function.
    for (i = 0; i < nuv; i++) {
       GCupval *uv = func_emptyuv(L);
       int32_t v = proto_uv(pt)[i];
       uv->immutable = ((v / PROTO_UV_IMMUTABLE) & 1);
       uv->dhash = (uint32_t)(uintptr_t)pt ^ (v << 24);
-      setgcref(fn->l.uvptr[i], obj2gco(uv));
+      captures[i] = uv;
    }
+   GCfunc *fn = func_newL(L, pt, env);
+   // NOBARRIER: The GCfunc is new (marked white).
+   for (i = 0; i < nuv; i++) setgcref(fn->l.uvptr[i], obj2gco(captures[i]));
    fn->l.nupvalues = (uint8_t)nuv;
    return fn;
 }
@@ -223,30 +266,13 @@ GCfunc * lj_func_newL_empty(lua_State *L, GCproto *pt, GCtab *env)
 
 GCfunc * lj_func_newL_gc(lua_State *L, GCproto *pt, GCfuncL *parent)
 {
-   GCfunc *fn;
-   GCRef *puv;
-   MSize i, nuv;
-   TValue *base;
    lj_gc_check_fixtop(L);
-   fn = func_newL(L, pt, tabref(parent->env));
-   // NOBARRIER: The GCfunc is new (marked white).
-   puv = parent->uvptr;
-   nuv = pt->sizeuv;
-   base = L->base;
-   for (i = 0; i < nuv; i++) {
-      uint32_t v = proto_uv(pt)[i];
-      GCupval* uv;
-      if ((v & PROTO_UV_LOCAL)) {
-         uv = func_finduv(L, base + (v & 0xff));
-         uv->immutable = ((v / PROTO_UV_IMMUTABLE) & 1);
-         uv->dhash = (uint32_t)(uintptr_t)mref<char>(parent->pc) ^ (v << 24);
-      }
-      else uv = &gcref(puv[v])->uv;
-
-      setgcref(fn->l.uvptr[i], obj2gco(uv));
-   }
-   fn->l.nupvalues = (uint8_t)nuv;
-   return fn;
+   // Resolve cells before publishing the function, as on trace.  A failed cell allocation must not leave a
+   // full-sized function with zero nupvalues in the GC list (its destructor would free/account the wrong size).
+   FUNC_PROBE_BEGIN(L, pt, 4);
+   GCfunc *function = func_newL_local(L, pt, parent, L->base);
+   FUNC_PROBE_END();
+   return function;
 }
 
 void lj_func_free(global_State* g, GCfunc* fn)

--- a/src/tiri/jit/src/runtime/lj_func.h
+++ b/src/tiri/jit/src/runtime/lj_func.h
@@ -20,3 +20,15 @@ LJ_FUNC [[nodiscard]] GCfunc *lj_func_newL_inherited(lua_State *L, GCproto *Prot
 LJ_FUNC [[nodiscard]] GCfunc *lj_func_newL_local(lua_State *L, GCproto *Proto, GCfuncL *Parent, TValue *Base);
 LJ_FUNCA [[nodiscard]] GCfunc *lj_func_newL_gc(lua_State *L, GCproto *pt, GCfuncL *parent);
 LJ_FUNC void lj_func_free(global_State *g, GCfunc *c);
+
+#ifdef UNIT_TESTS
+// State-confined observation only; the allocator owns injection and the protected caller resets this after unwind.
+struct ClosureAllocationProbe {
+   lua_State *state = nullptr;
+   GCproto *prototype = nullptr;
+   int helper = 0; // 1: zero, 2: inherited, 3: local, 4: interpreter.
+   int site = -1; // -1: function, otherwise the capture descriptor index.
+   bool active = false;
+};
+LJ_FUNC ClosureAllocationProbe &lj_func_allocation_probe();
+#endif

--- a/src/tiri/jit/src/runtime/unit_tests_allocator.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_allocator.cpp
@@ -10,6 +10,15 @@
 #include "lj_alloc.h"
 #include "lj_str.h"
 #include "lj_prng.h"
+#include "lj_func.h"
+#include "lj_dispatch.h"
+#include "lj_ircall.h"
+#include "lj_gc.h"
+#include "lj_target.h"
+#include "lualib.h"
+#include "../../../defs.h"
+#include <memory>
+#include <string>
 
 #include <array>
 #include <cstddef>
@@ -179,14 +188,383 @@ static bool test_mutable_string_buffers_are_zero_initialised(kt::Log &Log)
    return true;
 }
 
+// Injection is owned by the protected caller, never by an object in a VM-unwound frame.
+struct ClosureAllocator {
+   lua_Alloc original;
+   void *original_data;
+   lua_State *state;
+   GCproto *prototype;
+   int helper;
+   int fail_at;
+   int requests = 0;
+   int failed_site = -2;
+   int trace = 0;
+   uint8_t flags = 0;
+   bool armed = true;
+   int64_t balance = 0;
+
+   static void *allocate(void *Data, void *Block, size_t OldSize, size_t NewSize)
+   {
+      auto &self = *(ClosureAllocator *)Data;
+      auto &probe = lj_func_allocation_probe();
+      if (self.armed and NewSize > OldSize and probe.active and probe.state IS self.state and
+          probe.prototype IS self.prototype and probe.helper IS self.helper) {
+         if (self.requests IS 0) self.flags = self.prototype->flags;
+         ++self.requests;
+         if (self.requests IS self.fail_at) {
+            self.failed_site = probe.site;
+            self.trace = G(self.state)->vmstate;
+            self.armed = false;
+            return nullptr;
+         }
+      }
+      void *result = self.original(self.original_data, Block, OldSize, NewSize);
+      if (result or not NewSize) self.balance += int64_t(NewSize) - int64_t(OldSize);
+      return result;
+   }
+};
+
+static bool closure_integrity(lua_State *L, kt::Log &Log)
+{
+   auto *g = G(L);
+   TValue *previous = L->top;
+   unsigned count = 0;
+   for (GCobj *object = gcref(L->openupval); object; object = gcref(object->gch.nextgc)) {
+      auto *cell = gco_to_upval(object);
+      if (++count > 10000 or cell->closed or uvval(cell) >= previous or uvval(cell) < tvref(L->stack)) {
+         Log.error("invalid ordered open-cell list");
+         return false;
+      }
+      previous = uvval(cell);
+   }
+   count = 0;
+   for (auto *cell = uvnext(&g->uvhead); cell != &g->uvhead; cell = uvnext(cell)) {
+      if (++count > 10000 or cell->closed or uvnext(uvprev(cell)) != cell or uvprev(uvnext(cell)) != cell) {
+         Log.error("invalid reciprocal global cell list");
+         return false;
+      }
+   }
+   count = 0;
+   for (GCobj *object = gcref(g->gc.root); object; object = gcref(object->gch.nextgc)) {
+      if (++count > 1000000) return false;
+      if (object->gch.gct != uint8_t(~LJ_TFUNC)) continue;
+      auto *function = gco_to_function(object);
+      if (not isluafunc(function)) continue;
+      if (function->l.nupvalues != funcproto(function)->sizeuv) {
+         Log.error("partially sized function after allocation failure");
+         return false;
+      }
+      for (unsigned index = 0; index < function->l.nupvalues; ++index) {
+         if (not gcref(function->l.uvptr[index])) return false;
+      }
+   }
+   return true;
+}
+
+static bool test_closure_allocation_failures(kt::Log &Log)
+{
+   struct ScriptOwner {
+      objTiri *object = nullptr;
+      ~ScriptOwner() { if (object) FreeResource(object); }
+   } script;
+   if (NewObject(CLASSID::TIRI, &script.object) != ERR::Okay) return false;
+   if (script.object->setStatement("") != ERR::Okay or Action(AC::Init, script.object, nullptr) != ERR::Okay)
+      return false;
+
+   struct Shape { const char *body; int helper; int sites; int expected; bool sibling; };
+   constexpr Shape shapes[] = {
+      { "return () => num: 6", 1, 1, 6, false },
+      { "return () => num: inherited", 2, 1, 10, false },
+      { "local a=1; local b=2; local c=3; return () => num: a+b+c", 3, 4, 6, false },
+      { "local a=1; local b=2; local c=3; return () => num: inherited+a+b+c", 3, 4, 16, false },
+      { "local a=1; local b=2; local c=3; glSibling=() => num: a; "
+        "return () => num: inherited+a+b+c", 3, 3, 16, true }
+   };
+   for (bool compiled : { false, true }) {
+      for (const auto &shape : shapes) {
+         unsigned failed_sites = 0;
+         for (int failure = 1; failure <= shape.sites; ++failure) {
+            std::unique_ptr<lua_State, decltype(&lua_close)> state(
+               luaL_newstate((extTiri *)script.object), lua_close);
+            if (not state) return false;
+            auto *lua = state.get();
+            luaL_openlibs(lua);
+            std::string source = R"tiri(
+global glSibling = () => num: 0
+local inherited = 10
+global function factory():func
+)tiri";
+            source += shape.body;
+            source += R"tiri(
+end
+global glSample = factory()
+global function driver(Count:num):num
+   local total = 0
+   local index = 0
+   while index < Count do
+      local callback = factory()
+      total += callback()
+      index++
+   end
+   return total
+end
+jit.opt.start('hotloop=1', 'hotexit=1000', '-sink')
+)tiri";
+            if (not compiled) source += "jit.off()\n";
+            source += "assert(driver(1000) is " + std::to_string(shape.expected * 1000) + ")";
+            if (lua_load(lua, source.c_str(), "=closure-oom") or lua_pcall(lua, 0, 0, 0)) {
+               Log.error("closure OOM setup: %s", lua_tostring(lua, -1));
+               return false;
+            }
+            lua_getglobal(lua, "glSample");
+            auto *prototype = funcproto(funcV(lua->top - 1));
+            lua_pop(lua, 1);
+            prototype->flags &= PROTO_CLCOUNT - 1;
+            const IRCallID calls[] = { IRCALL_lj_func_newL_zero, IRCALL_lj_func_newL_inherited,
+               IRCALL_lj_func_newL_local };
+            bool loop_call = false;
+            auto *jit = L2J(lua);
+            for (TraceNo number = 1; number < jit->sizetrace; ++number) {
+               auto *trace = traceref(jit, number);
+               if (not trace) continue;
+               bool in_loop = false;
+               for (IRRef ref = REF_BASE; ref < trace->nins; ++ref) {
+                  auto &ins = trace->ir[ref];
+                  if (ins.o IS IR_LOOP) in_loop = true;
+                  if (in_loop and ins.o IS IR_CALLA and ins.op2 IS calls[shape.helper - 1]) loop_call = true;
+               }
+            }
+            if (compiled and not loop_call) {
+               Log.error("helper %d has no retained loop allocation", shape.helper);
+               return false;
+            }
+            lua_gc(lua, LUA_GCCOLLECT, 0);
+            lua_gc(lua, LUA_GCSTOP, 0);
+            lua_getglobal(lua, "driver");
+            lua_pushinteger(lua, 1000);
+            auto *g = G(lua);
+            ClosureAllocator allocator { g->allocf, g->allocd, lua, prototype,
+               compiled ? shape.helper : 4, failure };
+            auto original_total = g->gc.total;
+            g->allocf = ClosureAllocator::allocate;
+            g->allocd = &allocator;
+            int status = lua_pcall(lua, 1, 1, 0);
+            allocator.armed = false;
+            lj_func_allocation_probe() = {};
+            bool ok = status IS LUA_ERRMEM and allocator.failed_site >= -1 and
+               prototype->flags IS allocator.flags and closure_integrity(lua, Log);
+            if (compiled) {
+               auto *trace = allocator.trace > 0 and TraceNo(allocator.trace) < jit->sizetrace ?
+                  traceref(jit, allocator.trace) : nullptr;
+               bool entered_helper = false;
+               if (trace) for (IRRef ref = REF_BASE; ref < trace->nins; ++ref) {
+                  auto &ins = trace->ir[ref];
+                  if (ins.o IS IR_CALLA and ins.op2 IS calls[shape.helper - 1]) entered_helper = true;
+               }
+               ok = ok and entered_helper;
+            }
+            if (allocator.failed_site >= -1) failed_sites |= 1u << (allocator.failed_site + 1);
+            lua_settop(lua, 0);
+            lua_gc(lua, LUA_GCCOLLECT, 0);
+            ok = ok and closure_integrity(lua, Log);
+            if (shape.sibling) {
+               lua_getglobal(lua, "glSibling");
+               int sibling_status = lua_pcall(lua, 0, 1, 0);
+               ok = ok and sibling_status IS 0 and lua_tointeger(lua, -1) IS 1;
+               lua_settop(lua, 0);
+            }
+            lua_getglobal(lua, "driver");
+            lua_pushinteger(lua, 1000);
+            int recovery = lua_pcall(lua, 1, 1, 0);
+            ok = ok and recovery IS 0 and lua_tointeger(lua, -1) IS shape.expected * 1000;
+            lua_settop(lua, 0);
+            if (shape.sibling) {
+               lua_getglobal(lua, "glSibling");
+               ok = ok and lua_pcall(lua, 0, 1, 0) IS 0 and lua_tointeger(lua, -1) IS 1;
+               lua_settop(lua, 0);
+            }
+            lua_gc(lua, LUA_GCCOLLECT, 0);
+            ok = ok and int64_t(g->gc.total) IS int64_t(original_total) + allocator.balance;
+            // Restore both fields before lua_close: the bundled arena destructor recognises the original allocator.
+            g->allocf = allocator.original;
+            g->allocd = allocator.original_data;
+            Log.msg("closure OOM compiled=%d helper=%d request=%d site=%d trace=%d status=%d",
+               compiled, shape.helper, failure, allocator.failed_site, allocator.trace, status);
+            if (not ok) {
+               Log.error("closure allocation failure/recovery invariant failed");
+               return false;
+            }
+         }
+         unsigned distinct = 0;
+         for (; failed_sites; failed_sites >>= 1) distinct += failed_sites & 1;
+         if (distinct != unsigned(shape.sites)) {
+            Log.error("closure sweep did not fail every distinct allocation site");
+            return false;
+         }
+      }
+   }
+   return true;
+}
+
+static bool test_zero_closure_sinking(kt::Log &Log)
+{
+   struct ScriptOwner {
+      objTiri *object = nullptr;
+      ~ScriptOwner() { if (object) FreeResource(object); }
+   } script;
+   if (NewObject(CLASSID::TIRI, &script.object) != ERR::Okay) return false;
+   if (script.object->setStatement("") != ERR::Okay or Action(AC::Init, script.object, nullptr) != ERR::Okay)
+      return false;
+   std::unique_ptr<lua_State, decltype(&lua_close)> state(
+      luaL_newstate((extTiri *)script.object), lua_close);
+   if (not state) return false;
+   auto *lua = state.get();
+   luaL_openlibs(lua);
+   constexpr auto source = R"tiri(
+global glInside = -1
+global function factory():func
+   return function(Value:num):num
+      if Value is glInside then return Value + 2 end
+      return Value + 1
+   end
+end
+global glSample = factory()
+global function driver(Count:num, Stop:num):<any, any>
+   local total = 0
+   local index = 0
+   while index < Count do
+      local callback = factory()
+      local alias = callback
+      total += callback(index)
+      if index is Stop then return callback, alias end
+      index++
+   end
+   return total, nil
+end
+jit.opt.start('hotloop=1', 'hotexit=1000')
+assert(driver(1000, -1) is 500500)
+)tiri";
+   if (lua_load(lua, source, "=zero-closure-sink") or lua_pcall(lua, 0, 0, 0)) {
+      Log.error("sinking setup: %s", lua_tostring(lua, -1));
+      return false;
+   }
+   auto *jit = L2J(lua);
+   bool sunk = false;
+   for (TraceNo number = 1; number < jit->sizetrace; ++number) {
+      auto *trace = traceref(jit, number);
+      if (not trace) continue;
+      bool in_loop = false;
+      for (IRRef ref = REF_BASE; ref < trace->nins; ++ref) {
+         auto &ins = trace->ir[ref];
+         if (ins.o IS IR_LOOP) in_loop = true;
+         if (in_loop and ins.o IS IR_CALLA and ins.op2 IS IRCALL_lj_func_newL_zero and
+             (ins.r IS RID_SINK or ins.r IS RID_SUNK)) sunk = true;
+      }
+   }
+   if (not sunk) {
+      Log.error("no sunk zero-upvalue allocation in the loop");
+      return false;
+   }
+   lua_getglobal(lua, "glSample");
+   auto *prototype = funcproto(funcV(lua->top - 1));
+   lua_pop(lua, 1);
+   auto *g = G(lua);
+   ClosureAllocator allocator { g->allocf, g->allocd, lua, prototype, 1, INT_MAX };
+   g->allocf = ClosureAllocator::allocate;
+   g->allocd = &allocator;
+   lua_getglobal(lua, "driver");
+   lua_pushinteger(lua, 10000);
+   lua_pushinteger(lua, -1);
+   int status = lua_pcall(lua, 2, 1, 0);
+   allocator.armed = false;
+   lj_func_allocation_probe() = {};
+   g->allocf = allocator.original;
+   g->allocd = allocator.original_data;
+   bool ok = status IS 0 and lua_tointeger(lua, -1) IS 50005000 and allocator.requests < 5;
+   Log.msg("zero closure loop: helper allocations=%d for 10000 iterations", allocator.requests);
+   lua_settop(lua, 0);
+   if (not ok) return false;
+
+   // The cold return needs the same virtual closure in two slots. Repeated exits must create distinct identities.
+   constexpr auto exits = R"tiri(
+local previous:any = nil
+for index in {20 to 30} do
+   local first, second = driver(1000, index)
+   assert(first is second and first(41) is 42)
+   assert(first != previous)
+   previous = first
+end
+jit.opt.start('hotexit=1')
+for index in {30 to 60} do
+   local first, second = driver(1000, index)
+   assert(first is second and first(41) is 42 and first != previous)
+   previous = first
+end
+)tiri";
+   if (lua_load(lua, exits, "=zero-closure-exits") or lua_pcall(lua, 0, 0, 0)) {
+      Log.error("sinking exits: %s", lua_tostring(lua, -1));
+      return false;
+   }
+   bool replayed = false;
+   for (TraceNo number = 1; number < jit->sizetrace; ++number) {
+      auto *trace = traceref(jit, number);
+      if (not trace or not trace->root) continue;
+      for (IRRef ref = REF_BASE; ref < trace->nins; ++ref) {
+         auto &ins = trace->ir[ref];
+         if (ins.o IS IR_CALLA and ins.op2 IS IRCALL_lj_func_newL_zero) replayed = true;
+      }
+   }
+   if (not replayed) {
+      Log.error("no compiled side trace replayed the virtual closure");
+      return false;
+   }
+   lua_gc(lua, LUA_GCCOLLECT, 0);
+   // Disable new side traces so the next guard exit must reconstruct in the interpreter.
+   if (lua_load(lua, "jit.opt.start('hotexit=1000'); jit.flush(); assert(driver(1000,-1) is 500500)",
+       "=zero-closure-oom-warm") or lua_pcall(lua, 0, 0, 0)) return false;
+   // Repeat failure after the call and while its inlined frame is live in the snapshot.
+   for (int inside : { -1, 50 }) {
+      lua_pushinteger(lua, inside);
+      lua_setglobal(lua, "glInside");
+      lua_getglobal(lua, "driver");
+      lua_pushinteger(lua, 1000);
+      lua_pushinteger(lua, 50);
+      allocator.requests = 0;
+      allocator.fail_at = 1;
+      allocator.armed = true;
+      g->allocf = ClosureAllocator::allocate;
+      g->allocd = &allocator;
+      status = lua_pcall(lua, 2, 2, 0);
+      allocator.armed = false;
+      lj_func_allocation_probe() = {};
+      g->allocf = allocator.original;
+      g->allocd = allocator.original_data;
+      if (status != LUA_ERRMEM or allocator.requests != 1) {
+         Log.error("materialisation OOM not reached: status=%d allocations=%d", status, allocator.requests);
+         return false;
+      }
+      lua_settop(lua, 0);
+      lua_gc(lua, LUA_GCCOLLECT, 0);
+      if (not closure_integrity(lua, Log)) return false;
+      if (lua_load(lua, "local a,b=driver(1000,50); assert(a is b and a(41) is 42)", "=zero-closure-recovery") or
+          lua_pcall(lua, 0, 0, 0)) {
+         Log.error("materialisation recovery: %s", lua_tostring(lua, -1));
+         return false;
+      }
+   }
+   return true;
+}
+
 } // namespace
 
 extern void allocator_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 3> Tests = { {
+   constexpr std::array<TestCase, 5> Tests = { {
       { "allocator_returns_16_byte_aligned_blocks", test_allocator_returns_16_byte_aligned_blocks },
       { "allocator_realloc_preserves_16_byte_alignment", test_allocator_realloc_preserves_16_byte_alignment },
-      { "mutable_string_buffers_are_zero_initialised", test_mutable_string_buffers_are_zero_initialised }
+      { "mutable_string_buffers_are_zero_initialised", test_mutable_string_buffers_are_zero_initialised },
+      { "closure_allocation_failures", test_closure_allocation_failures },
+      { "zero_closure_sinking", test_zero_closure_sinking }
    } };
 
    for (const TestCase& Test : Tests) {


### PR DESCRIPTION
* Made closure allocation failure-safe across interpreter and compiled paths
* Added reconstruction support for sunk zero-upvalue closures on trace exits
* Added allocator failure and zero-closure sinking unit coverage